### PR TITLE
📐 Contractor: [API/mobile contract guard]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
 - API : `app/Http/Controllers/Api/V1/AttendanceController.php` — `today()` (vue manager) filtre `where('status', 'active')` et n'expose plus les employés archivés/suspendus (PT-29 / PT-43).
 - API : `app/Http/Middleware/TenantMiddleware.php` — bloque désormais les employés `suspended` en plus d'`archived` (`EMPLOYEE_SUSPENDED`, 403) — PT-68.
 - Contrat : `openapi.yaml` mis à jour pour le statut 422 sur `/attendance/check-in` (consolidation `ALREADY_CHECKED_IN` + `GPS_OUTSIDE_ZONE`).
+- Contractor : Alignment du `EmployeeController` (`index`, `show`, `store`, `update`) et `AttendanceController` (`today`, `index`) avec le contrat mobile (ajout `matricule`, `company_id`, et objet `employee` dans l'historique).
+- Tests : `tests/Feature/Contracts/EmployeeContractTest.php` ajouté pour verrouiller le contrat Employee; `tests/Feature/Contracts/MobilePayloadContractTest.php` mis à jour.
 - Tests : `tests/Feature/Attendance/CheckInTest.php`, `tests/Feature/Attendance/CheckOutTest.php`, `tests/Unit/AttendanceServiceTest.php` mis à jour pour refléter les nouveaux statuts (422) et les nouvelles valeurs `hours_worked`/`overtime_hours`.
 - Suite locale : 11/11 Unit + 87/87 Feature OK.
 

--- a/api/app/Http/Controllers/Api/V1/AttendanceController.php
+++ b/api/app/Http/Controllers/Api/V1/AttendanceController.php
@@ -86,7 +86,7 @@ class AttendanceController extends Controller
             $perPage = $request->integer('per_page', 50);
 
             $paginator = Employee::query()
-                ->select(['id', 'first_name', 'last_name', 'email', 'role', 'status'])
+                ->select(['id', 'matricule', 'first_name', 'last_name', 'email', 'role', 'status'])
                 ->where('status', 'active')
                 ->orderBy('id')
                 ->paginate(max(1, min(100, $perPage)));
@@ -161,6 +161,7 @@ class AttendanceController extends Controller
 
         $query = AttendanceLog::query()
             ->select(['id', 'employee_id', 'date', 'check_in', 'check_out', 'hours_worked', 'overtime_hours', 'status', 'method', 'source_device_code', 'late_minutes'])
+            ->with('employee:id,matricule,first_name,last_name,photo_path')
             ->orderByDesc('date')
             ->orderByDesc('id');
 
@@ -192,7 +193,7 @@ class AttendanceController extends Controller
 
     private function serializeLog(AttendanceLog $log): array
     {
-        return [
+        $data = [
             'id' => $log->id,
             'employee_id' => $log->employee_id,
             'date' => $log->date?->format('Y-m-d'),
@@ -205,6 +206,17 @@ class AttendanceController extends Controller
             'status' => $log->status,
             'late_minutes' => $log->late_minutes,
         ];
+
+        if ($log->relationLoaded('employee')) {
+            $data['employee'] = [
+                'id' => $log->employee->id,
+                'name' => trim(($log->employee->first_name ?? '').' '.($log->employee->last_name ?? '')),
+                'matricule' => $log->employee->matricule,
+                'photo_url' => $log->employee->photo_path,
+            ];
+        }
+
+        return $data;
     }
 
     private function serializeToday(Employee $employee, ?AttendanceLog $log, ?string $timezone = null): array
@@ -214,6 +226,7 @@ class AttendanceController extends Controller
         return [
             'employee_id' => $employee->id,
             'name' => trim(($employee->first_name ?? '').' '.($employee->last_name ?? '')),
+            'matricule' => $employee->matricule,
             'checked_in' => (bool) $log?->check_in,
             'check_in_time' => $log?->check_in?->setTimezone($timezone)->format('H:i'),
             'check_out_time' => $log?->check_out?->setTimezone($timezone)->format('H:i'),

--- a/api/app/Http/Controllers/Api/V1/EmployeeController.php
+++ b/api/app/Http/Controllers/Api/V1/EmployeeController.php
@@ -21,12 +21,21 @@ class EmployeeController extends Controller
 
         $perPage = max(1, min(100, (int) request()->integer('per_page', 20)));
         $paginator = Employee::query()
-            ->select(['id', 'first_name', 'last_name', 'email', 'role', 'status'])
+            ->select(['id', 'matricule', 'company_id', 'first_name', 'last_name', 'email', 'role', 'status'])
             ->orderBy('id')
             ->paginate($perPage);
 
         return new JsonResponse([
-            'data' => collect($paginator->items())->values(),
+            'data' => collect($paginator->items())->map(fn (Employee $employee) => [
+                'id' => $employee->id,
+                'matricule' => $employee->matricule,
+                'company_id' => $employee->company_id,
+                'first_name' => $employee->first_name,
+                'last_name' => $employee->last_name,
+                'email' => $employee->email,
+                'role' => $employee->role,
+                'status' => $employee->status,
+            ])->values(),
             'meta' => [
                 'current_page' => $paginator->currentPage(),
                 'per_page' => $paginator->perPage(),
@@ -47,6 +56,8 @@ class EmployeeController extends Controller
         return new JsonResponse([
             'data' => [
                 'id' => $employee->id,
+                'matricule' => $employee->matricule,
+                'company_id' => $employee->company_id,
                 'first_name' => $employee->first_name,
                 'last_name' => $employee->last_name,
                 'email' => $employee->email,
@@ -71,6 +82,8 @@ class EmployeeController extends Controller
         return new JsonResponse([
             'data' => [
                 'id' => $employee->id,
+                'matricule' => $employee->matricule,
+                'company_id' => $employee->company_id,
                 'first_name' => $employee->first_name,
                 'last_name' => $employee->last_name,
                 'email' => $employee->email,
@@ -104,6 +117,8 @@ class EmployeeController extends Controller
         return new JsonResponse([
             'data' => [
                 'id' => $employee->id,
+                'matricule' => $employee->matricule,
+                'company_id' => $employee->company_id,
                 'first_name' => $employee->first_name,
                 'last_name' => $employee->last_name,
                 'email' => $employee->email,

--- a/api/tests/Feature/Contracts/EmployeeContractTest.php
+++ b/api/tests/Feature/Contracts/EmployeeContractTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Feature\Contracts;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class EmployeeContractTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_employees_index_payload_includes_matricule_and_company_id(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'MGR-001',
+            'first_name' => 'Leila',
+            'last_name' => 'Manager',
+            'email' => 'manager@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+
+        Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'EMP-001',
+            'first_name' => 'Sami',
+            'last_name' => 'Employee',
+            'email' => 'employee@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson('/api/v1/employees');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'matricule',
+                    'company_id',
+                    'first_name',
+                    'last_name',
+                    'email',
+                    'role',
+                    'status',
+                ],
+            ],
+        ]);
+        $response->assertJsonPath('data.0.matricule', 'MGR-001');
+        $response->assertJsonPath('data.0.company_id', $company->id);
+    }
+
+    public function test_employee_show_payload_includes_matricule_and_company_id(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'MGR-001',
+            'first_name' => 'Leila',
+            'last_name' => 'Manager',
+            'email' => 'manager@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson("/api/v1/employees/{$manager->id}");
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'matricule',
+                'company_id',
+                'first_name',
+                'last_name',
+                'email',
+                'role',
+                'manager_role',
+                'status',
+            ],
+        ]);
+        $response->assertJsonPath('data.matricule', 'MGR-001');
+        $response->assertJsonPath('data.company_id', $company->id);
+    }
+
+    public function test_employee_store_payload_includes_matricule_and_company_id(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'MGR-001',
+            'first_name' => 'Leila',
+            'last_name' => 'Manager',
+            'email' => 'manager@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson('/api/v1/employees', [
+            'first_name' => 'New',
+            'last_name' => 'Employee',
+            'email' => 'new@company.test',
+            'role' => 'employee',
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'matricule',
+                'company_id',
+                'first_name',
+                'last_name',
+                'email',
+                'status',
+            ],
+        ]);
+        $response->assertJsonPath('data.company_id', $company->id);
+    }
+
+    public function test_employee_update_payload_includes_matricule_and_company_id(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'MGR-001',
+            'first_name' => 'Leila',
+            'last_name' => 'Manager',
+            'email' => 'manager@company.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->patchJson("/api/v1/employees/{$manager->id}", [
+            'first_name' => 'Updated',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'matricule',
+                'company_id',
+                'first_name',
+                'last_name',
+                'email',
+                'status',
+            ],
+        ]);
+        $response->assertJsonPath('data.matricule', 'MGR-001');
+        $response->assertJsonPath('data.company_id', $company->id);
+    }
+}

--- a/api/tests/Feature/Contracts/MobilePayloadContractTest.php
+++ b/api/tests/Feature/Contracts/MobilePayloadContractTest.php
@@ -143,6 +143,7 @@ class MobilePayloadContractTest extends TestCase
                     '*' => [
                         'employee_id',
                         'name',
+                        'matricule',
                         'checked_in',
                         'check_in_time',
                         'check_out_time',


### PR DESCRIPTION
**Endpoints/Models inspected:**
- `/api/v1/employees` (index, show, store, update)
- `/api/v1/attendance/today`
- `/api/v1/attendance/history` (index)

**Contract issue found:**
The mobile app expects `matricule` and `company_id` for employee models and list identification. The attendance history view also requires a nested `employee` object to avoid N+1 requests on the frontend.

**What was changed:**
- `EmployeeController`: Added `matricule` and `company_id` to index (select + map), store, show, and update responses.
- `AttendanceController`: Added `matricule` to `serializeToday` (Today view).
- `AttendanceController`: Added eager-loaded `employee` object (id, name, matricule, photo_url) to `serializeLog` (History view).
- Added `api/tests/Feature/Contracts/EmployeeContractTest.php`.
- Updated `api/tests/Feature/Contracts/MobilePayloadContractTest.php`.

**Backward compatibility statement:**
The changes are strictly additive. No existing fields were removed or renamed. Existing mobile clients will continue to function and can now utilize the missing fields.

**Tests/verification:**
- `php artisan test --filter EmployeeContractTest` -> PASS
- `php artisan test --filter MobilePayloadContractTest` -> PASS

**Rollback plan:**
`git revert` the merge commit. No database migrations were performed.

---
*PR created automatically by Jules for task [14359324980418783972](https://jules.google.com/task/14359324980418783972) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
