### PR TITLE
🎨 Palette: Improve accessibility in Modules screen

### DIFF
--- a/mobile/lib/features/modules/screens/modules_screen.dart
+++ b/mobile/lib/features/modules/screens/modules_screen.dart
@@ -85,7 +85,11 @@ class _EvaluationsTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(evaluationsProvider.future),
       child: asyncValue.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: "Chargement des évaluations...",
+          ),
+        ),
         error: (error, _) => ListView(
           children: [
             const SizedBox(height: 80),
@@ -316,7 +320,11 @@ class _SalaryAdvancesTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(salaryAdvancesProvider.future),
       child: asyncValue.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: "Chargement des demandes d'avances...",
+          ),
+        ),
         error: (error, _) => ListView(
           children: [
             const SizedBox(height: 80),
@@ -375,6 +383,7 @@ class _SalaryAdvancesTab extends ConsumerWidget {
                         onPressed: () =>
                             _showAdvanceActions(context, ref, item),
                         icon: const Icon(Icons.more_horiz),
+                        tooltip: 'Actions',
                       ),
                     ],
                   ),
@@ -546,7 +555,11 @@ class _PayrollsTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(payrollsProvider.future),
       child: asyncValue.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: "Chargement des bulletins de paie...",
+          ),
+        ),
         error: (error, _) => ListView(
           children: [
             const SizedBox(height: 80),
@@ -610,6 +623,7 @@ class _PayrollsTab extends ConsumerWidget {
                         onPressed: () =>
                             _showPayrollActions(context, ref, item),
                         icon: const Icon(Icons.more_horiz),
+                        tooltip: 'Actions',
                       ),
                     ],
                   ),
@@ -724,7 +738,11 @@ class _NotificationsTab extends ConsumerWidget {
     return RefreshIndicator(
       onRefresh: () async => ref.refresh(notificationsProvider.future),
       child: asyncValue.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: "Chargement des notifications...",
+          ),
+        ),
         error: (error, _) => ListView(
           children: [
             const SizedBox(height: 80),
@@ -929,7 +947,11 @@ class _CreateEvaluationSheetState
               team.when(
                 loading: () => const Padding(
                   padding: EdgeInsets.symmetric(vertical: 20),
-                  child: Center(child: CircularProgressIndicator()),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      semanticsLabel: "Chargement de l'équipe...",
+                    ),
+                  ),
                 ),
                 error: (error, _) => Text('Equipe indisponible : $error'),
                 data: (employees) => DropdownButtonFormField<int>(
@@ -1197,7 +1219,11 @@ class _CreatePayrollSheetState extends ConsumerState<_CreatePayrollSheet> {
               ),
               const SizedBox(height: 16),
               team.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
+                loading: () => const Center(
+                  child: CircularProgressIndicator(
+                    semanticsLabel: "Chargement de l'équipe...",
+                  ),
+                ),
                 error: (error, _) => Text('Equipe indisponible : $error'),
                 data: (employees) => DropdownButtonFormField<int>(
                   initialValue: _employeeId,


### PR DESCRIPTION
This PR improves the accessibility of the `ModulesScreen` by adding missing semantics and tooltips. 

### 💡 What: The UX enhancement added
- Added `semanticsLabel` to 6 `CircularProgressIndicator` widgets across all tabs of the Modules screen (Evaluations, Avances, Paies, Notifications) and within creation forms.
- Added `tooltip: 'Actions'` to 2 `IconButton` widgets (more_horiz) in the Salary Advances and Payrolls lists.

### 🎯 Why: The user problem it solves
- Users with screen readers currently only hear "Progress indicator" or "Button" without context. 
- Sighted users didn't have tooltips when hovering over the "more" action buttons.
- Standardized loading feedback makes the app feel more polished and professional.

### ♿ Accessibility: Any a11y improvements made
- Full screen reader compatibility for all loading states in the Modules feature.
- Proper tooltips for all interactive icon-only elements in the Modules screen.
- Used proper French typography (e.g., "l'équipe", "évaluations") for better clarity.

---
*PR created automatically by Jules for task [4542064155622230437](https://jules.google.com/task/4542064155622230437) started by @kitokoh*