### PR TITLE
🛡️ Sentinel: Harden tenant isolation for invitations, kiosks, and biometric requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.71] - 2026-04-24
+### Sentinel - Hardening Tenant Isolation
+
+- API : Renforcement de l'isolation tenant par l'ajout du trait `BelongsToCompany` aux modeles `UserInvitation`, `BiometricEnrollmentRequest` et `AttendanceKiosk`. Ces modeles beneficient desormais d'un scopying global automatique par `company_id`, prevenant toute fuite de donnees inter-tenant meme en cas d'omission de filtre manuel dans les requetes.
+- Tests : Correction du trait `CreatesMvpSchema` pour assurer la compatibilite SQLite (support des colonnes JSON/JSONB selon le driver), permettant l'execution fiable des tests de securite en memoire.
+- Tests : Ajout de `SentinelTenantIsolationHardeningTest` pour verrouiller le comportement d'isolation sur ces nouveaux modeles.
+
 ## [4.1.70] - 2026-04-23
 ### Audit de coherence PILOTAGE / CORRECTIONS (aucun changement fonctionnel)
 

--- a/api/app/Models/AttendanceKiosk.php
+++ b/api/app/Models/AttendanceKiosk.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AttendanceKiosk extends Model
 {
+    use BelongsToCompany;
     use HasFactory;
 
     protected $table = 'attendance_kiosks';

--- a/api/app/Models/BiometricEnrollmentRequest.php
+++ b/api/app/Models/BiometricEnrollmentRequest.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class BiometricEnrollmentRequest extends Model
 {
+    use BelongsToCompany;
     use HasFactory;
 
     protected $table = 'biometric_enrollment_requests';

--- a/api/app/Models/Company.php
+++ b/api/app/Models/Company.php
@@ -102,16 +102,23 @@ class Company extends Model
             // alors que l update d une company via le super-admin web s execute
             // avec search_path=public. On etend le search_path temporairement
             // pour que la revocation des tokens (Sanctum) voie les relations.
-            $schema = $company->schema_name ?: 'shared_tenants';
-            $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
-            DB::statement("SET search_path TO {$schema},public");
-            try {
+            if (DB::getDriverName() === 'pgsql') {
+                $schema = $company->schema_name ?: 'shared_tenants';
+                $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
+                DB::statement("SET search_path TO {$schema},public");
+                try {
+                    Employee::withoutGlobalScopes()
+                        ->where('company_id', $company->id)
+                        ->get()
+                        ->each(fn (Employee $employee) => $employee->tokens()->delete());
+                } finally {
+                    DB::statement("SET search_path TO {$previous}");
+                }
+            } else {
                 Employee::withoutGlobalScopes()
                     ->where('company_id', $company->id)
                     ->get()
                     ->each(fn (Employee $employee) => $employee->tokens()->delete());
-            } finally {
-                DB::statement("SET search_path TO {$previous}");
             }
         });
     }

--- a/api/app/Models/UserInvitation.php
+++ b/api/app/Models/UserInvitation.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 class UserInvitation extends Model
 {
+    use BelongsToCompany;
     use HasUuids;
 
     public $incrementing = false;

--- a/api/tests/Feature/MultiTenantSharedIsolationTest.php
+++ b/api/tests/Feature/MultiTenantSharedIsolationTest.php
@@ -52,8 +52,13 @@ class MultiTenantSharedIsolationTest extends TestCase
             $table->char('language', 2)->default('fr');
             $table->string('timezone', 50)->default('Africa/Algiers');
             $table->char('currency', 3)->default('DZD');
-            $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('features')->nullable();
+                $table->json('metadata')->nullable();
+            }
             $table->timestamps();
         });
 

--- a/api/tests/Feature/SentinelTenantIsolationHardeningTest.php
+++ b/api/tests/Feature/SentinelTenantIsolationHardeningTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceKiosk;
+use App\Models\BiometricEnrollmentRequest;
+use App\Models\Company;
+use App\Models\UserInvitation;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Support\CreatesMvpSchema;
+
+class SentinelTenantIsolationHardeningTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_user_invitations_are_isolated_by_company(): void
+    {
+        $companyA = $this->createTestCompany('Company A', 'company-a');
+        $companyB = $this->createTestCompany('Company B', 'company-b');
+
+        // Create invitation for A
+        UserInvitation::query()->create([
+            'id' => Str::uuid(),
+            'company_id' => $companyA->id,
+            'schema_name' => 'shared_tenants',
+            'employee_id' => 1,
+            'email' => 'invitation@company-a.test',
+            'role' => 'employee',
+            'invited_by_type' => 'manager',
+            'invited_by_email' => 'manager@company-a.test',
+            'token_hash' => Str::random(64),
+            'expires_at' => now()->addDays(7),
+        ]);
+
+        // Create invitation for B
+        UserInvitation::query()->create([
+            'id' => Str::uuid(),
+            'company_id' => $companyB->id,
+            'schema_name' => 'shared_tenants',
+            'employee_id' => 2,
+            'email' => 'invitation@company-b.test',
+            'role' => 'employee',
+            'invited_by_type' => 'manager',
+            'invited_by_email' => 'manager@company-b.test',
+            'token_hash' => Str::random(64),
+            'expires_at' => now()->addDays(7),
+        ]);
+
+        app()->instance('current_company', $companyA);
+
+        $visible = UserInvitation::all();
+        $this->assertCount(1, $visible, 'Company A should only see its own invitations');
+        $this->assertEquals('invitation@company-a.test', $visible->first()->email);
+    }
+
+    public function test_biometric_requests_are_isolated_by_company(): void
+    {
+        $companyA = $this->createTestCompany('Company A', 'company-a');
+        $companyB = $this->createTestCompany('Company B', 'company-b');
+
+        BiometricEnrollmentRequest::query()->create([
+            'company_id' => $companyA->id,
+            'employee_id' => 1,
+            'status' => 'pending',
+        ]);
+
+        BiometricEnrollmentRequest::query()->create([
+            'company_id' => $companyB->id,
+            'employee_id' => 2,
+            'status' => 'pending',
+        ]);
+
+        app()->instance('current_company', $companyA);
+
+        $visible = BiometricEnrollmentRequest::all();
+        $this->assertCount(1, $visible, 'Company A should only see its own biometric requests');
+    }
+
+    public function test_attendance_kiosks_are_isolated_by_company(): void
+    {
+        $companyA = $this->createTestCompany('Company A', 'company-a');
+        $companyB = $this->createTestCompany('Company B', 'company-b');
+
+        AttendanceKiosk::query()->create([
+            'company_id' => $companyA->id,
+            'name' => 'Kiosk A',
+            'device_code' => 'CODE-A',
+        ]);
+
+        AttendanceKiosk::query()->create([
+            'company_id' => $companyB->id,
+            'name' => 'Kiosk B',
+            'device_code' => 'CODE-B',
+        ]);
+
+        app()->instance('current_company', $companyA);
+
+        $visible = AttendanceKiosk::all();
+        $this->assertCount(1, $visible, 'Company A should only see its own kiosks');
+    }
+
+    private function createTestCompany(string $name, string $slug): Company
+    {
+        return Company::query()->create([
+            'id' => Str::uuid(),
+            'name' => $name,
+            'slug' => $slug,
+            'sector' => 'test',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => "contact@{$slug}.test",
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+    }
+}

--- a/api/tests/Feature/TenantIsolationTest.php
+++ b/api/tests/Feature/TenantIsolationTest.php
@@ -34,8 +34,13 @@ class TenantIsolationTest extends TestCase
             $table->char('language', 2)->default('fr');
             $table->string('timezone', 50)->default('Africa/Algiers');
             $table->char('currency', 3)->default('DZD');
-            $table->jsonb('features')->default(\DB::raw("'{}'::jsonb"));
-            $table->jsonb('metadata')->default(\DB::raw("'{}'::jsonb"));
+            if (\DB::getDriverName() === 'pgsql') {
+                $table->jsonb('features')->default(\DB::raw("'{}'::jsonb"));
+                $table->jsonb('metadata')->default(\DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('features')->nullable();
+                $table->json('metadata')->nullable();
+            }
             $table->timestamps();
         });
 

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -48,8 +48,13 @@ trait CreatesMvpSchema
             $table->string('timezone', 50)->default('Africa/Algiers');
             $table->char('currency', 3)->default('DZD');
             $table->text('notes')->nullable();
-            $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('features')->nullable();
+                $table->json('metadata')->nullable();
+            }
             $table->timestamps();
         });
 
@@ -116,7 +121,11 @@ trait CreatesMvpSchema
             $table->timestampTz('last_login_at')->nullable();
             $table->timestampTz('email_verified_at')->nullable();
             $table->json('extra_data')->nullable();
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('metadata')->nullable();
+            }
             $table->timestamps();
 
             $table->unique('email');


### PR DESCRIPTION
### Severity
MEDIUM (Defense in depth)

### What changed
- Added the `BelongsToCompany` trait to the following models:
  - `UserInvitation` (Public schema, sensitive tokens/roles)
  - `BiometricEnrollmentRequest` (Biometric metadata)
  - `AttendanceKiosk` (Kiosk device codes)
- This trait enforces a global query scope that automatically filters records by the authenticated tenant's `company_id`, providing a critical safety net against accidental data leaks.
- Fixed database driver compatibility issues (PostgreSQL vs. SQLite) in `CreatesMvpSchema.php`, `TenantIsolationTest.php`, and `MultiTenantSharedIsolationTest.php` to ensure security regression tests can run reliably in both environments.
- Guarded PostgreSQL-specific `search_path` manipulation in `Company.php` with a driver check.

### Why it is safe for MVP
- Uses the project's established `BelongsToCompany` pattern.
- No changes to the database schema.
- Non-breaking for legitimate tenant-scoped queries.
- Improves test coverage and reliability without altering core business logic.

### Tests/verification
- Created `api/tests/Feature/SentinelTenantIsolationHardeningTest.php` which specifically verifies isolation for the three hardened models.
- Verified that the new test fails without the trait and passes after applying it.
- Ran all existing tenant isolation tests (`TenantIsolationTest.php`, `MultiTenantSharedIsolationTest.php`) in an SQLite in-memory environment. All passed (8 tests, 66 assertions).

### Rollback plan
`git revert <commit-hash>` and run `php artisan test`. No migration rollback required.

---
*PR created automatically by Jules for task [4501461565925959143](https://jules.google.com/task/4501461565925959143) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
