### PR TITLE
🧪 Scout: [MVP regression test] Salary Advance isolation and RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@
 
 ## [4.1.85] - 2026-05-02
 
+### Scout - Tests de régression MVP (Salary Advances)
+
+- Tests : Ajout de `api/tests/Feature/Security/SalaryAdvanceSecurityTest.php` pour verrouiller l'isolation inter-tenant et les règles RBAC du module d'avances sur salaire.
+- Sécurité : Identification d'une absence de validation tenant-scoped sur `employee_id` dans `SalaryAdvanceIndexRequest`, permettant potentiellement le probing d'IDs d'autres entreprises (comportement rapporté pour correction).
+
 ### Contractor - Alignement contrat API/mobile (attendance today)
 
 - API : Mise à jour de `AttendanceTodayResource` pour inclure l'ID du pointage (`id`) et les minutes de retard (`late_minutes`), alignant ainsi le payload `/api/v1/attendance/today` et `/api/v1/me/daily-summary` sur les attentes des modèles mobiles.

--- a/api/tests/Feature/Security/SalaryAdvanceSecurityTest.php
+++ b/api/tests/Feature/Security/SalaryAdvanceSecurityTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\SalaryAdvance;
+use Illuminate\Support\Str;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class SalaryAdvanceSecurityTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_manager_cannot_filter_salary_advances_by_another_tenant_employee_id(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = $this->createEmployee($companyA, 'manager', 'principal');
+        $employeeB = $this->createEmployee($companyB, 'employee');
+
+        // This should return 422 because employeeB doesn't belong to companyA
+        $response = $this->actingAs($managerA, 'sanctum')
+            ->getJson("/api/v1/salary-advances?employee_id={$employeeB->id}");
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    public function test_employee_cannot_see_others_salary_advances(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $employeeA1 = $this->createEmployee($companyA, 'employee');
+        $employeeA2 = $this->createEmployee($companyA, 'employee');
+
+        SalaryAdvance::query()->create([
+            'company_id' => $companyA->id,
+            'employee_id' => $employeeA2->id,
+            'amount' => 500,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($employeeA1, 'sanctum')
+            ->getJson('/api/v1/salary-advances');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(0, 'data');
+    }
+
+    public function test_cross_tenant_access_to_salary_advance_detail_returns_404(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = $this->createEmployee($companyA, 'manager', 'principal');
+        $employeeB = $this->createEmployee($companyB, 'employee');
+
+        $advanceB = SalaryAdvance::query()->create([
+            'company_id' => $companyB->id,
+            'employee_id' => $employeeB->id,
+            'amount' => 1000,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($managerA, 'sanctum')
+            ->getJson("/api/v1/salary-advances/{$advanceB->id}");
+
+        $response->assertStatus(404);
+    }
+
+    private function createCompany(string $name): Company
+    {
+        return Company::query()->create([
+            'id' => (string) Str::uuid(),
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'sector' => 'test',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => strtolower(Str::random(8)).'@test.com',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+    }
+
+    private function createEmployee(Company $company, string $role, ?string $managerRole = null): Employee
+    {
+        return Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => $role,
+            'manager_role' => $managerRole,
+            'email' => strtolower(Str::random(10)).'@test.com',
+            'password_hash' => bcrypt('password'),
+            'status' => 'active',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a focused regression test suite for the Salary Advance module, focusing on tenant isolation and RBAC.

### Behavior Protected
- **Tenant Isolation (List):** Managers should only be able to filter by employees belonging to their company.
- **Tenant Isolation (Detail):** Accessing a Salary Advance ID from another tenant must return a 404.
- **RBAC (Employee):** Regular employees must not be able to see salary advances of other employees, even within the same company.

### Why it matters for MVP
Salary advances are sensitive financial data. Post-MVP stability requires that multi-tenant isolation is strictly enforced to prevent data leaks or unauthorized probing of employee IDs across companies.

### Test Added
`api/tests/Feature/Security/SalaryAdvanceSecurityTest.php`

### Verification Results
Tests run with SQLite:
- `test_manager_cannot_filter_salary_advances_by_another_tenant_employee_id`: **FAIL** (Expected 422, got 200 - confirming the missing validation guard).
- `test_employee_cannot_see_others_salary_advances`: **PASS**
- `test_cross_tenant_access_to_salary_advance_detail_returns_404`: **PASS**

### Rollback Plan
`git checkout main api/tests/Feature/Security/SalaryAdvanceSecurityTest.php CHANGELOG.md` or simply delete the new test file.

---
*PR created automatically by Jules for task [18400632345370102818](https://jules.google.com/task/18400632345370102818) started by @kitokoh*