### PR TITLE
🛡️ Sentinel: Fix SQL injection risk in SET search_path statements

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [PostgreSQL search_path Injection]
+**Vulnerability:** SQL injection via unescaped schema names in 'SET search_path' statements.
+**Learning:** PostgreSQL 'SET search_path' does not support standard parameter binding. Identifiers must be manually escaped by wrapping in double quotes and doubling any internal double quotes.
+**Prevention:** Use a centralized helper like 'Company::getSafeSearchPath()' to ensure all tenant switches are securely handled.


### PR DESCRIPTION
This PR addresses a security vulnerability where `schema_name` was being concatenated directly into PostgreSQL `SET search_path` statements, leading to a potential SQL injection risk. Since `SET search_path` does not support parameter binding, identifiers must be manually escaped.

A new method `getSafeSearchPath()` has been added to the `Company` model to centralize and secure the search path generation. It double-quotes the schema name and escapes internal quotes by doubling them, following PostgreSQL's standard for identifier escaping.

Impacted files (Requests, Controllers, and Services) have been refactored to use this new method, ensuring consistent and secure tenant context switching across the application.

Unit tests have been added to verify the escaping logic against common injection patterns.

---
*PR created automatically by Jules for task [1153187658679438990](https://jules.google.com/task/1153187658679438990) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
