### PR TITLE
🛡️ Sentinel: Enforce tenant isolation in HR index filters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Raw string interpolation of `$company->schema_name` into `DB::statement("SET search_path TO ...")` calls across multiple controllers and requests.
 **Learning:** Even internal metadata like schema names can become an injection vector if not properly sanitized, especially in multi-tenant architectures where schema names might be derived from user-controlled or less-trusted fields. Since schema identifiers cannot be parameterized in standard SQL, they must be rigorously whitelisted and quoted.
 **Prevention:** Always use a central, secure helper like `Company::getSafeSearchPath()` which enforces a strict alphanumeric/underscore whitelist and applies double-quoting to identifiers. Never trust model fields in raw `DB::statement` calls.
+
+## 2026-05-04 - IDOR in Multi-tenant Index Filters
+**Vulnerability:** Many index endpoints (Absences, Payroll, etc.) allowed filtering by `employee_id` without validating that the target employee belonged to the requester's company.
+**Learning:** Global scopes (like `BelongsToCompany`) protect the *results* of a query, but they don't necessarily prevent validation-layer probing. An attacker could potentially confirm the existence of an ID in another tenant if the validator doesn't scope its `exists` checks.
+**Prevention:** Always scope foreign key validation in Request classes. Use `Rule::exists('table', 'id')->where('company_id', $user->company_id)` for any user-provided IDs used in filters or commands.

--- a/api/app/Http/Controllers/Api/V1/EvaluationController.php
+++ b/api/app/Http/Controllers/Api/V1/EvaluationController.php
@@ -7,6 +7,7 @@ use App\Models\Evaluation;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
 
 /**
  * Module 7 (complément) — Evaluations
@@ -24,8 +25,16 @@ class EvaluationController extends Controller
         $actor = $request->user();
 
         $request->validate([
-            'employee_id' => ['nullable', 'integer', 'min:1'],
-            'evaluator_id' => ['nullable', 'integer', 'min:1'],
+            'employee_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $actor?->company_id),
+            ],
+            'evaluator_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $actor?->company_id),
+            ],
             'period' => ['nullable', 'string', 'max:20'],
             'status' => ['nullable', 'in:draft,submitted,acknowledged'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],

--- a/api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Absence;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AbsenceIndexRequest extends FormRequest
 {
@@ -14,7 +15,11 @@ class AbsenceIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'employee_id' => ['nullable', 'integer', 'min:1'],
+            'employee_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
             'status' => ['nullable', 'in:pending,approved,rejected,cancelled'],
             'month' => ['nullable', 'integer', 'between:1,12'],
             'year' => ['nullable', 'integer', 'min:2000'],

--- a/api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AttendanceIndexRequest extends FormRequest
 {
@@ -14,7 +15,11 @@ class AttendanceIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'employee_id' => ['nullable', 'integer', 'min:1'],
+            'employee_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
             'date_from' => ['nullable', 'date_format:Y-m-d'],
             'date_to' => ['nullable', 'date_format:Y-m-d'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],

--- a/api/app/Http/Requests/Api/V1/Payroll/PayrollIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Payroll/PayrollIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Payroll;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PayrollIndexRequest extends FormRequest
 {
@@ -13,6 +14,16 @@ class PayrollIndexRequest extends FormRequest
 
     public function rules(): array
     {
-        return ['employee_id' => ['nullable', 'integer', 'min:1'], 'month' => ['nullable', 'integer', 'between:1,12'], 'year' => ['nullable', 'integer', 'min:2000'], 'status' => ['nullable', 'in:draft,validated'], 'per_page' => ['nullable', 'integer', 'min:1', 'max:100']];
+        return [
+            'employee_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'month' => ['nullable', 'integer', 'between:1,12'],
+            'year' => ['nullable', 'integer', 'min:2000'],
+            'status' => ['nullable', 'in:draft,validated'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
     }
 }

--- a/api/app/Http/Requests/Api/V1/SalaryAdvance/SalaryAdvanceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/SalaryAdvance/SalaryAdvanceIndexRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\SalaryAdvance;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class SalaryAdvanceIndexRequest extends FormRequest
 {
@@ -13,6 +14,14 @@ class SalaryAdvanceIndexRequest extends FormRequest
 
     public function rules(): array
     {
-        return ['employee_id' => ['nullable', 'integer', 'min:1'], 'status' => ['nullable', 'in:pending,approved,rejected,active,repaid'], 'per_page' => ['nullable', 'integer', 'min:1', 'max:100']];
+        return [
+            'employee_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'status' => ['nullable', 'in:pending,approved,rejected,active,repaid'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
     }
 }

--- a/api/tests/Feature/Security/IndexRequestIsolationTest.php
+++ b/api/tests/Feature/Security/IndexRequestIsolationTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\Schedule;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class IndexRequestIsolationTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_manager_cannot_filter_absences_by_employee_from_another_company(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = Employee::query()->forceCreate([
+            'company_id' => $companyA->id,
+            'email' => 'manager@a.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'email' => 'employee@b.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($managerA);
+
+        // Currently this passes validation but returns 0 results.
+        // Sentinel requires it to fail validation.
+        $response = $this->getJson('/api/v1/absences?employee_id=' . $employeeB->id);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    public function test_manager_cannot_filter_payrolls_by_employee_from_another_company(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = Employee::query()->forceCreate([
+            'company_id' => $companyA->id,
+            'email' => 'manager-pr@a.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'email' => 'employee-pr@b.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson('/api/v1/payrolls?employee_id=' . $employeeB->id);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    public function test_manager_cannot_filter_salary_advances_by_employee_from_another_company(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = Employee::query()->forceCreate([
+            'company_id' => $companyA->id,
+            'email' => 'manager-sa@a.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'email' => 'employee-sa@b.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson('/api/v1/salary-advances?employee_id=' . $employeeB->id);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    public function test_manager_cannot_filter_attendances_by_employee_from_another_company(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = Employee::query()->forceCreate([
+            'company_id' => $companyA->id,
+            'email' => 'manager-at@a.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'email' => 'employee-at@b.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson('/api/v1/attendance?employee_id=' . $employeeB->id);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    public function test_manager_cannot_filter_evaluations_by_employee_from_another_company(): void
+    {
+        $companyA = $this->createCompany('Company A');
+        $companyB = $this->createCompany('Company B');
+
+        $managerA = Employee::query()->forceCreate([
+            'company_id' => $companyA->id,
+            'email' => 'manager-ev@a.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->forceCreate([
+            'company_id' => $companyB->id,
+            'email' => 'employee-ev@b.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson('/api/v1/evaluations?employee_id=' . $employeeB->id);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['employee_id']);
+    }
+
+    private function createCompany(string $name): Company
+    {
+        return Company::query()->create([
+            'name' => $name,
+            'slug' => $name,
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => $name . '@test.com',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+            'timezone' => 'UTC',
+        ]);
+    }
+}


### PR DESCRIPTION
This security enhancement addresses a potential Insecure Direct Object Reference (IDOR) vulnerability where users could probe for the existence of employee IDs in other tenants via filter parameters in index endpoints. 

By adding `Rule::exists` validation scoped to the requester's `company_id`, the application now explicitly rejects requests filtering by IDs outside their authorized scope with a 422 Unprocessable Entity response, rather than silently returning an empty list.

Modified files:
- `api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php`
- `api/app/Http/Requests/Api/V1/Payroll/PayrollIndexRequest.php`
- `api/app/Http/Requests/Api/V1/SalaryAdvance/SalaryAdvanceIndexRequest.php`
- `api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php`
- `api/app/Http/Controllers/Api/V1/EvaluationController.php`
- `api/tests/Feature/Security/IndexRequestIsolationTest.php` (New)
- `.jules/sentinel.md`

---
*PR created automatically by Jules for task [4014100566999340997](https://jules.google.com/task/4014100566999340997) started by @kitokoh*