### PR TITLE
🛡️ Sentinel: Hardening isolation Kiosque et statut employe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.70] - 2026-04-22
+### Sentinel 🛡️ - Hardening isolation Kiosque et statut employe
+
+- Kiosque : les endpoints `punch`, `roster` et `sync` verifient desormais le statut de la societe et retournent `403 ACCOUNT_SUSPENDED` si elle est suspendue ou expiree (auparavant, seule l auth utilisateur standard etait protegee)
+- Kiosque : l action `punch` refuse desormais les employes archives avec `403 EMPLOYEE_ARCHIVED` et la `sync` les ignore silencieusement
+- Tests : nouveau `KioskSecurityTest` (3 tests) couvrant ces garde-fous ; correctif de `CreatesMvpSchema` pour le support SQLite (JSONB fallback)
+- Fix : ajout de verifications du driver DB dans `KioskAttendanceService` et `KioskController` pour eviter les crashs `SET search_path` sous SQLite (tests)
+
 ## [4.1.69] - 2026-04-22
 ### Sprint D - UI super-admin pour toggler les modules + guides utilisateurs
 

--- a/api/app/Http/Controllers/Api/V1/KioskController.php
+++ b/api/app/Http/Controllers/Api/V1/KioskController.php
@@ -61,6 +61,10 @@ class KioskController extends Controller
 
         $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
 
+        if (in_array($kiosk->company->status, ['suspended', 'expired'], true)) {
+            return new JsonResponse(['error' => 'ACCOUNT_SUSPENDED'], 403);
+        }
+
         $company = $kiosk->company;
         app()->instance('current_company', $company);
 
@@ -85,6 +89,11 @@ class KioskController extends Controller
     public function roster(Request $request, string $deviceCode): JsonResponse
     {
         $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
+
+        if (in_array($kiosk->company->status, ['suspended', 'expired'], true)) {
+            return new JsonResponse(['error' => 'ACCOUNT_SUSPENDED'], 403);
+        }
+
         $company = $kiosk->company;
         app()->instance('current_company', $company);
         $this->setTenantSearchPath($company);
@@ -122,6 +131,12 @@ class KioskController extends Controller
 
     public function sync(Request $request, string $deviceCode): JsonResponse
     {
+        $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
+
+        if (in_array($kiosk->company->status, ['suspended', 'expired'], true)) {
+            return new JsonResponse(['error' => 'ACCOUNT_SUSPENDED'], 403);
+        }
+
         $validated = $request->validate([
             'events' => ['required', 'array'],
             'events.*.identifier' => ['required', 'string', 'max:150'],
@@ -131,7 +146,6 @@ class KioskController extends Controller
             'events.*.biometric_type' => ['nullable', 'in:fingerprint,face,mixed'],
         ]);
 
-        $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
         app()->instance('current_company', $kiosk->company);
         $this->setTenantSearchPath($kiosk->company);
 
@@ -148,7 +162,9 @@ class KioskController extends Controller
 
     private function resolveAuthorizedKiosk(Request $request, string $deviceCode): AttendanceKiosk
     {
-        DB::statement('SET search_path TO shared_tenants,public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants,public');
+        }
 
         $kiosk = AttendanceKiosk::query()
             ->where('device_code', strtoupper($deviceCode))
@@ -163,6 +179,10 @@ class KioskController extends Controller
 
     private function setTenantSearchPath(?Company $company): void
     {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
         if (! $company) {
             DB::statement('SET search_path TO shared_tenants,public');
 

--- a/api/app/Services/KioskAttendanceService.php
+++ b/api/app/Services/KioskAttendanceService.php
@@ -16,10 +16,12 @@ class KioskAttendanceService
 
     public function punch(AttendanceKiosk $kiosk, string $identifier, string $action = 'check_in'): AttendanceLog
     {
-        $searchPath = $kiosk->company?->tenancy_type === 'schema'
-            ? $kiosk->company->schema_name.',public'
-            : 'shared_tenants,public';
-        DB::statement('SET search_path TO '.$searchPath);
+        if (DB::getDriverName() === 'pgsql') {
+            $searchPath = $kiosk->company?->tenancy_type === 'schema'
+                ? $kiosk->company->schema_name.',public'
+                : 'shared_tenants,public';
+            DB::statement('SET search_path TO '.$searchPath);
+        }
 
         $employee = Employee::query()
             ->where('company_id', $kiosk->company_id)
@@ -33,6 +35,10 @@ class KioskAttendanceService
 
         if (! $employee) {
             throw (new ModelNotFoundException)->setModel(Employee::class);
+        }
+
+        if ($employee->status === 'archived') {
+            abort(403, 'EMPLOYEE_ARCHIVED');
         }
 
         if (! $employee->biometric_fingerprint_enabled && ! $employee->biometric_face_enabled) {
@@ -50,10 +56,12 @@ class KioskAttendanceService
 
     public function syncPunches(AttendanceKiosk $kiosk, array $events): array
     {
-        $searchPath = $kiosk->company?->tenancy_type === 'schema'
-            ? $kiosk->company->schema_name.',public'
-            : 'shared_tenants,public';
-        DB::statement('SET search_path TO '.$searchPath);
+        if (DB::getDriverName() === 'pgsql') {
+            $searchPath = $kiosk->company?->tenancy_type === 'schema'
+                ? $kiosk->company->schema_name.',public'
+                : 'shared_tenants,public';
+            DB::statement('SET search_path TO '.$searchPath);
+        }
 
         $processed = [];
 
@@ -73,7 +81,7 @@ class KioskAttendanceService
                 })
                 ->first();
 
-            if (! $employee) {
+            if (! $employee || $employee->status === 'archived') {
                 continue;
             }
 

--- a/api/tests/Feature/BiometricWorkflowTest.php
+++ b/api/tests/Feature/BiometricWorkflowTest.php
@@ -25,6 +25,13 @@ class BiometricWorkflowTest extends TestCase
         parent::tearDown();
     }
 
+    private function setPath(string $path): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement("SET search_path TO $path");
+        }
+    }
+
     public function test_employee_biometric_request_requires_manager_approval_before_activation(): void
     {
         $company = Company::query()->create([
@@ -40,7 +47,7 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        $this->setPath('shared_tenants,public');
 
         $manager = Employee::query()->create([
             'company_id' => $company->id,
@@ -107,7 +114,7 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        $this->setPath('shared_tenants,public');
 
         $employee = Employee::query()->create([
             'company_id' => $company->id,
@@ -134,7 +141,7 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO public');
+        $this->setPath('public');
 
         $kioskResponse = $this->actingAs($manager, 'sanctum')
             ->postJson('/api/v1/kiosks', [
@@ -170,7 +177,7 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        $this->setPath('shared_tenants,public');
 
         $manager = Employee::query()->create([
             'company_id' => $company->id,
@@ -196,7 +203,7 @@ class BiometricWorkflowTest extends TestCase
             'biometric_fingerprint_enabled' => true,
         ]);
 
-        DB::statement('SET search_path TO public');
+        $this->setPath('public');
 
         $kioskResponse = $this->actingAs($manager, 'sanctum')
             ->postJson('/api/v1/kiosks', [
@@ -235,7 +242,7 @@ class BiometricWorkflowTest extends TestCase
             ->assertOk()
             ->assertJsonPath('data.processed_count', 2);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        $this->setPath('shared_tenants,public');
 
         $this->assertDatabaseHas('attendance_logs', [
             'employee_id' => $employee->id,

--- a/api/tests/Feature/KioskSecurityTest.php
+++ b/api/tests/Feature/KioskSecurityTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceKiosk;
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class KioskSecurityTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    private function setPath(string $path): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement("SET search_path TO $path");
+        }
+    }
+
+    public function test_kiosk_punch_rejects_archived_employee(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $this->setPath('shared_tenants,public');
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'archived@company.test',
+            'matricule' => 'EMP-ARCHIVED',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'archived',
+            'biometric_fingerprint_enabled' => true,
+        ]);
+
+        $this->setPath('public');
+
+        $kiosk = AttendanceKiosk::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Kiosk 1',
+            'device_code' => 'KIOSK1',
+            'sync_token_hash' => Hash::make('token123'),
+            'status' => 'active',
+        ]);
+
+        $this->withHeader('X-Kiosk-Token', 'token123')
+            ->postJson('/api/v1/kiosks/KIOSK1/punch', [
+                'identifier' => 'EMP-ARCHIVED',
+                'action' => 'check_in',
+            ])
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'EMPLOYEE_ARCHIVED');
+    }
+
+    public function test_kiosk_endpoints_reject_suspended_company(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company Suspended',
+            'slug' => 'company-suspended',
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'suspended@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'suspended',
+        ]);
+
+        $this->setPath('public');
+
+        $kiosk = AttendanceKiosk::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Kiosk 1',
+            'device_code' => 'KIOSK_SUSPENDED',
+            'sync_token_hash' => Hash::make('token123'),
+            'status' => 'active',
+        ]);
+
+        // Test punch
+        $this->withHeader('X-Kiosk-Token', 'token123')
+            ->postJson('/api/v1/kiosks/KIOSK_SUSPENDED/punch', [
+                'identifier' => 'SOME-ID',
+            ])
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'ACCOUNT_SUSPENDED');
+
+        // Test roster
+        $this->withHeader('X-Kiosk-Token', 'token123')
+            ->getJson('/api/v1/kiosks/KIOSK_SUSPENDED/roster')
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'ACCOUNT_SUSPENDED');
+
+        // Test sync
+        $this->withHeader('X-Kiosk-Token', 'token123')
+            ->postJson('/api/v1/kiosks/KIOSK_SUSPENDED/sync', [
+                'events' => [],
+            ])
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'ACCOUNT_SUSPENDED');
+    }
+
+    public function test_kiosk_sync_skips_archived_employee_punches(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $this->setPath('shared_tenants,public');
+
+        $archived = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'archived@company.test',
+            'matricule' => 'ARCHIVED',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'archived',
+            'biometric_fingerprint_enabled' => true,
+        ]);
+
+        $active = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'active@company.test',
+            'matricule' => 'ACTIVE',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+            'biometric_fingerprint_enabled' => true,
+        ]);
+
+        $this->setPath('public');
+
+        $kiosk = AttendanceKiosk::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Kiosk 1',
+            'device_code' => 'KIOSK1',
+            'sync_token_hash' => Hash::make('token123'),
+            'status' => 'active',
+        ]);
+
+        $this->withHeader('X-Kiosk-Token', 'token123')
+            ->postJson('/api/v1/kiosks/KIOSK1/sync', [
+                'events' => [
+                    [
+                        'identifier' => 'ARCHIVED',
+                        'action' => 'check_in',
+                        'occurred_at' => now()->subHour()->toIso8601String(),
+                        'external_event_id' => 'evt-archived',
+                    ],
+                    [
+                        'identifier' => 'ACTIVE',
+                        'action' => 'check_in',
+                        'occurred_at' => now()->subHour()->toIso8601String(),
+                        'external_event_id' => 'evt-active',
+                    ],
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.processed_count', 1);
+
+        $this->setPath('shared_tenants,public');
+        $this->assertDatabaseMissing('attendance_logs', ['external_event_id' => 'evt-archived']);
+        $this->assertDatabaseHas('attendance_logs', ['external_event_id' => 'evt-active']);
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -48,8 +48,13 @@ trait CreatesMvpSchema
             $table->string('timezone', 50)->default('Africa/Algiers');
             $table->char('currency', 3)->default('DZD');
             $table->text('notes')->nullable();
-            $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('features')->nullable();
+                $table->json('metadata')->nullable();
+            }
             $table->timestamps();
         });
 
@@ -116,7 +121,11 @@ trait CreatesMvpSchema
             $table->timestampTz('last_login_at')->nullable();
             $table->timestampTz('email_verified_at')->nullable();
             $table->json('extra_data')->nullable();
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('metadata')->nullable();
+            }
             $table->timestamps();
 
             $table->unique('email');


### PR DESCRIPTION
### Severity: MEDIUM

### What changed
- Added company status verification (active/suspended/expired) to Kiosk endpoints (`punch`, `roster`, `sync`).
- Added employee status verification (active/archived) to Kiosk `punch` (403 error) and `sync` (skip).
- Improved database driver compatibility for `SET search_path` commands in `KioskAttendanceService` and `KioskController`.
- Hardened the `CreatesMvpSchema` test trait for SQLite compatibility regarding JSONB fields.

### Why it is safe for MVP
This is a security hardening change that enforces already established business rules (blocked accounts/archived employees) for the Kiosk interface, which previously bypassed some of these checks. It does not introduce new features or change the core attendance logic.

### Tests/verification
- New `api/tests/Feature/KioskSecurityTest.php` added and passed (3 tests).
- Verified `api/tests/Feature/BiometricWorkflowTest.php` for regressions (3 tests).
- All backend tests executed in SQLite environment: `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test`.

### Rollback plan
Revert the commit in the `sentinel/kiosk-hardening` branch. No database migrations were changed.

---
*PR created automatically by Jules for task [12102644343862083093](https://jules.google.com/task/12102644343862083093) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
