### PR TITLE
fix(auth): scope employee email uniqueness by tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,15 @@ CODE_VERSION     = Version release applicative (git tag)
 
 ---
 
+## [4.1.22] - 2026-04-06
+### Beta — Unicite email multi-tenant
+
+- Validation `email` employees scopee par `company_id` a la creation et a la mise a jour
+- Schema de tests et migration tenant alignes sur une unicite composite `company_id + email`
+- Ajout de tests de regression pour autoriser le meme email entre societes et refuser le doublon dans la meme societe
+
+---
+
 ## [4.1.11] - 2026-04-05
 ### MVP-06 — App Flutter (bootstrap)
 

--- a/api/app/Http/Requests/Api/V1/StoreEmployeeRequest.php
+++ b/api/app/Http/Requests/Api/V1/StoreEmployeeRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreEmployeeRequest extends FormRequest
 {
@@ -13,14 +14,21 @@ class StoreEmployeeRequest extends FormRequest
 
     public function rules(): array
     {
+        $companyId = $this->user()?->company_id
+            ?? (app()->bound('current_company') ? app('current_company')->id : null);
+
         return [
             'matricule' => ['nullable', 'string', 'max:20'],
             'first_name' => ['required', 'string', 'max:100'],
             'last_name' => ['required', 'string', 'max:100'],
-            'email' => ['required', 'email', 'max:150', 'unique:employees,email'],
+            'email' => [
+                'required',
+                'email',
+                'max:150',
+                Rule::unique('employees', 'email')->where(fn ($query) => $query->where('company_id', $companyId)),
+            ],
             'password' => ['required', 'string', 'min:8', 'max:255'],
             'role' => ['nullable', 'in:employee,manager'],
         ];
     }
 }
-

--- a/api/app/Http/Requests/Api/V1/UpdateEmployeeRequest.php
+++ b/api/app/Http/Requests/Api/V1/UpdateEmployeeRequest.php
@@ -15,6 +15,8 @@ class UpdateEmployeeRequest extends FormRequest
     public function rules(): array
     {
         $employeeId = $this->route('employee');
+        $companyId = $this->user()?->company_id
+            ?? (app()->bound('current_company') ? app('current_company')->id : null);
 
         return [
             'matricule' => ['sometimes', 'nullable', 'string', 'max:20'],
@@ -25,7 +27,9 @@ class UpdateEmployeeRequest extends FormRequest
                 'nullable',
                 'email',
                 'max:150',
-                Rule::unique('employees', 'email')->ignore($employeeId),
+                Rule::unique('employees', 'email')
+                    ->where(fn ($query) => $query->where('company_id', $companyId))
+                    ->ignore($employeeId),
             ],
             'password' => ['sometimes', 'nullable', 'string', 'min:8', 'max:255'],
             'role' => ['sometimes', 'nullable', 'in:employee,manager'],

--- a/api/database/migrations/tenant/2026_04_01_000101_create_employees_table.php
+++ b/api/database/migrations/tenant/2026_04_01_000101_create_employees_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
             $table->string('zkteco_id', 50)->nullable();            // ID dans le lecteur biométrique ZKTeco
             $table->string('first_name', 100);
             $table->string('last_name', 100);
-            $table->string('email', 150)->unique();                 // Unique dans le scope company
+            $table->string('email', 150);                           // Unique dans le scope company
             $table->string('phone', 30)->nullable();
             $table->string('password_hash', 255);
             $table->date('date_of_birth')->nullable();
@@ -88,6 +88,7 @@ return new class extends Migration
             $table->index(['manager_id', 'status']);
             $table->index('status');
             $table->index(['contract_end']);                        // Pour alertes fin de contrat
+            $table->unique(['company_id', 'email']);
         });
 
         DB::statement("COMMENT ON COLUMN employees.salary_base IS 'Salaire de base mensuel fixe. PAS le brut total — voir payrolls.gross_salary (calculé par PayrollService)'");

--- a/api/tests/Feature/EmployeesRbacTest.php
+++ b/api/tests/Feature/EmployeesRbacTest.php
@@ -240,6 +240,115 @@ class EmployeesRbacTest extends TestCase
         ]);
     }
 
+    public function test_manager_can_create_employee_with_email_used_by_another_company(): void
+    {
+        $companyA = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $companyB = Company::query()->create([
+            'name' => 'Company B',
+            'slug' => 'company-b',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Oran',
+            'email' => 'b@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $managerA = Employee::query()->create([
+            'company_id' => $companyA->id,
+            'email' => 'manager@a.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        Employee::withoutGlobalScopes()->create([
+            'company_id' => $companyB->id,
+            'email' => 'shared@tenant.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $token = $managerA->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/api/v1/employees', [
+                'first_name' => 'Leila',
+                'last_name' => 'Ait',
+                'email' => 'shared@tenant.test',
+                'password' => 'password123',
+                'role' => 'employee',
+            ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('employees', [
+            'company_id' => $companyA->id,
+            'email' => 'shared@tenant.test',
+        ]);
+    }
+
+    public function test_manager_cannot_update_employee_to_duplicate_email_within_same_company(): void
+    {
+        $companyA = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $managerA = Employee::query()->create([
+            'company_id' => $companyA->id,
+            'email' => 'manager@a.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $employeeA = Employee::query()->create([
+            'company_id' => $companyA->id,
+            'email' => 'employee.one@a.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->create([
+            'company_id' => $companyA->id,
+            'email' => 'employee.two@a.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $token = $managerA->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->patchJson("/api/v1/employees/{$employeeB->id}", [
+                'email' => 'employee.one@a.test',
+            ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['email']);
+    }
+
     public function test_employee_can_update_self_profile_but_role_is_ignored(): void
     {
         $companyA = Company::query()->create([

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -42,7 +42,7 @@ trait CreatesMvpSchema
             $table->string('matricule', 20)->nullable();
             $table->string('first_name', 100)->nullable();
             $table->string('last_name', 100)->nullable();
-            $table->string('email', 150)->unique();
+            $table->string('email', 150);
             $table->string('password_hash', 255);
             $table->string('salary_type', 20)->default('fixed');
             $table->decimal('salary_base', 10, 2)->default(0);
@@ -50,6 +50,8 @@ trait CreatesMvpSchema
             $table->string('role', 20)->default('employee');
             $table->string('status', 20)->default('active');
             $table->timestamps();
+
+            $table->unique(['company_id', 'email']);
         });
 
         Schema::create('schedules', function (Blueprint $table): void {


### PR DESCRIPTION
## Summary
- What changed:
- Why:

## Scope
- [ ] Phase 1 backlog ticket referenced (`docs/GESTION_PROJET/BACKLOG_PHASE1_UNIQUE.md`)
- Ticket ID:

## Governance Checks
- [ ] `CHANGELOG.md` updated (required for critical scope)
- [ ] `JOURNAL_RACINE.md` updated
- [ ] `INDEX_CANONIQUE.md` respected (no archive-based implementation)

## Technical Checks
- [ ] API contract aligned (`02_API_CONTRATS_COMPLET.md`) or N/A
- [ ] ERD/SQL impact reviewed or N/A
- [ ] RBAC impact reviewed or N/A
- [ ] Tenant isolation impact reviewed or N/A

## Testing
- [ ] Backend tests added/updated
- [ ] Mobile tests added/updated
- [ ] Manual verification notes included

## Risk / Rollback
- [ ] Rollback plan documented
- [ ] Relevant runbook referenced:
  - [ ] RUNBOOK_DEPLOY
  - [ ] RUNBOOK_ROLLBACK
  - [ ] RUNBOOK_BACKUP_RESTORE
  - [ ] RUNBOOK_INCIDENT_P1
