### PR TITLE
🛡️ Sentinel: harden index validation and add salary advance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - API : protection des creations d'absences et de bulletins contre les references inter-tenant via des validations `exists` scopees au `company_id` courant.
 - Tests : ajout de `api/tests/Feature/Security/CrossTenantValidationTest.php` et enrichissement de `CreatesMvpSchema` pour couvrir correctement `payrolls`, `payment_method` et `leave_balance`.
 
+### Sentinel - Sécurisation des index et tests de régression Salary Advance
+
+- API : Durcissement des requêtes de liste (IndexRequest) pour les modules `Absences`, `Payroll`, `Attendance` et `SalaryAdvances` via l'ajout d'une validation `exists` systématiquement scopée au tenant de l'utilisateur pour le champ `employee_id`.
+- Tests : Création de `SalaryAdvanceSecurityTest.php` pour verrouiller l'isolation inter-tenant et le RBAC du module des avances sur salaire.
+- Tests : Ajout de tests de régression dans `AbsenceIndexTest` et `TodayAndHistoryTest` pour vérifier la protection contre le filtrage par `employee_id` hors-tenant.
+
 ### Mobile - Contrat attendance et UX absences
 
 - Mobile : parsing de `photo_url`, `hire_date`, `overtime_hours` et `late_minutes` aligne sur les payloads backend actuels.

--- a/api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Absence;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AbsenceIndexRequest extends FormRequest
 {
@@ -14,7 +15,12 @@ class AbsenceIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'employee_id' => ['nullable', 'integer', 'min:1'],
+            'employee_id' => [
+                'nullable',
+                'integer',
+                'min:1',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
             'status' => ['nullable', 'in:pending,approved,rejected,cancelled'],
             'month' => ['nullable', 'integer', 'between:1,12'],
             'year' => ['nullable', 'integer', 'min:2000'],

--- a/api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AttendanceIndexRequest extends FormRequest
 {
@@ -14,7 +15,12 @@ class AttendanceIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'employee_id' => ['nullable', 'integer', 'min:1'],
+            'employee_id' => [
+                'nullable',
+                'integer',
+                'min:1',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
             'date_from' => ['nullable', 'date_format:Y-m-d'],
             'date_to' => ['nullable', 'date_format:Y-m-d'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],

--- a/api/app/Http/Requests/Api/V1/Payroll/PayrollIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Payroll/PayrollIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Payroll;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PayrollIndexRequest extends FormRequest
 {
@@ -13,6 +14,17 @@ class PayrollIndexRequest extends FormRequest
 
     public function rules(): array
     {
-        return ['employee_id' => ['nullable', 'integer', 'min:1'], 'month' => ['nullable', 'integer', 'between:1,12'], 'year' => ['nullable', 'integer', 'min:2000'], 'status' => ['nullable', 'in:draft,validated'], 'per_page' => ['nullable', 'integer', 'min:1', 'max:100']];
+        return [
+            'employee_id' => [
+                'nullable',
+                'integer',
+                'min:1',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'month' => ['nullable', 'integer', 'between:1,12'],
+            'year' => ['nullable', 'integer', 'min:2000'],
+            'status' => ['nullable', 'in:draft,validated'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
     }
 }

--- a/api/app/Http/Requests/Api/V1/SalaryAdvance/SalaryAdvanceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/SalaryAdvance/SalaryAdvanceIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\SalaryAdvance;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class SalaryAdvanceIndexRequest extends FormRequest
 {
@@ -13,6 +14,15 @@ class SalaryAdvanceIndexRequest extends FormRequest
 
     public function rules(): array
     {
-        return ['employee_id' => ['nullable', 'integer', 'min:1'], 'status' => ['nullable', 'in:pending,approved,rejected,active,repaid'], 'per_page' => ['nullable', 'integer', 'min:1', 'max:100']];
+        return [
+            'employee_id' => [
+                'nullable',
+                'integer',
+                'min:1',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'status' => ['nullable', 'in:pending,approved,rejected,active,repaid'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
     }
 }

--- a/api/tests/Feature/Absences/AbsenceIndexTest.php
+++ b/api/tests/Feature/Absences/AbsenceIndexTest.php
@@ -298,6 +298,21 @@ class AbsenceIndexTest extends TestCase
         $response->assertJsonPath('data.0.employee_id', $employee1->id);
     }
 
+    public function test_manager_cannot_filter_by_another_tenant_employee_id(): void
+    {
+        $companyA = Company::factory()->create();
+        $companyB = Company::factory()->create();
+        $managerA = Employee::factory()->create(['company_id' => $companyA->id, 'role' => 'manager', 'manager_role' => 'principal']);
+        $employeeB = Employee::factory()->create(['company_id' => $companyB->id]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson("/api/v1/absences?employee_id={$employeeB->id}");
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
     public function test_filter_by_status(): void
     {
         $company = Company::query()->create([

--- a/api/tests/Feature/Attendance/TodayAndHistoryTest.php
+++ b/api/tests/Feature/Attendance/TodayAndHistoryTest.php
@@ -240,4 +240,20 @@ class TodayAndHistoryTest extends TestCase
         $resp->assertOk();
         $this->assertSame([], $resp->json('data'));
     }
+
+    public function test_manager_cannot_filter_attendance_history_by_another_tenant_employee_id(): void
+    {
+        $companyA = Company::factory()->create();
+        $companyB = Company::factory()->create();
+
+        $managerA = Employee::factory()->create(['company_id' => $companyA->id, 'role' => 'manager', 'manager_role' => 'principal']);
+        $employeeB = Employee::factory()->create(['company_id' => $companyB->id]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson("/api/v1/attendance?employee_id={$employeeB->id}");
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
 }

--- a/api/tests/Feature/Security/SalaryAdvanceSecurityTest.php
+++ b/api/tests/Feature/Security/SalaryAdvanceSecurityTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\SalaryAdvance;
+use Illuminate\Support\Str;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class SalaryAdvanceSecurityTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_employee_can_only_see_their_own_salary_advances(): void
+    {
+        $company = $this->createCompany('Company A');
+        $employee1 = $this->createEmployee($company, 'employee');
+        $employee2 = $this->createEmployee($company, 'employee');
+
+        SalaryAdvance::query()->forceCreate([
+            'company_id' => $company->id,
+            'employee_id' => $employee1->id,
+            'amount' => 500,
+            'status' => 'pending',
+        ]);
+
+        SalaryAdvance::query()->forceCreate([
+            'company_id' => $company->id,
+            'employee_id' => $employee2->id,
+            'amount' => 1000,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($employee1, 'sanctum')
+            ->getJson('/api/v1/salary-advances');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.employee_id', $employee1->id);
+    }
+
+    public function test_manager_can_only_see_salary_advances_within_their_company(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = $this->createEmployee($companyA, 'manager', 'principal');
+        $employeeA = $this->createEmployee($companyA, 'employee');
+        $employeeB = $this->createEmployee($companyB, 'employee');
+
+        SalaryAdvance::query()->forceCreate([
+            'company_id' => $companyA->id,
+            'employee_id' => $employeeA->id,
+            'amount' => 500,
+            'status' => 'pending',
+        ]);
+
+        SalaryAdvance::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'employee_id' => $employeeB->id,
+            'amount' => 1000,
+            'status' => 'pending',
+        ]);
+
+        // Manager A should only see advance for Employee A
+        $response = $this->actingAs($managerA, 'sanctum')
+            ->getJson('/api/v1/salary-advances');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.employee_id', $employeeA->id);
+    }
+
+    public function test_manager_cannot_view_salary_advance_of_another_tenant(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = $this->createEmployee($companyA, 'manager', 'principal');
+        $employeeB = $this->createEmployee($companyB, 'employee');
+
+        $advanceB = SalaryAdvance::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'employee_id' => $employeeB->id,
+            'amount' => 1000,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($managerA, 'sanctum')
+            ->getJson("/api/v1/salary-advances/{$advanceB->id}");
+
+        $response->assertStatus(404);
+    }
+
+    public function test_manager_cannot_approve_salary_advance_of_another_tenant(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = $this->createEmployee($companyA, 'manager', 'principal');
+        $employeeB = $this->createEmployee($companyB, 'employee');
+
+        $advanceB = SalaryAdvance::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'employee_id' => $employeeB->id,
+            'amount' => 1000,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($managerA, 'sanctum')
+            ->putJson("/api/v1/salary-advances/{$advanceB->id}/approve", [
+                'repayment_months' => 3
+            ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_employee_cannot_cancel_salary_advance_of_another_employee(): void
+    {
+        $company = $this->createCompany('Company A');
+        $employee1 = $this->createEmployee($company, 'employee');
+        $employee2 = $this->createEmployee($company, 'employee');
+
+        $advance2 = SalaryAdvance::query()->forceCreate([
+            'company_id' => $company->id,
+            'employee_id' => $employee2->id,
+            'amount' => 500,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($employee1, 'sanctum')
+            ->deleteJson("/api/v1/salary-advances/{$advance2->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_manager_cannot_filter_by_another_tenant_employee_id(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = $this->createEmployee($companyA, 'manager', 'principal');
+        $employeeB = $this->createEmployee($companyB, 'employee');
+
+        $response = $this->actingAs($managerA, 'sanctum')
+            ->getJson("/api/v1/salary-advances?employee_id={$employeeB->id}");
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    public function test_non_manager_cannot_approve_salary_advance(): void
+    {
+        $company = $this->createCompany('Company A');
+        $employee = $this->createEmployee($company, 'employee');
+
+        $advance = SalaryAdvance::query()->forceCreate([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'amount' => 500,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($employee, 'sanctum')
+            ->putJson("/api/v1/salary-advances/{$advance->id}/approve", [
+                'repayment_months' => 3
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    private function createCompany(string $name): Company
+    {
+        return Company::query()->create([
+            'id' => (string) Str::uuid(),
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'sector' => 'test',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => strtolower(Str::random(8)).'@test.com',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+    }
+
+    private function createEmployee(Company $company, string $role, ?string $managerRole = null): Employee
+    {
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => $role,
+            'manager_role' => $managerRole,
+            'email' => strtolower(Str::random(10)).'@test.com',
+            'password_hash' => bcrypt('password'),
+            'status' => 'active',
+        ]);
+
+        return $employee;
+    }
+}


### PR DESCRIPTION
**Severity: LOW**

This PR implements a defense-in-depth security enhancement by tightening the input validation for resource listing endpoints. 

### What changed
- Added `Rule::exists('employees', 'id')->where('company_id', $companyId)` to the `employee_id` field in:
    - `SalaryAdvanceIndexRequest`
    - `AbsenceIndexRequest`
    - `PayrollIndexRequest`
    - `AttendanceIndexRequest`
- Created `api/tests/Feature/Security/SalaryAdvanceSecurityTest.php` to lock in security behavior for the Salary Advance module (isolation, RBAC).
- Added cross-tenant filtering regression tests to `AbsenceIndexTest.php` and `TodayAndHistoryTest.php`.

### Why it is safe for MVP
These changes do not modify the core business logic or response shapes for legitimate users. They only ensure that the API returns a standard `422` validation error instead of an empty set when a user attempts to filter by an `employee_id` that does not belong to their company. This is a standard security best practice for multi-tenant applications.

### Tests/verification
- Verified with new `SalaryAdvanceSecurityTest.php` (7 tests).
- Verified with updated `AbsenceIndexTest.php` and `TodayAndHistoryTest.php`.
- Verified all security tests pass with `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter Security`.
- Verified system integrity with a subset of feature tests.

### Rollback plan
- `git revert` this commit. No database migrations were added.

---
*PR created automatically by Jules for task [15225685510272392956](https://jules.google.com/task/15225685510272392956) started by @kitokoh*