### PR TITLE
🎨 Palette: improve Salary Advance list accessibility and feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@ This journal contains critical UX and accessibility learnings for the Leopardo R
 ## 2026-05-20 - Pull-to-Refresh in Empty States
 **Learning:** In Flutter, `RefreshIndicator` only works with scrollable widgets. When a screen is in an empty or error state, it often loses its scrollability, making it impossible for users to refresh.
 **Action:** Always wrap `EmptyState` or error messages in a `ListView` or `SingleChildScrollView` with `physics: AlwaysScrollableScrollPhysics()` to ensure pull-to-refresh remains functional. Use a `SizedBox(height: 80)` as the first child for consistent spacing.
+
+## 2026-05-20 - Unified List Item Semantics
+**Learning:** List items with multiple text children (title, subtitle, trailing) can be noisy for screen readers if read as separate elements.
+**Action:** Wrap the entire list item card or `ListTile` in a `Semantics(container: true, label: '...')` that provides a cohesive, translated announcement. Use `ExcludeSemantics` on the children to prevent redundant readings. This ensures the user gets the full context (e.g., amount, reason, and status) in a single, clear announcement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [4.1.96] - 2026-05-07
 
+### Mobile - Ameliorations UX et accessibilite
+
+- Mobile : amelioration de l'accessibilite de la liste des avances de salaire avec labels semantiques unifies (montant, motif, statut) et tooltip de retour.
+- Mobile : ajout d'un rafraichissement manuel (`RefreshIndicator`) et d'etats vides/erreur scrollables sur l'ecran des avances.
+
 ### Mobile - Fondation i18n
 
 - Mobile : ajout de la configuration `gen-l10n`, des premiers catalogues ARB FR/EN/TR/AR et du helper `context.l10n`.

--- a/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
+++ b/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
@@ -23,60 +24,116 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          onPressed: () => Navigator.of(context).pop(),
+          tooltip: 'Retour',
+          onPressed: () => context.pop(),
         ),
       ),
-      body: advancesAsync.when(
-        data:
-            (advances) =>
-                advances.isEmpty
-                    ? const EmptyState(
-                      icon: Icons.payments,
-                      title: 'Aucune avance',
-                      description:
-                          'Vous n\'avez pas encore demandé d\'avance de salaire.',
-                    )
-                    : ListView.builder(
-                      padding: const EdgeInsets.all(20),
-                      itemCount: advances.length,
-                      itemBuilder: (context, index) {
-                        final advance = advances[index];
-                        return Card(
-                          color: AppColors.cardDark,
-                          margin: const EdgeInsets.only(bottom: 12),
-                          child: ListTile(
-                            title: Text(
-                              '${advance.amount} DZD',
-                              style: AppTypography.subtitle.copyWith(
-                                color: AppColors.textDark,
-                              ),
-                            ),
-                            subtitle: Text(
-                              advance.reason ?? 'Aucun motif',
-                              style: AppTypography.bodySmall.copyWith(
-                                color: AppColors.textMutedDark,
-                              ),
-                            ),
-                            trailing: Text(
-                              advance.status,
-                              style: TextStyle(
-                                color: _getStatusColor(advance.status),
-                              ),
-                            ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.refresh(salaryAdvancesProvider.future),
+        child: advancesAsync.when(
+          data:
+              (advances) =>
+                  advances.isEmpty
+                      ? ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: const [
+                          SizedBox(height: 80),
+                          EmptyState(
+                            icon: Icons.payments,
+                            title: 'Aucune avance',
+                            description:
+                                'Vous n\'avez pas encore demandé d\'avance de salaire.',
                           ),
-                        );
-                      },
-                    ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error:
-            (e, _) => Center(
-              child: Text(
-                e.toString(),
-                style: const TextStyle(color: Colors.red),
+                        ],
+                      )
+                      : ListView.builder(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.all(20),
+                        itemCount: advances.length,
+                        itemBuilder: (context, index) {
+                          final advance = advances[index];
+                          final amount = '${advance.amount ?? 0} DZD';
+                          final reason = advance.reason ?? 'Aucun motif';
+                          final status = _getStatusLabel(advance.status);
+
+                          return Semantics(
+                            label:
+                                'Avance de $amount, motif : $reason, statut $status.',
+                            container: true,
+                            child: ExcludeSemantics(
+                              child: Card(
+                                color: AppColors.cardDark,
+                                margin: const EdgeInsets.only(bottom: 12),
+                                child: ListTile(
+                                  title: Text(
+                                    amount,
+                                    style: AppTypography.subtitle.copyWith(
+                                      color: AppColors.textDark,
+                                    ),
+                                  ),
+                                  subtitle: Text(
+                                    reason,
+                                    style: AppTypography.bodySmall.copyWith(
+                                      color: AppColors.textMutedDark,
+                                    ),
+                                  ),
+                                  trailing: Text(
+                                    advance.status,
+                                    style: TextStyle(
+                                      color: _getStatusColor(advance.status),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+          loading:
+              () => const Center(
+                child: CircularProgressIndicator(
+                  semanticsLabel: 'Chargement des avances...',
+                ),
               ),
-            ),
+          error:
+              (e, _) => ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  SizedBox(
+                    height: MediaQuery.of(context).size.height * 0.4,
+                    child: Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Text(
+                          e.toString(),
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(color: Colors.red),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+        ),
       ),
     );
+  }
+
+  String _getStatusLabel(String status) {
+    switch (status) {
+      case 'active':
+        return 'active';
+      case 'approved':
+        return 'approuvée';
+      case 'pending':
+        return 'en attente';
+      case 'rejected':
+        return 'rejetée';
+      case 'cancelled':
+        return 'annulée';
+      default:
+        return status;
+    }
   }
 
   Color _getStatusColor(String status) {


### PR DESCRIPTION
### What changed
Implemented several micro-UX and accessibility improvements in `SalaryAdvanceListScreen`:
- Added a `RefreshIndicator` to allow users to manually refresh their salary advance requests.
- Wrapped the `EmptyState` and error widgets in a scrollable `ListView` with `AlwaysScrollableScrollPhysics` so the pull-to-refresh gesture works even when no data is present.
- Added a "Retour" tooltip to the back button and migrated it to `context.pop()`.
- Added a `semanticsLabel` to the `CircularProgressIndicator`.
- Introduced a unified French `Semantics` label for list items, combining the amount, reason, and status into a single clear announcement for screen readers.

### Why it helps users
- **Clarity:** Pull-to-refresh is a standard mobile pattern that was missing, giving users more control.
- **Error Comprehension:** Error states are now actionable via refresh.
- **Accessibility:** Screen reader users now receive a cohesive summary of each item instead of hearing fragments, making the interface much more usable for the visually impaired.

### Accessibility impact
Improved screen reader feedback and added missing navigation labels.

### Verification performed
- `flutter analyze` on the modified file passed with no issues.
- Verified widget nesting and semantics logic via code review.

### Rollback plan
Revert this commit using `git revert`.

---
*PR created automatically by Jules for task [15086660195633727258](https://jules.google.com/task/15086660195633727258) started by @kitokoh*