### PR TITLE
test: lock onboarding invitation roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.60] - 2026-04-21
+### Couverture onboarding invitations
+
+- Ajout d assertions feature pour verrouiller la creation d une societe avec manager principal et invitation email depuis le super-admin
+- Verification explicite des invitations RH et employe creees par un manager, avec `role`, `manager_role`, origine d invitation et lien `/activate`
+- Ces tests securisent le parcours pilote: entreprise -> manager principal -> RH/employes -> activation de compte par email
+
 ## [4.1.59] - 2026-04-21
 ### Optimisations backend ciblees
 
@@ -946,7 +953,6 @@ docs(erd): unify manager_id and remove supervisor_id from employees
    
  
  
-
 
 
 

--- a/api/tests/Feature/EmployeeInvitationOnboardingTest.php
+++ b/api/tests/Feature/EmployeeInvitationOnboardingTest.php
@@ -100,10 +100,17 @@ class EmployeeInvitationOnboardingTest extends TestCase
 
         $this->assertDatabaseHas('user_invitations', [
             'email' => 'fatima.rh@company.test',
+            'role' => 'manager',
+            'manager_role' => 'rh',
             'invited_by_type' => 'manager',
         ]);
 
-        Mail::assertSentCount(1);
+        Mail::assertSent(UserInvitationMail::class, function (UserInvitationMail $mail): bool {
+            return $mail->employee->email === 'fatima.rh@company.test'
+                && $mail->employee->role === 'manager'
+                && $mail->employee->manager_role === 'rh'
+                && str_contains($mail->activationUrl, '/activate/');
+        });
     }
 
     public function test_invited_employee_can_activate_account_from_link(): void
@@ -158,6 +165,15 @@ class EmployeeInvitationOnboardingTest extends TestCase
         });
 
         $token = basename(parse_url($activationUrl, PHP_URL_PATH));
+
+        DB::statement('SET search_path TO public');
+
+        $this->assertDatabaseHas('user_invitations', [
+            'email' => 'karim.aouad@company.test',
+            'role' => 'employee',
+            'manager_role' => null,
+            'invited_by_type' => 'manager',
+        ]);
 
         $this->withoutMiddleware()
             ->post('/activate/'.$token, [

--- a/api/tests/Feature/PlatformCompanyProvisioningTest.php
+++ b/api/tests/Feature/PlatformCompanyProvisioningTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Mail\UserInvitationMail;
 use App\Models\SuperAdmin;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -82,10 +83,17 @@ class PlatformCompanyProvisioningTest extends TestCase
 
         $this->assertDatabaseHas('user_invitations', [
             'email' => 'salim.kaci@nouvelle-societe.dz',
+            'role' => 'manager',
+            'manager_role' => 'principal',
             'invited_by_type' => 'super_admin',
         ]);
 
-        Mail::assertSentCount(1);
+        Mail::assertSent(UserInvitationMail::class, function (UserInvitationMail $mail): bool {
+            return $mail->employee->email === 'salim.kaci@nouvelle-societe.dz'
+                && $mail->employee->role === 'manager'
+                && $mail->employee->manager_role === 'principal'
+                && str_contains($mail->activationUrl, '/activate/');
+        });
     }
 
     public function test_super_admin_api_login_returns_token(): void


### PR DESCRIPTION
## Summary
- What changed:
- Why:

## Scope
- [ ] Phase 1 backlog ticket referenced (`docs/GESTION_PROJET/BACKLOG_PHASE1_UNIQUE.md`)
- Ticket ID:

## Governance Checks
- [ ] `CHANGELOG.md` updated (required for critical scope)
- [ ] `JOURNAL_RACINE.md` updated
- [ ] `INDEX_CANONIQUE.md` respected (no archive-based implementation)

## Technical Checks
- [ ] API contract aligned (`02_API_CONTRATS_COMPLET.md`) or N/A
- [ ] ERD/SQL impact reviewed or N/A
- [ ] RBAC impact reviewed or N/A
- [ ] Tenant isolation impact reviewed or N/A

## Testing
- [ ] Backend tests added/updated
- [ ] Mobile tests added/updated
- [ ] Manual verification notes included

## Risk / Rollback
- [ ] Rollback plan documented
- [ ] Relevant runbook referenced:
  - [ ] RUNBOOK_DEPLOY
  - [ ] RUNBOOK_ROLLBACK
  - [ ] RUNBOOK_BACKUP_RESTORE
  - [ ] RUNBOOK_INCIDENT_P1
