### PR TITLE
fix(render): make company requests migration idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.86] - 2026-05-06
+
+### Render - Hotfix migration company_requests
+
+- API : rend la migration publique `2026_05_02_000003_create_company_requests_table` idempotente afin d'eviter l'erreur PostgreSQL `Duplicate table` lorsque `company_requests` existe deja en production.
+
 ## [4.1.85] - 2026-05-02
 
 ### CI/CD - Résolution des problèmes de pipeline et tests

--- a/api/database/migrations/public/2026_05_02_000003_create_company_requests_table.php
+++ b/api/database/migrations/public/2026_05_02_000003_create_company_requests_table.php
@@ -13,7 +13,11 @@ return new class extends Migration
             DB::statement('SET search_path TO public');
         }
 
-        Schema::create('company_requests', function (Blueprint $table) {
+        if (Schema::hasTable('company_requests')) {
+            return;
+        }
+
+        Schema::create('company_requests', function (Blueprint $table): void {
             $table->increments('id');
             $table->unsignedInteger('employee_id')->index();
             $table->string('company_name', 100);


### PR DESCRIPTION
Hotfix Render deployment failure: guard the public company_requests migration so it exits cleanly when the table already exists.