### PR TITLE
🎨 Palette: Improve Payroll List UX & Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@ This journal contains critical UX and accessibility learnings for the Leopardo R
 ## 2026-05-20 - Pull-to-Refresh in Empty States
 **Learning:** In Flutter, `RefreshIndicator` only works with scrollable widgets. When a screen is in an empty or error state, it often loses its scrollability, making it impossible for users to refresh.
 **Action:** Always wrap `EmptyState` or error messages in a `ListView` or `SingleChildScrollView` with `physics: AlwaysScrollableScrollPhysics()` to ensure pull-to-refresh remains functional. Use a `SizedBox(height: 80)` as the first child for consistent spacing.
+
+## 2026-05-24 - Navigation & A11y Polish
+**Learning:** Standardizing back buttons with `context.pop()` and tooltips provides a consistent feel and better accessibility for screen readers. `RefreshIndicator` is expected on most list screens in the Leopardo app.
+**Action:** Include `tooltip: 'Retour'`, `context.pop()`, and `RefreshIndicator` on all new or updated list-based feature screens.

--- a/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
+++ b/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
@@ -23,49 +24,66 @@ class PayrollListScreen extends ConsumerWidget {
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          onPressed: () => Navigator.of(context).pop(),
+          tooltip: 'Retour',
+          onPressed: () => context.pop(),
         ),
       ),
-      body: payrollsAsync.when(
-        data: (payrolls) => payrolls.isEmpty
-            ? const EmptyState(
-                icon: Icons.description,
-                title: 'Aucune fiche de paie',
-                description:
-                    'Vos fiches de paie apparaîtront ici dès qu\'elles seront validées.',
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(20),
-                itemCount: payrolls.length,
-                itemBuilder: (context, index) {
-                  final payroll = payrolls[index];
-                  return Card(
-                    color: AppColors.cardDark,
-                    margin: const EdgeInsets.only(bottom: 12),
-                    child: ListTile(
-                      title: Text(
-                        'Mois: ${payroll.month}/${payroll.year}',
-                        style: AppTypography.subtitle.copyWith(
-                          color: AppColors.textDark,
-                        ),
-                      ),
-                      subtitle: Text(
-                        'Salaire Net: ${payroll.netSalary} DZD',
-                        style: AppTypography.bodySmall.copyWith(
-                          color: AppColors.textMutedDark,
-                        ),
-                      ),
-                      trailing: const Icon(
-                        Icons.download,
-                        color: AppColors.info,
-                      ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(payrollsProvider.future),
+        child: payrollsAsync.when(
+          data: (payrolls) => payrolls.isEmpty
+              ? ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [
+                    SizedBox(height: 80),
+                    EmptyState(
+                      icon: Icons.description,
+                      title: 'Aucune fiche de paie',
+                      description:
+                          'Vos fiches de paie apparaîtront ici dès qu\'elles seront validées.',
                     ),
-                  );
-                },
-              ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                  ],
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(20),
+                  itemCount: payrolls.length,
+                  itemBuilder: (context, index) {
+                    final payroll = payrolls[index];
+                    return Card(
+                      color: AppColors.cardDark,
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: ListTile(
+                        title: Text(
+                          'Mois: ${payroll.month}/${payroll.year}',
+                          style: AppTypography.subtitle.copyWith(
+                            color: AppColors.textDark,
+                          ),
+                        ),
+                        subtitle: Text(
+                          'Salaire Net: ${payroll.netSalary} DZD',
+                          style: AppTypography.bodySmall.copyWith(
+                            color: AppColors.textMutedDark,
+                          ),
+                        ),
+                        trailing: const Icon(
+                          Icons.download,
+                          color: AppColors.info,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+          loading: () => const Center(
+            child: CircularProgressIndicator(
+              semanticsLabel: 'Chargement des fiches de paie...',
+            ),
+          ),
+          error: (e, _) => Center(
+            child: Text(
+              e.toString(),
+              style: const TextStyle(color: Colors.red),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
💡 What: Improved the `PayrollListScreen` by adding pull-to-refresh, standardizing navigation, and enhancing accessibility.

🎯 Why: Users expect to be able to refresh their payroll list, and icon-only buttons need tooltips for better accessibility.

♿ Accessibility:
- Added `tooltip: 'Retour'` to the back button.
- Added `semanticsLabel: 'Chargement des fiches de paie...'` to the `CircularProgressIndicator`.
- Ensured pull-to-refresh works in the empty state by wrapping it in a scrollable view with `AlwaysScrollableScrollPhysics`.
- Updated navigation to use `context.pop()`.

---
*PR created automatically by Jules for task [11670233043823622811](https://jules.google.com/task/11670233043823622811) started by @kitokoh*