### PR TITLE
🎨 Palette: improve accessibility for EmptyState widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.71] - 2026-04-24
+### Palette - Accessibilite EmptyState mobile
+
+- Mobile : Amelioration de l'accessibilite du widget `EmptyState` par l'ajout de labels `Semantics` regroupant le titre et la description, permettant aux lecteurs d'ecran d'annoncer clairement le contexte des listes vides.
+
 ## [4.1.70] - 2026-04-23
 ### Audit de coherence PILOTAGE / CORRECTIONS (aucun changement fonctionnel)
 

--- a/mobile/lib/core/widgets/empty_state.dart
+++ b/mobile/lib/core/widgets/empty_state.dart
@@ -27,34 +27,40 @@ class EmptyState extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Icon(
-              icon ?? Icons.inbox_outlined,
-              size: 56,
-              color: AppColors.textMuted,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              title,
-              style: AppTypography.title.copyWith(color: AppColors.textMuted),
-              textAlign: TextAlign.center,
-            ),
-            if (description != null) ...[
-              const SizedBox(height: 8),
+        child: Semantics(
+          label: description != null ? '$title. $description' : title,
+          container: true,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              ExcludeSemantics(
+                child: Icon(
+                  icon ?? Icons.inbox_outlined,
+                  size: 56,
+                  color: AppColors.textMuted,
+                ),
+              ),
+              const SizedBox(height: 16),
               Text(
-                description!,
-                style: AppTypography.bodySmall.copyWith(color: AppColors.textMuted),
+                title,
+                style: AppTypography.title.copyWith(color: AppColors.textMuted),
                 textAlign: TextAlign.center,
               ),
+              if (description != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  description!,
+                  style: AppTypography.bodySmall.copyWith(color: AppColors.textMuted),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              if (action != null) ...[
+                const SizedBox(height: 16),
+                action!,
+              ],
             ],
-            if (action != null) ...[
-              const SizedBox(height: 16),
-              action!,
-            ],
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### What changed
- Added a `Semantics` widget wrapping the content of the `EmptyState` widget in `mobile/lib/core/widgets/empty_state.dart`.
- The semantic label is constructed from the `title` and `description` fields.
- The decorative icon is wrapped in `ExcludeSemantics` to avoid noisy screen reader announcements.
- Updated `CHANGELOG.md` to record the change under version 4.1.71.

### Why it helps users
It ensures that users relying on screen readers (TalkBack/VoiceOver) receive a clear and unified announcement of why a screen or list is empty, rather than having to navigate through disconnected text fragments.

### Accessibility impact
- **Clarity**: High. Groups the context of the empty state.
- **Usability**: Improved. Avoids announcing decorative icons.

### Verification performed
- `git diff --check`: Passed.
- `flutter analyze` in `mobile/`: Passed (2 irrelevant deprecation warnings in team_screen.dart ignored as per mission scope).
- `flutter test` in `mobile/`: All 7 tests passed.
- Manual inspection of code changes.

### Rollback plan
Perform a `git revert` of the submission commit.

---
*PR created automatically by Jules for task [14594272305310061362](https://jules.google.com/task/14594272305310061362) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
