### PR TITLE
🧹 Janitor: remove stale bot artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [4.1.83] - 2026-05-01
 
+### Janitor - Hygiène du dépôt
+
+- Dépôt : Suppression de l'artefact de bot obsolète `.codex-pr-140` (submodule fantôme) à la racine du dépôt.
+
 ### DocKeeper - Alignement documentation et maintenance
 
 - Dépôt : Nettoyage du `README.md` racine pour supprimer les liens morts vers les documents archivés (`INDEX_CANONIQUE.md`, `EXECUTION_BLOCKERS_AND_NEXT.md`) et consolidation des points d'entrée.


### PR DESCRIPTION
- What was cleaned: Removed the phantom submodule link `.codex-pr-140` from the repository root.
- Why it was safe: It was a non-functional artifact from a bot/AI tool (Codex) that was not referenced in `.gitmodules` and had no actual content.
- What was intentionally not touched: Product code, backend/mobile logic, and other remote branches.
- Verification performed: Verified with `git status` (shows deleted) and `ls` (confirmed gone). Ran `php artisan test` (baseline failures only).
- Rollback plan: `git revert <commit-hash>`. Since it was a phantom submodule, reverting would restore the link in the git index.

---
*PR created automatically by Jules for task [6366067252041580628](https://jules.google.com/task/6366067252041580628) started by @kitokoh*