### PR TITLE
fix(mobile): remove flutter haptic dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.89] - 2026-05-06
+
+### Mobile - Android release build
+
+- Mobile : suppression de la dependance `flutter_haptic`, inutilisee dans le code et incompatible avec le build Android release CI faute de `namespace` declare.
+
 ## [4.1.88] - 2026-05-06
 
 ### Render - Release integration hardening

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
   flutter_animate: ^4.5.2
   google_sign_in: ^6.2.2
   cached_network_image: ^3.4.1
-  flutter_haptic: ^0.0.1+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove the unused flutter_haptic dependency from the mobile app
- unblock Android release APK builds on CI where the package fails for missing Android namespace
- record the hotfix in CHANGELOG.md

## Testing
- not run locally; verified against GitHub Actions deployment failure log