### PR TITLE
🎨 Palette: improve Team and Badge accessibility semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.83] - 2026-05-23
+
+### Palette - Accessibilité Team et Badges
+
+- Mobile : Amélioration de l'accessibilité du widget `LeopardoBadge` par l'ajout de labels `Semantics` regroupant l'icône et le texte, évitant les annonces fragmentées pour les lecteurs d'écran.
+- Mobile : Amélioration de l'accessibilité de l'écran `TeamScreen` par l'exclusion des initiales redondantes dans les avatars et l'ajout de labels `Semantics` explicites sur tous les indicateurs de chargement (`CircularProgressIndicator`).
+- Mobile : Amélioration de l'accessibilité de l'écran `HistoryScreen` par l'ajout de labels `Semantics` sur les indicateurs de chargement.
+
 ## [4.1.80] - 2026-04-27
 
 ### API - Module Evaluations (module 7 complément)

--- a/mobile/lib/core/widgets/leopardo_badge.dart
+++ b/mobile/lib/core/widgets/leopardo_badge.dart
@@ -52,29 +52,35 @@ class LeopardoBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: color.withValues(alpha: 0.3)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (icon != null) ...[
-            Icon(icon, size: 14, color: color),
-            const SizedBox(width: 4),
-          ],
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: color,
-            ),
+    return Semantics(
+      label: label,
+      container: true,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: color.withValues(alpha: 0.3)),
+        ),
+        child: ExcludeSemantics(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: 14, color: color),
+                const SizedBox(width: 4),
+              ],
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: color,
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -85,7 +85,11 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
             WidgetsBinding.instance.addPostFrameCallback((_) {
               ref.read(authProvider.notifier).logout();
             });
-            return const Center(child: CircularProgressIndicator());
+            return const Center(
+              child: CircularProgressIndicator(
+                semanticsLabel: 'Chargement de l\'historique...',
+              ),
+            );
           }
 
           if (errorText.contains('403') || errorText.contains('FORBIDDEN')) {
@@ -142,7 +146,11 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                     if (index == logs.length) {
                       return const Padding(
                         padding: EdgeInsets.all(16.0),
-                        child: Center(child: CircularProgressIndicator()),
+                        child: Center(
+                          child: CircularProgressIndicator(
+                            semanticsLabel: 'Chargement de l\'historique...',
+                          ),
+                        ),
                       );
                     }
                     final log = logs[index];

--- a/mobile/lib/features/team/screens/team_screen.dart
+++ b/mobile/lib/features/team/screens/team_screen.dart
@@ -108,7 +108,11 @@ class _EmployeesTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(teamListProvider),
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: 'Chargement des employés...',
+          ),
+        ),
         error: (err, _) => Center(child: Text('Erreur : $err')),
         data: (employees) {
           if (employees.isEmpty) {
@@ -130,7 +134,9 @@ class _EmployeesTab extends ConsumerWidget {
               final e = employees[index];
               return ListTile(
                 leading: CircleAvatar(
-                  child: Text(_initials(e)),
+                  child: ExcludeSemantics(
+                    child: Text(_initials(e)),
+                  ),
                 ),
                 title: Text(e.fullName),
                 subtitle: Text('${e.email}\nRole : ${_roleLabel(e)}'),
@@ -232,7 +238,11 @@ class _InvitationsTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(invitationsListProvider),
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: 'Chargement des invitations...',
+          ),
+        ),
         error: (err, _) => Center(child: Text('Erreur : $err')),
         data: (invitations) {
           if (invitations.isEmpty) {
@@ -407,7 +417,10 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
                     ? const SizedBox(
                         width: 20,
                         height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          semanticsLabel: 'Envoi en cours...',
+                        ),
                       )
                     : const Text('Envoyer l invitation'),
               ),


### PR DESCRIPTION
This PR focuses on micro-UX and accessibility improvements for the Flutter mobile application, specifically targeting screen-reader usability.

### What changed
- **LeopardoBadge**: Wrapped the entire badge in a `Semantics` widget and used `ExcludeSemantics` on its internal `Row`. This ensures that a badge (e.g., "Présent" or "En retard") is announced as a single coherent unit rather than as separate icon and text pieces.
- **TeamScreen**:
    - The redundant initials shown in the `CircleAvatar` for employees are now excluded from the semantic tree, as the full name is immediately announced by the `ListTile`.
    - Added meaningful `semanticsLabel` to the `CircularProgressIndicator` in the employee list, invitation list, and the "Add Employee" form to inform users when a background action is in progress.
- **HistoryScreen**: Added `semanticsLabel` to the loading indicators used during history fetching.
- **I18n**: Ensured all new French labels use proper accents (e.g., "employés") for higher-quality screen-reader output.

### Why it helps users
- Screen-reader users (TalkBack/VoiceOver) will experience less noise and more clarity when navigating lists of employees and invitations.
- Loading states are no longer "silent" for visually impaired users, providing essential feedback that the application is busy.

### Accessibility impact
- Significant improvement in semantic clarity for badges and employee lists.
- Compliance with the project's accessibility guidelines for loading feedback.

### Verification performed
- `flutter analyze`: Passed (with 3 unrelated infos).
- `flutter test`: All 9 tests passed.
- Manual inspection of the code structure to ensure proper semantic grouping.

### Rollback plan
`git revert` this commit. No database migrations or logic changes were made.

---
*PR created automatically by Jules for task [916574192515356266](https://jules.google.com/task/916574192515356266) started by @kitokoh*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kitokoh/gestionemployerbackend/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
