### PR TITLE
🎨 Palette: Accessibilite et Feedback Mobile

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@ This journal contains critical UX and accessibility learnings for the Leopardo R
 ## 2026-04-22 - Loading State Accessibility
 **Learning:** `CircularProgressIndicator` doesn't provide feedback to screen readers by default.
 **Action:** Wrap loading indicators in `Semantics` widgets with a descriptive `label` (e.g., 'Connexion en cours...') to inform users that an action is being processed. Avoid `const` on `Semantics` if the child or label might be dynamic, and watch for "const_with_non_const" analyzer errors.
+
+## 2026-05-21 - Aesthetic vs Semantic Balance
+**Learning:** Purely decorative elements (like name initials in a circle) can clutter screen reader navigation if they don't add unique information already present in text (like the full name).
+**Action:** Use `ExcludeSemantics` to hide redundant decorative elements from screen readers while keeping them for sighted users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.73] - 2026-05-21
+
+### Palette - Accessibilite et Feedback Mobile
+
+- Mobile : Amelioration de l'accessibilite et du feedback visuel dans `SettingsScreen` par l'ajout d'indicateurs de chargement et de labels `Semantics` sur les boutons d'action (profil, mot de passe, biometrie).
+- Mobile : Renforcement de l'accessibilite globale par l'ajout de labels `Semantics` sur les indicateurs de chargement dans `TeamScreen` et `HistoryScreen`.
+- Mobile : Optimisation des lecteurs d'ecran dans `TeamScreen` par l'exclusion des elements decoratifs (initiales) de la navigation semantique.
+
 ## [4.1.72] - 2026-04-25
 
 ### Seeder - Stabilisation demo multi-company

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -85,7 +85,12 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
             WidgetsBinding.instance.addPostFrameCallback((_) {
               ref.read(authProvider.notifier).logout();
             });
-            return const Center(child: CircularProgressIndicator());
+            return Center(
+              child: Semantics(
+                label: 'Redirection vers la connexion...',
+                child: const CircularProgressIndicator(),
+              ),
+            );
           }
 
           if (errorText.contains('403') || errorText.contains('FORBIDDEN')) {
@@ -140,9 +145,14 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                   itemCount: logs.length + (_isLoadingMore ? 1 : 0),
                   itemBuilder: (context, index) {
                     if (index == logs.length) {
-                      return const Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: Center(child: CircularProgressIndicator()),
+                      return Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Center(
+                          child: Semantics(
+                            label: 'Chargement de plus de pointages...',
+                            child: const CircularProgressIndicator(),
+                          ),
+                        ),
                       );
                     }
                     final log = logs[index];

--- a/mobile/lib/features/settings/screens/settings_screen.dart
+++ b/mobile/lib/features/settings/screens/settings_screen.dart
@@ -196,7 +196,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               ),
             FilledButton(
               onPressed: _profileSaving ? null : _saveProfile,
-              child: Text(_profileSaving ? 'Enregistrement...' : 'Enregistrer le profil'),
+              child: _profileSaving
+                  ? Semantics(
+                      label: 'Enregistrement en cours...',
+                      child: const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      ),
+                    )
+                  : const Text('Enregistrer le profil'),
             ),
           ],
         ),
@@ -261,7 +273,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               ),
             FilledButton(
               onPressed: _passwordSaving ? null : _savePassword,
-              child: Text(_passwordSaving ? 'Mise a jour...' : 'Mettre a jour le mot de passe'),
+              child: _passwordSaving
+                  ? Semantics(
+                      label: 'Mise à jour en cours...',
+                      child: const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      ),
+                    )
+                  : const Text('Mettre a jour le mot de passe'),
             ),
           ],
         ),
@@ -385,12 +409,35 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           const SizedBox(height: 16),
           FilledButton(
             onPressed: _preferencesSaving ? null : _savePreferences,
-            child: Text(_preferencesSaving ? 'Enregistrement...' : 'Enregistrer la preparation'),
+            child: _preferencesSaving
+                ? Semantics(
+                    label: 'Enregistrement en cours...',
+                    child: const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    ),
+                  )
+                : const Text('Enregistrer la preparation'),
           ),
           const SizedBox(height: 12),
           FilledButton.tonal(
             onPressed: _biometricSubmitting ? null : _submitBiometricEnrollment,
-            child: Text(_biometricSubmitting ? 'Soumission...' : 'Soumettre au manager / RH'),
+            child: _biometricSubmitting
+                ? Semantics(
+                    label: 'Soumission en cours...',
+                    child: const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                      ),
+                    ),
+                  )
+                : const Text('Soumettre au manager / RH'),
           ),
           const SizedBox(height: 8),
           const Text(

--- a/mobile/lib/features/team/screens/team_screen.dart
+++ b/mobile/lib/features/team/screens/team_screen.dart
@@ -108,7 +108,12 @@ class _EmployeesTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(teamListProvider),
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => Center(
+          child: Semantics(
+            label: 'Chargement des employés...',
+            child: const CircularProgressIndicator(),
+          ),
+        ),
         error: (err, _) => Center(child: Text('Erreur : $err')),
         data: (employees) {
           if (employees.isEmpty) {
@@ -129,8 +134,10 @@ class _EmployeesTab extends ConsumerWidget {
             itemBuilder: (_, index) {
               final e = employees[index];
               return ListTile(
-                leading: CircleAvatar(
-                  child: Text(_initials(e)),
+                leading: ExcludeSemantics(
+                  child: CircleAvatar(
+                    child: Text(_initials(e)),
+                  ),
                 ),
                 title: Text(e.fullName),
                 subtitle: Text('${e.email}\nRole : ${_roleLabel(e)}'),
@@ -232,7 +239,12 @@ class _InvitationsTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(invitationsListProvider),
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => Center(
+          child: Semantics(
+            label: 'Chargement des invitations...',
+            child: const CircularProgressIndicator(),
+          ),
+        ),
         error: (err, _) => Center(child: Text('Erreur : $err')),
         data: (invitations) {
           if (invitations.isEmpty) {
@@ -404,10 +416,13 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               ElevatedButton(
                 onPressed: _submitting ? null : _submit,
                 child: _submitting
-                    ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                    ? Semantics(
+                        label: 'Envoi en cours...',
+                        child: const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
                       )
                     : const Text('Envoyer l invitation'),
               ),


### PR DESCRIPTION
### What changed
- Added `Semantics` labels to loading indicators in `SettingsScreen`, `TeamScreen`, and `HistoryScreen`.
- Added visual loading feedback (spinners) to buttons in `SettingsScreen` during profile, password, and biometric updates.
- Wrapped decorative initials in `ExcludeSemantics` in the employee list within `TeamScreen`.
- Updated `CHANGELOG.md` and `.jules/palette.md` with new entries and learnings.

### Why it helps users
- **Accessibility:** Screen-reader users now receive explicit feedback when the app is performing background tasks (loading lists, saving data).
- **Clarity:** Sighted users get consistent visual feedback (spinners) during all data-saving actions in the settings.
- **Usability:** Reduces semantic noise for screen readers by hiding redundant decorative elements like initials in avatars.

### Accessibility impact
- High. Screen readers now announce: "Enregistrement en cours...", "Chargement des employés...", "Redirection vers la connexion...", etc.
- Improved focus management by excluding decorative elements.

### Verification performed
- `flutter analyze`: Passed (fixed `const` constructor issues).
- `flutter test`: Passed (8/8 tests).
- Code review: Passed with #Correct# rating.

### Rollback plan
- `git revert` of the commit.

---
*PR created automatically by Jules for task [13064058283709239012](https://jules.google.com/task/13064058283709239012) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
