### PR TITLE
🧪 Scout: [MVP regression test] Kiosk security and employee status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.64] - 2026-04-22
+### Securite et isolation Kiosk
+
+- Ajout d'un test de regression `KioskSecurityTest` pour verrouiller l'interface Kiosk/Biometrie
+- Verification que les employes archives ne peuvent plus pointer via borne
+- Verification que les bornes rattachees a une societe suspendue ou expiree sont bloquees
+
 ## [4.1.63] - 2026-04-22
 ### API self-service et parite CRUD mobile
 

--- a/api/tests/Feature/KioskSecurityTest.php
+++ b/api/tests/Feature/KioskSecurityTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceKiosk;
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class KioskSecurityTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_archived_employee_cannot_punch_via_kiosk(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Karim',
+            'last_name' => 'Archived',
+            'email' => 'karim@company.test',
+            'zkteco_id' => 'FP-001',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'archived',
+            'biometric_fingerprint_enabled' => true,
+        ]);
+
+        $plainToken = Str::random(48);
+        $kiosk = AttendanceKiosk::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Entree',
+            'device_code' => 'KIOSK01',
+            'sync_token_hash' => Hash::make($plainToken),
+            'status' => 'active',
+        ]);
+
+        $response = $this->withHeader('X-Kiosk-Token', $plainToken)
+            ->postJson('/api/v1/kiosks/KIOSK01/punch', [
+                'identifier' => 'FP-001',
+                'action' => 'check_in',
+            ]);
+
+        // Expected behavior: blocked because employee is archived.
+        $response->assertStatus(403);
+    }
+
+    public function test_suspended_company_kiosk_is_blocked(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company Suspended',
+            'slug' => 'company-suspended',
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'suspended@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'suspended',
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'employee@suspended.test',
+            'zkteco_id' => 'FP-002',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+            'biometric_fingerprint_enabled' => true,
+        ]);
+
+        $plainToken = Str::random(48);
+        $kiosk = AttendanceKiosk::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Entree',
+            'device_code' => 'KIOSK02',
+            'sync_token_hash' => Hash::make($plainToken),
+            'status' => 'active',
+        ]);
+
+        $response = $this->withHeader('X-Kiosk-Token', $plainToken)
+            ->postJson('/api/v1/kiosks/KIOSK02/punch', [
+                'identifier' => 'FP-002',
+                'action' => 'check_in',
+            ]);
+
+        // Expected behavior: blocked because company is suspended.
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
### Behavior protected
Ensuring that archived employees and suspended companies cannot use the Kiosk/Biometric interface to punch in/out.

### Why it matters for MVP
Tenant isolation and authentication integrity are priority security areas. Allowing archived employees or suspended companies to bypass security via the Kiosk interface is a critical gap that must be closed for pilot stability.

### Test added
`api/tests/Feature/KioskSecurityTest.php`

### Verification command/result
Command: `cd api && DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/KioskSecurityTest.php`
Result: **FAILED** (Expected response status code [403] but received 201).
This confirms the security gap where the Kiosk interface currently ignores the employee and company status.

### Rollback plan
Delete the test file `api/tests/Feature/KioskSecurityTest.php` and revert the corresponding entry in `CHANGELOG.md`.

---
*PR created automatically by Jules for task [4202071842982282610](https://jules.google.com/task/4202071842982282610) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
