### PR TITLE
🎨 Palette: Unified semantics for attendance history items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Mobile : parsing de `photo_url`, `hire_date`, `overtime_hours` et `late_minutes` aligne sur les payloads backend actuels.
 - Mobile : `AbsenceListScreen` gagne le pull-to-refresh, un meilleur etat vide scrollable et de petites ameliorations d'accessibilite.
+- Mobile : Amelioration de l'accessibilite de `HistoryScreen` par le regroupement des informations de pointage dans un label `Semantics` unique.
 
 ### Depot - Hygiene
 

--- a/mobile/lib/features/attendance/screens/history_screen.dart
+++ b/mobile/lib/features/attendance/screens/history_screen.dart
@@ -218,27 +218,54 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                           break;
                       }
 
-                      return ListTile(
-                        leading: CircleAvatar(
-                          backgroundColor: statusColor.withValues(alpha: 0.2),
-                          child: Icon(
-                            Icons.circle,
-                            color: statusColor,
-                            size: 12,
+                      String statusLabel = 'à l\'heure';
+                      if (log.status == 'late') statusLabel = 'en retard';
+                      if (log.status == 'absent') statusLabel = 'absent';
+
+                      final dateStr =
+                          '${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}';
+                      final semanticLabel = log.checkIn != null
+                          ? 'Journée du $dateStr, statut $statusLabel, de '
+                              '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} à '
+                              '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}, '
+                              '${log.workedHours ?? 0} heures travaillées'
+                          : 'Journée du $dateStr, statut absent';
+
+                      return Semantics(
+                        label: semanticLabel,
+                        container: true,
+                        child: ListTile(
+                          leading: ExcludeSemantics(
+                            child: CircleAvatar(
+                              backgroundColor:
+                                  statusColor.withValues(alpha: 0.2),
+                              child: Icon(
+                                Icons.circle,
+                                color: statusColor,
+                                size: 12,
+                              ),
+                            ),
                           ),
-                        ),
-                        title: Text(
-                          '${log.date.day.toString().padLeft(2, '0')}/${log.date.month.toString().padLeft(2, '0')}',
-                        ),
-                        subtitle: Text(
-                          log.checkIn != null
-                              ? '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} -> '
-                                  '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}'
-                              : 'Absence',
-                        ),
-                        trailing: Text(
-                          '${log.workedHours ?? 0}h',
-                          style: const TextStyle(fontWeight: FontWeight.bold),
+                          title: ExcludeSemantics(
+                            child: Text(
+                              dateStr,
+                            ),
+                          ),
+                          subtitle: ExcludeSemantics(
+                            child: Text(
+                              log.checkIn != null
+                                  ? '${log.checkIn!.hour.toString().padLeft(2, '0')}:${log.checkIn!.minute.toString().padLeft(2, '0')} -> '
+                                      '${log.checkOut != null ? "${log.checkOut!.hour.toString().padLeft(2, '0')}:${log.checkOut!.minute.toString().padLeft(2, '0')}" : "En cours"}'
+                                  : 'Absence',
+                            ),
+                          ),
+                          trailing: ExcludeSemantics(
+                            child: Text(
+                              '${log.workedHours ?? 0}h',
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ),
                         ),
                       );
                     },


### PR DESCRIPTION
Improve accessibility of HistoryScreen by grouping attendance log details into a single semantic unit. This ensures screen readers provide a coherent announcement (date, status, times, and hours) for each entry instead of fragmented elements.

What changed:
- Wrapped ListTile in Semantics with container: true in HistoryScreen.
- Added unified French semantic label construction logic.
- Excluded internal widgets from semantics to avoid redundancy.

Why it helps users: Grouping related information makes it much easier for non-visual users to understand their attendance history without navigating multiple focus points per row.

Accessibility impact: Coherent French announcements.

Verification performed:
- flutter analyze
- flutter test
- manual logic review

Rollback plan: git revert the commit.

---
*PR created automatically by Jules for task [15079514155523150852](https://jules.google.com/task/15079514155523150852) started by @kitokoh*