### PR TITLE
📐 Contractor: [Attendance contract guard - overtime mapping]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - API : renforcement de `api/tests/Feature/Contracts/MobilePayloadContractTest.php` pour verrouiller ce nouveau contrat mobile.
 - Mobile : realignement de `welcome`, `login`, `home` et `modules hub` sur l'experience mobile-first documentee, avec consommation directe du payload backend (`features` + `mobile_experience`).
 - Mobile : ajout des modeles `MobileExperience`, `MobileModule`, `MobileQuickAction` et du mapping d'icones associe pour garder une navigation coherente avec les routes reelles de l'application.
+- Mobile : correction du mapping `overtimeHours` dans `AttendanceRepository.decodeTodayResponse` pour assurer l'alignement avec le contrat API de presence.
 - Web : suppression de la dependance au telechargement Google Fonts au build, correction des effets React penalises par linter, et fallback API aligne sur `https://gestionemployerbackend.onrender.com/api/v1`.
 - Web : remplacement des liens dashboard cassés par de vraies pages RH branchees a l'API pour `employees`, `attendance` et `absences`.
 

--- a/mobile/lib/features/attendance/data/attendance_repository.dart
+++ b/mobile/lib/features/attendance/data/attendance_repository.dart
@@ -145,6 +145,9 @@ class AttendanceRepository {
         workedHours: today['hours_worked'] != null
             ? double.tryParse(today['hours_worked'].toString())
             : 0.0,
+        overtimeHours: today['overtime_hours'] != null
+            ? double.tryParse(today['overtime_hours'].toString())
+            : 0.0,
       ),
       'context': context,
     };


### PR DESCRIPTION
Fixed a contract drift in AttendanceRepository.decodeTodayResponse where overtime_hours was missing from manual AttendanceLog instantiation, causing incorrect data in the mobile app's today status view.

- Endpoint inspected: /api/v1/attendance/today
- Contract issue found: Missing mapping for overtime_hours in the mobile repository's manual decoding logic.
- What was changed: Added overtimeHours mapping in decodeTodayResponse using double.tryParse for robustness.
- Backward compatibility statement: Fully backward compatible; defaults to 0.0 if the field is missing from the API response.
- Tests/verification: Ran flutter analyze and verified backend contract tests pass.
- Rollback plan: git revert this commit.

---
*PR created automatically by Jules for task [12621398302964420801](https://jules.google.com/task/12621398302964420801) started by @kitokoh*