### PR TITLE
🛡️ Sentinel: Fix cross-tenant employee lookup in Google OAuth

### DIFF
--- a/api/app/Http/Controllers/Api/V1/AuthController.php
+++ b/api/app/Http/Controllers/Api/V1/AuthController.php
@@ -160,7 +160,7 @@ class AuthController extends Controller
             return new JsonResponse(['error' => 'GOOGLE_AUTH_FAILED', 'message' => $e->getMessage()], 422);
         }
 
-        $employee = Employee::where('email', $googleUser->getEmail())->first();
+        $employee = Employee::withoutGlobalScopes()->where('email', $googleUser->getEmail())->first();
 
         if (! $employee) {
             $employee = Employee::create([
@@ -197,7 +197,7 @@ class AuthController extends Controller
             return new JsonResponse(['error' => 'GOOGLE_AUTH_FAILED', 'message' => $e->getMessage()], 422);
         }
 
-        $employee = Employee::where('email', $googleUser->getEmail())->first();
+        $employee = Employee::withoutGlobalScopes()->where('email', $googleUser->getEmail())->first();
 
         if (! $employee) {
             $employee = Employee::create([

--- a/api/tests/Feature/Security/GoogleAuthGlobalLookupTest.php
+++ b/api/tests/Feature/Security/GoogleAuthGlobalLookupTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Laravel\Socialite\Facades\Socialite;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+use Tests\Support\CreatesMvpSchema;
+
+class GoogleAuthGlobalLookupTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_google_login_finds_employee_even_when_another_tenant_is_bound_to_container()
+    {
+        // 1. Create Tenant A and an Employee
+        $companyA = Company::factory()->create(['name' => 'Company A']);
+        $employee = Employee::factory()->create([
+            'company_id' => $companyA->id,
+            'email' => 'shared@example.com',
+            'first_name' => 'Existing',
+            'last_name' => 'User',
+            'role' => 'employee',
+        ]);
+
+        // 2. Create Tenant B and bind it to the container
+        $companyB = Company::factory()->create(['name' => 'Company B']);
+        app()->instance('current_company', $companyB);
+
+        // 3. Mock Socialite to return the email of the employee in Tenant A
+        $abstractUser = \Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser->shouldReceive('getEmail')->andReturn('shared@example.com');
+        $abstractUser->shouldReceive('getName')->andReturn('Existing User');
+        $abstractUser->shouldReceive('offsetGet')->with('given_name')->andReturn('Existing');
+        $abstractUser->shouldReceive('offsetGet')->with('family_name')->andReturn('User');
+
+        Socialite::shouldReceive('driver')->with('google')->andReturn($provider = \Mockery::mock('Laravel\Socialite\Two\GoogleProvider'));
+        $provider->shouldReceive('stateless')->andReturn($provider);
+        $provider->shouldReceive('user')->andReturn($abstractUser);
+
+        // 4. Call the callback
+        $response = $this->getJson('/api/v1/auth/google/callback');
+
+        // 5. Assert success
+        // Before the fix, this would fail with a DB error (duplicate email) because Employee::where('email')
+        // would only look in Company B due to the BelongsToCompany global scope.
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.email', 'shared@example.com');
+        $response->assertJsonPath('data.id', $employee->id);
+
+        // Verify no new employee was created
+        $this->assertEquals(1, Employee::withoutGlobalScopes()->where('email', 'shared@example.com')->count());
+    }
+
+    public function test_google_token_login_finds_employee_even_when_another_tenant_is_bound_to_container()
+    {
+        // 1. Create Tenant A and an Employee
+        $companyA = Company::factory()->create(['name' => 'Company A']);
+        $employee = Employee::factory()->create([
+            'company_id' => $companyA->id,
+            'email' => 'token-shared@example.com',
+            'role' => 'employee',
+        ]);
+
+        // 2. Create Tenant B and bind it to the container
+        $companyB = Company::factory()->create(['name' => 'Company B']);
+        app()->instance('current_company', $companyB);
+
+        // 3. Mock Socialite
+        $abstractUser = \Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser->shouldReceive('getEmail')->andReturn('token-shared@example.com');
+        $abstractUser->shouldReceive('getName')->andReturn('Existing User');
+        $abstractUser->shouldReceive('offsetGet')->with('given_name')->andReturn('Existing');
+        $abstractUser->shouldReceive('offsetGet')->with('family_name')->andReturn('User');
+
+        Socialite::shouldReceive('driver')->with('google')->andReturn($provider = \Mockery::mock('Laravel\Socialite\Two\GoogleProvider'));
+        $provider->shouldReceive('stateless')->andReturn($provider);
+        $provider->shouldReceive('userFromToken')->with('fake-token')->andReturn($abstractUser);
+
+        // 4. Call the token endpoint
+        $response = $this->postJson('/api/v1/auth/google/token', [
+            'token' => 'fake-token',
+            'device_name' => 'test-device'
+        ]);
+
+        // 5. Assert success
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.id', $employee->id);
+
+        $this->assertEquals(1, Employee::withoutGlobalScopes()->where('email', 'token-shared@example.com')->count());
+    }
+}


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

### 🚨 Severity: HIGH
### 💡 Vulnerability: Cross-Tenant Authentication Lookup Failure (Google OAuth)
### 🎯 Impact:
In a multi-tenant environment, if the application container has a specific tenant bound (e.g., from a previous lifecycle event or middleware), the standard `Employee::where('email', ...)->first()` query in `AuthController` will only look within that specific tenant due to the `BelongsToCompany` global scope.
If an existing employee from *another* tenant tries to log in via Google, the lookup fails. The application then tries to create a new `Employee` record, which triggers a `QueryException` because the `email` column has a global unique index. This results in a 500 Internal Server Error and prevents the user from logging in.

### 🔧 Fix:
Updated `handleGoogleCallback` and `handleGoogleToken` in `api/app/Http/Controllers/Api/V1/AuthController.php` to use `Employee::withoutGlobalScopes()->where('email', ...)->first()`. This ensures the identity check is performed against the entire platform, which is the correct behavior for a centralized Social Login.

### ✅ Verification:
Created a dedicated security test `api/tests/Feature/Security/GoogleAuthGlobalLookupTest.php` that simulates a "dirty container" state (a different company bound to the app) and verifies that:
1. Google callback correctly finds the employee in their original tenant.
2. Google token exchange correctly finds the employee in their original tenant.
3. No duplicate employee records are created.

Test run command: `cd api && DB_CONNECTION=sqlite DB_DATABASE=:memory: ./vendor/bin/pest tests/Feature/Security/GoogleAuthGlobalLookupTest.php`
Result: **PASS** (2 tests, 7 assertions)

---
*PR created automatically by Jules for task [16348658312417883731](https://jules.google.com/task/16348658312417883731) started by @kitokoh*