### PR TITLE
🧪 Scout: [MVP regression test] authenticated employee guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 ### Scout - Tests de régression MVP
 
 - Tests : ajout de `api/tests/Feature/Security/TenantModelIsolationTest.php` pour verrouiller l'isolation inter-tenant des modèles de kiosque, d'enrôlement biométrique et d'invitation.
+- Tests : ajout de `api/tests/Feature/Security/AuthenticatedGuardrailsTest.php` pour garantir que les employés archivés ou suspendus sont immédiatement bloqués par le `TenantMiddleware` lors des sessions actives.
 ### Contractor - Alignement contrat API/mobile (employee)
 
 - API : Mise à jour de `EmployeeResource` pour inclure `photo_url` (alias de `photo_path`) et `hire_date` (alias de `contract_start` formaté en Y-m-d) pour la compatibilité avec les modèles mobiles.

--- a/api/tests/Feature/Security/AuthenticatedGuardrailsTest.php
+++ b/api/tests/Feature/Security/AuthenticatedGuardrailsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Support\Facades\Hash;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class AuthenticatedGuardrailsTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    private function createCompany(string $name, string $status = 'active'): Company
+    {
+        return Company::query()->create([
+            'name' => $name,
+            'slug' => \Illuminate\Support\Str::slug($name),
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => strtolower(str_replace(' ', '', $name)).'@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => $status,
+        ]);
+    }
+
+    private function createEmployee(Company $company, string $email, string $status = 'active'): Employee
+    {
+        return Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => $email,
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => $status,
+        ]);
+    }
+
+    public function test_authenticated_employee_blocked_when_archived(): void
+    {
+        $company = $this->createCompany('Company A');
+        $employee = $this->createEmployee($company, 'emp@test.com');
+
+        $this->actingAs($employee, 'sanctum');
+
+        $this->getJson('/api/v1/auth/me')
+            ->assertStatus(200);
+
+        $employee->status = 'archived';
+        $employee->save();
+
+        $response = $this->getJson('/api/v1/auth/me');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'EMPLOYEE_ARCHIVED');
+    }
+
+    public function test_authenticated_employee_blocked_when_suspended(): void
+    {
+        $company = $this->createCompany('Company A');
+        $employee = $this->createEmployee($company, 'emp@test.com');
+
+        $this->actingAs($employee, 'sanctum');
+
+        $this->getJson('/api/v1/auth/me')
+            ->assertStatus(200);
+
+        $employee->status = 'suspended';
+        $employee->save();
+
+        $response = $this->getJson('/api/v1/auth/me');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'EMPLOYEE_SUSPENDED');
+    }
+}


### PR DESCRIPTION
### Behavior protected
Ensures that the `TenantMiddleware` correctly blocks authenticated employees during an active session if their status is changed to `archived` or `suspended`. This is critical for security and MVP stability as it prevents unauthorized access immediately after a status change, without waiting for token expiration.

### Why it matters for MVP
Security and proper employee status enforcement are core pillars of the Leopardo RH MVP. If an employee is fired (archived) or suspended, they must not be able to access any further data, even if they have a valid session token.

### Test added
- `api/tests/Feature/Security/AuthenticatedGuardrailsTest.php`:
    - `test_authenticated_employee_blocked_when_archived`
    - `test_authenticated_employee_blocked_when_suspended`

### Verification command/result
Executed via SQLite in-memory:
`cd api && DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/Security/AuthenticatedGuardrailsTest.php`
Result: `Tests: 2 passed (6 assertions)`

### Rollback plan
`git revert` of the commit. No production code was changed.

### Bug found
`App\Models\Company::booted()` uses `SHOW search_path` (PostgreSQL specific), causing failures in SQLite tests when company status changes. Tests for company-level suspension were implemented but had to be removed from this PR to avoid changing production code (which is forbidden for Scout mission). Reported for a future fix PR.

---
*PR created automatically by Jules for task [977156566125371791](https://jules.google.com/task/977156566125371791) started by @kitokoh*