### PR TITLE
📚 DocKeeper: [documentation alignment]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.64] - 2026-04-22
+### DocKeeper : alignement post-GO MVP
+
+- Alignement de `PILOTAGE.md` avec le statut post-GO MVP (version 4.1.63)
+- Mise à jour du statut de déploiement Render dans `PILOTAGE.md`
+- Résolution des bloqueurs obsolètes dans `EXECUTION_BLOCKERS_AND_NEXT.md` concernant Docker local
+
 ## [4.1.63] - 2026-04-22
 ### API self-service et parite CRUD mobile
 

--- a/PILOTAGE.md
+++ b/PILOTAGE.md
@@ -1,5 +1,5 @@
 # 📑 PILOTAGE — LEOPARDO RH
-# PROGRAM_VERSION = 4.1.58 | 14 Mai 2025
+# PROGRAM_VERSION = 4.1.63 | 22 Avril 2026
 # CE FICHIER EST LA SEULE SOURCE DE VÉRITÉ OPÉRATIONNELLE
 # Statut des anciens fichiers : voir section "Gouvernance documentaire"
 
@@ -32,11 +32,11 @@ MVP : "Combien je dois à mes employés aujourd'hui ?" — en 1 clic.
 ## ÉTAT ACTUEL
 
 ```
-Date MAJ       : 05 Avril 2026
+Date MAJ       : 22 Avril 2026
 Conception     : ✅ Terminée (40+ documents dans docs/dossierdeConception/)
 Code           : ✅ MVP-01 à MVP-06 mergés sur `main`
-Phase active   : MVP — scope verrouillé ci-dessous
-Prochaine action : SPRINT 4 — Beta réelle + déploiement VPS
+Phase active   : Beta / Pilote (GO MVP prononcé)
+Prochaine action : SPRINT 4 — Beta réelle + déploiement Render
 Objectif       : Premier utilisateur payant en 8 semaines
 Validation locale backend : Docker d'abord (voir `docs/GESTION_PROJET/RUNBOOK_LOCAL_TESTS.md`)
 ```
@@ -151,7 +151,7 @@ Pays MVP :
 
 | # | Ticket | Responsable | Critère de validation | Statut |
 |---|--------|-------------|----------------------|--------|
-| S4-1 | Déployer backend + web sur VPS | Humain | Domaine/VPS répondent, login web OK | ⬜ |
+| S4-1 | Déployer backend + web sur Render | Humain | Domaine/Render répondent, login web OK | ✅ |
 | S4-2 | Brancher mobile sur environnement beta réel | IA/Humain | Login, check-in/out, history OK sur backend déployé | ⬜ |
 | S4-3 | Inviter 3-5 prospects beta | Humain | Retours collectés | ⬜ |
 | S4-4 | Corrections prioritaires | IA | Feedback implémenté | ⬜ |

--- a/docs/GESTION_PROJET/EXECUTION_BLOCKERS_AND_NEXT.md
+++ b/docs/GESTION_PROJET/EXECUTION_BLOCKERS_AND_NEXT.md
@@ -5,7 +5,7 @@ This file tracks what still cannot be solved by documentation alone.
 
 ## Current hard blockers
 
-1. La commande Docker locale officielle de test backend n'est pas encore versionnée dans le repo.
+1. (Résolu) La commande Docker locale officielle de test backend est versionnée (`api/start-local.ps1` et `api/docker-compose.yml`).
 2. Sur cette machine, `docker context ls` répond mais `docker version` / `docker ps` expirent : Docker doit être stabilisé avant d'en faire le validateur principal.
 3. GitHub branch protection must be configured in repo settings (external to local files).
 


### PR DESCRIPTION
### What changed
- Aligned `PILOTAGE.md` with the post-GO MVP status: updated `PROGRAM_VERSION` to `4.1.63` (2026-04-22) and set `Phase active` to `Beta / Pilote`.
- Updated the deployment target in `PILOTAGE.md` from "VPS" to "Render" and marked the deployment step (`S4-1`) as completed (✅).
- Resolved an outdated blocker in `docs/GESTION_PROJET/EXECUTION_BLOCKERS_AND_NEXT.md` regarding the missing local Docker test command, which is now provided by `api/start-local.ps1`.
- Updated `CHANGELOG.md` to version `4.1.64` to reflect these documentation alignments.

### Why it was outdated/confusing
- `PILOTAGE.md` was still using a placeholder version from 2025 and did not reflect that the GO MVP decision had been made on 2026-04-21.
- The mention of "VPS" was inconsistent with the actual infrastructure target (Render) used for the MVP.
- `EXECUTION_BLOCKERS_AND_NEXT.md` listed a blocker that had already been addressed by the addition of the local startup script.

### Source of truth used
- `docs/GESTION_PROJET/GO_NO_GO_MVP.md` (for the 2026-04-21 GO date).
- `docs/GESTION_PROJET/RENDER_SETUP.md` (for the infrastructure choice).
- Presence of `api/start-local.ps1` and `api/docker-compose.yml`.
- Latest `CHANGELOG.md` entries.

### Verification performed
- Verified existence of all required governance files.
- Ran `git diff --check`.
- Performed a manual code review.

### Rollback plan
Revert the commit using `git revert` and push the change.

---
*PR created automatically by Jules for task [9781582988247959567](https://jules.google.com/task/9781582988247959567) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
