### PR TITLE
🧪 Scout: [MVP regression test] Suspended employee blocking

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,0 +1,12 @@
+# Scout Learnings
+
+## Security Regression Guards
+- **Middleware Stale State**: When performing security checks in a Middleware (like `TenantMiddleware`), never rely on the `$request->user()` object's properties without calling `fresh()`. Authenticated user objects are often cached in memory for the duration of the request or across some sessions, which can lead to security holes if the user's status (e.g., `archived` or `suspended`) changed after the token was issued but before the current request.
+- **Priority Areas**: Always prioritize regression tests for:
+    1. Tenant isolation (data leakage).
+    2. Authentication guardrails (blocking of inactive accounts).
+    3. RBAC (unauthorized access to manager/admin routes).
+
+## Test Environment Stability
+- **SQLite Compatibility**: In monorepos or environments using SQLite for fast feature testing, PostgreSQL-specific commands like `SET search_path` must always be guarded with `if (DB::getDriverName() === 'pgsql')`. Failure to do so will break the test suite in CI or local development.
+- **Bootstrap Requirements**: Backend tests often require a valid `.env` file even when using in-memory databases. Always ensure `api/.env` is present (copy from `.env.example` if missing) before running `php artisan test`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 ### Documentation - Plan d'Action d'Amelioration
 
 - `docs/GESTION_PROJET/PLAN_ACTION_AMELIORATION.md` : ajout du plan d'action detaillant les 15 ameliorations identifiees lors de l'audit technique, organise en 4 phases (Securite, Qualite, Robustesse, Scalabilite) avec instructions d'implementation, code d'exemple et criteres d'acceptation pour chaque action.
+### Tests - Renforcement securite et isolation (Scout)
+
+- Tests : `api/tests/Feature/SuspendedEmployeeGuardTest.php` verrouille le blocage des employes suspendus au login (403 EMPLOYEE_NOT_ACTIVE) et via le `TenantMiddleware` pour les sessions actives (403 EMPLOYEE_SUSPENDED).
+
 ### Pointage - Corrections CRITIQUES (rapport Leopardo_RH_Pointage_Validation_Finale)
 
 - API : `app/Exceptions/AlreadyCheckedInException.php` et `app/Exceptions/MissingCheckInException.php` renvoient désormais HTTP **422** (au lieu de 409) — alignement avec les règles R-PT-03 / R-PT-04 / PT-08 / PT-17.

--- a/api/app/Http/Controllers/Api/V1/KioskController.php
+++ b/api/app/Http/Controllers/Api/V1/KioskController.php
@@ -148,7 +148,9 @@ class KioskController extends Controller
 
     private function resolveAuthorizedKiosk(Request $request, string $deviceCode): AttendanceKiosk
     {
-        DB::statement('SET search_path TO shared_tenants,public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants,public');
+        }
 
         $kiosk = AttendanceKiosk::query()
             ->where('device_code', strtoupper($deviceCode))
@@ -163,6 +165,10 @@ class KioskController extends Controller
 
     private function setTenantSearchPath(?Company $company): void
     {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
         if (! $company) {
             DB::statement('SET search_path TO shared_tenants,public');
 

--- a/api/app/Http/Middleware/TenantMiddleware.php
+++ b/api/app/Http/Middleware/TenantMiddleware.php
@@ -44,7 +44,9 @@ class TenantMiddleware
             abort(403);
         }
 
-        if ($employee->status === 'archived') {
+        $status = $employee->fresh()?->status ?? $employee->status;
+
+        if ($status === 'archived') {
             if ($request->expectsJson() || $request->is('api/*')) {
                 return new JsonResponse(['error' => 'EMPLOYEE_ARCHIVED'], 403);
             }
@@ -52,7 +54,7 @@ class TenantMiddleware
             abort(403);
         }
 
-        if ($employee->status === 'suspended') {
+        if ($status === 'suspended') {
             if ($request->expectsJson() || $request->is('api/*')) {
                 return new JsonResponse(['error' => 'EMPLOYEE_SUSPENDED'], 403);
             }

--- a/api/app/Models/Company.php
+++ b/api/app/Models/Company.php
@@ -102,16 +102,23 @@ class Company extends Model
             // alors que l update d une company via le super-admin web s execute
             // avec search_path=public. On etend le search_path temporairement
             // pour que la revocation des tokens (Sanctum) voie les relations.
-            $schema = $company->schema_name ?: 'shared_tenants';
-            $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
-            DB::statement("SET search_path TO {$schema},public");
-            try {
+            if (DB::getDriverName() === 'pgsql') {
+                $schema = $company->schema_name ?: 'shared_tenants';
+                $previous = DB::selectOne('SHOW search_path')->search_path ?? 'public';
+                DB::statement("SET search_path TO {$schema},public");
+                try {
+                    Employee::withoutGlobalScopes()
+                        ->where('company_id', $company->id)
+                        ->get()
+                        ->each(fn (Employee $employee) => $employee->tokens()->delete());
+                } finally {
+                    DB::statement("SET search_path TO {$previous}");
+                }
+            } else {
                 Employee::withoutGlobalScopes()
                     ->where('company_id', $company->id)
                     ->get()
                     ->each(fn (Employee $employee) => $employee->tokens()->delete());
-            } finally {
-                DB::statement("SET search_path TO {$previous}");
             }
         });
     }

--- a/api/app/Services/KioskAttendanceService.php
+++ b/api/app/Services/KioskAttendanceService.php
@@ -16,10 +16,12 @@ class KioskAttendanceService
 
     public function punch(AttendanceKiosk $kiosk, string $identifier, string $action = 'check_in'): AttendanceLog
     {
-        $searchPath = $kiosk->company?->tenancy_type === 'schema'
-            ? $kiosk->company->schema_name.',public'
-            : 'shared_tenants,public';
-        DB::statement('SET search_path TO '.$searchPath);
+        if (DB::getDriverName() === 'pgsql') {
+            $searchPath = $kiosk->company?->tenancy_type === 'schema'
+                ? $kiosk->company->schema_name.',public'
+                : 'shared_tenants,public';
+            DB::statement('SET search_path TO '.$searchPath);
+        }
 
         $employee = Employee::query()
             ->where('company_id', $kiosk->company_id)
@@ -50,10 +52,12 @@ class KioskAttendanceService
 
     public function syncPunches(AttendanceKiosk $kiosk, array $events): array
     {
-        $searchPath = $kiosk->company?->tenancy_type === 'schema'
-            ? $kiosk->company->schema_name.',public'
-            : 'shared_tenants,public';
-        DB::statement('SET search_path TO '.$searchPath);
+        if (DB::getDriverName() === 'pgsql') {
+            $searchPath = $kiosk->company?->tenancy_type === 'schema'
+                ? $kiosk->company->schema_name.',public'
+                : 'shared_tenants,public';
+            DB::statement('SET search_path TO '.$searchPath);
+        }
 
         $processed = [];
 

--- a/api/tests/Feature/BiometricWorkflowTest.php
+++ b/api/tests/Feature/BiometricWorkflowTest.php
@@ -40,7 +40,9 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants,public');
+        }
 
         $manager = Employee::query()->create([
             'company_id' => $company->id,
@@ -107,7 +109,9 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants,public');
+        }
 
         $employee = Employee::query()->create([
             'company_id' => $company->id,
@@ -134,7 +138,9 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+        }
 
         $kioskResponse = $this->actingAs($manager, 'sanctum')
             ->postJson('/api/v1/kiosks', [
@@ -170,7 +176,9 @@ class BiometricWorkflowTest extends TestCase
             'status' => 'active',
         ]);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants,public');
+        }
 
         $manager = Employee::query()->create([
             'company_id' => $company->id,
@@ -196,7 +204,9 @@ class BiometricWorkflowTest extends TestCase
             'biometric_fingerprint_enabled' => true,
         ]);
 
-        DB::statement('SET search_path TO public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+        }
 
         $kioskResponse = $this->actingAs($manager, 'sanctum')
             ->postJson('/api/v1/kiosks', [
@@ -235,7 +245,9 @@ class BiometricWorkflowTest extends TestCase
             ->assertOk()
             ->assertJsonPath('data.processed_count', 2);
 
-        DB::statement('SET search_path TO shared_tenants,public');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants,public');
+        }
 
         $this->assertDatabaseHas('attendance_logs', [
             'employee_id' => $employee->id,

--- a/api/tests/Feature/SuspendedEmployeeGuardTest.php
+++ b/api/tests/Feature/SuspendedEmployeeGuardTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Support\Facades\Hash;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class SuspendedEmployeeGuardTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    /**
+     * Verifie qu'un employe suspendu ne peut pas se connecter.
+     * Priorite MVP 3 & 7.
+     */
+    public function test_login_rejects_suspended_employee(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'suspended@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'suspended',
+        ]);
+
+        $response = $this->postJson('/api/v1/auth/login', [
+            'email' => 'suspended@company.test',
+            'password' => 'password123',
+            'device_name' => 'tests',
+        ]);
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'EMPLOYEE_NOT_ACTIVE');
+    }
+
+    /**
+     * Verifie qu'un employe dont le statut passe a suspendu est bloque par le middleware.
+     * Priorite MVP 3 & 7.
+     */
+    public function test_suspended_employee_token_is_blocked_by_middleware(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'employee@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $token = $employee->createToken('tests')->plainTextToken;
+
+        // Ok quand actif
+        $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/auth/me')
+            ->assertOk();
+
+        // Suspendre l'employe
+        $employee->status = 'suspended';
+        $employee->save();
+
+        // Bloque apres suspension
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/auth/me');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'EMPLOYEE_SUSPENDED');
+    }
+}


### PR DESCRIPTION
### Behavior protected
This PR adds a critical security regression guard for **suspended employees**. It ensures that:
1. Suspended employees are rejected during the login process (returning 403 `EMPLOYEE_NOT_ACTIVE`).
2. Employees who are suspended *after* they have already obtained an active session are immediately blocked from any further protected API requests (returning 403 `EMPLOYEE_SUSPENDED`).

### Why it matters for MVP
Security and account lifecycle management are P0/P1 priorities. In a pilot phase, the ability to instantly revoke access to a specific employee (without waiting for token expiration) is essential for customer trust and data protection.

### Test added
- `api/tests/Feature/SuspendedEmployeeGuardTest.php`: focused regression test for the two behaviors mentioned above.
- Corrected `api/tests/Feature/BiometricWorkflowTest.php` to support SQLite.

### Fixes included
- **Critical Fix**: `TenantMiddleware` now calls `fresh()` on the employee object. This prevents suspended users from continuing to use the app via a stale in-memory status check.
- **Stability Fix**: Guarded `SET search_path` with `DB::getDriverName() === 'pgsql'` in `Company` model, `KioskController`, and `KioskAttendanceService` to maintain compatibility with SQLite-based testing environments.

### Verification command/result
Executed via SQLite in-memory:
`cd api && DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/SuspendedEmployeeGuardTest.php tests/Feature/AuthLoginGuardrailsTest.php tests/Feature/AuthMeLogoutTest.php tests/Feature/Attendance/CheckInTest.php tests/Feature/Attendance/CheckOutTest.php tests/Feature/Attendance/TodayAndHistoryTest.php tests/Feature/BiometricWorkflowTest.php`

**Result**: 20 tests passed (75 assertions).

### Rollback plan
`git revert` the commit. The changes are strictly additive (new test) or corrective (middleware logic and SQLite guards) and do not involve database migrations.

---
*PR created automatically by Jules for task [4566248434472502909](https://jules.google.com/task/4566248434472502909) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
