### PR TITLE
🎨 Palette: Micro UX and Accessibility improvements for Absences and Salary Advances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 ### API - Stabilisation seed demo / deploiement
 
 - API : `DemoCompanyOnceSeeder` detecte desormais une base deja peuplee en `shared_tenants`, pose proprement son verrou SQL et se skip sans casser le deploiement si le lock a disparu mais que les donnees demo existent deja.
+
+### Palette - UX et Accessibilité (Absences & Avances)
+
+- Mobile : Amélioration de l'accessibilité des écrans `Mes Absences` et `Mes Avances` par l'ajout de labels `Semantics` sur les indicateurs de chargement et de tooltips sur les boutons de retour.
+- Mobile : Ajout de la fonctionnalité de rafraîchissement (`RefreshIndicator`) sur les listes d'absences et d'avances de salaire.
+- Mobile : Durcissement des états vides et d'erreur pour garantir la disponibilité du rafraîchissement tactile même sans données affichées.
 ## [4.1.82] - 2026-04-29
 
 ### Janitor - Hygiène du dépôt et sécurité

--- a/mobile/lib/features/absences/screens/absence_list_screen.dart
+++ b/mobile/lib/features/absences/screens/absence_list_screen.dart
@@ -23,51 +23,80 @@ class AbsenceListScreen extends ConsumerWidget {
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          tooltip: 'Retour',
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
-      body: absencesAsync.when(
-        data: (absences) => absences.isEmpty
-            ? const EmptyState(
-                icon: Icons.calendar_today,
-                title: 'Aucune absence',
-                description:
-                    'Vous n\'avez pas encore fait de demande d\'absence.',
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(20),
-                itemCount: absences.length,
-                itemBuilder: (context, index) {
-                  final absence = absences[index];
-                  return Card(
-                    color: AppColors.cardDark,
-                    margin: const EdgeInsets.only(bottom: 12),
-                    child: ListTile(
-                      title: Text(
-                        absence.absenceTypeName ?? 'Absence',
-                        style: AppTypography.subtitle.copyWith(
-                          color: AppColors.textDark,
-                        ),
-                      ),
-                      subtitle: Text(
-                        '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
-                        style: AppTypography.bodySmall.copyWith(
-                          color: AppColors.textMutedDark,
-                        ),
-                      ),
-                      trailing: Text(
-                        absence.status,
-                        style: TextStyle(
-                          color: _getStatusColor(absence.status),
-                        ),
-                      ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(absencesProvider.future),
+        child: absencesAsync.when(
+          data: (absences) => absences.isEmpty
+              ? ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [
+                    SizedBox(height: 80),
+                    EmptyState(
+                      icon: Icons.calendar_today,
+                      title: 'Aucune absence',
+                      description:
+                          'Vous n\'avez pas encore fait de demande d\'absence.',
                     ),
-                  );
-                },
+                  ],
+                )
+              : ListView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(20),
+                  itemCount: absences.length,
+                  itemBuilder: (context, index) {
+                    final absence = absences[index];
+                    return Card(
+                      color: AppColors.cardDark,
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: ListTile(
+                        title: Text(
+                          absence.absenceTypeName ?? 'Absence',
+                          style: AppTypography.subtitle.copyWith(
+                            color: AppColors.textDark,
+                          ),
+                        ),
+                        subtitle: Text(
+                          '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
+                          style: AppTypography.bodySmall.copyWith(
+                            color: AppColors.textMutedDark,
+                          ),
+                        ),
+                        trailing: Text(
+                          absence.status,
+                          style: TextStyle(
+                            color: _getStatusColor(absence.status),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+          loading: () => Center(
+            child: Semantics(
+              label: 'Chargement des absences...',
+              child: CircularProgressIndicator(),
+            ),
+          ),
+          error: (e, _) => ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: [
+              const SizedBox(height: 80),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(
+                    e.toString(),
+                    style: const TextStyle(color: Colors.red),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
               ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Text(e.toString(), style: const TextStyle(color: Colors.red)),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
+++ b/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
@@ -23,51 +23,80 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          tooltip: 'Retour',
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
-      body: advancesAsync.when(
-        data: (advances) => advances.isEmpty
-            ? const EmptyState(
-                icon: Icons.payments,
-                title: 'Aucune avance',
-                description:
-                    'Vous n\'avez pas encore demandé d\'avance de salaire.',
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(20),
-                itemCount: advances.length,
-                itemBuilder: (context, index) {
-                  final advance = advances[index];
-                  return Card(
-                    color: AppColors.cardDark,
-                    margin: const EdgeInsets.only(bottom: 12),
-                    child: ListTile(
-                      title: Text(
-                        '${advance.amount} DZD',
-                        style: AppTypography.subtitle.copyWith(
-                          color: AppColors.textDark,
-                        ),
-                      ),
-                      subtitle: Text(
-                        advance.reason ?? 'Aucun motif',
-                        style: AppTypography.bodySmall.copyWith(
-                          color: AppColors.textMutedDark,
-                        ),
-                      ),
-                      trailing: Text(
-                        advance.status,
-                        style: TextStyle(
-                          color: _getStatusColor(advance.status),
-                        ),
-                      ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(salaryAdvancesProvider.future),
+        child: advancesAsync.when(
+          data: (advances) => advances.isEmpty
+              ? ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [
+                    SizedBox(height: 80),
+                    EmptyState(
+                      icon: Icons.payments,
+                      title: 'Aucune avance',
+                      description:
+                          'Vous n\'avez pas encore demandé d\'avance de salaire.',
                     ),
-                  );
-                },
+                  ],
+                )
+              : ListView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(20),
+                  itemCount: advances.length,
+                  itemBuilder: (context, index) {
+                    final advance = advances[index];
+                    return Card(
+                      color: AppColors.cardDark,
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: ListTile(
+                        title: Text(
+                          '${advance.amount} DZD',
+                          style: AppTypography.subtitle.copyWith(
+                            color: AppColors.textDark,
+                          ),
+                        ),
+                        subtitle: Text(
+                          advance.reason ?? 'Aucun motif',
+                          style: AppTypography.bodySmall.copyWith(
+                            color: AppColors.textMutedDark,
+                          ),
+                        ),
+                        trailing: Text(
+                          advance.status,
+                          style: TextStyle(
+                            color: _getStatusColor(advance.status),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+          loading: () => Center(
+            child: Semantics(
+              label: 'Chargement des avances...',
+              child: CircularProgressIndicator(),
+            ),
+          ),
+          error: (e, _) => ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: [
+              const SizedBox(height: 80),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(
+                    e.toString(),
+                    style: const TextStyle(color: Colors.red),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
               ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Text(e.toString(), style: const TextStyle(color: Colors.red)),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
🎨 Palette: Micro UX and Accessibility improvements for Absences and Salary Advances

**What changed:**
- Added `RefreshIndicator` for pull-to-refresh in `AbsenceListScreen` and `SalaryAdvanceListScreen`.
- Ensured `EmptyState` and error messages are scrollable so that pull-to-refresh works even when no data is displayed.
- Added `Semantics` to loading indicators with French labels ('Chargement des absences...', 'Chargement des avances...').
- Added `tooltip: 'Retour'` to back buttons.
- Updated `CHANGELOG.md`.

**Why it helps users:**
- Provides a standard way to refresh lists that was previously missing.
- Improves screen reader support for loading and navigation actions.
- Ensures the app remains interactive even in empty or error states.

**Accessibility impact:**
- High: Loading states are now announced by screen readers.
- High: Back buttons are now identifiable by their action instead of just "Button".

**Verification performed:**
- `flutter analyze` (mobile): Clean.
- `flutter test` (mobile): 9/9 tests passed.
- Manual check of `read_file` results.

**Rollback plan:**
- `git revert` this commit. No database migrations or backend changes were involved.

---
*PR created automatically by Jules for task [7037117595681881](https://jules.google.com/task/7037117595681881) started by @kitokoh*