### PR TITLE
📚 DocKeeper: [documentation alignment]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.86] - 2026-05-03
+
+### DocKeeper - Alignement documentation
+
+- Ops : Mise à jour du `docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md` (v1.1) pour l'aligner sur l'infrastructure Render + Neon (PaaS), remplaçant les instructions VPS obsolètes.
+- Gouvernance : Synchronisation de `PROGRAM_VERSION` à `4.1.86` dans `PILOTAGE.md`, `CHANGELOG.md`, `docs/README.md` et `api/config/app.php`.
+- Gouvernance : Mise à jour de la date de dernière mise à jour dans `PILOTAGE.md` (2026-05-03).
+
 ## [4.1.84] - 2026-04-30 
 
 ### API / Mobile / Web - Experience client alignee et modernisee

--- a/PILOTAGE.md
+++ b/PILOTAGE.md
@@ -47,9 +47,9 @@ MVP : "Combien je dois à mes employés aujourd'hui ?" — en 1 clic.
 ## ÉTAT ACTUEL
 
 ```
-Date MAJ       : 2026-05-02
+Date MAJ       : 2026-05-03
 Conception     : ✅ Terminée (40+ documents dans docs/dossierdeConception/ + README d'orientation)
-Code           : ✅ `main` inclut le MVP livré + i18n + hardening P0/P1/P2 + salary advances + payroll RH (voir CHANGELOG.md jusqu'à 4.1.85)
+Code           : ✅ `main` inclut le MVP livré + i18n + hardening P0/P1/P2 + salary advances + payroll RH (voir CHANGELOG.md jusqu'à 4.1.86)
 Phase active   : Stabilisation beta + gouvernance documentaire + durcissement progressif (voir docs/REFERENTIEL_PRODUIT/ROADMAP.md)
                  Note: la section "SCOPE MVP VERROUILLÉ" plus bas reflète
                  le scope initial figé, pas l'état actuel du code.

--- a/docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md
+++ b/docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md
@@ -1,60 +1,50 @@
 # RUNBOOK BETA ENV SETUP
-# Version 1.0 | 2026-04-06
+# Version 1.1 | 2026-05-03
 
-But: preparer un environnement Beta exploitable avant la recette humaine.
+But: preparer un environnement Beta exploitable sur infrastructure Render + Neon.
 
-## Checklist infrastructure
+## Checklist infrastructure (Render + Neon)
 
-- VPS cree et accessible en SSH
-- Domaine ou sous-domaine pointe vers le VPS
-- TLS actif
-- PostgreSQL accessible
-- PHP/FPM et serveur web actifs
-- dossier `storage/` accessible en ecriture
-- dossier `bootstrap/cache/` accessible en ecriture
+- [ ] Compte Neon.tech actif avec base PostgreSQL 16
+- [ ] Connection string Neon recuperee (DB_URL)
+- [ ] Web Service Render cree avec Docker context `api/`
+- [ ] Dockerfile path positionne sur `Dockerfile.prod`
+- [ ] Instance type positionne sur `Free` ou `Starter`
+- [ ] Health Check Path positionne sur `/api/v1/health`
+- [ ] Auto-Deploy GitHub desactive (pilotage par workflow `deploy-main.yml`)
 
-## Checklist application
+## Checklist application (Variables d'environnement Render)
 
-- Code de `main` deploie
-- `composer install --no-dev --optimize-autoloader` execute
-- `php artisan key:generate` execute si environnement neuf
-- `php artisan migrate --force` execute
-- `php artisan config:cache` execute
-- `php artisan route:cache` execute
-- `php artisan view:cache` execute
+- [ ] `APP_KEY` positionnee
+- [ ] `DB_CONNECTION=pgsql`
+- [ ] `DB_URL` (Connection string Neon avec sslmode=require)
+- [ ] `DB_SEARCH_PATH=shared_tenants,public`
+- [ ] `APP_ENV=production`
+- [ ] `APP_DEBUG=false`
+- [ ] `RUN_MIGRATIONS=true` (pour le premier bootstrap)
+- [ ] `FILESYSTEM_DISK=local`
+- [ ] `TENANCY_DEFAULT_TYPE=shared`
 
-## Variables d'environnement MVP attendues
+## Donnees minimales de recette (Seeders)
 
-- `APP_ENV=production`
-- `APP_DEBUG=false`
-- `DB_CONNECTION=pgsql`
-- `CACHE_STORE=file`
-- `SESSION_DRIVER=file`
-- `QUEUE_CONNECTION=sync`
-- `FILESYSTEM_DISK=local`
-- `TENANCY_DEFAULT_TYPE=shared`
-
-## Donnees minimales de recette
-
-- 1 company active
-- 1 manager actif
-- 1 employee actif
-- 1 ou 2 logs de pointage existants pour verifier dashboard, historique et PDF
+- [ ] `php artisan db:seed --class=DatabaseSeeder` execute (via bootstrap Render)
+- [ ] `DEMO_SEED_ONCE=true` active pour injecter le jeu de donnees pilote
+- [ ] Verifier presence des managers de demo (Ahmed, Fatima)
+- [ ] Verifier presence de l'employe de demo (Karim)
 
 ## Verification express
 
-- `GET /api/v1/health` -> 200
-- `GET /login` -> 200
-- login manager -> redirect `/dashboard`
-- fiche employe accessible
-- quick estimate OK
-- PDF OK
+- [ ] `GET /api/v1/health` -> 200 (checks database: ok)
+- [ ] `GET /login` -> 200
+- [ ] Login manager -> redirect `/dashboard`
+- [ ] Consultation employe -> ok
+- [ ] Generation PDF recu -> ok (DomPDF test)
 
-## Blocage immediate
+## Blocage immediat
 
 Stop Beta si:
-- login impossible
-- erreur 500 sur dashboard
-- PDF KO
-- fuite tenant
-- RBAC manager/employee incoherent
+- Login impossible (401/500)
+- Erreur 500 persistante sur le dashboard
+- PDF corrompu ou vide
+- Fuite de donnees inter-tenant (Isolation Test KO)
+- `search_path` non respecte (relation "employees" not found)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # LEOPARDO RH - Documentation Technique
-## Version documentaire 4.1.85 | Mai 2026
+## Version documentaire 4.1.86 | Mai 2026
 ## Reference programme : `PILOTAGE.md` fait foi
 
 ---


### PR DESCRIPTION
### 📚 DocKeeper: documentation alignment

#### What changed
- **Runbook Update**: `docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md` updated to v1.1. Outdated VPS/SSH manual setup steps were replaced with modern Render/Neon PaaS instructions (Docker context, environment variables, health checks).
- **Version Synchronization**: Synchronized `PROGRAM_VERSION` to `4.1.86` across `PILOTAGE.md`, `CHANGELOG.md`, and `docs/README.md`.
- **Status Alignment**: Updated the `Code : ✅` status line in `PILOTAGE.md` to point to version `4.1.86`.

#### Why it was outdated/confusing
The Beta environment setup guide was still referencing Phase 0 VPS infrastructure, which contradicted the "GO MVP" decision to use Render and Neon. This drift could lead to setup failures for pilot environments.

#### Source of truth used
- `docs/GESTION_PROJET/GO_NO_GO_MVP.md` (Priority #8)
- `docs/GESTION_PROJET/RENDER_SETUP.md`
- `PILOTAGE.md` (Operational source of truth)

#### Verification performed
- **Backend Tests**: `php artisan test --testsuite=Unit` passed (11/11).
- **Mobile Tests**: `flutter test` passed (10/10).
- **Governance**: `git diff --check` passed. Verified file existence and version markers via `grep`.
- **Validation**: Confirmed `api/config/app.php` is already at `4.1.86`.

#### Rollback plan
`git revert` of this PR. Documentation changes are low-risk and do not affect application logic.

---
*PR created automatically by Jules for task [528929335822892667](https://jules.google.com/task/528929335822892667) started by @kitokoh*