### PR TITLE
🎨 Palette: Enhance HistoryScreen with pull-to-refresh and EmptyState

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@ This journal contains critical UX and accessibility learnings for the Leopardo R
 ## 2026-04-22 - Loading State Accessibility
 **Learning:** `CircularProgressIndicator` doesn't provide feedback to screen readers by default.
 **Action:** Wrap loading indicators in `Semantics` widgets with a descriptive `label` (e.g., 'Connexion en cours...') to inform users that an action is being processed. Avoid `const` on `Semantics` if the child or label might be dynamic, and watch for "const_with_non_const" analyzer errors.
+
+## 2026-05-20 - Pull-to-Refresh in Empty States
+**Learning:** In Flutter, `RefreshIndicator` only works with scrollable widgets. When a screen is in an empty or error state, it often loses its scrollability, making it impossible for users to refresh.
+**Action:** Always wrap `EmptyState` or error messages in a `ListView` or `SingleChildScrollView` with `physics: AlwaysScrollableScrollPhysics()` to ensure pull-to-refresh remains functional. Use a `SizedBox(height: 80)` as the first child for consistent spacing.

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -1,3 +1,4 @@
+import 'package:leopardo_rh/core/widgets/empty_state.dart';
 import 'package:leopardo_rh/core/widgets/shimmer_loading.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -56,165 +57,208 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
           ),
         ],
       ),
-      body: historyAsync.when(
-        loading: () => ListView.separated(
-          padding: const EdgeInsets.all(16),
-          itemCount: 6,
-          separatorBuilder: (_, __) => const SizedBox(height: 16),
-          itemBuilder: (_, __) => Row(
-            children: [
-              const ShimmerLoading(width: 40, height: 40, borderRadius: 20),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const ShimmerLoading(width: 100, height: 16),
-                    const SizedBox(height: 8),
-                    const ShimmerLoading(width: double.infinity, height: 16),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-        error: (err, stack) {
-          final errorText = err.toString();
-
-          if (errorText.contains('401') || errorText.contains('UNAUTHENTICATED')) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              ref.read(authProvider.notifier).logout();
-            });
-            return const Center(child: CircularProgressIndicator());
-          }
-
-          if (errorText.contains('403') || errorText.contains('FORBIDDEN')) {
-            return const Center(
-              child: Padding(
-                padding: EdgeInsets.all(24),
-                child: Text('Compte suspendu ou acces refuse.'),
-              ),
-            );
-          }
-
-          if (err.toString().contains('NOT_IMPLEMENTED')) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(Icons.build_circle_outlined, size: 64, color: Colors.grey),
-                  const SizedBox(height: 16),
-                  const Text('Fonction bientôt disponible', style: TextStyle(fontSize: 20)),
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () => ref.refresh(historyProvider(DateTime(now.year, now.month))),
-                    child: const Text('Réessayer'),
-                  ),
-                ],
-              ),
-            );
-          }
-          return Center(child: Text('Erreur : $err'));
-        },
-        data: (logs) {
-          if (logs.isEmpty) {
-            return const Center(child: Text('Aucun historique pour ce mois.'));
-          }
-          final totalJours = logs.length;
-          final totalHeures = logs.fold<double>(0, (sum, log) => sum + (log.workedHours ?? 0));
-          return Column(
-            children: [
-              Container(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text('Mois actuel', style: Theme.of(context).textTheme.titleLarge),
-                  ],
-                ),
-              ),
-              const Divider(),
-              Expanded(
-                child: ListView.builder(
-                  controller: _scrollController,
-                  itemCount: logs.length + (_isLoadingMore ? 1 : 0),
-                  itemBuilder: (context, index) {
-                    if (index == logs.length) {
-                      return const Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: Center(child: CircularProgressIndicator()),
-                      );
-                    }
-                    final log = logs[index];
-                    Color statusColor = Colors.grey;
-                    switch (log.status) {
-                      case 'ontime':
-                        statusColor = Colors.green;
-                        break;
-                      case 'late':
-                        statusColor = Colors.orange;
-                        break;
-                      case 'absent':
-                        statusColor = Colors.red;
-                        break;
-                    }
-                    
-                    return ListTile(
-                      leading: CircleAvatar(
-                        backgroundColor: statusColor.withValues(alpha: 0.2),
-                        child: Icon(Icons.circle, color: statusColor, size: 12),
-                      ),
-                      title: Text('${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}'),
-                      subtitle: Text(
-                        log.checkIn != null 
-                          ? '${log.checkIn!.hour.toString().padLeft(2,'0')}:${log.checkIn!.minute.toString().padLeft(2,'0')} -> '
-                            '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2,'0')}:${log.checkOut!.minute.toString().padLeft(2,'0')}" : "En cours"}'
-                          : 'Absence'
-                      ),
-                      trailing: Text('${log.workedHours ?? 0}h', style: const TextStyle(fontWeight: FontWeight.bold)),
-                    );
-                  },
-                ),
-              ),
-              Container(
-                padding: const EdgeInsets.all(24),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).cardColor,
-                  borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: SafeArea(
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(historyProvider(DateTime(now.year, now.month)).future),
+        child: historyAsync.when(
+          loading: () => ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: 6,
+            separatorBuilder: (_, __) => const SizedBox(height: 16),
+            itemBuilder: (_, __) => Row(
+              children: [
+                const ShimmerLoading(width: 40, height: 40, borderRadius: 20),
+                const SizedBox(width: 16),
+                Expanded(
                   child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          const Text('Total jours'),
-                          Text('$totalJours', style: const TextStyle(fontWeight: FontWeight.bold)),
-                        ],
-                      ),
+                      const ShimmerLoading(width: 100, height: 16),
                       const SizedBox(height: 8),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          const Text('Total heures'),
-                          Text('${totalHeures.toStringAsFixed(1)}h', style: const TextStyle(fontWeight: FontWeight.bold)),
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          const Text('Heures supplémentaires', style: TextStyle(color: Colors.grey)),
-                          Text('${(totalHeures > 160 ? totalHeures - 160 : 0).toStringAsFixed(1)}h', style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.grey)),
-                        ],
-                      ),
+                      const ShimmerLoading(width: double.infinity, height: 16),
                     ],
                   ),
                 ),
-              ),
-            ],
-          );
-        },
+              ],
+            ),
+          ),
+          error: (err, stack) {
+            final errorText = err.toString();
+
+            if (errorText.contains('401') || errorText.contains('UNAUTHENTICATED')) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                ref.read(authProvider.notifier).logout();
+              });
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (errorText.contains('403') || errorText.contains('FORBIDDEN')) {
+              return const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Text('Compte suspendu ou acces refuse.'),
+                ),
+              );
+            }
+
+            if (err.toString().contains('NOT_IMPLEMENTED')) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  const SizedBox(height: 100),
+                  Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.build_circle_outlined,
+                            size: 64, color: Colors.grey),
+                        const SizedBox(height: 16),
+                        const Text('Fonction bientôt disponible',
+                            style: TextStyle(fontSize: 20)),
+                        const SizedBox(height: 16),
+                        ElevatedButton(
+                          onPressed: () => ref.refresh(historyProvider(
+                              DateTime(now.year, now.month))),
+                          child: const Text('Réessayer'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              );
+            }
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                const SizedBox(height: 100),
+                Center(child: Text('Erreur : $err')),
+              ],
+            );
+          },
+          data: (logs) {
+            if (logs.isEmpty) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const [
+                  SizedBox(height: 80),
+                  EmptyState(
+                    icon: Icons.history_toggle_off,
+                    title: 'Aucun historique',
+                    description:
+                        'Rien ici pour le moment. Vos pointages apparaitront au fur et a mesure.',
+                  ),
+                ],
+              );
+            }
+            final totalJours = logs.length;
+            final totalHeures =
+                logs.fold<double>(0, (sum, log) => sum + (log.workedHours ?? 0));
+            return Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text('Mois actuel',
+                          style: Theme.of(context).textTheme.titleLarge),
+                    ],
+                  ),
+                ),
+                const Divider(),
+                Expanded(
+                  child: ListView.builder(
+                    controller: _scrollController,
+                    itemCount: logs.length + (_isLoadingMore ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == logs.length) {
+                        return const Padding(
+                          padding: EdgeInsets.all(16.0),
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      }
+                      final log = logs[index];
+                      Color statusColor = Colors.grey;
+                      switch (log.status) {
+                        case 'ontime':
+                          statusColor = Colors.green;
+                          break;
+                        case 'late':
+                          statusColor = Colors.orange;
+                          break;
+                        case 'absent':
+                          statusColor = Colors.red;
+                          break;
+                      }
+
+                      return ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: statusColor.withValues(alpha: 0.2),
+                          child:
+                              Icon(Icons.circle, color: statusColor, size: 12),
+                        ),
+                        title: Text(
+                            '${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}'),
+                        subtitle: Text(log.checkIn != null
+                            ? '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} -> '
+                                '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}'
+                            : 'Absence'),
+                        trailing: Text('${log.workedHours ?? 0}h',
+                            style:
+                                const TextStyle(fontWeight: FontWeight.bold)),
+                      );
+                    },
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).cardColor,
+                    borderRadius:
+                        const BorderRadius.vertical(top: Radius.circular(24)),
+                  ),
+                  child: SafeArea(
+                    child: Column(
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text('Total jours'),
+                            Text('$totalJours',
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text('Total heures'),
+                            Text('${totalHeures.toStringAsFixed(1)}h',
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text('Heures supplémentaires',
+                                style: TextStyle(color: Colors.grey)),
+                            Text(
+                                '${(totalHeures > 160 ? totalHeures - 160 : 0).toStringAsFixed(1)}h',
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.grey)),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
This PR implements a micro-UX improvement for the `HistoryScreen` in the mobile application.

### 💡 What
- Added a `RefreshIndicator` to the `HistoryScreen`.
- Integrated the `EmptyState` widget for a better visual experience when no history is available.
- Modified error and empty states to be scrollable, enabling users to "pull-to-refresh" even when no data is displayed or when a load fails.

### 🎯 Why
- Users should be able to manually refresh their history to see newly recorded pointages.
- Providing a conversational and visual `EmptyState` is more pleasant than a simple text label.
- Ensuring the screen remains scrollable in all states prevents the UI from feeling "stuck" when an error occurs.

### ♿ Accessibility
- The `EmptyState` widget includes semantic labels for screen readers.
- `RefreshIndicator` provides standard haptic and visual feedback for refresh actions.

---
*PR created automatically by Jules for task [11850082007596951622](https://jules.google.com/task/11850082007596951622) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
