### PR TITLE
🧪 Scout: [MVP regression test] suspended employee blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [4.1.72] - 2026-04-25
 
+### Scout 🧪 - MVP Regression Testing
+
+- Tests : Ajout d'un test de régression `test_suspended_employee_token_is_blocked_by_tenant_middleware` dans `api/tests/Feature/AuthMeLogoutTest.php` pour verrouiller le blocage des employés suspendus par le `TenantMiddleware`.
+- Fix : Sécurisation du modèle `Company` contre les erreurs de driver SQL lors de la révocation des tokens à la suspension d'une entreprise (compatibilité SQLite pour les tests).
 
 ### Documentation - Plan d'Action d'Amelioration
 

--- a/api/app/Models/Company.php
+++ b/api/app/Models/Company.php
@@ -103,15 +103,23 @@ class Company extends Model
             // avec search_path=public. On etend le search_path temporairement
             // pour que la revocation des tokens (Sanctum) voie les relations.
             $schema = $company->schema_name ?: 'shared_tenants';
-            $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
-            DB::statement("SET search_path TO {$schema},public");
-            try {
+
+            if (DB::getDriverName() === 'pgsql') {
+                $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
+                DB::statement("SET search_path TO {$schema},public");
+                try {
+                    Employee::withoutGlobalScopes()
+                        ->where('company_id', $company->id)
+                        ->get()
+                        ->each(fn (Employee $employee) => $employee->tokens()->delete());
+                } finally {
+                    DB::statement("SET search_path TO {$previous}");
+                }
+            } else {
                 Employee::withoutGlobalScopes()
                     ->where('company_id', $company->id)
                     ->get()
                     ->each(fn (Employee $employee) => $employee->tokens()->delete());
-            } finally {
-                DB::statement("SET search_path TO {$previous}");
             }
         });
     }

--- a/api/tests/Feature/AuthMeLogoutTest.php
+++ b/api/tests/Feature/AuthMeLogoutTest.php
@@ -117,6 +117,37 @@ class AuthMeLogoutTest extends TestCase
         $response->assertJsonPath('error', 'EMPLOYEE_ARCHIVED');
     }
 
+    public function test_suspended_employee_token_is_blocked_by_tenant_middleware(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'suspended@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'suspended',
+        ]);
+
+        $plain = $employee->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$plain}")
+            ->getJson('/api/v1/auth/me');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'EMPLOYEE_SUSPENDED');
+    }
+
     public function test_company_suspension_revokes_employee_tokens(): void
     {
         $company = Company::query()->create([


### PR DESCRIPTION
### Behavior protected
This PR ensures that employees with a `suspended` status are correctly blocked from accessing the API by the `TenantMiddleware`, even if they have a valid Sanctum token.

### Why it matters for MVP
Maintaining strict control over employee access (active vs suspended/archived) is a core security requirement of the MVP to ensure that terminated or temporarily suspended employees cannot access company data.

### Changes
- **Tests**: Added `test_suspended_employee_token_is_blocked_by_tenant_middleware` to verify the 403 `EMPLOYEE_SUSPENDED` response.
- **Production Fix**: Hardened the `Company` model's `booted` hook to be compatible with SQLite (used in tests) by adding a `DB::getDriverName() === 'pgsql'` check before executing PostgreSQL-specific `SHOW search_path` and `SET search_path` commands.

### Verification performed
Ran the following command in the `api/` directory:
`DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/AuthMeLogoutTest.php`

Result:
```
   PASS  Tests\Feature\AuthMeLogoutTest
  ✓ me returns authenticated employee
  ✓ logout revokes current token
  ✓ archived employee token is blocked by tenant middleware
  ✓ suspended employee token is blocked by tenant middleware
  ✓ company suspension revokes employee tokens
```

### Rollback plan
`git revert` the commit. The change is safe as it only adds a test and a non-breaking driver check in production code.

---
*PR created automatically by Jules for task [18288261531402514478](https://jules.google.com/task/18288261531402514478) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
