### PR TITLE
🎨 Palette: HistoryScreen UX Improvement

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,11 @@ This journal contains critical UX and accessibility learnings for the Leopardo R
 ## 2026-04-22 - Loading State Accessibility
 **Learning:** `CircularProgressIndicator` doesn't provide feedback to screen readers by default.
 **Action:** Wrap loading indicators in `Semantics` widgets with a descriptive `label` (e.g., 'Connexion en cours...') to inform users that an action is being processed. Avoid `const` on `Semantics` if the child or label might be dynamic, and watch for "const_with_non_const" analyzer errors.
+
+## 2026-04-22 - Flutter Pull-to-Refresh with Riverpod
+**Learning:** When using `RefreshIndicator` with Riverpod, returning `ref.refresh(provider)` might not wait for the actual async operation to complete, causing the spinner to disappear too early.
+**Action:** Always use `await ref.refresh(provider.future)` to ensure the `RefreshIndicator` remains active until the data is fully reloaded.
+
+## 2026-04-22 - Scrollable Empty States
+**Learning:** A common UX issue in Flutter is the "dead" empty state that prevents pull-to-refresh because the view is not scrollable.
+**Action:** Wrap empty states in a `ListView` or `SingleChildScrollView` with `physics: AlwaysScrollableScrollPhysics()` to maintain gesture consistency. Use a `SizedBox(height: 80)` at the top of empty states within lists to maintain a balanced visual breathing room.

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:leopardo_rh/core/widgets/empty_state.dart';
 import 'package:leopardo_rh/core/widgets/shimmer_loading.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -117,9 +118,6 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           return Center(child: Text('Erreur : $err'));
         },
         data: (logs) {
-          if (logs.isEmpty) {
-            return const Center(child: Text('Aucun historique pour ce mois.'));
-          }
           final totalJours = logs.length;
           final totalHeures = logs.fold<double>(0, (sum, log) => sum + (log.workedHours ?? 0));
           return Column(
@@ -135,45 +133,61 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
               ),
               const Divider(),
               Expanded(
-                child: ListView.builder(
-                  controller: _scrollController,
-                  itemCount: logs.length + (_isLoadingMore ? 1 : 0),
-                  itemBuilder: (context, index) {
-                    if (index == logs.length) {
-                      return const Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: Center(child: CircularProgressIndicator()),
-                      );
-                    }
-                    final log = logs[index];
-                    Color statusColor = Colors.grey;
-                    switch (log.status) {
-                      case 'ontime':
-                        statusColor = Colors.green;
-                        break;
-                      case 'late':
-                        statusColor = Colors.orange;
-                        break;
-                      case 'absent':
-                        statusColor = Colors.red;
-                        break;
-                    }
-                    
-                    return ListTile(
-                      leading: CircleAvatar(
-                        backgroundColor: statusColor.withValues(alpha: 0.2),
-                        child: Icon(Icons.circle, color: statusColor, size: 12),
-                      ),
-                      title: Text('${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}'),
-                      subtitle: Text(
-                        log.checkIn != null 
-                          ? '${log.checkIn!.hour.toString().padLeft(2,'0')}:${log.checkIn!.minute.toString().padLeft(2,'0')} -> '
-                            '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2,'0')}:${log.checkOut!.minute.toString().padLeft(2,'0')}" : "En cours"}'
-                          : 'Absence'
-                      ),
-                      trailing: Text('${log.workedHours ?? 0}h', style: const TextStyle(fontWeight: FontWeight.bold)),
-                    );
-                  },
+                child: RefreshIndicator(
+                  onRefresh: () async => await ref.refresh(historyProvider(DateTime(now.year, now.month)).future),
+                  child: logs.isEmpty
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          children: const [
+                            SizedBox(height: 80),
+                            EmptyState(
+                              title: 'Aucun historique',
+                              description: 'Aucun pointage n\'a été enregistré pour ce mois.',
+                              icon: Icons.history_toggle_off,
+                            ),
+                          ],
+                        )
+                      : ListView.builder(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          controller: _scrollController,
+                          itemCount: logs.length + (_isLoadingMore ? 1 : 0),
+                          itemBuilder: (context, index) {
+                            if (index == logs.length) {
+                              return const Padding(
+                                padding: EdgeInsets.all(16.0),
+                                child: Center(child: CircularProgressIndicator()),
+                              );
+                            }
+                            final log = logs[index];
+                            Color statusColor = Colors.grey;
+                            switch (log.status) {
+                              case 'ontime':
+                                statusColor = Colors.green;
+                                break;
+                              case 'late':
+                                statusColor = Colors.orange;
+                                break;
+                              case 'absent':
+                                statusColor = Colors.red;
+                                break;
+                            }
+
+                            return ListTile(
+                              leading: CircleAvatar(
+                                backgroundColor: statusColor.withValues(alpha: 0.2),
+                                child: Icon(Icons.circle, color: statusColor, size: 12),
+                              ),
+                              title: Text(
+                                  '${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}'),
+                              subtitle: Text(log.checkIn != null
+                                  ? '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} -> '
+                                      '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}'
+                                  : 'Absence'),
+                              trailing:
+                                  Text('${log.workedHours ?? 0}h', style: const TextStyle(fontWeight: FontWeight.bold)),
+                            );
+                          },
+                        ),
                 ),
               ),
               Container(


### PR DESCRIPTION
This PR enhances the `HistoryScreen` UX by introducing a dedicated empty state and pull-to-refresh functionality.

### 💡 What:
- Replaced the basic "Aucun historique" text with the design system's `EmptyState` widget.
- Wrapped the history list in a `RefreshIndicator`.
- Ensured the list is always scrollable (using `AlwaysScrollableScrollPhysics`) so the refresh gesture is always available.
- Updated the refresh logic to correctly handle asynchronous Riverpod provider updates.

### 🎯 Why:
- Provides a more professional and helpful "empty" experience.
- Empowers users to manually refresh their history data without leaving the screen.
- Aligns `HistoryScreen` with the UX patterns used in `TeamScreen` and `AttendanceScreen`.

### ♿ Accessibility:
- `EmptyState` includes proper semantics labels for screen readers.
- Improved gesture consistency makes the app more predictable for all users.

### 📖 Learnings:
- Documented best practices for `RefreshIndicator` + Riverpod and scrollable empty states in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7026677145651806684](https://jules.google.com/task/7026677145651806684) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
