### PR TITLE
feat: add mobile i18n foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,13 @@ Procedure recommandee :
 
 ## Historique utile
 
+### 2026-05-07 - Mobile i18n
+
+- Avant d'estimer un chantier i18n mobile, verifier l'etat reel sur `origin/main` : `flutter_localizations`, `intl`, locale et RTL peuvent etre branches sans que `gen-l10n`, `l10n.yaml`, les `.arb` et `context.l10n` existent deja.
+- Ne pas migrer 500+ cles d'un coup. La sequence la plus sure est : fondation `gen-l10n`, un ecran prioritaire, CI mobile, puis extension par lots verticaux.
+- Pour l'arabe, tester explicitement les petits viewports : les textes traduits peuvent casser les `Column` avec `Spacer`; preferer des zones scrollables bornees ou des layouts qui degradent proprement.
+- Les plans i18n doivent distinguer les cles reellement utilisees dans le code des cles "catalogue" prevues plus tard, sinon la progression annoncee devient trompeuse.
+
 ### 2026-05-06 - PR #268 Feature/vitrine restructure
 
 - Le PR #268 a ete merge dans `main` avec le commit `08d4316a2b9baaf2e95b2d40ffa8dd69bdc40af5`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.96] - 2026-05-07
+
+### Mobile - Fondation i18n
+
+- Mobile : ajout de la configuration `gen-l10n`, des premiers catalogues ARB FR/EN/TR/AR et du helper `context.l10n`.
+- Mobile : raccord de `AppLocalizations.delegate` dans l'application Flutter existante.
+- Mobile : migration initiale de l'ecran Welcome vers les cles localisees, en gardant le support RTL deja present.
+- Docs : ajout dans `AGENTS.md` d'une lecon operationnelle sur le demarrage progressif des chantiers i18n mobile.
+
 ## [4.1.95] - 2026-05-07
 
 ### Backend - Intelligence pointage

--- a/mobile/l10n.yaml
+++ b/mobile/l10n.yaml
@@ -1,0 +1,7 @@
+arb-dir: lib/l10n
+template-arb-file: app_fr.arb
+output-localization-file: app_localizations.dart
+output-dir: lib/l10n/generated
+output-class: AppLocalizations
+synthetic-package: false
+nullable-getter: false

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -27,6 +27,7 @@ import 'package:leopardo_rh/features/user_auth/screens/user_register_screen.dart
 import 'package:leopardo_rh/features/user_auth/screens/user_login_screen.dart';
 import 'package:leopardo_rh/features/user_auth/screens/user_home_screen.dart';
 import 'package:leopardo_rh/features/user_auth/screens/company_request_screen.dart';
+import 'package:leopardo_rh/l10n/l10n.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
   final authListenable = ValueNotifier<AuthState>(ref.read(authProvider));
@@ -160,8 +161,7 @@ class LeopardoApp extends ConsumerWidget {
     final preferences = ref.watch(appPreferencesProvider);
     final deviceLanguage =
         PlatformDispatcher.instance.locale.languageCode.toLowerCase();
-    final languageCode =
-        authState.employee?.language ??
+    final languageCode = authState.employee?.language ??
         (preferences.preferredLanguage.isNotEmpty
             ? preferences.preferredLanguage
             : deviceLanguage);
@@ -182,6 +182,7 @@ class LeopardoApp extends ConsumerWidget {
         Locale('en'),
       ],
       localizationsDelegates: const [
+        AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,

--- a/mobile/lib/features/auth/screens/welcome_screen.dart
+++ b/mobile/lib/features/auth/screens/welcome_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
+import 'package:leopardo_rh/l10n/l10n.dart';
 
 class WelcomeScreen extends StatefulWidget {
   const WelcomeScreen({super.key});
@@ -15,29 +16,30 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   final PageController _pageController = PageController();
   int _currentPage = 0;
 
-  static const List<_StoryCardData> _stories = <_StoryCardData>[
-    _StoryCardData(
-      title: 'Une home qui vous parle avant de vous noyer',
-      body:
-          'Leopardo RH commence par quelques actions claires: pointer, suivre le mois et retrouver les informations qui comptent.',
-      domain: 'ia',
-      icon: Icons.forum_outlined,
-    ),
-    _StoryCardData(
-      title: 'Mobile-first pour le terrain',
-      body:
-          'Le telephone est la surface principale de l employe. Votre pointage, vos absences et vos documents vivent ici.',
-      domain: 'rh',
-      icon: Icons.phone_android_outlined,
-    ),
-    _StoryCardData(
-      title: 'Modules actifs, feuille de route visible',
-      body:
-          'Le produit ouvre d abord ce qui est utile aujourd hui, puis garde Finance, Securite et Leo dans un cap lisible.',
-      domain: 'finance',
-      icon: Icons.dashboard_customize_outlined,
-    ),
-  ];
+  static List<_StoryCardData> _stories(BuildContext context) {
+    final l10n = context.l10n;
+
+    return <_StoryCardData>[
+      _StoryCardData(
+        title: l10n.welcomeStoryClarityTitle,
+        body: l10n.welcomeStoryClarityBody,
+        domain: 'ia',
+        icon: Icons.forum_outlined,
+      ),
+      _StoryCardData(
+        title: l10n.welcomeStoryFieldTitle,
+        body: l10n.welcomeStoryFieldBody,
+        domain: 'rh',
+        icon: Icons.phone_android_outlined,
+      ),
+      _StoryCardData(
+        title: l10n.welcomeStoryModulesTitle,
+        body: l10n.welcomeStoryModulesBody,
+        domain: 'finance',
+        icon: Icons.dashboard_customize_outlined,
+      ),
+    ];
+  }
 
   @override
   void dispose() {
@@ -49,6 +51,8 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   Widget build(BuildContext context) {
     final background = AppColors.backgroundFor(context);
     final compact = MediaQuery.of(context).size.height < 740;
+    final stories = _stories(context);
+    final l10n = context.l10n;
 
     return Scaffold(
       backgroundColor: background,
@@ -75,19 +79,19 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
               Expanded(
                 child: PageView.builder(
                   controller: _pageController,
-                  itemCount: _stories.length,
+                  itemCount: stories.length,
                   onPageChanged: (index) {
                     setState(() {
                       _currentPage = index;
                     });
                   },
                   itemBuilder: (context, index) {
-                    return _StoryCard(story: _stories[index]);
+                    return _StoryCard(story: stories[index]);
                   },
                 ),
               ),
               const SizedBox(height: 12),
-              _Dots(count: _stories.length, current: _currentPage),
+              _Dots(count: stories.length, current: _currentPage),
               Padding(
                 padding: EdgeInsets.fromLTRB(
                     24, compact ? 10 : 16, 24, compact ? 14 : 24),
@@ -97,7 +101,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                       width: double.infinity,
                       child: ElevatedButton(
                         onPressed: () => context.go('/login'),
-                        child: const Text('Se connecter'),
+                        child: Text(l10n.login),
                       ),
                     ),
                     const SizedBox(height: 12),
@@ -105,7 +109,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                       width: double.infinity,
                       child: OutlinedButton(
                         onPressed: () => context.go('/register'),
-                        child: const Text('Acces employe (invitation)'),
+                        child: Text(l10n.employeeInvitationAccess),
                       ),
                     ),
                     const SizedBox(height: 10),
@@ -114,7 +118,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                       child: TextButton.icon(
                         onPressed: () => context.go('/user-register'),
                         icon: const Icon(Icons.person_add_outlined, size: 18),
-                        label: const Text('Creer un compte personnel'),
+                        label: Text(l10n.createPersonalAccount),
                         style: TextButton.styleFrom(
                           foregroundColor: AppColors.ia,
                         ),
@@ -122,7 +126,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                     ),
                     const SizedBox(height: 10),
                     Text(
-                      'Compte personnel : organisez vos documents, puis creez ou rejoignez une entreprise depuis votre espace.',
+                      l10n.personalAccountExplanation,
                       textAlign: TextAlign.center,
                       style: AppTypography.caption.copyWith(
                         color: AppColors.textSecondaryFor(context),
@@ -197,12 +201,12 @@ class _WelcomeHero extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Leopardo RH',
+                      context.l10n.appTitle,
                       style: AppTypography.title.copyWith(color: text),
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      'Conversationnelle, mobile-first, modulaire.',
+                      context.l10n.welcomeBrandSubtitle,
                       style: AppTypography.bodySmall.copyWith(color: muted),
                     ),
                   ],
@@ -212,7 +216,7 @@ class _WelcomeHero extends StatelessWidget {
           ),
           SizedBox(height: compact ? 12 : 22),
           Text(
-            'Votre journee commence ici, pas dans un back-office.',
+            context.l10n.welcomeHeroTitle,
             style: AppTypography.display.copyWith(
               color: text,
               fontSize: compact ? 24 : 30,
@@ -220,7 +224,7 @@ class _WelcomeHero extends StatelessWidget {
           ),
           SizedBox(height: compact ? 6 : 10),
           Text(
-            'Pointage, suivi personnel et modules RH actifs s ouvrent d abord sur le telephone, avec une experience simple et lisible.',
+            context.l10n.welcomeHeroDescription,
             style: AppTypography.body.copyWith(color: muted),
           ),
         ],

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "ar",
+  "appTitle": "ليوباردو للموارد البشرية",
+  "welcomeBrandSubtitle": "تجربة محادثية، موجهة للهاتف، وقابلة للتوسع.",
+  "welcomeHeroTitle": "يبدأ يومك من هنا، وليس من مكتب خلفي.",
+  "welcomeHeroDescription": "الحضور، المتابعة الشخصية، ووحدات الموارد البشرية النشطة تظهر أولا على الهاتف بتجربة بسيطة وواضحة.",
+  "welcomeStoryClarityTitle": "واجهة رئيسية ترشدك قبل أن تربكك",
+  "welcomeStoryClarityBody": "يبدأ ليوباردو بخطوات واضحة: تسجيل الحضور، متابعة الشهر، والوصول إلى المعلومات المهمة.",
+  "welcomeStoryFieldTitle": "تجربة هاتف أولا لفرق الميدان",
+  "welcomeStoryFieldBody": "الهاتف هو الواجهة الأساسية للموظف. الحضور، الغيابات، والمستندات كلها هنا.",
+  "welcomeStoryModulesTitle": "وحدات نشطة وخارطة طريق واضحة",
+  "welcomeStoryModulesBody": "يفتح المنتج أولا ما يفيد اليوم، ثم يحافظ على مسار واضح للمالية، الأمان، وليو.",
+  "login": "تسجيل الدخول",
+  "employeeInvitationAccess": "دخول الموظف (بدعوة)",
+  "createPersonalAccount": "إنشاء حساب شخصي",
+  "personalAccountExplanation": "الحساب الشخصي: نظم مستنداتك، ثم أنشئ شركة أو انضم إليها من مساحتك."
+}

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "en",
+  "appTitle": "Leopardo HR",
+  "welcomeBrandSubtitle": "Conversational, mobile-first, modular.",
+  "welcomeHeroTitle": "Your workday starts here, not in a back office.",
+  "welcomeHeroDescription": "Clock-ins, personal tracking, and active HR modules open first on the phone, with a simple and readable experience.",
+  "welcomeStoryClarityTitle": "A home screen that speaks before it overwhelms",
+  "welcomeStoryClarityBody": "Leopardo HR starts with a few clear actions: clock in, follow the month, and find the information that matters.",
+  "welcomeStoryFieldTitle": "Mobile-first for field teams",
+  "welcomeStoryFieldBody": "The phone is the employee's main surface. Clock-ins, absences, and documents live here.",
+  "welcomeStoryModulesTitle": "Active modules, visible roadmap",
+  "welcomeStoryModulesBody": "The product opens what is useful today first, then keeps Finance, Security, and Leo on a readable path.",
+  "login": "Sign in",
+  "employeeInvitationAccess": "Employee access (invitation)",
+  "createPersonalAccount": "Create a personal account",
+  "personalAccountExplanation": "Personal account: organize your documents, then create or join a company from your space."
+}

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "fr",
+  "appTitle": "Leopardo RH",
+  "welcomeBrandSubtitle": "Conversationnelle, mobile-first, modulaire.",
+  "welcomeHeroTitle": "Votre journee commence ici, pas dans un back-office.",
+  "welcomeHeroDescription": "Pointage, suivi personnel et modules RH actifs s ouvrent d abord sur le telephone, avec une experience simple et lisible.",
+  "welcomeStoryClarityTitle": "Une home qui vous parle avant de vous noyer",
+  "welcomeStoryClarityBody": "Leopardo RH commence par quelques actions claires: pointer, suivre le mois et retrouver les informations qui comptent.",
+  "welcomeStoryFieldTitle": "Mobile-first pour le terrain",
+  "welcomeStoryFieldBody": "Le telephone est la surface principale de l employe. Votre pointage, vos absences et vos documents vivent ici.",
+  "welcomeStoryModulesTitle": "Modules actifs, feuille de route visible",
+  "welcomeStoryModulesBody": "Le produit ouvre d abord ce qui est utile aujourd hui, puis garde Finance, Securite et Leo dans un cap lisible.",
+  "login": "Se connecter",
+  "employeeInvitationAccess": "Acces employe (invitation)",
+  "createPersonalAccount": "Creer un compte personnel",
+  "personalAccountExplanation": "Compte personnel : organisez vos documents, puis creez ou rejoignez une entreprise depuis votre espace."
+}

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "tr",
+  "appTitle": "Leopardo IK",
+  "welcomeBrandSubtitle": "Sohbet odakli, mobil oncelikli, moduler.",
+  "welcomeHeroTitle": "Is gununuz burada baslar, arka ofiste degil.",
+  "welcomeHeroDescription": "Puantaj, kisisel takip ve aktif IK modulleri once telefonda acilir; deneyim sade ve okunabilir kalir.",
+  "welcomeStoryClarityTitle": "Bogmadan once konusan bir ana ekran",
+  "welcomeStoryClarityBody": "Leopardo IK birkac net eylemle baslar: giris yapmak, ayi takip etmek ve onemli bilgilere ulasmak.",
+  "welcomeStoryFieldTitle": "Saha ekipleri icin mobil oncelikli",
+  "welcomeStoryFieldBody": "Telefon calisanin ana yuzeyidir. Puantajiniz, izinleriniz ve belgeleriniz burada yasar.",
+  "welcomeStoryModulesTitle": "Aktif moduller, gorunur yol haritasi",
+  "welcomeStoryModulesBody": "Urun once bugun gerekli olani acar, sonra Finans, Guvenlik ve Leo icin okunabilir bir rota tutar.",
+  "login": "Giris yap",
+  "employeeInvitationAccess": "Calisan erisimi (davet)",
+  "createPersonalAccount": "Kisisel hesap olustur",
+  "personalAccountExplanation": "Kisisel hesap: belgelerinizi duzenleyin, sonra alaninizdan bir sirket olusturun veya katilin."
+}

--- a/mobile/lib/l10n/l10n.dart
+++ b/mobile/lib/l10n/l10n.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/widgets.dart';
+import 'package:leopardo_rh/l10n/generated/app_localizations.dart';
+
+export 'package:leopardo_rh/l10n/generated/app_localizations.dart';
+
+extension AppLocalizationsX on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -40,6 +40,7 @@ dev_dependencies:
   json_serializable: ^6.7.1
 
 flutter:
+  generate: true
   uses-material-design: true
 
   assets:

--- a/mobile/test/features/auth/welcome_screen_test.dart
+++ b/mobile/test/features/auth/welcome_screen_test.dart
@@ -1,12 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leopardo_rh/features/auth/screens/welcome_screen.dart';
+import 'package:leopardo_rh/l10n/l10n.dart';
 
 void main() {
   testWidgets('WelcomeScreen renders brand, feature slide and CTAs', (
     tester,
   ) async {
-    await tester.pumpWidget(const MaterialApp(home: WelcomeScreen()));
+    await tester.pumpWidget(
+      const MaterialApp(
+        locale: Locale('fr'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: WelcomeScreen(),
+      ),
+    );
 
     // Brand header.
     expect(find.text('Leopardo RH'), findsOneWidget);


### PR DESCRIPTION
## Summary
- add Flutter gen-l10n configuration and initial FR/EN/TR/AR ARB catalogs
- wire AppLocalizations into the existing mobile MaterialApp locale/RTL setup
- migrate WelcomeScreen and its widget test to context.l10n
- document the safer phased i18n approach in AGENTS.md and CHANGELOG.md

## Notes
The original i18n plan is directionally good, but main did not yet contain l10n.yaml, ARB catalogs, or context.l10n. This PR starts with a small verifiable foundation before expanding to Login/Register/Home.

## Validation
- dart format on changed Dart files
- git diff --check
- ARB JSON parsed locally
- Flutter SDK is not available locally in this workspace; GitHub Actions should run gen-l10n/analyze/tests.