### PR TITLE
🎨 Palette: Improve AbsenceListScreen UX and accessibility

### DIFF
--- a/mobile/lib/features/absences/screens/absence_list_screen.dart
+++ b/mobile/lib/features/absences/screens/absence_list_screen.dart
@@ -23,51 +23,66 @@ class AbsenceListScreen extends ConsumerWidget {
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          tooltip: 'Retour',
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
-      body: absencesAsync.when(
-        data: (absences) => absences.isEmpty
-            ? const EmptyState(
-                icon: Icons.calendar_today,
-                title: 'Aucune absence',
-                description:
-                    'Vous n\'avez pas encore fait de demande d\'absence.',
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(20),
-                itemCount: absences.length,
-                itemBuilder: (context, index) {
-                  final absence = absences[index];
-                  return Card(
-                    color: AppColors.cardDark,
-                    margin: const EdgeInsets.only(bottom: 12),
-                    child: ListTile(
-                      title: Text(
-                        absence.absenceTypeName ?? 'Absence',
-                        style: AppTypography.subtitle.copyWith(
-                          color: AppColors.textDark,
-                        ),
-                      ),
-                      subtitle: Text(
-                        '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
-                        style: AppTypography.bodySmall.copyWith(
-                          color: AppColors.textMutedDark,
-                        ),
-                      ),
-                      trailing: Text(
-                        absence.status,
-                        style: TextStyle(
-                          color: _getStatusColor(absence.status),
-                        ),
-                      ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(absencesProvider.future),
+        child: absencesAsync.when(
+          data: (absences) => absences.isEmpty
+              ? ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [
+                    SizedBox(height: 80),
+                    EmptyState(
+                      icon: Icons.calendar_today,
+                      title: 'Aucune absence',
+                      description:
+                          'Vous n\'avez pas encore fait de demande d\'absence.',
                     ),
-                  );
-                },
-              ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                  ],
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(20),
+                  itemCount: absences.length,
+                  itemBuilder: (context, index) {
+                    final absence = absences[index];
+                    return Card(
+                      color: AppColors.cardDark,
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: ListTile(
+                        title: Text(
+                          absence.absenceTypeName ?? 'Absence',
+                          style: AppTypography.subtitle.copyWith(
+                            color: AppColors.textDark,
+                          ),
+                        ),
+                        subtitle: Text(
+                          '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
+                          style: AppTypography.bodySmall.copyWith(
+                            color: AppColors.textMutedDark,
+                          ),
+                        ),
+                        trailing: Text(
+                          absence.status,
+                          style: TextStyle(
+                            color: _getStatusColor(absence.status),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+          loading: () => const Center(
+            child: CircularProgressIndicator(
+              semanticsLabel: 'Chargement des absences...',
+            ),
+          ),
+          error: (e, _) => Center(
+            child:
+                Text(e.toString(), style: const TextStyle(color: Colors.red)),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
💡 What: Improved the UX and accessibility of the AbsenceListScreen.
🎯 Why: Users need a way to manually refresh their absences, and the interface should be accessible to screen reader users. Pull-to-refresh is a standard mobile pattern that was missing or broken in empty states.
♿ Accessibility: Added ARIA-equivalent tooltips to icon buttons and semantics labels to progress indicators.

---
*PR created automatically by Jules for task [1488159323460809968](https://jules.google.com/task/1488159323460809968) started by @kitokoh*