### PR TITLE
📐 Contractor: API/mobile contract alignment for auth/me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.71] - 2026-04-24
+### Contractor - Alignement contrat API/mobile (auth/me)
+
+- API : Mise a jour de `AuthController@serializeEmployee` pour inclure le `matricule` a la racine et un objet `company` imbrique (id, name, language, timezone, currency) conformement au contrat MVP.
+- Mobile : Mise a jour du modele `Employee` pour inclure et parser le champ `matricule`.
+- Tests : Renforcement de `MobilePayloadContractTest` pour verrouiller la presence de `matricule` et de la structure `company` dans la reponse `/api/v1/auth/me`.
+
 ## [4.1.70] - 2026-04-23
 ### Audit de coherence PILOTAGE / CORRECTIONS (aucun changement fonctionnel)
 

--- a/api/app/Http/Controllers/Api/V1/AuthController.php
+++ b/api/app/Http/Controllers/Api/V1/AuthController.php
@@ -91,8 +91,11 @@ class AuthController extends Controller
 
     private function serializeEmployee(Employee $employee): array
     {
+        $company = $this->resolveCompany($employee);
+
         return [
             'id' => $employee->id,
+            'matricule' => $employee->matricule,
             'company_id' => $employee->company_id,
             'first_name' => $employee->first_name,
             'middle_name' => $employee->middle_name,
@@ -113,8 +116,15 @@ class AuthController extends Controller
             'emergency_contact_phone' => $employee->emergency_contact_phone,
             'extra_data' => $employee->extra_data ?? [],
             'capabilities' => $this->capabilitiesFor($employee),
-            'features' => FeatureFlag::for($this->resolveCompany($employee)),
+            'features' => FeatureFlag::for($company),
             'suggested_home_route' => $employee->homeRoute(),
+            'company' => $company ? [
+                'id' => $company->id,
+                'name' => $company->name,
+                'language' => $company->language,
+                'timezone' => $company->timezone,
+                'currency' => $company->currency,
+            ] : null,
         ];
     }
 

--- a/api/tests/Feature/Contracts/MobilePayloadContractTest.php
+++ b/api/tests/Feature/Contracts/MobilePayloadContractTest.php
@@ -43,6 +43,7 @@ class MobilePayloadContractTest extends TestCase
 
         $employee = Employee::query()->create([
             'company_id' => $company->id,
+            'matricule' => 'EMP-NORA',
             'first_name' => 'Nora',
             'last_name' => 'Ait',
             'email' => 'nora@company.test',
@@ -59,16 +60,26 @@ class MobilePayloadContractTest extends TestCase
         $response->assertJsonStructure([
             'data' => [
                 'id',
+                'matricule',
                 'company_id',
                 'first_name',
                 'last_name',
                 'email',
                 'role',
                 'status',
+                'company' => [
+                    'id',
+                    'name',
+                    'language',
+                    'timezone',
+                    'currency',
+                ],
             ],
         ]);
         $response->assertJsonPath('data.email', 'nora@company.test');
+        $response->assertJsonPath('data.matricule', 'EMP-NORA');
         $response->assertJsonPath('data.role', 'employee');
+        $response->assertJsonPath('data.company.name', 'Company A');
     }
 
     public function test_attendance_today_collection_payload_matches_mobile_contract(): void

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -48,8 +48,13 @@ trait CreatesMvpSchema
             $table->string('timezone', 50)->default('Africa/Algiers');
             $table->char('currency', 3)->default('DZD');
             $table->text('notes')->nullable();
-            $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('features')->default(DB::raw("'{}'::jsonb"));
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('features')->default('{}');
+                $table->json('metadata')->default('{}');
+            }
             $table->timestamps();
         });
 
@@ -116,7 +121,11 @@ trait CreatesMvpSchema
             $table->timestampTz('last_login_at')->nullable();
             $table->timestampTz('email_verified_at')->nullable();
             $table->json('extra_data')->nullable();
-            $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            if (DB::getDriverName() === 'pgsql') {
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+            } else {
+                $table->json('metadata')->default('{}');
+            }
             $table->timestamps();
 
             $table->unique('email');

--- a/mobile/lib/models/employee.dart
+++ b/mobile/lib/models/employee.dart
@@ -1,5 +1,6 @@
 class Employee {
   final int id;
+  final String? matricule;
   final String? companyId;
   final String firstName;
   final String lastName;
@@ -18,6 +19,7 @@ class Employee {
 
   Employee({
     required this.id,
+    this.matricule,
     this.companyId,
     required this.firstName,
     required this.lastName,
@@ -50,6 +52,7 @@ class Employee {
 
     return Employee(
       id: json['id'],
+      matricule: json['matricule'] as String?,
       companyId: json['company_id'] as String?,
       firstName: (json['first_name'] ?? '') as String,
       lastName: (json['last_name'] ?? '') as String,


### PR DESCRIPTION
Aligned the `/api/v1/auth/me` and `/api/v1/auth/login` endpoints with the documented MVP contract by adding the `matricule` field and a nested `company` object (id, name, language, timezone, currency).
Updated the mobile `Employee` model to parse the `matricule` field.
Fixed the `CreatesMvpSchema` trait to support SQLite tests by providing a fallback for PostgreSQL-specific `jsonb` syntax.
Verified with `php artisan test` and `flutter test`.

---
*PR created automatically by Jules for task [12137365276053567462](https://jules.google.com/task/12137365276053567462) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
