### PR TITLE
📚 DocKeeper: [documentation alignment]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 - API : optimisation de `EmployeeController@index` et `EmployeeController@show` par l'ajout de `with('company')` pour eliminer les requetes N+1 lors de la resolution de la ressource.
 - API : ajout explicite de `preferred_language` et `extra_data` dans le `select()` de `EmployeeController@index` pour garantir l'integrite du payload `EmployeeResource` et des services associes.
 
+### DocKeeper - Alignement documentation
+
+- Ops : Mise à jour de `RUNBOOK_BETA_ENV_SETUP.md` (v1.1) pour refléter le passage au PaaS (Render + Neon) et supprimer les instructions VPS obsolètes.
+
 ## [4.1.85] - 2026-05-02
 
 ### Contractor - Alignement contrat API/mobile (attendance today)

--- a/docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md
+++ b/docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md
@@ -1,33 +1,35 @@
 # RUNBOOK BETA ENV SETUP
-# Version 1.0 | 2026-04-06
+# Version 1.1 | 2026-05-03
 
-But: preparer un environnement Beta exploitable avant la recette humaine.
+But: preparer un environnement Beta exploitable sur Render (PaaS) avant la recette humaine.
 
-## Checklist infrastructure
+## Checklist infrastructure (Render + Neon)
 
-- VPS cree et accessible en SSH
-- Domaine ou sous-domaine pointe vers le VPS
-- TLS actif
-- PostgreSQL accessible
-- PHP/FPM et serveur web actifs
-- dossier `storage/` accessible en ecriture
-- dossier `bootstrap/cache/` accessible en ecriture
+- Web Service cree sur Render (Docker context: `api/`, Dockerfile: `Dockerfile.prod`)
+- Base de donnees creee sur Neon.tech
+- URL de connexion Neon (PostgreSQL) recuperee
+- TLS (HTTPS) actif par defaut sur Render
+- `DB_URL` configuree sur Render avec l'URL Neon
+- `DB_SEARCH_PATH` configure a `shared_tenants,public`
+- `APP_KEY` generee et configuree
+- `RUN_MIGRATIONS=true` pour le premier deploiement
 
 ## Checklist application
 
-- Code de `main` deploie
-- `composer install --no-dev --optimize-autoloader` execute
-- `php artisan key:generate` execute si environnement neuf
-- `php artisan migrate --force` execute
-- `php artisan config:cache` execute
-- `php artisan route:cache` execute
-- `php artisan view:cache` execute
+- Code de `main` deploie via GitHub
+- `composer install` automatique via Docker build
+- `php artisan migrate --force` (gere par `api/docker-entrypoint.sh` si `RUN_MIGRATIONS=true`)
+- `php artisan config:cache` (gere au startup)
+- `php artisan route:cache` (gere au startup)
+- `php artisan view:cache` (gere au startup)
 
 ## Variables d'environnement MVP attendues
 
 - `APP_ENV=production`
 - `APP_DEBUG=false`
 - `DB_CONNECTION=pgsql`
+- `DB_URL=postgresql://...`
+- `DB_SEARCH_PATH=shared_tenants,public`
 - `CACHE_STORE=file`
 - `SESSION_DRIVER=file`
 - `QUEUE_CONNECTION=sync`
@@ -36,21 +38,21 @@ But: preparer un environnement Beta exploitable avant la recette humaine.
 
 ## Donnees minimales de recette
 
-- 1 company active
+- 1 company active (via `db:seed` ou `DemoCompanyOnceSeeder`)
 - 1 manager actif
 - 1 employee actif
-- 1 ou 2 logs de pointage existants pour verifier dashboard, historique et PDF
+- logs de pointage existants pour verifier dashboard, historique et PDF
 
 ## Verification express
 
-- `GET /api/v1/health` -> 200
+- `GET /api/v1/health` -> 200, `status=ok`
 - `GET /login` -> 200
 - login manager -> redirect `/dashboard`
 - fiche employe accessible
 - quick estimate OK
 - PDF OK
 
-## Blocage immediate
+## Blocage immediat
 
 Stop Beta si:
 - login impossible


### PR DESCRIPTION
What changed:
- Updated `docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md` from v1.0 to v1.1.
- Replaced manual VPS/SSH instructions with modern PaaS (Render + Neon) setup steps.
- Updated the environment variables checklist to include `DB_URL` and `DB_SEARCH_PATH`.
- Aligned the application startup checklist with the Dockerized FrankenPHP entrypoint logic.
- Added a record of this change in `CHANGELOG.md` under version [4.1.86].

Why it was outdated/confusing:
The runbook still referenced VPS and manual SSH steps, which were obsolete since the project transitioned to Render and Neon PaaS. This drift could lead to incorrect setup procedures for the Beta environment.

Source of truth used:
- `docs/GESTION_PROJET/RENDER_SETUP.md`
- `api/docker-entrypoint.sh`
- `PILOTAGE.md` (Operational reality)

Verification performed:
- Manual file read verification of `docs/GESTION_PROJET/RUNBOOK_BETA_ENV_SETUP.md`.
- `git diff --check` for whitespace errors.
- Backend smoke test (`HealthEndpointTest`) passed.

Rollback plan:
`git revert` of this PR.

---
*PR created automatically by Jules for task [1739420748194084864](https://jules.google.com/task/1739420748194084864) started by @kitokoh*