### PR TITLE
fix(ci): scope web workflows to web changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,14 @@ name: Build & Deploiement
 on:
   push:
     branches: [main, develop, staging]
+    paths:
+      - 'web/**'
+      - '.github/workflows/build.yml'
   pull_request:
     branches: [main, develop, staging]
+    paths:
+      - 'web/**'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,14 @@ name: Linting & Type Checking
 on:
   push:
     branches: [main, develop, staging]
+    paths:
+      - 'web/**'
+      - '.github/workflows/lint.yml'
   pull_request:
     branches: [main, develop, staging]
+    paths:
+      - 'web/**'
+      - '.github/workflows/lint.yml'
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,14 @@ name: Tests Automatiques
 on:
   push:
     branches: [main, develop, staging]
+    paths:
+      - 'web/**'
+      - '.github/workflows/test.yml'
   pull_request:
     branches: [main, develop, staging]
+    paths:
+      - 'web/**'
+      - '.github/workflows/test.yml'
 
 jobs:
   test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Eviter les longues commandes locales si elles bloquent sur Windows : `dart format`, `jest`, `npm run build`, `flutter analyze` peuvent etre lents ou produire du bruit localement.
 - `npx tsc --strict --noEmit` est acceptable localement quand il faut verifier vite une erreur TypeScript evidente.
 - Les checks GitHub Actions qui ont permis de merger le PR #268 : backend, backend quality, mobile, build, lint, type-check, test Node 20, CodeQL, governance.
+- Les workflows web `build.yml`, `lint.yml` et `test.yml` doivent rester limites aux changements `web/**` ou a leur propre fichier workflow pour eviter les CI inutiles sur des PR backend/docs.
 
 ## Pieges connus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.91] - 2026-05-06
+
+### CI - Ciblage web par chemins
+
+- CI : limitation des workflows web `build.yml`, `lint.yml` et `test.yml` aux modifications de `web/**` ou de leur propre fichier YAML pour eviter les executions inutiles sur des PR backend, mobile ou documentation.
+
 ## [4.1.90] - 2026-05-06
 
 ### CI - Workflows GitHub


### PR DESCRIPTION
## Summary
- restrict web build, lint and test workflows to web/** changes or their own workflow file
- document the rule in AGENTS.md for future merge batches
- record the optimization in CHANGELOG.md

## Why
- backend-only, mobile-only and docs-only PRs should not pay the full web CI cost
- this fits the area-based batching strategy for future federation branches