### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL injection in PostgreSQL search_path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-21 - PostgreSQL search_path SQL Injection Fix
+**Vulnerability:** SQL Injection via PostgreSQL `SET search_path` statements. Multiple locations in the codebase were concatenating `schema_name` directly into SQL statements.
+**Learning:** PostgreSQL identifiers (like schema names) cannot be parameterized in `DB::statement`. While some parts of the app attempted to sanitize inputs using `preg_replace`, many others were completely unprotected, and there was no centralized standard for safe schema switching.
+**Prevention:** Use the centralized `Company::getSafeSearchPath(string $schema)` helper for all `SET search_path` calls. It ensures identifiers are properly double-quoted and internal double-quotes are escaped.

--- a/api/app/Http/Controllers/Api/V1/KioskController.php
+++ b/api/app/Http/Controllers/Api/V1/KioskController.php
@@ -148,7 +148,7 @@ class KioskController extends Controller
 
     private function resolveAuthorizedKiosk(Request $request, string $deviceCode): AttendanceKiosk
     {
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
         $kiosk = AttendanceKiosk::query()
             ->where('device_code', strtoupper($deviceCode))
@@ -164,18 +164,18 @@ class KioskController extends Controller
     private function setTenantSearchPath(?Company $company): void
     {
         if (! $company) {
-            DB::statement('SET search_path TO shared_tenants,public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
             return;
         }
 
         if ($company->tenancy_type === 'schema' && $company->schema_name) {
-            DB::statement('SET search_path TO '.$company->schema_name.',public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($company->schema_name));
 
             return;
         }
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
     }
 
     private function serializeKiosk(AttendanceKiosk $kiosk): array

--- a/api/app/Http/Controllers/Web/BiometricAdminController.php
+++ b/api/app/Http/Controllers/Web/BiometricAdminController.php
@@ -119,17 +119,17 @@ class BiometricAdminController extends Controller
     private function setTenantSearchPath(?Company $company): void
     {
         if (! $company) {
-            DB::statement('SET search_path TO shared_tenants,public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
             return;
         }
 
         if ($company->tenancy_type === 'schema' && $company->schema_name) {
-            DB::statement('SET search_path TO '.$company->schema_name.',public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($company->schema_name));
 
             return;
         }
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
     }
 }

--- a/api/app/Http/Controllers/Web/KioskController.php
+++ b/api/app/Http/Controllers/Web/KioskController.php
@@ -19,7 +19,7 @@ class KioskController extends Controller
 
     public function show(string $deviceCode): View
     {
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
         $kiosk = AttendanceKiosk::query()
             ->where('device_code', strtoupper($deviceCode))
@@ -41,7 +41,7 @@ class KioskController extends Controller
             'action' => ['nullable', 'in:check_in,check_out'],
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
         $kiosk = AttendanceKiosk::query()
             ->where('device_code', strtoupper($deviceCode))
@@ -65,17 +65,17 @@ class KioskController extends Controller
     private function setTenantSearchPath(?Company $company): void
     {
         if (! $company) {
-            DB::statement('SET search_path TO shared_tenants,public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
             return;
         }
 
         if ($company->tenancy_type === 'schema' && $company->schema_name) {
-            DB::statement('SET search_path TO '.$company->schema_name.',public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($company->schema_name));
 
             return;
         }
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
     }
 }

--- a/api/app/Http/Controllers/Web/PlatformCompanyController.php
+++ b/api/app/Http/Controllers/Web/PlatformCompanyController.php
@@ -22,7 +22,7 @@ class PlatformCompanyController extends Controller
 
     public function index(Request $request): View|JsonResponse
     {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         $companies = Company::query()->latest()->limit(50)->get();
 
@@ -39,7 +39,7 @@ class PlatformCompanyController extends Controller
 
     public function create(): View
     {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         return view('platform.companies.create', [
             'plans' => DB::table('plans')->orderBy('id')->get(),
@@ -48,7 +48,7 @@ class PlatformCompanyController extends Controller
 
     public function store(Request $request): RedirectResponse|JsonResponse
     {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:100'],
@@ -107,7 +107,7 @@ class PlatformCompanyController extends Controller
      */
     public function edit(string $companyId): View
     {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         $company = Company::query()->findOrFail($companyId);
 
@@ -128,7 +128,7 @@ class PlatformCompanyController extends Controller
      */
     public function update(Request $request, string $companyId): RedirectResponse|JsonResponse
     {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         $company = Company::query()->findOrFail($companyId);
 
@@ -183,11 +183,11 @@ class PlatformCompanyController extends Controller
         string $companyId,
         \App\Services\UserInvitationService $invitationService,
     ): RedirectResponse {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         $company = Company::query()->findOrFail($companyId);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
         $managerEmployee = \App\Models\Employee::query()
             ->withoutGlobalScopes()
             ->where('company_id', $company->id)
@@ -196,14 +196,14 @@ class PlatformCompanyController extends Controller
             ->first();
 
         if ($managerEmployee === null) {
-            DB::statement('SET search_path TO public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
             return back()->withErrors(['resend' => 'Aucun manager principal trouve pour cette societe.']);
         }
 
         /** @var SuperAdmin $superAdmin */
         $superAdmin = $request->user('super_admin_web') ?? $request->user('super_admin_api');
 
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
         $invitationService->createAndSend(
             company: $company,
             employee: $managerEmployee,

--- a/api/app/Http/Middleware/TenantMiddleware.php
+++ b/api/app/Http/Middleware/TenantMiddleware.php
@@ -64,9 +64,8 @@ class TenantMiddleware
         app()->instance('current_company', $company);
 
         if (DB::getDriverName() === 'pgsql') {
-            $rawSchema = $company->schema_name ?: 'shared_tenants';
-            $schema = preg_replace('/[^a-zA-Z0-9_]/', '', $rawSchema) ?: 'shared_tenants';
-            DB::statement('SET search_path TO "'.$schema.'",public');
+            $schema = $company->schema_name ?: 'shared_tenants';
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($schema));
         }
 
         return $next($request);

--- a/api/app/Http/Requests/Api/V1/StoreEmployeeRequest.php
+++ b/api/app/Http/Requests/Api/V1/StoreEmployeeRequest.php
@@ -106,11 +106,11 @@ class StoreEmployeeRequest extends FormRequest
         }
 
         if ($company->tenancy_type === 'schema' && $company->schema_name) {
-            DB::statement('SET search_path TO '.$company->schema_name.',public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($company->schema_name));
 
             return;
         }
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
     }
 }

--- a/api/app/Http/Requests/Api/V1/UpdateEmployeeRequest.php
+++ b/api/app/Http/Requests/Api/V1/UpdateEmployeeRequest.php
@@ -102,11 +102,11 @@ class UpdateEmployeeRequest extends FormRequest
         }
 
         if ($company->tenancy_type === 'schema' && $company->schema_name) {
-            DB::statement('SET search_path TO '.$company->schema_name.',public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($company->schema_name));
 
             return;
         }
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
     }
 }

--- a/api/app/Models/Company.php
+++ b/api/app/Models/Company.php
@@ -104,7 +104,7 @@ class Company extends Model
             // pour que la revocation des tokens (Sanctum) voie les relations.
             $schema = $company->schema_name ?: 'shared_tenants';
             $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
-            DB::statement("SET search_path TO {$schema},public");
+            DB::statement('SET search_path TO '.self::getSafeSearchPath($schema));
             try {
                 Employee::withoutGlobalScopes()
                     ->where('company_id', $company->id)
@@ -129,5 +129,18 @@ class Company extends Model
     public function attendanceKiosks(): HasMany
     {
         return $this->hasMany(AttendanceKiosk::class, 'company_id');
+    }
+
+    /**
+     * Retourne une chaine securisee pour un SET search_path PostgreSQL.
+     * Protege contre l'injection SQL dans les identifiants de schema.
+     */
+    public static function getSafeSearchPath(string $schema): string
+    {
+        // En PostgreSQL, pour echapper un identifiant double-quote,
+        // on double les double-quotes internes.
+        $escaped = str_replace('"', '""', $schema);
+
+        return '"'.$escaped.'",public';
     }
 }

--- a/api/app/Services/CompanyProvisioningService.php
+++ b/api/app/Services/CompanyProvisioningService.php
@@ -19,7 +19,7 @@ class CompanyProvisioningService
      */
     public function provisionSharedCompany(array $payload, SuperAdmin $superAdmin): array
     {
-        DB::statement('SET search_path TO public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
         $result = DB::transaction(function () use ($payload): array {
             $plan = DB::table('plans')->where('id', $payload['plan_id'])->first();
@@ -48,7 +48,7 @@ class CompanyProvisioningService
             ]);
 
             DB::statement('CREATE SCHEMA IF NOT EXISTS shared_tenants');
-            DB::statement('SET search_path TO shared_tenants,public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
             /** @var Employee $manager */
             $manager = Employee::query()->create([
@@ -72,7 +72,7 @@ class CompanyProvisioningService
                 ],
             ]);
 
-            DB::statement('SET search_path TO public');
+            DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('public'));
 
             return [
                 'company' => $company,
@@ -87,7 +87,7 @@ class CompanyProvisioningService
             invitedByEmail: $superAdmin->email,
         );
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
         return $result;
     }

--- a/api/app/Services/KioskAttendanceService.php
+++ b/api/app/Services/KioskAttendanceService.php
@@ -16,10 +16,10 @@ class KioskAttendanceService
 
     public function punch(AttendanceKiosk $kiosk, string $identifier, string $action = 'check_in'): AttendanceLog
     {
-        $searchPath = $kiosk->company?->tenancy_type === 'schema'
-            ? $kiosk->company->schema_name.',public'
-            : 'shared_tenants,public';
-        DB::statement('SET search_path TO '.$searchPath);
+        $schema = $kiosk->company?->tenancy_type === 'schema'
+            ? $kiosk->company->schema_name
+            : 'shared_tenants';
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($schema ?: 'shared_tenants'));
 
         $employee = Employee::query()
             ->where('company_id', $kiosk->company_id)
@@ -50,10 +50,10 @@ class KioskAttendanceService
 
     public function syncPunches(AttendanceKiosk $kiosk, array $events): array
     {
-        $searchPath = $kiosk->company?->tenancy_type === 'schema'
-            ? $kiosk->company->schema_name.',public'
-            : 'shared_tenants,public';
-        DB::statement('SET search_path TO '.$searchPath);
+        $schema = $kiosk->company?->tenancy_type === 'schema'
+            ? $kiosk->company->schema_name
+            : 'shared_tenants';
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($schema ?: 'shared_tenants'));
 
         $processed = [];
 

--- a/api/app/Services/UserInvitationService.php
+++ b/api/app/Services/UserInvitationService.php
@@ -67,11 +67,11 @@ class UserInvitationService
         abort_if($invitation->expires_at?->isPast(), 410, 'INVITATION_EXPIRED');
 
         $company = Company::query()->findOrFail($invitation->company_id);
-        $searchPath = $company->tenancy_type === 'schema'
-            ? sprintf('"%s",public', str_replace('"', '""', $company->schema_name))
-            : 'shared_tenants,public';
+        $schema = $company->tenancy_type === 'schema'
+            ? $company->schema_name
+            : 'shared_tenants';
 
-        DB::statement("SET search_path TO {$searchPath}");
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath($schema ?: 'shared_tenants'));
 
         /** @var Employee $employee */
         $employee = Employee::query()->findOrFail($invitation->employee_id);
@@ -80,7 +80,7 @@ class UserInvitationService
         $employee->invitation_accepted_at = now();
         $employee->save();
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        DB::statement('SET search_path TO '.\App\Models\Company::getSafeSearchPath('shared_tenants'));
 
         $invitation->accepted_at = now();
         $invitation->save();

--- a/api/tests/Unit/CompanySearchPathTest.php
+++ b/api/tests/Unit/CompanySearchPathTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Company;
+use PHPUnit\Framework\TestCase;
+
+class CompanySearchPathTest extends TestCase
+{
+    /** @test */
+    public function it_generates_safe_search_path()
+    {
+        // Simple case
+        $this->assertEquals('"public",public', Company::getSafeSearchPath('public'));
+
+        // Shared tenants case
+        $this->assertEquals('"shared_tenants",public', Company::getSafeSearchPath('shared_tenants'));
+
+        // Potential injection via double quotes
+        // In PostgreSQL, to escape a double quote in an identifier, you double it.
+        // SET search_path TO "some""schema",public
+        $this->assertEquals('"some""schema",public', Company::getSafeSearchPath('some"schema'));
+
+        // Complex malicious attempt
+        // If someone tries: my_schema",public; DROP TABLE users; --
+        // It should become: "my_schema"",public; DROP TABLE users; --",public
+        $this->assertEquals('"my_schema"",public; DROP TABLE users; --",public', Company::getSafeSearchPath('my_schema",public; DROP TABLE users; --'));
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Direct string concatenation of schema names into `SET search_path` statements.
🎯 Impact: An attacker with control over a company's `schema_name` could execute arbitrary SQL by breaking out of the search_path identifier.
🔧 Fix: Centralized search_path generation in `Company::getSafeSearchPath` with proper identifier escaping (double-quoting and doubling internal double-quotes).
✅ Verification: Added `CompanySearchPathTest` unit test and refactored all occurrences in the `api/` directory.

---
*PR created automatically by Jules for task [9707856204047589195](https://jules.google.com/task/9707856204047589195) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
