### PR TITLE
🎨 Palette: Improve accessibility and pull-to-refresh in payroll screen

### DIFF
--- a/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
+++ b/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
@@ -23,18 +24,27 @@ class PayrollListScreen extends ConsumerWidget {
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          onPressed: () => Navigator.of(context).pop(),
+          tooltip: 'Retour',
+          onPressed: () => context.pop(),
         ),
       ),
-      body: payrollsAsync.when(
-        data: (payrolls) => payrolls.isEmpty
-            ? const EmptyState(
-                icon: Icons.description,
-                title: 'Aucune fiche de paie',
-                description:
-                    'Vos fiches de paie apparaîtront ici dès qu\'elles seront validées.',
-              )
-            : ListView.builder(
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(payrollsProvider.future),
+        child: payrollsAsync.when(
+          data: (payrolls) => payrolls.isEmpty
+              ? ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [
+                    SizedBox(height: 80),
+                    EmptyState(
+                      icon: Icons.description,
+                      title: 'Aucune fiche de paie',
+                      description:
+                          'Vos fiches de paie apparaîtront ici dès qu\'elles seront validées.',
+                    ),
+                  ],
+                )
+              : ListView.builder(
                 padding: const EdgeInsets.all(20),
                 itemCount: payrolls.length,
                 itemBuilder: (context, index) {
@@ -63,9 +73,14 @@ class PayrollListScreen extends ConsumerWidget {
                   );
                 },
               ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
+          loading: () => const Center(
+            child: CircularProgressIndicator(
+              semanticsLabel: 'Chargement des fiches de paie...',
+            ),
+          ),
+          error: (e, _) => Center(
           child: Text(e.toString(), style: const TextStyle(color: Colors.red)),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
💡 What: Added Pull-to-Refresh support and accessibility enhancements to the Payroll list screen.
🎯 Why: Improving the user experience by allowing manual data refresh and ensuring the screen is fully accessible to screen readers.
♿ Accessibility:
- Added `tooltip` to the back button.
- Added `semanticsLabel` to the loading indicator.
- Used `context.pop()` for consistent navigation.
- Ensured the empty state is scrollable to keep the `RefreshIndicator` functional.

---
*PR created automatically by Jules for task [9842694388879822738](https://jules.google.com/task/9842694388879822738) started by @kitokoh*