### PR TITLE
feat(mobile): page d'accueil avant connexion + écran d'information inscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 # Versioning : Semantic Versioning (semver.org)
 
 ## [4.1.70] - 2026-04-23
+### Mobile - Page d'accueil (WelcomeScreen) avant la connexion
+
+- Mobile : nouvel ecran `/welcome` (`mobile/lib/features/auth/screens/welcome_screen.dart`) affiche par defaut aux utilisateurs non authentifies a la place du saut direct sur `/login`. L'ecran met en valeur les benefices employe-centres de l'app : pointage + total d'heures, parcours professionnel cumule (meme d'une entreprise a l'autre), coffre-fort de documents personnels (diplomes, contrats), et notifications des entreprises qui ont recrute l'employe. Deux CTA : "Se connecter" -> `/login` et "Creer un compte" -> `/register`
+- Mobile : nouvel ecran `/register` (`mobile/lib/features/auth/screens/register_screen.dart`) qui explique le flow d'onboarding par invitation employeur (3 etapes : invitation RH -> email -> activation) et propose une capture d'email "me prevenir a l'ouverture de l'inscription libre" (UX placeholder, non branche au backend). L'inscription publique libre reste hors scope Phase 1 (pas de route API `/auth/register`, l'onboarding passe toujours par `user_invitations`)
+- Mobile : `mobile/lib/app.dart` - redirection `GoRouter` mise a jour pour autoriser les routes publiques `/welcome`, `/login`, `/register` (les utilisateurs non authentifies sont maintenant rediriges vers `/welcome` au lieu de `/login`, les utilisateurs authentifies sont rediriges hors de ces routes publiques vers `/`)
+- Mobile : `mobile/lib/features/auth/screens/login_screen.dart` - ajout d'un bouton "retour" (IconButton en top-left) pour revenir sur `/welcome` depuis l'ecran de connexion
+- Tests : nouveau `mobile/test/features/auth/welcome_screen_test.dart` (smoke test : rendu de l'ecran, presence des CTA `Se connecter` / `Creer un compte`, presence de la marque `Leopardo RH`)
+- Aucun changement backend, aucune migration. Rollback = `git revert` de la PR
+
 ### Audit de coherence PILOTAGE / CORRECTIONS (aucun changement fonctionnel)
 
 - `PILOTAGE.md` : en-tete re-aligne sur `PROGRAM_VERSION = 4.1.70 | 2026-04-23` (precedemment `4.1.58 | 14 Mai 2025`, date erronee), date MAJ corrigee, bloc "CONVENTION DE VERSIONING" precise que la version doit rester synchrone entre CHANGELOG.md, `api/config/app.php` et `/api/v1/health`

--- a/JOURNAL_RACINE.md
+++ b/JOURNAL_RACINE.md
@@ -24,6 +24,7 @@ Ce journal trace les opérations transverses du repo (structure, documentation, 
 | 2026-04-04 | Codex | Normalisation finale coherence | Pilotage/OpenAPI/Multitenancy | PROGRAM_VERSION fixe a 4.1.4, retrait propre de /auth/refresh OpenAPI, correction doc trait BelongsToCompany |
 | 2026-04-04 | Antigravity | Restructuration globale (v4.1.4) | `PILOTAGE.md`, `GARDE_FOUS.md`, `v3/prompts` | Source de vérité unique activée, prompts MVP v3, scope verrouillé |
 | 2026-04-21 | Codex | Decision GO MVP | `docs/GESTION_PROJET/GO_NO_GO_MVP.md`, `CHANGELOG.md`, tag `v0.1.0-mvp` | Render, Neon/PostgreSQL, Firebase mobile et tests de connexion reels valides; passage en pilote client encadre |
+| 2026-04-23 | Devin | Mobile landing page | `mobile/lib/features/auth/screens/welcome_screen.dart`, `mobile/lib/features/auth/screens/register_screen.dart`, `mobile/lib/app.dart`, `mobile/lib/features/auth/screens/login_screen.dart`, `mobile/test/features/auth/welcome_screen_test.dart`, `CHANGELOG.md` | Nouvelle page `/welcome` (hero + carrousel de 4 benefices employe + CTA Se connecter / Creer un compte), nouvelle page `/register` explicatrice du flow d'invitation, back-button sur `/login`, redirection non-auth desormais vers `/welcome` au lieu de `/login` |
 
 ## Template d'entrée
 

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_theme.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_rh/features/auth/screens/login_screen.dart';
+import 'package:leopardo_rh/features/auth/screens/register_screen.dart';
+import 'package:leopardo_rh/features/auth/screens/welcome_screen.dart';
 import 'package:leopardo_rh/features/attendance/screens/attendance_screen.dart';
 import 'package:leopardo_rh/features/attendance/screens/history_screen.dart';
 import 'package:leopardo_rh/features/attendance/screens/monthly_summary_screen.dart';
@@ -29,15 +31,26 @@ final routerProvider = Provider<GoRouter>((ref) {
 
       if (authState.isLoading) return null;
 
-      final loggingIn = state.matchedLocation == '/login';
-      if (!isAuth && !loggingIn) return '/login';
-      if (isAuth && loggingIn) return '/';
+      final location = state.matchedLocation;
+      const publicRoutes = {'/welcome', '/login', '/register'};
+      final onPublic = publicRoutes.contains(location);
+
+      if (!isAuth && !onPublic) return '/welcome';
+      if (isAuth && onPublic) return '/';
       return null;
     },
     routes: [
       GoRoute(
+        path: '/welcome',
+        builder: (context, state) => const WelcomeScreen(),
+      ),
+      GoRoute(
         path: '/login',
         builder: (context, state) => const LoginScreen(),
+      ),
+      GoRoute(
+        path: '/register',
+        builder: (context, state) => const RegisterScreen(),
       ),
       GoRoute(
         path: '/',

--- a/mobile/lib/features/auth/screens/login_screen.dart
+++ b/mobile/lib/features/auth/screens/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
@@ -29,106 +30,142 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     ref.listen<AuthState>(authProvider, (previous, next) {
       if (next.error != null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(next.error!), backgroundColor: Theme.of(context).colorScheme.error),
+          SnackBar(
+              content: Text(next.error!),
+              backgroundColor: Theme.of(context).colorScheme.error),
         );
       }
     });
 
     return Scaffold(
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Form(
-            key: _formKey,
-            autovalidateMode: AutovalidateMode.onUserInteraction,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const Text(
-                  'Leopardo RH',
-                  style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: Colors.white),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 48),
-                TextFormField(
-                  controller: _emailController,
-                  decoration: InputDecoration(
-                    labelText: 'Email',
-                    prefixIcon: const Icon(Icons.email_outlined),
-                    filled: true,
-                    fillColor: Theme.of(context).cardColor,
-                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-                  ),
-                  keyboardType: TextInputType.emailAddress,
-                  textInputAction: TextInputAction.next,
-                  validator: (value) {
-                    final email = value?.trim() ?? '';
-                    if (email.isEmpty) {
-                      return 'Email obligatoire';
-                    }
-                    if (!email.contains('@') || !email.contains('.')) {
-                      return 'Email invalide';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _passwordController,
-                  decoration: InputDecoration(
-                    labelText: 'Mot de passe',
-                    prefixIcon: const Icon(Icons.lock_outline),
-                    suffixIcon: IconButton(
-                      icon: Icon(
-                        _obscurePassword ? Icons.visibility_off : Icons.visibility,
-                        color: Colors.grey,
+        child: Stack(
+          children: [
+            Positioned(
+              top: 4,
+              left: 4,
+              child: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                tooltip: 'Retour',
+                onPressed: () {
+                  if (context.canPop()) {
+                    context.pop();
+                  } else {
+                    context.go('/welcome');
+                  }
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Form(
+                key: _formKey,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text(
+                      'Leopardo RH',
+                      style: TextStyle(
+                          fontSize: 32,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 48),
+                    TextFormField(
+                      controller: _emailController,
+                      decoration: InputDecoration(
+                        labelText: 'Email',
+                        prefixIcon: const Icon(Icons.email_outlined),
+                        filled: true,
+                        fillColor: Theme.of(context).cardColor,
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                            borderSide: BorderSide.none),
                       ),
-                      tooltip: _obscurePassword ? 'Afficher le mot de passe' : 'Masquer le mot de passe',
-                      onPressed: () {
-                        setState(() {
-                          _obscurePassword = !_obscurePassword;
-                        });
+                      keyboardType: TextInputType.emailAddress,
+                      textInputAction: TextInputAction.next,
+                      validator: (value) {
+                        final email = value?.trim() ?? '';
+                        if (email.isEmpty) {
+                          return 'Email obligatoire';
+                        }
+                        if (!email.contains('@') || !email.contains('.')) {
+                          return 'Email invalide';
+                        }
+                        return null;
                       },
                     ),
-                    filled: true,
-                    fillColor: Theme.of(context).cardColor,
-                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-                  ),
-                  obscureText: _obscurePassword,
-                  textInputAction: TextInputAction.done,
-                  onFieldSubmitted: (_) => _submit(),
-                  validator: (value) {
-                    if ((value ?? '').isEmpty) {
-                      return 'Mot de passe obligatoire';
-                    }
-                    if ((value ?? '').length < 4) {
-                      return 'Mot de passe trop court';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 32),
-                ElevatedButton(
-                  onPressed: authState.isLoading ? null : _submit,
-                  style: ElevatedButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 16)),
-                  child: authState.isLoading
-                      ? Semantics(
-                          label: 'Connexion en cours...',
-                          child: SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                            ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _passwordController,
+                      decoration: InputDecoration(
+                        labelText: 'Mot de passe',
+                        prefixIcon: const Icon(Icons.lock_outline),
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _obscurePassword
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                            color: Colors.grey,
                           ),
-                        )
-                      : const Text('Se connecter', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                          tooltip: _obscurePassword
+                              ? 'Afficher le mot de passe'
+                              : 'Masquer le mot de passe',
+                          onPressed: () {
+                            setState(() {
+                              _obscurePassword = !_obscurePassword;
+                            });
+                          },
+                        ),
+                        filled: true,
+                        fillColor: Theme.of(context).cardColor,
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                            borderSide: BorderSide.none),
+                      ),
+                      obscureText: _obscurePassword,
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => _submit(),
+                      validator: (value) {
+                        if ((value ?? '').isEmpty) {
+                          return 'Mot de passe obligatoire';
+                        }
+                        if ((value ?? '').length < 4) {
+                          return 'Mot de passe trop court';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 32),
+                    ElevatedButton(
+                      onPressed: authState.isLoading ? null : _submit,
+                      style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 16)),
+                      child: authState.isLoading
+                          ? Semantics(
+                              label: 'Connexion en cours...',
+                              child: SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                      Colors.white),
+                                ),
+                              ),
+                            )
+                          : const Text('Se connecter',
+                              style: TextStyle(
+                                  fontSize: 16, fontWeight: FontWeight.bold)),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/mobile/lib/features/auth/screens/register_screen.dart
+++ b/mobile/lib/features/auth/screens/register_screen.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:leopardo_rh/core/theme/app_colors.dart';
+import 'package:leopardo_rh/core/theme/app_typography.dart';
+
+/// Ecran d'information pour la creation de compte.
+///
+/// Leopardo RH fonctionne par invitation : un manager / RH envoie un lien
+/// d'invitation (table `user_invitations`) et l'employe active son compte
+/// avec un mot de passe. Il n'existe pas d'auto-inscription publique.
+///
+/// Cet ecran l'explique clairement et propose les deux chemins utiles :
+///  - "J'ai deja recu une invitation" (retour vers la connexion)
+///  - "Je veux etre contacte quand l'inscription libre sera ouverte" (capture
+///    d'email locale, pas encore branchee au backend — UX placeholder).
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  bool _submitted = false;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+    FocusScope.of(context).unfocus();
+    setState(() => _submitted = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.bgDark,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          tooltip: 'Retour',
+          onPressed: () {
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go('/welcome');
+            }
+          },
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const _RegisterHero(),
+              const SizedBox(height: 28),
+              const _InvitationExplainerCard(),
+              const SizedBox(height: 16),
+              _RequestAccessCard(
+                formKey: _formKey,
+                controller: _emailController,
+                submitted: _submitted,
+                onSubmit: _submit,
+              ),
+              const SizedBox(height: 24),
+              Center(
+                child: TextButton(
+                  onPressed: () => context.go('/login'),
+                  child: const Text(
+                    'J\'ai deja un compte, me connecter',
+                    style: TextStyle(color: AppColors.rh),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RegisterHero extends StatelessWidget {
+  const _RegisterHero();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: const LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [AppColors.ia, AppColors.iaDark],
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.ia.withValues(alpha: 0.35),
+                blurRadius: 20,
+                spreadRadius: 1,
+              ),
+            ],
+          ),
+          child: const Icon(
+            Icons.mark_email_read_outlined,
+            color: Colors.white,
+            size: 30,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Creer un compte Leopardo RH',
+          textAlign: TextAlign.center,
+          style: AppTypography.title.copyWith(color: AppColors.textDark),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'Le compte est cree par votre employeur via une invitation.',
+          textAlign: TextAlign.center,
+          style:
+              AppTypography.bodySmall.copyWith(color: AppColors.textMutedDark),
+        ),
+      ],
+    );
+  }
+}
+
+class _InvitationExplainerCard extends StatelessWidget {
+  const _InvitationExplainerCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.cardDark,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.borderDark),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.verified_user_outlined, color: AppColors.rh, size: 22),
+              const SizedBox(width: 8),
+              Text(
+                'Comment acceder a l\'application',
+                style:
+                    AppTypography.subtitle.copyWith(color: AppColors.textDark),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          const _InvitationStep(
+            number: '1',
+            text:
+                'Votre manager ou votre RH ajoute votre email dans Leopardo RH.',
+          ),
+          const SizedBox(height: 10),
+          const _InvitationStep(
+            number: '2',
+            text:
+                'Vous recevez un email d\'invitation avec un lien d\'activation.',
+          ),
+          const SizedBox(height: 10),
+          const _InvitationStep(
+            number: '3',
+            text:
+                'Vous definissez votre mot de passe, puis vous vous connectez ici.',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InvitationStep extends StatelessWidget {
+  const _InvitationStep({required this.number, required this.text});
+
+  final String number;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 24,
+          height: 24,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: AppColors.rh.withValues(alpha: 0.15),
+            shape: BoxShape.circle,
+            border: Border.all(color: AppColors.rh.withValues(alpha: 0.4)),
+          ),
+          child: Text(
+            number,
+            style: AppTypography.caption.copyWith(
+              color: AppColors.rh,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            text,
+            style: AppTypography.bodySmall.copyWith(color: AppColors.textDark),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RequestAccessCard extends StatelessWidget {
+  const _RequestAccessCard({
+    required this.formKey,
+    required this.controller,
+    required this.submitted,
+    required this.onSubmit,
+  });
+
+  final GlobalKey<FormState> formKey;
+  final TextEditingController controller;
+  final bool submitted;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.cardDark,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.borderDark),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.schedule_outlined, color: AppColors.warning, size: 22),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Pas encore d\'entreprise ? Inscrivez-vous a la liste',
+                  style: AppTypography.subtitle
+                      .copyWith(color: AppColors.textDark),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'L\'inscription libre pour les employes independants arrive. Laissez votre email pour etre prevenu des son ouverture.',
+            style: AppTypography.bodySmall
+                .copyWith(color: AppColors.textMutedDark),
+          ),
+          const SizedBox(height: 14),
+          if (submitted)
+            _SuccessTile(email: controller.text.trim())
+          else
+            Form(
+              key: formKey,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextFormField(
+                    controller: controller,
+                    keyboardType: TextInputType.emailAddress,
+                    textInputAction: TextInputAction.done,
+                    onFieldSubmitted: (_) => onSubmit(),
+                    decoration: InputDecoration(
+                      labelText: 'Votre email',
+                      prefixIcon: const Icon(Icons.email_outlined),
+                      filled: true,
+                      fillColor: AppColors.bgDark,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(10),
+                        borderSide: BorderSide(color: AppColors.borderDark),
+                      ),
+                    ),
+                    validator: (value) {
+                      final email = value?.trim() ?? '';
+                      if (email.isEmpty) return 'Email obligatoire';
+                      if (!email.contains('@') || !email.contains('.')) {
+                        return 'Email invalide';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    height: 48,
+                    child: ElevatedButton(
+                      onPressed: onSubmit,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.rh,
+                        foregroundColor: Colors.white,
+                        elevation: 0,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                      ),
+                      child: const Text('Me prevenir'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SuccessTile extends StatelessWidget {
+  const _SuccessTile({required this.email});
+
+  final String email;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.rh.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.rh.withValues(alpha: 0.35)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.check_circle_outline, color: AppColors.rh),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              email.isEmpty
+                  ? 'Merci, vous etes dans la liste.'
+                  : 'Merci, nous contacterons $email des l\'ouverture.',
+              style:
+                  AppTypography.bodySmall.copyWith(color: AppColors.textDark),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/auth/screens/welcome_screen.dart
+++ b/mobile/lib/features/auth/screens/welcome_screen.dart
@@ -1,0 +1,409 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:leopardo_rh/core/theme/app_colors.dart';
+import 'package:leopardo_rh/core/theme/app_typography.dart';
+
+/// Page d'accueil non authentifiee (landing).
+///
+/// Objectif : presenter en quelques ecrans ce que Leopardo RH apporte a un
+/// employe, puis l'orienter vers la connexion ou la demande d'invitation.
+/// Les benefices affiches sont volontairement tournes vers l'employe lui-meme
+/// (son parcours, ses documents, ses heures) pour que l'app ait de la valeur
+/// meme en dehors d'une entreprise active.
+class WelcomeScreen extends StatefulWidget {
+  const WelcomeScreen({super.key});
+
+  @override
+  State<WelcomeScreen> createState() => _WelcomeScreenState();
+}
+
+class _WelcomeScreenState extends State<WelcomeScreen> {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  static const List<_WelcomeFeature> _features = <_WelcomeFeature>[
+    _WelcomeFeature(
+      icon: Icons.fingerprint,
+      title: 'Pointez en un geste',
+      description:
+          'Check-in, check-out, pauses : votre pointage est sauvegarde meme hors ligne et synchronise des que vous retrouvez du reseau.',
+      accent: AppColors.rh,
+      accentDark: AppColors.rhDark,
+    ),
+    _WelcomeFeature(
+      icon: Icons.insights,
+      title: 'Suivez votre temps reel',
+      description:
+          'Total d\'heures travaillees, heures supplementaires, jours presents : gardez une vue claire de votre mois et de votre carriere.',
+      accent: AppColors.info,
+      accentDark: AppColors.securityDark,
+    ),
+    _WelcomeFeature(
+      icon: Icons.folder_shared_outlined,
+      title: 'Votre coffre personnel',
+      description:
+          'Classez vos diplomes, contrats et pieces d\'identite dans un espace securise qui vous suit d\'une entreprise a l\'autre.',
+      accent: AppColors.finance,
+      accentDark: AppColors.financeDark,
+    ),
+    _WelcomeFeature(
+      icon: Icons.notifications_active_outlined,
+      title: 'Restez connecte a vos employeurs',
+      description:
+          'Recevez les annonces et notifications des societes qui vous ont recrute, gardez votre historique meme si vous changez de travail.',
+      accent: AppColors.ia,
+      accentDark: AppColors.iaDark,
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final screenHeight = mediaQuery.size.height;
+    final isCompact = screenHeight < 720;
+
+    return Scaffold(
+      backgroundColor: AppColors.bgDark,
+      body: Stack(
+        children: [
+          const _AmbientBackground(),
+          SafeArea(
+            child: Column(
+              children: [
+                SizedBox(height: isCompact ? 12 : 24),
+                const _BrandHeader(),
+                SizedBox(height: isCompact ? 16 : 28),
+                Expanded(
+                  child: PageView.builder(
+                    controller: _pageController,
+                    itemCount: _features.length,
+                    onPageChanged: (index) =>
+                        setState(() => _currentPage = index),
+                    itemBuilder: (context, index) =>
+                        _FeatureSlide(feature: _features[index]),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _PageDots(count: _features.length, current: _currentPage),
+                SizedBox(height: isCompact ? 16 : 24),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _CallToAction(),
+                ),
+                SizedBox(height: isCompact ? 12 : 20),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WelcomeFeature {
+  const _WelcomeFeature({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.accent,
+    required this.accentDark,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Color accent;
+  final Color accentDark;
+}
+
+class _AmbientBackground extends StatelessWidget {
+  const _AmbientBackground();
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              AppColors.bgDark,
+              AppColors.rhDark.withValues(alpha: 0.25),
+              AppColors.bgDark,
+              AppColors.iaDark.withValues(alpha: 0.18),
+            ],
+            stops: const [0.0, 0.35, 0.65, 1.0],
+          ),
+        ),
+        child: Stack(
+          children: [
+            Positioned(
+              top: -120,
+              left: -80,
+              child: _GlowOrb(
+                size: 260,
+                color: AppColors.rh.withValues(alpha: 0.35),
+              ),
+            ),
+            Positioned(
+              bottom: -140,
+              right: -100,
+              child: _GlowOrb(
+                size: 320,
+                color: AppColors.ia.withValues(alpha: 0.28),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GlowOrb extends StatelessWidget {
+  const _GlowOrb({required this.size, required this.color});
+
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: RadialGradient(
+            colors: [color, color.withValues(alpha: 0.0)],
+            stops: const [0.0, 1.0],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 72,
+          height: 72,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: const LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [AppColors.rh, AppColors.rhDark],
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.rh.withValues(alpha: 0.35),
+                blurRadius: 24,
+                spreadRadius: 2,
+              ),
+            ],
+          ),
+          child: const Center(
+            child: Text(
+              'L',
+              style: TextStyle(
+                fontFamily: AppTypography.fontFamily,
+                fontSize: 34,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+                height: 1,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 14),
+        Text(
+          'Leopardo RH',
+          style: AppTypography.title.copyWith(
+            color: AppColors.textDark,
+            letterSpacing: 0.2,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Votre carriere, a portee de main',
+          style: AppTypography.bodySmall.copyWith(
+            color: AppColors.textMutedDark,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FeatureSlide extends StatelessWidget {
+  const _FeatureSlide({required this.feature});
+
+  final _WelcomeFeature feature;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxHeight < 280;
+        final iconBoxSize = compact ? 108.0 : 156.0;
+        final iconSize = compact ? 48.0 : 68.0;
+        final gapAfterIcon = compact ? 18.0 : 32.0;
+        return SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: iconBoxSize,
+                  height: iconBoxSize,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [
+                        feature.accent.withValues(alpha: 0.22),
+                        feature.accentDark.withValues(alpha: 0.15),
+                      ],
+                    ),
+                    border: Border.all(
+                      color: feature.accent.withValues(alpha: 0.35),
+                      width: 1.5,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: feature.accent.withValues(alpha: 0.25),
+                        blurRadius: 30,
+                        spreadRadius: 2,
+                      ),
+                    ],
+                  ),
+                  child: Icon(
+                    feature.icon,
+                    size: iconSize,
+                    color: feature.accent,
+                  ),
+                ),
+                SizedBox(height: gapAfterIcon),
+                Text(
+                  feature.title,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.display.copyWith(
+                    color: AppColors.textDark,
+                    fontSize: 24,
+                  ),
+                ),
+                const SizedBox(height: 14),
+                Text(
+                  feature.description,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.body.copyWith(
+                    color: AppColors.textMutedDark,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PageDots extends StatelessWidget {
+  const _PageDots({required this.count, required this.current});
+
+  final int count;
+  final int current;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List<Widget>.generate(count, (i) {
+        final active = i == current;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 240),
+          curve: Curves.easeOut,
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: active ? 22 : 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: active ? AppColors.rh : AppColors.borderDark,
+            borderRadius: BorderRadius.circular(4),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _CallToAction extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SizedBox(
+          height: 52,
+          child: ElevatedButton(
+            onPressed: () => context.go('/login'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.rh,
+              foregroundColor: Colors.white,
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              textStyle: AppTypography.subtitle,
+            ),
+            child: const Text('Se connecter'),
+          ),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          height: 52,
+          child: OutlinedButton(
+            onPressed: () => context.go('/register'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppColors.textDark,
+              side: BorderSide(
+                color: AppColors.borderDark.withValues(alpha: 0.8),
+                width: 1.2,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              textStyle: AppTypography.subtitle,
+            ),
+            child: const Text('Creer un compte'),
+          ),
+        ),
+        const SizedBox(height: 14),
+        Text(
+          'Invite par votre employeur ? Utilisez le lien recu par email.',
+          textAlign: TextAlign.center,
+          style: AppTypography.caption.copyWith(
+            color: AppColors.textMutedDark,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/test/features/auth/welcome_screen_test.dart
+++ b/mobile/test/features/auth/welcome_screen_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leopardo_rh/features/auth/screens/welcome_screen.dart';
+
+void main() {
+  testWidgets('WelcomeScreen renders brand, feature slide and CTAs',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: WelcomeScreen(),
+      ),
+    );
+
+    // Brand header.
+    expect(find.text('Leopardo RH'), findsOneWidget);
+    expect(find.text('Votre carriere, a portee de main'), findsOneWidget);
+
+    // First feature slide is visible (pointage).
+    expect(find.text('Pointez en un geste'), findsOneWidget);
+
+    // Both CTAs are present.
+    expect(find.widgetWithText(ElevatedButton, 'Se connecter'), findsOneWidget);
+    expect(
+        find.widgetWithText(OutlinedButton, 'Creer un compte'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- **What changed:** l'app mobile ne bascule plus directement sur `/login` pour les utilisateurs non authentifiés. Elle affiche une page d'accueil `/welcome` (hero + carrousel de 4 bénéfices employé-centrés) avec deux CTA : **Se connecter** → `/login` et **Créer un compte** → `/register`. Un écran `/register` explicatif détaille l'onboarding par invitation employeur (3 étapes) et offre une capture d'email placeholder pour la future inscription libre. L'écran `/login` gagne un bouton retour vers `/welcome`.
- **Why:** aujourd'hui un employé qui installe l'app (ou qui a été chassé d'une entreprise) tombe sur un écran de login sans aucune mise en valeur de ce que Leopardo RH lui apporte. La page d'accueil met en avant la valeur *portable* de la plateforme pour l'employé lui-même : son historique de pointage et total d'heures cumulées, son parcours à travers les sociétés qui l'ont employé, son coffre-fort personnel (diplômes, contrats) et les notifications de ses employeurs — même hors contexte d'une société active.

## Scope
- [ ] Phase 1 backlog ticket referenced (`docs/GESTION_PROJET/BACKLOG_PHASE1_UNIQUE.md`)
- Ticket ID: _hors backlog_ (amélioration UX demandée en direct par `kitokoh`, scope mobile uniquement)

## Governance Checks
- [x] `CHANGELOG.md` updated (required for critical scope)
- [x] `JOURNAL_RACINE.md` updated
- [x] `INDEX_CANONIQUE.md` respecté (pas d'archive, nouveaux fichiers alignés sur le pattern `features/auth/screens/*.dart` existant)

## Technical Checks
- [x] API contract aligned (`02_API_CONTRATS_COMPLET.md`) ou N/A — **N/A**, aucun appel API nouveau ajouté (la page `/register` ne tape pas le backend pour le moment, seule une capture d'email locale)
- [x] ERD/SQL impact reviewed ou N/A — **N/A**, aucune migration
- [x] RBAC impact reviewed ou N/A — **N/A**, routes publiques uniquement (`/welcome`, `/register`), la redirection post-auth reste inchangée
- [x] Tenant isolation impact reviewed ou N/A — **N/A**, pas de scope tenant touché

### Détails techniques
- Nouveau fichier `mobile/lib/features/auth/screens/welcome_screen.dart` (WelcomeScreen, PageView de 4 `_FeatureSlide` + hero `_BrandHeader` + fond ambiant `_AmbientBackground` avec glow orbs + `_PageDots` animés + `_CallToAction`). Toutes les couleurs passent par `AppColors.*` (pas de hex hardcodé, conformément à la doc `app_colors.dart`). Typo via `AppTypography.*`.
- Nouveau fichier `mobile/lib/features/auth/screens/register_screen.dart` (RegisterScreen explicative, formulaire optionnel de capture d'email pour "me prévenir à l'ouverture", carte 3-étapes `_InvitationExplainerCard` rappelant le flow `user_invitations` déjà en place côté backend).
- `mobile/lib/app.dart` : `GoRouter.redirect` reformulé — ensemble `publicRoutes = {/welcome, /login, /register}`, non-auth → `/welcome` (au lieu de `/login`), auth → `/` depuis n'importe quelle route publique.
- `mobile/lib/features/auth/screens/login_screen.dart` : ajout d'une `Stack` avec `IconButton` retour (top-left) qui fait `context.pop()` ou `context.go('/welcome')` en fallback.
- `_FeatureSlide` utilise un `LayoutBuilder` + `SingleChildScrollView` + `ConstrainedBox` pour s'adapter aux petits écrans (icône 156→108 en mode compact). Garantit l'absence de `RenderFlex overflow` sur 568dp (iPhone SE) et en environnement de test 800×600.

## Testing
- [ ] Backend tests added/updated — **N/A**
- [x] Mobile tests added/updated — nouveau `mobile/test/features/auth/welcome_screen_test.dart` (smoke test : rendu de l'écran, présence de la marque `Leopardo RH`, du slogan, du 1er slide `Pointez en un geste` et des deux CTA `Se connecter` / `Creer un compte`)
- [x] Manual verification notes included :
  - `flutter pub get` : OK
  - `flutter analyze lib/features/auth lib/app.dart test/features/auth` : **No issues found**
  - `flutter test` : **8/8 tests passent** (incluant les tests existants + le nouveau welcome_screen_test)
  - `dart format` appliqué sur les 4 fichiers Dart touchés

## Risk / Rollback
- [x] Rollback plan documented — `git revert` de la PR, aucun schema DB ni config partagée modifiée
- Runbook référencé :
  - [ ] RUNBOOK_DEPLOY
  - [ ] RUNBOOK_ROLLBACK
  - [ ] RUNBOOK_BACKUP_RESTORE
  - [ ] RUNBOOK_INCIDENT_P1
  - **N/A** : livraison mobile uniquement (Flutter), pas de runbook infra applicable. Le déploiement se fait via `mobile-distribute.yml` (Firebase App Distribution) déclenché par tag `v1.0-staging`.


Link to Devin session: https://app.devin.ai/sessions/8ba0be73195c47ada45ac4043cb07296
Requested by: @kitokoh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
