### PR TITLE
🎨 Palette: micro accessibility improvement for History screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - API : renforcement de `api/tests/Feature/Contracts/MobilePayloadContractTest.php` pour verrouiller ce nouveau contrat mobile.
 - Mobile : realignement de `welcome`, `login`, `home` et `modules hub` sur l'experience mobile-first documentee, avec consommation directe du payload backend (`features` + `mobile_experience`).
 - Mobile : ajout des modeles `MobileExperience`, `MobileModule`, `MobileQuickAction` et du mapping d'icones associe pour garder une navigation coherente avec les routes reelles de l'application.
+- Mobile : amélioration de l'accessibilité de l'écran d'historique de présence avec des labels `Semantics` unifiés pour les lecteurs d'écran.
 - Web : suppression de la dependance au telechargement Google Fonts au build, correction des effets React penalises par linter, et fallback API aligne sur `https://gestionemployerbackend.onrender.com/api/v1`.
 - Web : remplacement des liens dashboard cassés par de vraies pages RH branchees a l'API pour `employees`, `attendance` et `absences`.
 

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -218,27 +218,53 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                           break;
                       }
 
-                      return ListTile(
-                        leading: CircleAvatar(
-                          backgroundColor: statusColor.withValues(alpha: 0.2),
-                          child: Icon(
-                            Icons.circle,
-                            color: statusColor,
-                            size: 12,
+                      final statusLabel = switch (log.status) {
+                        'ontime' => 'à l\'heure',
+                        'late' => 'en retard',
+                        'absent' => 'absent',
+                        _ => log.status,
+                      };
+
+                      final hours = log.workedHours ?? 0;
+                      final hoursLabel = hours <= 1 ? 'heure travaillée' : 'heures travaillées';
+
+                      final timeInfo = log.checkIn != null
+                          ? ' de ${log.checkIn!.hour}h${log.checkIn!.minute.toString().padLeft(2, '0')} à '
+                              '${log.checkOut != null ? "${log.checkOut!.hour}h${log.checkOut!.minute.toString().padLeft(2, '0')}" : "en cours"}'
+                          : '';
+
+                      final semanticLabel =
+                          'Journée du ${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}, statut $statusLabel,$timeInfo $hours $hoursLabel.';
+
+                      return Semantics(
+                        label: semanticLabel,
+                        container: true,
+                        child: ExcludeSemantics(
+                          child: ListTile(
+                            leading: CircleAvatar(
+                              backgroundColor:
+                                  statusColor.withValues(alpha: 0.2),
+                              child: Icon(
+                                Icons.circle,
+                                color: statusColor,
+                                size: 12,
+                              ),
+                            ),
+                            title: Text(
+                              '${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}',
+                            ),
+                            subtitle: Text(
+                              log.checkIn != null
+                                  ? '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} -> '
+                                      '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}'
+                                  : 'Absence',
+                            ),
+                            trailing: Text(
+                              '${log.workedHours ?? 0}h',
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
                           ),
-                        ),
-                        title: Text(
-                          '${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}',
-                        ),
-                        subtitle: Text(
-                          log.checkIn != null
-                              ? '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} -> '
-                                  '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}'
-                              : 'Absence',
-                        ),
-                        trailing: Text(
-                          '${log.workedHours ?? 0}h',
-                          style: const TextStyle(fontWeight: FontWeight.bold),
                         ),
                       );
                     },


### PR DESCRIPTION
### What changed
Wrapped the `ListTile` items in the `HistoryScreen` with a `Semantics` widget to provide a unified, descriptive label in French. Each entry now announces the date, status, check-in/out times (if available), and worked hours in a single logical sentence. Children widgets of the `ListTile` are wrapped in `ExcludeSemantics` to avoid redundancy. Correct French pluralization for "heure travaillée" is handled.

### Why it helps users
Previously, screen readers would announce the internal icons, fragments of text, and timestamps separately, making it difficult for non-visual users to quickly grasp their attendance history. This change provides a clear, professional summary of each record.

### Accessibility impact
Significantly improves the screen-reader experience on the History screen, making it compliant with best practices for mobile accessibility.

### Verification performed
- `flutter analyze` passed.
- `flutter test` passed (including existing history screen tests).
- Code inspection verified correct implementation of `Semantics` and `ExcludeSemantics`.
- Lock file stability verified (reverted unintended downgrades).

### Rollback plan
Revert the commit on the `main` branch or this feature branch. No database or API changes are involved.

---
*PR created automatically by Jules for task [12628802140645499955](https://jules.google.com/task/12628802140645499955) started by @kitokoh*