### PR TITLE
🎨 Palette: Improve History empty state and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,11 @@ This journal contains critical UX and accessibility learnings for the Leopardo R
 ## 2026-04-22 - Loading State Accessibility
 **Learning:** `CircularProgressIndicator` doesn't provide feedback to screen readers by default.
 **Action:** Wrap loading indicators in `Semantics` widgets with a descriptive `label` (e.g., 'Connexion en cours...') to inform users that an action is being processed. Avoid `const` on `Semantics` if the child or label might be dynamic, and watch for "const_with_non_const" analyzer errors.
+
+## 2026-05-22 - Pull-to-refresh for empty states
+**Learning:** To keep the `RefreshIndicator` functional in Flutter when displaying empty or error states, the content MUST be wrapped in a scrollable widget (e.g., `ListView`) with its physics set to `AlwaysScrollableScrollPhysics`.
+**Action:** Use `ListView` with `AlwaysScrollableScrollPhysics` when implementing pull-to-refresh on screens that might have empty states or errors.
+
+## 2026-05-22 - CircularProgressIndicator Accessibility
+**Learning:** In Flutter, `CircularProgressIndicator` has a `semanticsLabel` property. Using it is cleaner and more concise than wrapping it in a `Semantics` widget.
+**Action:** Prefer using `semanticsLabel` directly on `CircularProgressIndicator` for providing accessibility feedback.

--- a/mobile/lib/core/widgets/pulse_button.dart
+++ b/mobile/lib/core/widgets/pulse_button.dart
@@ -69,7 +69,10 @@ class _PulseButtonState extends State<PulseButton> with SingleTickerProviderStat
                 ),
                 child: Center(
                   child: widget.isLoading
-                      ? const CircularProgressIndicator(color: Colors.white)
+                      ? const CircularProgressIndicator(
+                          color: Colors.white,
+                          semanticsLabel: 'Traitement en cours...',
+                        )
                       : Text(
                           widget.isCheckedIn ? 'CHECK OUT' : 'CHECK IN',
                           style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),

--- a/mobile/lib/features/attendance/screens/attendance_screen.dart
+++ b/mobile/lib/features/attendance/screens/attendance_screen.dart
@@ -114,13 +114,13 @@ class AttendanceScreen extends ConsumerWidget {
                 shape: BoxShape.circle,
                 color: Theme.of(context).primaryColor.withValues(alpha: 0.12),
               ),
-              child: Center(
-                child: Semantics(
-                  label: 'Chargement de votre présence...',
-                  child: SizedBox(
-                    height: 28,
-                    width: 28,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+              child: const Center(
+                child: SizedBox(
+                  height: 28,
+                  width: 28,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    semanticsLabel: 'Chargement de votre présence...',
                   ),
                 ),
               ),
@@ -194,14 +194,14 @@ class AttendanceScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 12),
           if (state.isLoading && employees.isEmpty) ...[
-            Row(
+            const Row(
               children: [
-                Semantics(
-                  label: 'Chargement du suivi d\'équipe...',
-                  child: SizedBox(
-                    height: 18,
-                    width: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                SizedBox(
+                  height: 18,
+                  width: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    semanticsLabel: 'Chargement du suivi d\'équipe...',
                   ),
                 ),
                 SizedBox(width: 12),

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:leopardo_rh/core/widgets/empty_state.dart';
 import 'package:leopardo_rh/core/widgets/shimmer_loading.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -56,70 +57,104 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           ),
         ],
       ),
-      body: historyAsync.when(
-        loading: () => ListView.separated(
-          padding: const EdgeInsets.all(16),
-          itemCount: 6,
-          separatorBuilder: (_, __) => const SizedBox(height: 16),
-          itemBuilder: (_, __) => Row(
-            children: [
-              const ShimmerLoading(width: 40, height: 40, borderRadius: 20),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const ShimmerLoading(width: 100, height: 16),
-                    const SizedBox(height: 8),
-                    const ShimmerLoading(width: double.infinity, height: 16),
-                  ],
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(historyProvider(DateTime(now.year, now.month))),
+        child: historyAsync.when(
+          loading: () => ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: 6,
+            separatorBuilder: (_, __) => const SizedBox(height: 16),
+            itemBuilder: (_, __) => Row(
+              children: [
+                const ShimmerLoading(width: 40, height: 40, borderRadius: 20),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const ShimmerLoading(width: 100, height: 16),
+                      const SizedBox(height: 8),
+                      const ShimmerLoading(width: double.infinity, height: 16),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
-        error: (err, stack) {
-          final errorText = err.toString();
+          error: (err, stack) {
+            final errorText = err.toString();
 
-          if (errorText.contains('401') || errorText.contains('UNAUTHENTICATED')) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              ref.read(authProvider.notifier).logout();
-            });
-            return const Center(child: CircularProgressIndicator());
-          }
+            if (errorText.contains('401') || errorText.contains('UNAUTHENTICATED')) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                ref.read(authProvider.notifier).logout();
+              });
+              return const Center(
+                child: CircularProgressIndicator(
+                  semanticsLabel: 'Déconnexion en cours...',
+                ),
+              );
+            }
 
-          if (errorText.contains('403') || errorText.contains('FORBIDDEN')) {
-            return const Center(
-              child: Padding(
-                padding: EdgeInsets.all(24),
-                child: Text('Compte suspendu ou acces refuse.'),
-              ),
-            );
-          }
-
-          if (err.toString().contains('NOT_IMPLEMENTED')) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(Icons.build_circle_outlined, size: 64, color: Colors.grey),
-                  const SizedBox(height: 16),
-                  const Text('Fonction bientôt disponible', style: TextStyle(fontSize: 20)),
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () => ref.refresh(historyProvider(DateTime(now.year, now.month))),
-                    child: const Text('Réessayer'),
+            if (errorText.contains('403') || errorText.contains('FORBIDDEN')) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const [
+                  SizedBox(height: 80),
+                  Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: Text('Compte suspendu ou accès refusé.'),
+                    ),
                   ),
                 ],
-              ),
+              );
+            }
+
+            if (err.toString().contains('NOT_IMPLEMENTED')) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  const SizedBox(height: 80),
+                  Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.build_circle_outlined, size: 64, color: Colors.grey),
+                        const SizedBox(height: 16),
+                        const Text('Fonction bientôt disponible', style: TextStyle(fontSize: 20)),
+                        const SizedBox(height: 16),
+                        ElevatedButton(
+                          onPressed: () => ref.refresh(historyProvider(DateTime(now.year, now.month))),
+                          child: const Text('Réessayer'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              );
+            }
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                const SizedBox(height: 80),
+                Center(child: Text('Erreur : $err')),
+              ],
             );
-          }
-          return Center(child: Text('Erreur : $err'));
-        },
-        data: (logs) {
-          if (logs.isEmpty) {
-            return const Center(child: Text('Aucun historique pour ce mois.'));
-          }
+          },
+          data: (logs) {
+            if (logs.isEmpty) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const [
+                  SizedBox(height: 80),
+                  EmptyState(
+                    title: 'Aucun historique',
+                    description:
+                        'Rien ici pour le moment. Vos pointages s\'afficheront ici au fur et à mesure.',
+                  ),
+                ],
+              );
+            }
           final totalJours = logs.length;
           final totalHeures = logs.fold<double>(0, (sum, log) => sum + (log.workedHours ?? 0));
           return Column(
@@ -142,7 +177,11 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                     if (index == logs.length) {
                       return const Padding(
                         padding: EdgeInsets.all(16.0),
-                        child: Center(child: CircularProgressIndicator()),
+                        child: Center(
+                          child: CircularProgressIndicator(
+                            semanticsLabel: 'Chargement de la suite...',
+                          ),
+                        ),
                       );
                     }
                     final log = logs[index];
@@ -216,6 +255,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           );
         },
       ),
+    ),
     );
   }
 }

--- a/mobile/lib/features/auth/screens/login_screen.dart
+++ b/mobile/lib/features/auth/screens/login_screen.dart
@@ -145,16 +145,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       style: ElevatedButton.styleFrom(
                           padding: const EdgeInsets.symmetric(vertical: 16)),
                       child: authState.isLoading
-                          ? Semantics(
-                              label: 'Connexion en cours...',
-                              child: SizedBox(
-                                height: 20,
-                                width: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                      Colors.white),
-                                ),
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                    Colors.white),
+                                semanticsLabel: 'Connexion en cours...',
                               ),
                             )
                           : const Text('Se connecter',

--- a/mobile/lib/features/team/screens/team_screen.dart
+++ b/mobile/lib/features/team/screens/team_screen.dart
@@ -108,7 +108,11 @@ class _EmployeesTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(teamListProvider),
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: 'Chargement des employés...',
+          ),
+        ),
         error: (err, _) => Center(child: Text('Erreur : $err')),
         data: (employees) {
           if (employees.isEmpty) {
@@ -232,7 +236,11 @@ class _InvitationsTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(invitationsListProvider),
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: 'Chargement des invitations...',
+          ),
+        ),
         error: (err, _) => Center(child: Text('Erreur : $err')),
         data: (invitations) {
           if (invitations.isEmpty) {
@@ -407,7 +415,10 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
                     ? const SizedBox(
                         width: 20,
                         height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          semanticsLabel: 'Envoi en cours...',
+                        ),
                       )
                     : const Text('Envoyer l invitation'),
               ),


### PR DESCRIPTION
### 🎨 Palette: Improve History empty state and accessibility

This PR introduces several micro-UX and accessibility enhancements to the Flutter mobile application:

#### 💡 What:
- **Pull-to-refresh on History Screen:** Users can now swipe down to refresh their attendance logs.
- **Improved Empty & Error States:** The History screen now uses the design system's `EmptyState` widget and ensures that error messages are scrollable, allowing pull-to-refresh to remain active even when data fails to load.
- **Enhanced Screen Reader Support:** Added `semanticsLabel` to all `CircularProgressIndicator` widgets across the app (Login, Check-in button, Team management, etc.) to provide meaningful feedback during loading states.

#### 🎯 Why:
- **UX Consistency:** Pull-to-refresh is a standard mobile interaction that was missing from the History screen.
- **Accessibility:** Without `semanticsLabel`, screen readers often stay silent or just say "Button/Progress indicator" during loading, which is a poor experience.
- **UI/UX Polish:** The previous "Aucun historique pour ce mois" text was replaced with a more conversational and visually pleasing `EmptyState`.

#### ♿ Accessibility:
- Replaced `Semantics` wrapper with the native `semanticsLabel` property of `CircularProgressIndicator` for cleaner code and better a11y support.
- Added descriptive labels like "Connexion en cours...", "Chargement des employés...", etc.

#### 📸 Verification:
- Ran `flutter analyze` and `flutter test` - both passed.
- Verified correct French typography and accents.
- Logged critical learnings in `.jules/palette.md`.

---
*PR created automatically by Jules for task [3878026511074032674](https://jules.google.com/task/3878026511074032674) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
