### PR TITLE
feat(api): implement module 6  Public Onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [4.1.78] - 2026-04-27
 
+### API - Public onboarding par invitation
+
+- API : ajout de `GET /api/v1/onboarding/invitation/{token}` pour verifier un token d'invitation public et retourner les informations minimales d'activation (`email`, `role`, `manager_role`, `employee_name`, `expires_at`).
+- API : ajout de `POST /api/v1/onboarding/invitation/{token}/activate` pour activer un compte employe invite, valider le mot de passe et emettre un token Sanctum de connexion immediate.
+- API : ajout du controleur `OnboardingController` et des routes publiques throttlees (`10 req/min`) pour l'onboarding sans authentification prealable.
+
 ### Contractor - Alignement contract API/mobile (attendance)
 
 - API : Mise à jour de `AttendanceTodayResource` pour inclure le `matricule` et les champs d'estimation (`base_gain`, `overtime_gain`, `total_estimated`, `currency`) résolus via `EstimationService`.

--- a/api/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/api/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserInvitation;
+use App\Services\UserInvitationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Module 6 — Public Onboarding API
+ *
+ * Endpoints publics (sans auth) permettant à un employé invité de :
+ *   1. Vérifier la validité de son token d'invitation
+ *   2. Activer son compte en définissant son mot de passe
+ *
+ * Utilisé par l'app mobile et le web frontend.
+ */
+class OnboardingController extends Controller
+{
+    public function __construct(private readonly UserInvitationService $userInvitationService) {}
+
+    /**
+     * GET /onboarding/invitation/{token}
+     *
+     * Vérifie qu'un token d'invitation est valide et retourne les infos
+     * nécessaires pour afficher le formulaire d'activation (nom, email, company).
+     */
+    public function show(Request $request, string $token): JsonResponse
+    {
+        $invitation = UserInvitation::query()
+            ->where('token_hash', hash('sha256', $token))
+            ->first();
+
+        if (! $invitation) {
+            return new JsonResponse([
+                'error' => [
+                    'code'    => 'INVITATION_NOT_FOUND',
+                    'message' => 'Token d\'invitation invalide ou introuvable.',
+                ],
+            ], 404);
+        }
+
+        if ($invitation->accepted_at !== null) {
+            return new JsonResponse([
+                'error' => [
+                    'code'    => 'INVITATION_ALREADY_ACCEPTED',
+                    'message' => 'Cette invitation a déjà été acceptée.',
+                ],
+            ], 410);
+        }
+
+        if ($invitation->expires_at?->isPast()) {
+            return new JsonResponse([
+                'error' => [
+                    'code'    => 'INVITATION_EXPIRED',
+                    'message' => 'Cette invitation a expiré.',
+                ],
+            ], 410);
+        }
+
+        return new JsonResponse([
+            'data' => [
+                'email'        => $invitation->email,
+                'role'         => $invitation->role,
+                'manager_role' => $invitation->manager_role,
+                'expires_at'   => $invitation->expires_at?->toIso8601String(),
+                'employee_name' => $invitation->metadata['employee_name'] ?? null,
+            ],
+        ]);
+    }
+
+    /**
+     * POST /onboarding/invitation/{token}/activate
+     *
+     * Active le compte de l'employé en définissant son mot de passe.
+     * Retourne un token Sanctum pour connexion immédiate après activation.
+     */
+    public function activate(Request $request, string $token): JsonResponse
+    {
+        $validated = $request->validate([
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        // Check token validity before calling service
+        $invitation = UserInvitation::query()
+            ->where('token_hash', hash('sha256', $token))
+            ->first();
+
+        if (! $invitation) {
+            return new JsonResponse([
+                'error' => [
+                    'code'    => 'INVITATION_NOT_FOUND',
+                    'message' => 'Token d\'invitation invalide ou introuvable.',
+                ],
+            ], 404);
+        }
+
+        if ($invitation->accepted_at !== null) {
+            return new JsonResponse([
+                'error' => [
+                    'code'    => 'INVITATION_ALREADY_ACCEPTED',
+                    'message' => 'Cette invitation a déjà été acceptée.',
+                ],
+            ], 410);
+        }
+
+        if ($invitation->expires_at?->isPast()) {
+            return new JsonResponse([
+                'error' => [
+                    'code'    => 'INVITATION_EXPIRED',
+                    'message' => 'Cette invitation a expiré.',
+                ],
+            ], 410);
+        }
+
+        $employee = $this->userInvitationService->accept($token, $validated['password']);
+
+        // Issue a Sanctum token for immediate login after activation
+        $deviceName = $request->input('device_name', 'mobile');
+        $sanctumToken = $employee->createToken($deviceName);
+
+        return new JsonResponse([
+            'data' => [
+                'employee' => [
+                    'id'         => $employee->id,
+                    'email'      => $employee->email,
+                    'first_name' => $employee->first_name,
+                    'last_name'  => $employee->last_name,
+                    'role'       => $employee->role,
+                ],
+                'token'            => $sanctumToken->plainTextToken,
+                'token_type'       => 'Bearer',
+                'token_expires_at' => null,
+            ],
+            'message' => 'ACCOUNT_ACTIVATED',
+        ], 201);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\BiometricEnrollmentController;
 use App\Http\Controllers\Api\V1\HealthController;
+use App\Http\Controllers\Api\V1\OnboardingController;
 use App\Http\Controllers\Api\V1\PlatformAuthController;
 use App\Http\Controllers\Web\PlatformCompanyController;
 use Illuminate\Support\Facades\Route;
@@ -17,6 +18,12 @@ Route::prefix('v1')->group(function (): void {
     Route::middleware(['throttle:10,1'])->group(function (): void {
         Route::post('/auth/login', [AuthController::class, 'login']);
         Route::post('/platform/auth/login', [PlatformAuthController::class, 'login']);
+    });
+
+    // Module 6 — Public Onboarding (sans auth, throttle strict)
+    Route::middleware(['throttle:10,1'])->prefix('onboarding')->group(function (): void {
+        Route::get('/invitation/{token}', [OnboardingController::class, 'show']);
+        Route::post('/invitation/{token}/activate', [OnboardingController::class, 'activate']);
     });
 
     Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {


### PR DESCRIPTION
Expose 2 endpoints publics (sans auth) pour l'activation de compte via invitation:

  GET  /api/v1/onboarding/invitation/{token}
       - Vérifie la validité du token (404/410 si invalide/expiré/déjà accepté)
       - Retourne email, role, employee_name, expires_at pour afficher le formulaire

  POST /api/v1/onboarding/invitation/{token}/activate
       - Valide password + password_confirmation (min 8 chars)
       - Appelle UserInvitationService::accept() (transaction atomique existante)
       - Retourne un token Sanctum pour connexion immédiate (HTTP 201)
       - Codes d'erreur: INVITATION_NOT_FOUND, INVITATION_ALREADY_ACCEPTED, INVITATION_EXPIRED

Throttle: 10 req/min (même groupe que /auth/login)
RBAC: public, aucune auth requise
Tenant: résolu automatiquement par UserInvitationService via TenantManager

## Summary
- What changed:
- Why:

## Scope
- [ ] Phase 1 backlog ticket referenced (`docs/GESTION_PROJET/BACKLOG_PHASE1_UNIQUE.md`)
- Ticket ID:

## Governance Checks
- [ ] `CHANGELOG.md` updated (required for critical scope)
- [ ] `JOURNAL_RACINE.md` updated
- [ ] `INDEX_CANONIQUE.md` respected (no archive-based implementation)

## Technical Checks
- [ ] API contract aligned (`02_API_CONTRATS_COMPLET.md`) or N/A
- [ ] ERD/SQL impact reviewed or N/A
- [ ] RBAC impact reviewed or N/A
- [ ] Tenant isolation impact reviewed or N/A

## Testing
- [ ] Backend tests added/updated
- [ ] Mobile tests added/updated
- [ ] Manual verification notes included

## Risk / Rollback
- [ ] Rollback plan documented
- [ ] Relevant runbook referenced:
  - [ ] RUNBOOK_DEPLOY
  - [ ] RUNBOOK_ROLLBACK
  - [ ] RUNBOOK_BACKUP_RESTORE
  - [ ] RUNBOOK_INCIDENT_P1
