### PR TITLE
[codex] add go-to-market viability center

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,13 @@ Procedure recommandee :
 - Les anomalies avancees utilisent `company.metadata.attendance_geofence` avec `{lat,lng,radius_meters}` pour detecter les pointages hors zone, et signalent aussi les pointages a heure trop repetitive.
 - Pour les prochaines PR, privilegier les features qui donnent un ROI client visible : reduction fraude/erreurs, temps admin economise, exports comptables, alertes manager simples.
 
+### 2026-05-07 - Dossier Go-To-Market racine
+
+- Le dossier racine de strategie commerciale s'appelle `GOTO_MARKET/`, pas `marketing/`, sur demande explicite.
+- Le PDF inspirant `Leopardo_RH_Production_Creative.pdf` doit etre conserve dans `GOTO_MARKET/00_inspiration/` et sert de base creative IA-first.
+- Les prochaines actions GTM doivent rester connectees au wedge produit prioritaire : pointage, anomalies, rapport mensuel, onboarding et ROI client mesurable.
+- `GOTO_MARKET/` est aussi le centre de reflexion sur la viabilite globale : utiliser la tech pour repondre a un besoin actuel, gagner de l'argent, et ne pas hesiter a repositionner ou moderniser le produit/offre quand le marche l'exige.
+
 ### 2026-05-07 - Federation de PR ouvertes
 
 - Quand plusieurs PR ouvertes sont propres mais en retard sur `main`, il est souvent plus rapide de creer une branche federatrice depuis `origin/main`, puis de `cherry-pick` uniquement les commits utiles des PR au lieu de tenter des merges historiques un par un.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ Procedure recommandee :
 - Le PDF inspirant `Leopardo_RH_Production_Creative.pdf` doit etre conserve dans `GOTO_MARKET/00_inspiration/` et sert de base creative IA-first.
 - Les prochaines actions GTM doivent rester connectees au wedge produit prioritaire : pointage, anomalies, rapport mensuel, onboarding et ROI client mesurable.
 - `GOTO_MARKET/` est aussi le centre de reflexion sur la viabilite globale : utiliser la tech pour repondre a un besoin actuel, gagner de l'argent, et ne pas hesiter a repositionner ou moderniser le produit/offre quand le marche l'exige.
+- Les fichiers destines a presenter Leopardo RH au public doivent aller dans `GOTO_MARKET/public/` avec un sous-dossier par canal : `social/`, `landing/`, `video/`, `press/`, `partners/`, `ads/`, `content_calendar/`, `metrics/`.
 
 ### 2026-05-07 - Federation de PR ouvertes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Docs : ajout du dossier racine `GOTO_MARKET/` pour centraliser la strategie commerciale, les segments ICP, le packaging, le playbook vente, les canaux d'acquisition, le calendrier 90 jours, les KPI, les templates operationnels et les assets d'inspiration.
 - Docs : integration du document inspirant `Leopardo_RH_Production_Creative.pdf` comme source de production creative IA-first, sans creer de dossier nomme `marketing`.
 - Docs : ajout d'une boussole de viabilite et repositionnement pour rappeler que le projet doit utiliser la tech afin de repondre a des besoins actuels, generer du revenu et accepter les modernisations necessaires.
+- Docs : ajout de `GOTO_MARKET/public/` pour structurer les contenus publics de presentation sur LinkedIn, WhatsApp, Instagram/Facebook, landing pages, videos, presse, partenaires, ads, calendrier editorial et metriques.
 
 ## [4.1.98] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.99] - 2026-05-07
+
+### Go-To-Market - Viabilite globale
+
+- Docs : ajout du dossier racine `GOTO_MARKET/` pour centraliser la strategie commerciale, les segments ICP, le packaging, le playbook vente, les canaux d'acquisition, le calendrier 90 jours, les KPI, les templates operationnels et les assets d'inspiration.
+- Docs : integration du document inspirant `Leopardo_RH_Production_Creative.pdf` comme source de production creative IA-first, sans creer de dossier nomme `marketing`.
+- Docs : ajout d'une boussole de viabilite et repositionnement pour rappeler que le projet doit utiliser la tech afin de repondre a des besoins actuels, generer du revenu et accepter les modernisations necessaires.
+
 ## [4.1.98] - 2026-05-07
 
 ### Federation - PR ouvertes utiles

--- a/GOTO_MARKET/00_STRATEGIE_GO_TO_MARKET.md
+++ b/GOTO_MARKET/00_STRATEGIE_GO_TO_MARKET.md
@@ -1,0 +1,111 @@
+# Strategie Go-To-Market - Leopardo RH
+
+## Positionnement
+
+Leopardo RH aide les PME du Maghreb et du pourtour mediterraneen a reprendre le controle du temps de travail terrain : pointage mobile, anomalies, rapports mensuels et onboarding simple.
+
+La promesse prioritaire n'est pas "un logiciel RH complet". C'est :
+
+> En 14 jours, un manager voit qui est present, qui est en retard, quelles heures sont douteuses, et combien de temps administratif il economise.
+
+## These commerciale 2026
+
+Le produit a deja ses 10 premiers clients payants. Le prochain palier n'est pas d'ajouter des modules RH generiques, mais de rendre la valeur mesurable et vendable :
+
+- moins de fraude ou d'erreurs de pointage ;
+- moins de temps passe a consolider Excel, WhatsApp et papier ;
+- rapports mensuels exportables pour manager, comptable et dirigeant ;
+- installation client simple via checklist d'onboarding ;
+- experience multilingue FR, AR, TR, EN.
+
+## Marche de depart
+
+Priorite 1 : PME 10-200 employes avec equipes terrain.
+
+Pays de depart :
+
+- Algerie ;
+- Maroc ;
+- Tunisie.
+
+Expansion opportuniste :
+
+- Turquie si les ecrans mobiles i18n et les contenus TR sont prets ;
+- France pour dirigeants diaspora ou PME avec equipes operationnelles ;
+- Senegal et Cote d'Ivoire apres validation Maghreb.
+
+## Wedge produit
+
+Le wedge de vente est le pointage et le controle terrain, pas toute la suite RH.
+
+Angle d'entree :
+
+> "Montrez-moi votre methode actuelle de pointage, je vous montre les anomalies et le temps perdu."
+
+Fonctions a montrer en premier :
+
+- pointage arrivee/depart ;
+- anomalies de presence ;
+- rapport mensuel JSON/CSV/PDF ;
+- geofence et pointages hors zone ;
+- detection des pointages trop rapproches ou trop repetitifs ;
+- checklist d'installation.
+
+## Strategie en 3 mouvements
+
+### Mouvement 1 - Prouver la valeur
+
+Objectif : convertir les 10 clients actuels en preuves.
+
+Livrables :
+
+- 5 mini-cas clients anonymises ;
+- 3 chiffres ROI par client : heures economisees, anomalies detectees, temps de preparation paie ;
+- 1 capture dashboard par cas ;
+- 1 temoignage court par segment.
+
+### Mouvement 2 - Repeter la vente
+
+Objectif : obtenir 30 clients payants.
+
+Actions :
+
+- prospection dirigeant/DRH/comptable ;
+- demos de 20 minutes centrees pointage ;
+- essai pilote de 14 jours avec checklist ;
+- offre starter claire ;
+- relance basee sur donnees reelles du pilote.
+
+### Mouvement 3 - Creer un canal scalable
+
+Objectif : arriver a 100 clients avec moins de vente manuelle.
+
+Canaux :
+
+- SEO local : logiciel pointage Algerie, gestion presence PME Maroc, paie et pointage Tunisie ;
+- partenariats revendeurs ZKTeco et integrateurs IT locaux ;
+- contenus LinkedIn/WhatsApp en FR et AR ;
+- lead magnets pratiques : checklist pointage, modele rapport mensuel, guide erreurs paie ;
+- campagnes paid tres petites, mesurees par cout demo qualifiee.
+
+## Differenciation
+
+Leopardo RH gagne si le message reste concret :
+
+- mobile-first pour employes terrain ;
+- multilingue FR/AR/TR/EN avec RTL arabe ;
+- adapte PME, pas usine a gaz enterprise ;
+- preuve temps reel sur les presences ;
+- exports utiles au manager et au comptable ;
+- prix et onboarding lisibles.
+
+## Anti-strategie
+
+A eviter :
+
+- vendre "tout le RH" avant d'avoir prouve le pointage ;
+- produire du contenu IA generique sans captures produit ;
+- lancer des ads sans page de conversion claire ;
+- viser les grands comptes trop tot ;
+- promettre une conformite pays non verifiee juridiquement ;
+- multiplier les langues si FR/AR ne convertissent pas encore.

--- a/GOTO_MARKET/00_inspiration/Leopardo_RH_Production_Creative.pdf
+++ b/GOTO_MARKET/00_inspiration/Leopardo_RH_Production_Creative.pdf
@@ -1,0 +1,780 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 6 0 R /F5 8 0 R /F6 9 0 R 
+  /F7 12 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /ZapfDingbats /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 43 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .08
+>> /gRLs1 <<
+/ca 1
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 44 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+9 0 obj
+<<
+/BaseFont /Symbol /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+10 0 obj
+<<
+/Contents 45 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 46 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F7 /Subtype /Type1 /Type /Font
+>>
+endobj
+13 0 obj
+<<
+/Contents 47 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 48 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 49 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/Contents 50 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+17 0 obj
+<<
+/Contents 51 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+18 0 obj
+<<
+/Contents 52 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 53 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/Contents 54 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+21 0 obj
+<<
+/Contents 55 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+22 0 obj
+<<
+/Contents 56 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+23 0 obj
+<<
+/Contents 57 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+24 0 obj
+<<
+/Contents 58 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+25 0 obj
+<<
+/Contents 59 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+26 0 obj
+<<
+/Contents 60 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+27 0 obj
+<<
+/Contents 61 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+28 0 obj
+<<
+/Contents 62 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+29 0 obj
+<<
+/Contents 63 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+30 0 obj
+<<
+/Contents 64 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+31 0 obj
+<<
+/Contents 65 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+32 0 obj
+<<
+/Contents 66 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+33 0 obj
+<<
+/Contents 67 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+34 0 obj
+<<
+/Contents 68 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+35 0 obj
+<<
+/Contents 69 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+36 0 obj
+<<
+/Contents 70 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+37 0 obj
+<<
+/Contents 71 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+38 0 obj
+<<
+/Contents 72 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .2
+>> /gRLs1 <<
+/ca 1
+>> /gRLs2 <<
+/ca .05
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+39 0 obj
+<<
+/Contents 73 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+40 0 obj
+<<
+/PageMode /UseNone /Pages 42 0 R /Type /Catalog
+>>
+endobj
+41 0 obj
+<<
+/Author (\311quipe Fondatrice Leopardo RH) /CreationDate (D:20260506155742+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260506155742+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Leopardo RH \204 Production Cr\351ative IA-First) /Trapped /False
+>>
+endobj
+42 0 obj
+<<
+/Count 31 /Kids [ 5 0 R 7 0 R 10 0 R 11 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 
+  19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 
+  29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 
+  39 0 R ] /Type /Pages
+>>
+endobj
+43 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2601
+>>
+stream
+GauI8>>sQA(<>>2.J0oGb\X]7rN^?8"$KU<!unQEYf2MJ0u5Z&S[KP^q=]/G99u;odg[$-WX/Dj5!#%&UuRgb%)6?J]@\7ub8d'Z&k".:59RgaNonsW@\/"iE\+Sp*9Gg\@O0*Qj9eQ0Y-NA`>SrT%,p^p/jB<L^g(HRHSE4!Kcr!Q;ie!iY:r?]C\F=St]C%@VFb:"?A?LS>_32SX-]ApUBc'V3n=4HK@>:;':J=l[6qH@/dDY+1:^I`t>SCrcV7BQ_..7gm5"Pr[683KiC:J`(kketn'b4g]2jjH._$Dn*N%=i/7_YFc)K@BN/u8?XRA"X8RA"RZf<0'h9DAZpn2YL-"q+riOJXL/6jbd.TTe]"S(k:&q$iekMU4M?3RR6\k58R.k>sUWUQ;a.7`a9\lLP1j3r<lA27o@XK][cYq9O5QfK-u3k2>Kqoul$%o?=nnh<W&KI^6;X[TXo5WSFsuUEX4SMriHBog7*@(8qiskD$4WQ1LKW];pi-3ktGZJ;<_PD!,I%8!9l+!Lu+ijrtZB%J#5PN]n6O;t5j+q+E#5>:A[s^[IR5D1guqY-!U^R<f#hYTYM@QZ(')`%'B/o3o5BkIQ-o];fgm=dMoqI9lcuNUM@tQ@E(.b3/<n&C1(>H!,$gS[pFsbLk:1(2=%B)'';oj8r.JRuBn$6_SbOet@#@HDD-%r?u&Ij&cn<*4*_<VIcthBdRJs%A7+b&9$D%i0?alX4Po?betrk[4/MIogk5%<m\L_lU^UZ"m\A;_gF&Aa3:`8i.2D$a;5Z-JWGd7?j&4cNb_ktdn?!3I8\Za)%Z-&/I\0X\)G]#k(Fa@@Da3qP&n5c%U28(eG"p&U?Z2s?J(]&U.dno-DOb*4)I@oKn=8;,)mN'8%JO%,nL`s5YRuaRKi)lm_OZD9^jnN6^4m37*M+Z.??cW_%oi1?:W_V"t&Zb3]Y:5)i11ek6?*qmh0\(?mm1[:SIN5Yu<!9"/WnrS,'k46gC/]FN1OYi7VW\G#Te;NIg'legH`FArer2b,%<N!N;XpTH_X!&sN!&,FNob5QtKs:^j[8.i)h-P6BK.Ohhf)i*T!CO!n-);'4rd%6uY8PO\,5F@;d0S&qqraUU/BB8X0JfhH/Kd!DB1b;`u<*Lf`AC:>c4'*Bnu(-'`Y>2:UA`D9)K->7st896WtepZA,%tU,+CES?fR*+W[2-A`BO$O)-etb`ietc#U@'VtuPCn7rJJbP(cAXo]s)2*Q="pHh[bQ\+MgDe6]#VJoLFBYGZM-^gBt-C%N50S=_nkcZjqPB`4eO"=1-*;h=6@FdJt+S2)gZ2]#!%_ZAOf.MJ7IHYUhD01]m6(51,IYW1QUu@Oa!Q%"Z7ueYt:@pP0%I73+%8(SM-,b+p`?tN(I>b,ed<P+)>ZrT<&OZgObu5[r&Hr/.qa!@0?InM1imqGD,BO:&Sf`&L#_T'@5\XrHn#F9tg2`YN>ARZ:=R9:Y!neo?I50L]-nf;cEYHIh4QmE)j@tf:Dpm]ncAKp97<F)jQf(;$dqFPHkEJ-gX^#Z:@L/T"RdVfc/hhm#=W]hP`gVOd&"d;t^Jlg%,dY].V)K0?7[c:s[(&;6P.SpHIepC$_tpaWErQH;*Zgp;m`EejWq/GW!(m*['S.WGK2HWB7I<dGhG+Z7Ae]gMWLhIl1^E%[2=\S.[R=P_g.]1LZ6q<dUGnbYlG7:Dq&ZT.qlp`iquO)jQ3pShc%'_O0q4*@isTbf?+3jiEB8,CK$2fe$9:s"9*rZ[?MGITQ1J3[K_;gToU6]?Q.o"/jiFeJ^$/`GSW*^"qsMnPh,;f@6`Pg?J^H<\2k+7gna+'!t+S7Vbs)84o[k.@HjJZqShU=s[i:XnU1_mj#30&u"EO!/\0'.5F=baV6<K6*TZa9_*4?[$:8Q5B"-9.bj]+.nk$9\%>)DCJ/c\.GDPZ^8b84B[LY)CENiUV*"RC)@ju?fWXRPZRJrC"+u_!0S`pBcMAh(K0c]]9W/X]Ti0*(,lf03MO?.IB%!KB.@akEa?F3nUmNTo@Q#\J0K@$FRM7Pd;TsLk_6/\NaigqDPJl&p$JUp?mX6bsdsQ<J=>tD;!7'c4\JjA\2I5eNKk#H9%&3-BfYs_dr4oY8+''.MoNST#bJ&<dD&fI\ELbH8.Y/O6;VF*)BbN>"9sBj?_=qXW4JbdAPdXGG\7$h'Ju5npRaU=C#^0L48R@EO)s88pgD2]5rdB*uBUX4Qld-Pr^TEt9TNa8-k7?=AK,q&tG+QbGF8X29m;\1Us64]uh?_&AJM0u]?XpA"#L,Fu3m`BC_]k^c8p%6'j,QiAA^]/nc6nnfO#8>8<E9F59#cBt^Ijjl5mRE^3j!B8*_t?%$<S/#q(K`X"3FW`,,a(B4\[oZNFX=&U^nQk]I<mh[g!0I\K?C9K0)sBPeu^i?Wun%EHV!6Tk_4=85V)<+AaF?cm(up(p%#*">G>^!n$EOiE4(W$G's\Hbs)3pmtrBUfb.f3B,mI?8/O%hGj1,1hteObc@TaJ?GW6U#E$cJ[n#$*ic&R>fu`Li9b$o0=tt'U<BE?(4BC=8iTM5D:'sTqs\_Fp!ot6s3/2f#Fh1qcm]S0SbNBnT^70&fA.n~>endstream
+endobj
+44 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2021
+>>
+stream
+GauI8>>s9;&:i[6(&N*Ap.QJuQ>_h8#"f+-9enjb]SKYm(WT:!U#k1(Q$fJT0uVOL+Aihg=8VAZJc`b1WrF^'!65HaT2M<j(3`$S_-q<ae&B_\,D0+$b;^?W,Lj'9TJh"M%E[l`!q$uVFZgOG_@/oD"5Ir,f5kc$"uT-,EZpQapYeXN@,MlfP2MVK)r.ih@tDI`_^u4Ma#oASi8XM3/X:.J:t)YYBu4<gUPnBeojmd\$>,pf_r:nP5,]4>NBEP;HAl#;(u4*l@=YC\";gFITu9>b?<>>[WWq'Hm,uPCLa+lNDG5tG/9mCu55BFA,\[HAb]_od<kM2Mf1#KrrS#f*&n_eHmGI?S4,K`E^m@n6aKY?-iKff#:iCqFcq`)9NkmFZLChLA0Gpr]9TQY3][8dJ&DJte&R7u04*aMO&/\jLEsN1Z/]=kD1#"jj-&/srK()HmVSGI1]PL:0RYGIM0ftGM1>[i*O$=uc`\Ll0*rUhr?%_(Cq1rHVcbY^qmJ/?M6u@"IpIk16RGRCG0fct8_PcW</glSK)j?H<FP]mQAJH%>bZY0b0_g?/qQ_tVAnT1lXg(>/fEH<t+j?PbW9H%gCC<sV?T8Vuc:HtT+3c9W%F8JH(b!g$=(:IFAYrHjA\.6)V`H>tSA/WH2"nYKRI.GsK=:6V1?7_tVn+D-(T$S'R6'bBSLK&HSLN61B:HZP)!6_p'C@c5YNsV%FD5-*@Al<s(\#S'l'9QAZphq&cCuOM[tY,XT@Fgb(=cQKlI8rfUB?XYA[f]5N3;W%0M^ZQIF--rs1l0?]U?q3PqF:g_HJ3LF1G:4`\?Qeei#q"N/FJkXMPYcg`e,4[eLmK^PhAs''Gt4PI)1O:c5NcAN;l8n2#QL<@L7H,08\t=Gn<XDF_L5%Dn"q?r`-MR7I^E%DYlm4;5mCnDD31(5+-rdU`D2hMEMCOf5>A#W)B*PZ\Ml[:TYb$@LqdEIjmYp,trf)-3!]bu<:.,bjQKo_9sL=WV*8JY?(u!+tp)<f9!Q=G!$d0ou)ipi2`,18uFV0pj"m(.>3C%oBZ'LOts?[rEV@V2U]Q[%jQjb%*phH;p"K7jYII@(R@t:`+pp_Y5j#6lj3VHtmgB79]=*kb)t[-I,f.D^qKgM)MV>hb:t;N6N[Z`Ai@)Z?quD@f0@mS]NXGk0#%&A0ng4(+2ne0t)Ml#96&BX`Cs&aqu4tKNUHoetW!R4Ue:38b(VBc#Xdqo^rT3]A4M;3'L;-3sjq<-BM`2H>Km_HA;rU$)mXg4OWnHKrIrFggfT1]ATr&;P`+N?7"l46Eb&e?4i/c)>ON?n)I(HAIiHjW2+\Vpcmb#M.Bc'YW[l+bIUB9,'jsBgWOj;ODiQ.)PrBj<-VK_;0SBIlKj;WM#'1nF<3(;&]1C:"&ZuVesB'"3Re@bZnE`U1`PNeV0O)ZQm489kX#(.A`ipZ?=`;2Z`-8EbsVYY+gF^u%%BtNH5B9C$j+oF!L(:hG^^dZ$PE3eXMD5GaU71mWTL_96gRDI"g\HW>5*[8@,5:WUjcf(F#k79B&gjH4T/GQiq07`Or>DEE`?>r/rF2,,3\]m87#L'qbb"OY@VXK3Q:$@DTe1&>h'QOf3q1:^*thZ:rT[G1em9qOcM4TWR5"U.R(ZiConTq4H&Lj7pkJ7C^3UGOCK=Xqb]D,SFV!Hj2>k>e#GOQ%'A%eb*B80Uq9RuV[#k-Vuu"X=N]AXIMb;mV>:Vq][]"KDF7)J4#$4kMBqS/Zbg'R,7htt;YY2[<ftVKBY==dg983K6e0)\4RhZpP^Brg#_TKF6p-CKU=K'`Q[\-cK:qLLZ1<)Hi/%_Nj<o2,#EOE##Lgs]r+I];WFB5<]K7_%pB\:&RMq-_8CcltF%k-*Y):u.RV#`7dND;B)nqZe_AE.KZ1X_@ZSPPtIb!',lfR2+%FqS-Fkb`D_I5T]I+hLYXJXKAG&'\ZlRC\QV2"XWm4>2jeWdY&DG@*=4iL!*MN_Y0FC_@Z2._!?A[cjEG"kh0FJLbnQM>V+8,iYkaD[U~>endstream
+endobj
+45 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3670
+>>
+stream
+Gb"/)=``=W&q8H95ZOgbSgao\_/nJ'`1D5)R:I<)4S]/X+INO)3[!Z)n#tVdJ<q6Q8!MiSDG=Au6l_1Uj86D,!'+KWa6dNF,37jE]XZmQ$SkotmST%hY/pETnp*Qi+%=$kPf8U%!MMXF65C-=SE.VH.$()^+qYJf0J=\X*76/E"2ZLR1@cZ!1g0`9Ylb7E;BJDb)tDF9!YP9^$5%SJ-SuUD#>0MckeJ,`qbal!^*b4pXiSW7q7HB6f<=(olSh%ifgdgp&LB=KGrgtE"ntAN4l;0c+<\X9+E2`Kc6Nf4Y7G[VWfd%QR+Fop(--YODPYTYPs/l%H1q.[2.]3o6kGN>C\N8.I*\8Mo3^,BCPVLaM";/.a*UhIMfc,n.b34F+,q13`Lo/BjT%C4nED]]P(npLEPDo=nsPHMi@95OFh0j?T)oQJhl;%s@+'u>-A&.R+@p#JTg:ca30FK`LrdV*GVY4`"\J3!ZSB-adPq5:Y'%p0ENdU!G])q_;QL(.IfjA.$fSMUo)e4K3!;iiD@j`mf3fOP-9h'+9tXT><F@))LO]R0a+nPTJ2B%F++9;G\d'?V2L(*n(jMhiiX=1+LYiDs#[c9'8VE_;mD;[t11;:gK2:+7I:=)`Ir[IKCi&(iMrjV3aiLc@R6`!]!=Sne'C5pHo8G^&@DVJ*7'We,AG"2-na6_Hh`Wf.BVg5bqKXq&Z*WRPlRf!U-dl0b=;+4DplT4Vb,P#P)Lu!r*&!%]=<ls31_!<-2`p9$eb2=LD-Jip>sN*?Y\DO5@;2Y0#k.J-Z5f)9S-O@-)?5lEci@QC5bge$a'MQ<"@R8\jo([lX*5ZB_:Q6jPF'lCB&mmko(Dg^Zch$]jBi>38`]d^B2l7Lq[p=kE(L*,-m2XuSgoQ2*0l:3-n+X_UjkGGH_jAu'Qp9g;nA,nRXD99i5KbVLFTFI8$u6/q;l.@[@rhU&\H.g<!Yn2d/3UrGS.?TeRHdN4cD;2PXt013C<F'Vcc&!Eu>=D#'%Gqa8s\(.-V0i),ebSBLk]i_[&k\iXIp4qa4-T+VgLl&K<Gg7[?NXO.c.7$Xmg^_Je"J@OMXnlSYoS9q!^dh8f,oo\t$TU*E&6J'ZONZj9KH*8@o8)M10.kp]h"*PE@S>I"J1dApUo5T@b^$1fAR,=KBH2bO3--#dE9Tcf+f)j=T5p`7X+K'PE!gIcEbZTeH);g!S.MWE&0(CQ^;!*79bRAYsBPC$:2Ji1Y,+?QcK?5!cB9Q=99.9',a,?^uA%^'eCMRlEd&qgn*]$IT1Y=PK\d\Sa6KtiGP`UK\H;R\>l<]M+PX!/ii9bp07o!CeR8tD<H,ZA6F)Jt\6;_27+!4;rhY,3o<6JWQX+A`cmA4pSlT,*1Z"PTS@SS)((TWQ_F=;Ie;W&cS^Vk7aiccHOZ`N%DP"GSGt>X<(#6%X1.7!lu\kut%cD1l'Iha'EHd'bk%,JG6YA]%5lSX[>8XAdT!\p]l3C'ltsVXPRO>:BWc2:=p$&MJ_Wn\U#?Y=6*cq]UD=1W<PUj35aO1="MS]nio2'V6VJn6L[D*N13QR_l&g3]Sej<gN6VQGRD$>.@?ZHQ)P9L/Yb>]BmR3.#?JA`uLbQ%._Eth']7t6IM]@=kgk7-r=!W;Fs+F2F==bU*]8LboODI[)p*l5F8*9kI[BtgP>lNT)3BI:LfbR,S2eM,&%Gf8\aZ36S[fda\@r/Lc;`p+ZTmQ$AQt<9pdf'>:$m1AThKN[j>m.M(B4`I[b?i7'^sF9h*&]8iV*#<)9%%@/3.3+>3jo65Hmr0_[IsIc]AP%6/FEP3tVVJt?t(:_'0B'F=`BR*Bmdqp&'d64+Wc&?WZEo\$`f$#,5$$idW/BB,^L-?.`9eHT12E3G0(aRk$&gfh&CQ1j+f!.8X62`7Ciq/-K.0\h/N@+.[8EesH:Z\W)KQb#<PA;R#6W#Qe@NSccI:V06C&\dIk'^!+`$DV[Q)i6\;pX[%>_Rf0a^FPMN#V*uIei`4Sd?&hlO/R1m.@onHmPdt^%eAUGY*J/=YGkWB:(D*s:Ms+'O^;8ThN81T`SPYPrg&6T/:dChfuP-llDjF"XZ&.%TIjm\8-jfP=6X4'[b@PK$Ju8^/!WJR>(-cQXg^Y2OsSm>*90IogK]"70-\(S!Uq/c!TZ)*b*R7C3^_#+Od;ApG@_<9X13Sndfau\P;q+t;n#i=2]?^`E6BQ)oAI"LEXJE<DfZ8\4D.lDI[DeAlkK/5$-1@3D6<C$Z%k\l,=Bf8#L[Q5&g"a]QakH@K_0%]IbV^Aj^>]Je;3g/*Fe/Kd`),Tc9^Md%.7=Wr919LcCXC=PMKG.V!dN40u\1&G!5;]3#2LU,XK[FfYbVPrLp0:2'0+ZqO`*hn9?f#NO.JdA0-X^L[b0piVSc1GU#NE&r?pd&YNVt*>VtJ(g\B8kYGcYVqVuqVtRA`RpK9Cc.+&3l`mCd=U#;d>M1#<R?_+oM99utgH.<a6=tFS:*f/9rDkN=N5!:&Z`F\:ZeBf0dlmDRrm<_8]!oPX1f6,uU\!_U9BPpUWQt7rp!G*)V=h<*h''UYPl;o-m(qlFQYC%Vm3e&<OA_:Sq@ieg4g+(jA\DY04"_UJX6JC1?dA`BG\.B#BcD]D!ScF)6iEUBl"r=RQ&`cZVa$pj?55IA(_<g6:Qi>3YqULQNr$Sj'_g*@:LMYbci/4ijCeZCd@D5[aGX&%>)g[5.^=TdI@hX1]HW,c`G\*,D\A`;M9e]Hk@IB;,8?D8ocCS?-00.?@\7?2%9D[&'04Ft6-i,FfAC54+O9F6.IdfDs#>>;J,StlK0Fd,kK9jANBWrcP7OEAUd/9:gTH"4eeK72CMmcAW*jD[Cs[.JA44e#HL9DZTF)dQ.M8ja_.-[aXiZKIELn.N^ltgL]s@6&W+,MJX2p"XS-%8c%t-TSm'qrGh*YO&H0DJip"dNY4q8QqCjl3-erO-d8^=d%D+V1r@TnH$?^G."-^S2,p5LkP"8n7H[Ec)?ri<`5/W%%jMlbLqiGTA^Jp7N>A2q*q)QElDBs,RMj#[=K3T3.s#^p#8a,PN\)?cTCClac!i<NXf=KcK"88#Dq=7.XPEc9Ag8adBfrhlZb:WW?()jS[i1X9=H&U3qGc&HpM-OH4K2q4h(j<%Bj21Z_3N4jnZ/aB@W9Cch@G%qE=S>.rU1[1*FF^LLCchC_W'LW14Y3eg;K?DWQ4ind1V!DmBj&'%Xs%QEFML81A@WcHEgA416.SXBla>7u?T)5TL0epX6QR0j=f@_V6EH>u;YkC_THs2u5#+>5.O?)$CU$<!R5T2nSoSJjB(le(SdqC4&n,bY];tYO%e]q4)g5oq`IXKFI3fDO#WUiN1XjU,-Gne%!7%JMR,E"B[J9l&BYRllVpLU&m7@#8>O`[!m@$<Xl[ng%<]pk4XMZVd"\L9#FQ:=ks>3VLu!(R4^qn?b=$6BcgUoVdCP[*NcSH6Zt7KbBq%PaL"^,+Yj%E6JggPs4B'm44bd;[17KNo0akI:]"_)k)9QRPfgj;YXu>uU;tTu0h)K-EN_B*g`BoQC&2cr87LY=YSj"R7qW*&=qRGj<]3Q7c1.h!$76^Up8%"lR">)(JRGi/*q+UcH`:h+-o,Vqg=eK,^.t7t\WN7=V..s4_8:n9n2]`g/RXh7oJn4hLVW?q6NECjLB8.qdjXR#R<O^Ap3f.E)~>endstream
+endobj
+46 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1510
+>>
+stream
+Gatm;9ip(/']%qR]Nru-:aPpaag<`h&"QTF_^ZVE;8C\i>Y.\YIm6a"#7_='oRoJg,!EW?H`s"T"r(Fg^ZQ?I*t.jg`di&2Ck.3bKZ++b/nR=\KLT[u6Qe4\/;o(`3)!uoqIWbqQkG^^=UHV>K[VW+0M>!+,r%*jJfp%Nck85YAj-6NKL@F[ek])Y2!.@4K_$IJ(m'\h+bIMO0nAp>+0r,$6t$YBU4W3[l*nj"X3]\]lEBrd\:_a*2e0Uaa*E8qZR>he7U\bHi%,JZ$$Ytp)IT:U2pDu/_512u2ReC?iKIRP&JMV*8iT$q4tF"FYiKd*B33p\Ujk#nkNUm9pkEl&:#,U*h0bho]d_O<[Y67[E?sq>aq-L#3KPVS4I.,s84%$R4ifn:L^%!A<T,mi)3_uN5pN1fLO6>W71#LTpot)E;P/W\6^msKR\\nVj@"6W`iBZ&HTY)9Qj+goOj'B#;Q<4M[5umJ,ZiMAoK-7Rai^?F&qlS/Q?^[M(mi34j%/esB@uQaB$O*1\7@W-<URkg/E',Y$CRVRgc\RW6t93;T8VEoR:a2g1QHl(F;4.IgFKTTMJ"&/cZCPAY;=\[)*V)h5mj\4.IH=@nOup%q44\F>b-Y<6\_pp4:<3[1p=ULcO?D_(K$%+m.b#S#i&R9->@Kk1r4VtbCEJ="Z3'sj^(d)9fQ5gH0>-<%K+NcBZqphdBP&*05m+U#)lRX%kM1/j%<MBhK8:oPm3QG>T)9sdMr^8k!lbid+Gm+3d5)Y&Zf.f7=,Q>l@O(Se7SOU%D3`q-!tWqD.?s*TmS5V##))63\[CWCMm-(]./26Qr]LW)HY&h$XtW-fP48KY%fKQ[MsBrQE@Dq\6;,n@pTmm;2MS4<phmUlGLJkXD/pI0bF[C<qr&\j(S`CC'34NnI9O,Y`;OqIl+i)!?P[X\"X?*6<3Cn)?X7gclB8YP1EM5<aBBS-ro,-M39ht)mn-a;?)aDo,9fBmJ+]$>d^tQ]k/oWa.8@uiV$FipWiA:J!&o=dXkLMAY&G+IEDeSkG>+qgkNUuM"1`:7p7]t#Za_o\WuiA=IJ$D%WnUbjT+<VXG!KF6A+ntIOcE9%dj]M7bJsC>o.:C><-fBU=9:;eeo:*<Xi`iTG(WZlnF6urj0'KY2>B%I>-4o*8A?AJn51J$G=5m9K/UVXc\.odBu,aN@HVEpQabB%YOBRgI@,#6><)jLcGa?s(C0)7LS#=@Ig8tl4@>uetTFZC%Jd?=O>6s1RZ"!iJ'VoD!*Q)Z*#@'[)b)^f_d%r*G2qWAK,W^9)>EcJBPLt(fl(R\0L4,j1`c<>@QE6gK>44_L_a<?t<ICSs`('87)D,*dm.['crTq$;nO$VSR<p<k)A+,Oc*?h<k/UFS4gU+jOHTh6NJskJCg;s6T]iJ?^@:6N-S")XK\-iO*%[Ul4Yg9Qu4d#47st&'X"(470oIfS.r3Bbr[_/o4:/n9=*cpXVp&D\&BekG/Ji>mF#9B*>\qZ15&Mn,<KsrrK2oT4e~>endstream
+endobj
+47 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3662
+>>
+stream
+Gb"/*>BAOW(4Ol=^dDboFB8mR,`mePEF#Kae7i/Xh0nf$/\s>LMH!-h>OScQErb]E>BX7IB=FXXC(_3jJFhaT5#>^A_LKf.?*4M0DF*-l@t\j-\0Oa;Ot9ALnRD3'(/^ncQR&;[1)#k-`A4,AWNKh:OZHrT)bi0N&Z7B-dca5k,UP'O6>32eA]a&C1H,=^8Yg;0'8DRDNd7?i`-EOA,E^qS_BNB,&7Aq/r@CW18d[j"CN=B7r9<kCm/'T>m/:_*pm!DE`=[_Hds6W*9I1sI8fGhYN1q^/31bn&!>Cmk2!;)"Ea"a/mBXjVJfIeR6F!o>DCkU&3.I8pF[OH"S<.r-rd#EaMf:iYBtV0'3^j_359A-p<#1hRaqd]`o7:/B"&]?S9jp*`-^IH8+V@R<Bk$pULpWnnaPea6':j$(=@HU'>.N`9hGdWQ39B[P'0+BWOsk4GH.\8adr;F.'.22<>u1YWpOap&LeJ4bNl5sBDUN9"cE$8E=fr"(5D*Zo)^/G\A/m%1&o`^)42aU3*HjH_9S(uF-B7N,5Y2HF3/V4#NG`sUBgg`8'j8hn"uoOFBUL9*-0YV2S91ODr=W^q90Vql_C]Un.#t[);&DHO^V5@#MpK3=B@erDN?,b.k3D</VW=`]c/<"U@N,:2$?d)04Um;`CcJl52ZAmo7c-\S],'\h2$+3R."Fso<rg0Qbu!^HckJ:pOPgTM&]I@8LF\:96oBd>Rj/Ai%!tBjO3eITn$Ng8X]>daC\o<GD?GUI^sFB4n7fAk#Q4!]6'f?]@NU0X8!Mp(B'=cU+c^X]Q_DoNPaDa=7es\V4Sk1fs6A&dM[q2-+]LMc,q#l+cTWHNFEg-45(,OV3F:L#h:b@H7O-c)TJQd+#YZsB.WDcui`0g_cHR!*_0,TcCIu'R+?$bIHs1D<nmu$;+Z-)sG"Gpa\"UiNhUniIEP9)e4Em/"d=L"#n#V2;PmjFMJj>8q/DYVAE;!mdIu)MMOVfA?+;JUH4B04a#(X(mnV/KFMoq`O-5!"V%pbDgM2!Ck,E@/9O*jnrS2#-00T8Dl$ff,f#iZ$4fT59+5nKbM(n.]<B'd*^$U3r&&WP19ELS*p5rs%KG3EeeBu<%4BY?\mDhCKOX%8c7o`uRH3Qs-T[*/)>@@?Lrib@9#mgYX)_`Gr*93`kTM\]akhWMnE$NI^P]E[+gS\5CfXb5*g/2-=0F.HJ)Q9`l%gL=kIP2=h;a_gFI\gCKYg2+)"gZ5ZGG+EL%&NNSO)EVlZ-G<-3L2;bV>QMiX_#2Yj7Il](ffEn"=kT:g\h5s-<jXc2d.rBW'`2g[l6dc'Q<\6-=108Hfq^X]TOY*#@%C=59YI]8W.tA*#"fAOc7+1J0!h"r)1h&Zf:LOD.>"TI;!(_7abn+#H$3argEmj#l(9&:"0Na9'2Eaq:r?fb@U`jbDB)otY7a"*3GI!qOd(aDIcQKfD2Y)0EA@)1*c.r!Kqh`eSU:7p"8h.35BZ\AT4jjZ%W944<Tc#1,<j7QN-\2PHq7?SiQd:iFABc>mh#?3@^objpP\Z1IZ:?JMbCNKmagTKpqQT?R]fD(!7oPXM#0.IZ*57A\UXg)-Y4/3?U&h&\B16aQ7gi1r!2\kOt>(i]1^IW5?@e5Sa86P$.WVAU!!H1j*^P&HpI]01:86hqEt-gCf2f=5,adOJL(P-gO^"*BdZF,J</66hsE6D7Ee:S1XaGT'JgEIbb(Z!n[b-^EX&p-Sc';Mh$d3=KWO$=_tR1ocjqgM--pGU>h_;4VtED4/]hrK:_3OOGD@u'[(780b/tk>FFabR.1W>LJnKlbUjTu\`\Hn@Nk6&l%&L.#g'7;'L/3sjqhGE8;R\_ndu!cm*@cS_0F!B;Rg0nUIM(38@0(MPL95H$\Xni25B-iphfQ_PZWh*))JV"RFrX@+"S]WYPEJ?=/Z.@;G9Mh"_di-NU_!:?kVRiU!cd>#:T0@&D',QgT@"hXVDi4Q<oeS=:9t"3f9^=Yl+>(i\LB7kf#oPt1d`3iStJRTl6:f4WiLo5):T7k'h!7u=,?<r7R0=[UrP)di%=d3>SG=,GRYOf'u62InF%"19O'mkH,f5I-\/[nPMd@S1ZL>ddg@5CDI&HS6<s2$s,&$E!:#76>riqa5Qe?,GldY=gh1KaEDXg<T]-FdV7Qoj/`NG1`rWA0X]>FSZ19j[j)GW%LBBr0%_10O!*=r.LjQXq%L9bOYJpUf'aiIk_r1lULSJsm4:%C$&2`i@^qX<#G`*];Z3UM<K2/NK7RuT,Lm82g(**[#D`oiL+N3&f&GJ*7$H+pqZTs?>a;>[;'R#U\_`SEf-6<GO5:mLaA?aQn_7We2rhd#Dh8+Y03BR`AGi6t9^dIisUp\61CQF8=D6F\iBZ?Wt#?7p$kRN[$8`L;]?j94A7)P[["&T56`nDACYcq$F@/sFDcZ#R8kj"s0Dkbt3]8k;G]CUnt5^YKV)oTK@>/LJt.2^"famM/GR%/GP_E=?#$MSIbbQo\Ecr^EmKe\Cg(%RM!D947ZC.FT<ibE8N1:tWpPL5ZFUFZ-S>nB;Pe.>o!%D"T76l0=P"C9u>Kc6\Dc\?k#piFdsrq,9sg!@"O%>RM;,"L8#s0?C$lHTq>_4[f8AbDoO&D6jJ"?:9$q%(n_Q!OIh/IPdD.e_\So@P8totgiOiQnsb&92@m\f/n-i$,%SF!o2b&93(Ull3m8K/iU<ro-?XkIurgJ9[LF:i>pFm#Krn<rmbpSnCbW;+RD%aF5L*g2&:ti(ph%#d"SVW/i<^j)Kl#//]WAX[-#9NJJPJZ)\U,7jjc7nP0YT^137Q%c!X-aqm@uQZb,.a1lQ8WWBVH5sCmO*'lMZ7WBJGoX`1rffH/S)(k*b3C*de/j%1`hqULW+(7-Q+:^Gf!M4r'gqR&j0*:/rmYYrR(0"OOKg.6]a0re@hZBPN;`p6&jr;ouN6Y)h#b;c@:ZqIorZO?&hVS6>M\k@CfCnp\(6_g]HRAcBa5m7\+R^qJ[]d*erp:<^Ne'NObr51i[TK7pYse+FPM\1l4d4bZq)spkE@1_/-83i57C$V6ON=<;pS5n\"5OXdk7IGX\f%bF5^(oA%HMQAb"?]EgDa@eU_i]q\j(t]T4Ao#X+bChY+_N(0=%,.bFmrSOJ+eMaAUZA9j1i"=_#5+KOiE\4^VPql"]P0qU5A&0lV=jPWW1HF$GU)YQ:m?*rkWlr3PTL5jD[(Xg/.IQiW+0J*i*k;.\4RXH<#%DZ[=2@*8.eN7JC9#d*93:[@b^rZPHpP\uMi%Jc@(GS+]*9K1.31Sse,^;2.Mra0(,HHba9!OES_3`?!r1&J]LL#nQP`rfqWrrBCGYJ=&T]"S!WJ*H@^M>bK#B[SEc-\T6s]%km.-A*R?]4;>2)S=keB`emkXNg&iMsRoAq:hLdn*0bAcL:#qT$G)1Sc>o(n(*6$H?[+"k0=;3T$0EebTHgfD@tQ9RL>W!lg`+MbG%P6\k\/0IMm!Ze8r=JRr%M<dJaUR1MQjIAs4I`mS'W4/',kr]"-(f40r\:1g$YdNF/(YML&E+lhq4f5OsE_]pqT;c!-"mm`,\GQ#_5Cs#A>3i,:mYY=lb$;*;Pl4:E]>H@`j)-k#b_Ood^PA>?AW08jK*&Xq#g:%.KMFj4:i#9LJaX2!jo4RfsT*tBC#*B!a<0:DbTXQNj-~>endstream
+endobj
+48 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3604
+>>
+stream
+Gb"/*?$G)4&UiPDJVTiN8Lte;"T0SsG3X.3`jKs;(VS2-PXLj2DFgoKs81(A,R@;RUg7oe\lmdC+Lmd>k$eV?*RKaAprhH8\L-D!3I1Um&]Vrg-"/QkjSVO=l?r-f,,*-r/kJA]AQG"JBphjnR]AkGUe-q.edt2o_Pp4cZmILceV#5B#bqfBEcV!C_KEXcROIO=p?E<*1f"iX3)?A[,dH,s(^)5l!S.d%m"L9a8Kl1NRQUQ=e^&/0hgPM\H2"ddaSA>Hr[hmO%@Qr8/8$FYM,_o$:-a`3TQ&TqUB3K^dr$dGB]O#/YI;WWW%2o>>R8<SY.2TqS(!SQ7FQG@K'SZ6Icno'^-(l-=+?j&Ds0sD'^aN$rm'foZ<63g=6*p<Q^AgC$fe*<*InerkL5NM,c*?*j"r#N;.4#u$[\T]3mfDX7ki'pp[k=39#<%/o1@lY\5!Z"FRscRMRqb9i?ZXYEO2;E(3bB[NC^,T0IL=@?>m,]<M),"ag,5CUAk5F%MKujbCiP'ZRNO"n0@pdZ$jnfhu*P=6N4Zs((.FM(X`X$3@,tNFJ:Y18sfs16\HM]MC]S(gVQi9'rj/`[3S$Ij.(c4Yd/pgYq-\t/`+r!8"INYJjM+:>^[Q@`Fn\g0<Q*E^V0(>7(_g(0KZP`7]+k,D>'#Fc?eemCn=)mX>^\Q^4PK$Z_@!DH?<r=$e$0#$d]Ai$Zr=KAU]hE5@u"k\\"b\G=Of(+8e]Kla'o'maRMp/h-)\D7>t2#$r#R^.]!K1/]fgqIu(DpF'gI*MYt25W1N/e/5:']A3FL-E/_3I)%.Qo+S-!FKCpa1DjY!`Ycqmcjs0CiukQ5_La,g^uW#&grqX8:G`E><@9n._a"HDBLQHK5Gr_o-$RV(PUs*'1W0.(DXr0\CtEk^<aH`?$/]H<!ddl+FT55T^QJB`P&/=Ea\Mat;&4#8P>tYkUj>q?2g#5Q?ak;`k+p5$X)78?2$2<N?GP$,'Dhh%.rcb@jV56$_a:K-pB)`J=LMOTMe0FackJGK<!:6a:e5iAn.sms-rY]!TTm1L+Fn6k`Tn.ZVW\GIH"f3-5lbg,[\B_,FCj@S+FmS+ER!VQYr29jANCDi.[![o;t"08BKm4M[jp#k\DKUm%`3N3Pk$d^*H4h%$kR=h#A$"-=S?>9!k9X/O+XYX#E]31?u64cBo`@\%L8[t\C5t\+4ndtTZ]qj^i2>c!DriQ^b+>*m0a/N<ZVC]4:$ZH&FeD7%W;p^1_rBmZF=NZ^bq:#&@D!NBG!MVU\AHi6."D>TLYUn">ohb(C8_gSDejI_L6csAKD(G;\'#65m%a9iippB_7Wj9r[)m$$#lOeLPKF^%p0SP4O!"X`csV)nT^GKpBCY'dF_cM=9qbHRNCscKTu5j_(:6uLkeDX:Gn=Uh_]hX/8T`Z720/(`,H`3;,\hOQ4l.R*Z@Wu/=l:W*1t2eHh!ZXD!8Yi"\P;]lum20%kHU-i-jN5gn/j[#psuN=@1<9l_5sLZE8.fK+%Cl;a\;EX.nG"<Uld,>I(90NatlX!UfQ>FP@#Nlh9>-*?^]u6SA0SEq!d29uW2]/SaRH&TUuGArmBJ/6!$<5)\1hiqktN!=#::%g"bmM,"pR?Gj5&i""B#^C?Z@R17nX>Ap^OU;PeBhZ72h4i@mnbTI\FTu:DrTb]M.dKhQDF,7@?jt)6(T>bYonU2PBT&b`\5g4XM,8,%nE=62EK;dW@?/E$c1V@Y<lpFWrCu'_TR5M.U"42#QJ;,1l"uJa,J/(^eTV3,YFj^Q&F[*KWZ#Ai:dhq3]OW>D7ZMU;2*A6n*+T'ed-KN]q/pM0Q:N+5DJ"HZ!ao.^OiH`th&'hH;J#^*G]Ibm:Dol.j3SS^=J:5jum3.US;`gVC\25(m3C1UZ6jCc,h2+MqA-2F\_`DPf/(b*n'2Q$d6-qgC+\X7:@-@J)=i*eD7#YiD\'N[1H@+T-GF=q[([r@@V18JDTYP^$9NUPl\N\VrlegA\1%X9p##I&5b>ca]1,TYNL5P$7:^4WBpGBrgVsqln!ND(g96G&R)VL:BWGRCg+iZf,BO0N-DsNKZ"*)7iJ<=3/$o!-)phAJf-<]kMM1D0ZY&EQN>RJ:93!E]7S,tBlAGep@;?02,)$%k?"98Ro;uVh74A%C\-Rjk-r+!@SjlMHt>95SMULW:*L,We_Yt$_?:]1+#qH\>1W-8rXKQX6a)<!;7jCu:81#JLa9iGE9[Tq<^L"*lnJ`A9G3PM4"a+k!5H,Tj*=2K$+#i?ZCf6#1*JXp5@J:!<[H,T51GK/"FnNA%gW7,baTpn=J3qq[gS)Z$443)P)!'bZe%$Vb^aB;X'p^RO)@iWN2bR-oBNZ?s8+KWU,:j.jbCB.+V*3^-Kis3*CJ:erq^)XnCiUkOa<\"]5@31/SZn&Vg%HG?1iE<mI!R7K?Q4LE5VLX#ZmpHEsS\'BHh`)H0pFtgYlNRBDUj=[2JE8jngZ,LOX8T%IemVZt:U,H#Sh??H+i0lt?tbK$UNJ)JUU'=5o@Z>9^H)dWmJ.Jn=:"2Yf1fNcD<;</Z^Z>6<d@?lZG6N.rL78M7%iB?j0+bP*JV=tJ\I_,Rl2'Lb;'<%8bjW=Dm$E)a7Kbj1U=!\A[cg?s!cUM@CYWn9p'Qq725#ueeUpV_0Q1U&7n`N,i)7a.)3NJ9LmMg9GX!I;N>aXMg5-t^1U:mAl4)QRZOIs,78Q*'+I.a)8+;D%U(iLp"J5:,Hu];a/e:RcQGSP(K(\#(rd*rq#[1CXY6A3PZ*<'&-HL2QtjI.8_huC+KkF8&/^"P@1a:rj.qrB.,U\9#G^7,Ph_>J$i*)g5o5l*OPC;n\+!IH2W('B+83"E5sr;=UF$<5k6"Boi9N0XQ2M?bo<p0l(7)XWRm[!Q>Rl[m$A.)hgdl1,^R#4ohSHknLA(Z-'`K/_3?H&p3e[O4=FI9[9pL2ha<CIBW1/2[P$!)DE-q*^L=0">.K9WJiJ0_kVsk8VNi2C;Q6mJlKu25&b-;ih3bUl2,&;BMj%:ScZLJY.D>#EZ\jpc1cb:9@*l7l,+]sGb`Wp7Z-cJ-YJd;fFpoS'%p=@VQ`#2cAW>O5E+R[;Apu?YtnN?eq*rkHqpj72Uj)P"h3<!4_YqE$kKEJFc[s<%IMt$I0]<%J:\T=Bm!8Xh>/Tg3?p[`3b2rlu:JOPifmgs$^d+4\Hj;#e:X"p0K^'Cn@W`)6>5&u.6EC?5,O2<D43Ub%4dk7uT+2\U$78@a+VLW>-Ilu"`D-H/=-gp.-@_CWemM,a!*@^.6m:TREP<BuAY;[bLcia!'qOum7S-'/g_=GQ(iJ>0NAZu`\JC$-["2?J>rgT(+:YCGHJEq9"jSDBLs*:dIAsLtL9m5j\Ft]_"oZHkfBg7&_s8.7]ImBas:1sL6L1.^0X/GiaXLZQ4DP[,u]'XZ$O?\p+,KW05r$0<JP5Ih5r9mnsh\=0&rA$P3khE;miU_$_#t#Eh+1_E#?etJVd/ihgh']^=4H37rcNo3ogU?^ck;1P7g0eHu\Lr?ek"1_0s0om#/b%u25STU\Ud.#b'23HLH.1&&BfMsop.Gj&rhV-\\W;Su_gEuoj6>`oJXq6BP(lp9Mc'`iAHFiN1BD%V+%-D<(]~>endstream
+endobj
+49 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2905
+>>
+stream
+Gb"/)968mu&\cSpkX0+PFY!l<!]d&KCKXtFfk[^)Nk00iPY?j"cB9ten%VXW!-60._j7$mOq_cbO<Dp[i9Nk-q_L5dr6,%W^'=@H$--Zu\:EZUE0VhRIXnoN`UA_<BkrESKK7&CJV4u-1'?q:U'>0BDQU6QR7IHZ.4AgBlV[gIiDNirTe53fe\Vh>+AF\Pi1g'9=X-fRM%HZ7*"jWh_F^D@']<toqbajs[#u&fCO#[6mAKQ>MpkI@nahgGquY&CUbOL_E#e*Ff-qt;/&qdc(<o\7F<&RO%cjM)>iO8k]PU]]Hs8Kd]P0$qk1R2U.H(0Hd95.G>IY@oKsQ\V4c.d%]Y=>U3kp,'bu.`[R?%$=WNXHE;/aXP)Ta9`,3<e#%*a>_nat0:WD$40;R\SP@Ps?ENNM\<FG<)?:='TSp<u18C!-hd'B[XI!j!Ih1&Wg#HdZRE@5Sq]?l3g9'^0QrR**Ri)$G")<Y`k+CKJbXq`2cfogn^VFR?mUWaD/nM<6G0/V,S>0?t$)9jf7#,*2qfUd&hg%W)8s/F%pY-0p8*1*Fl8_M1X@iRA\qJK%"GI8`MIfP_OsHE!V&P11lse8QR=(k<MbN_7o<&_,5l)s!AfQnK;:;W2QX'7T0`meOib`D<]*>8oR;%cA]"Eg)3fdE:7\dbK=aD([BbNE>:VGqQ0/rOp5=\@uD@K4o?Wg^Q^p7g877S&4X=XM2ddrB*78F&IQ^_a!C&<A%t-8^i5`UAqOKir1Xq^^R?^PiOS/ekf74E"*](R\>Gf>*j2?/[]O"a#@^q>&3jC3+Ler6dpt]Rl1iu-TEO7*)54L6]HIX$#63=A;RR)'AlgB6V[G*L4o:q0AJLAM>#Y:'r0;K;r2qQggr19GiHeEHF'0M7BnIhlT6:id)K34p-Iu8*AKQ&+LPPKC!i3t24u*O<O)5e#rYMem9[^+ko'J<r,L+m4O<6d^aIk<qe"RaDf<c5]kt?c([qu`'8aP';S^?*Cg?H2/cjS3?3j'QC-dqqF;\mc6(q((gei/d>6M./UgA:GTjo`@n]9*r:-)<o"jVb-\'Q6_[uu%ldTQB]*2XMpV#@q9/4IY6LUWR@Uf871(@6,t`du)2cd:p0VhGDSL;uTkJ:lDR#AjYbZlLJa[tKCB!=-3UAb?*=LipL!\q#E,#95Fj%)A9]"(",#dd5pf#9:Un*fU7^X>2pI-PI=&"b[0;_B7%]i^#7ZJ7*X&_286rqMhhV>69?k9-DS=Y,N51^rQT`7L'K`*'c3)mkH#:?pk"2m!Z#Q0Jr?a5VRB@%*JqapZID+_XW-YB5%?t,#F='T/\A0=Rb8!<O`o/h%"Cc.Z]AF!=oTr4W\e87FhZ*X:9F,^$kUq'[QQ<n8Ob[?io0E1!(U]3k)Z;KSJE(jQ3B"9$g$82qm518&#0.SsYb8@r'TE9B3lTp[<ltapT^QgioZ/j1\Cg;#qU@E*T.N^JKA@Rm0RlEQ'-!Wq*=fN(KlVW::#IHu@*0CggBUTbf=grgeOl<S;5X])8Z[]#u21+'lhe\k3s:Mr%),kqTd%)Kk`$KJ!Ig"*C@UQ?nKB4WF-Ti_MiV'+"_.4:A_;rOfE=4uTJ4W[q>lp8^F,nn(r<],'kXF`q&4hiFfl!EVr'%WI]g6c6sS@VaKD9,"Hp*o\Z^Yi'"rl.NRb'RpIm,*Zs8=`>*!@?CkdjA]QrnD^fkMbn\FKY`^jHtF_jYs-S_^6oK/&l.2Y,aXk]3nN%;s'34P'P5l_oce1Xhhpk]&-cBX+AA.5%"oKY@a*<+JZq#slD;TfcG0'5AF/Mke$40rZH0aiP^SF3SB"PkMfD)'V\47OFjm^%1sYnMmuB-I48sK-TIVM!;2++#e#p%EpS3$K;%7;B,Hpi:5Oj$OGOpChk`Hc/qgM$Vd\@,G7ip/WkG[;fW#gZX>!ECr7qP<?iGYrsI$o,PN7rOQ"^c7t.2Y-Q@lVL/Son>Dm4c<KWVn)khd+tE1Xu,BGMr2R%N6kB^-eNC+<3-OPbn9:/S:oC&C=oR!7B=14s4I`6X,S/Ag,2PZ\\EHY=4OTeF!F*U^O%U6)C5oH5T2`W*GY&>)lnJKq8dnnq33_n7rYc0bOl4YSP#7.%D*8-Rl?572Ht*`-sZd&Z."o1kSVlV=&I4j_$%?/45Kf9@)6VqW),A`eOs0b6-I)QlnnOi7]JpJcl$Q0d;#!D9JqHDp*H5mg!sFc(BKmjgM7oiVgm-r(1,kYe);WM/SSLpL*q!_'V>+5VnsQMbZ;bMTpohTp&NUWLE(Is$Ad2r[i+;TCfB:.nZFlEG0ZJ&r<C*O8.dS3mp"f]/>S7-PrtY/A(frA>^a>b\PJ9f$%pS][h_Jeq67t-FTei<eEn29-n4Y#!+=#o)adfY1ftsH9]Zsn,K#6RFdns>!6Y'Ab`IChA)+c;>:DVB0'frB3c3OM+J-lo\#R:[uG9`\]n^,K!C>S2GI8gWotS+YX@eBYrEk<^B+.(:^)I9HpmE8VpaqGi0+YR1,?^@<g>2B^aAZKGh(le/Z,%'LgN:Hm?tI&'3CX-ImB$Uk?DE"g7jL!eXjPh'*8OTrGl1ABDucA9'L8u%627nD4'"2LH]%DZJDO2@m&JNmCVuOo6eU<PpTWOr&dL"8[Bl2XIRt"s*ZfbJqDH$$S2G.UT^B7gN#ZR\&>ITMKMBVl7/hr4OQ;f0jU54BphWo\b)Les1.e%GEi)>R*O<[0;A$7%d!_GpoQ>Wr!\(O](MpL^LB>0l`C&5pR'*G-3?Y)^aYjo23ggfB[M!F'Sb(SAd4iZ)&Vl!e\qOX"_ns*UOqT*=!6Y+?/W;+<o=:c^p9j=g-E[Qs&6M&'X%t<E1oebc"I'LW,qUs?+&Ksk=7Q,bR0<0Xn_"8rQC!*^tS*F&KS[,:Ha]A75K&\C1%7WD\3(LN/7R;r"GZN=LJ~>endstream
+endobj
+50 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1281
+>>
+stream
+GauHJa`?,q&A@ZcqWLKs0QmLfO-`G<>iS5<Dn[n>/9?Oi'2nPu:H&8OP..s`OA^oX5kP%^!s1I]7"!Q)J3TB>Hm(aG=PeVU9Z-E6cBlMrJoTh@eA/TW_HUEblB5?gejTht1#\XHi4*<\lOpRKbk]\=?pZ;T*"2l94quCpKT[4Yi3Ra,SX$#P-=s09!9U-0kQEA*!Kir.=V6N/XV<<FE--ASp%;j8Fp3fMJ&(Us=FMBP3KU.^PaB7O^pML\90b(`UV]A[Jh&\=&'`n(C[cK1<tFu4krUjFDNtga[Wr;NjlFlZ1Q5PJQ*u@(72etm\BO"/hhV2*jpWmlIX>bs[.!FO<TpkcB_USTbF.qb2ofrHSj`C]%&IDZkG@($JN:W5fDASCT@oWl=Mk[Uc9ukP*f$TraeaDh":6\!@<OEt3g03\88"k,:X$a,32#6lA88$0\!YAAYr;5=WaXG-)X^baDtZT6+ggE!kUCr61*_1'P^%J+om5Ka(,6/KEgoCBQ)_Wn`JJ0W$C]2h6..0nRi85`H%KRApL^"^<l;#W8=6gFH]8e\BT&Yu?hkta8Q/o6eDB1@D+IH+6iInr"_-L$/fq24QQq:YLlpX?;jQ1q*oLio`T[O^=E'^#kL5d!@lL=$k8D6':N@@#/XVl1>WEr^C-b_3Od`FL0bZ=>5V[&ENd2@5BaOrA/<9H!)/I1>NkCLE:XQ-Ueg*]LVS/5>=?mT/R().-<bIJ#iSD,7X?`\"l9LsZ=3oQY)sD+Bb[nJ>Un2>+TL@:M]j0?_/oMNgE-;=r=4c&2c51H4WJ5o?[cuA`c[3)n>tJu^-dRdik(O8d;MRSrQ.W"9Ir82LW>Q0&q]Uo@kj"7U06Yf7lD8nfVM2dRgoWH@<O[D_,P8mblC*jhH5N9p/Rpi,Re&P[*<@>j+T%/>?k4Ralfcb_-?k8l\[sisMtWohrFr8Uo0S_*%L-iskn5=cAuFKuB?::#DP*JOPn$l=*'Bml4J8Ta;@)8m<hkLh=[0Wq+:X"^UbfH1/At*t+]r@[a";S0eb:noM.n/g,A1mf9[Jo9kQT@%PO5k)Da](Cnl&83-E6@pUeSO`BtN@IoE=!Dkc,mki>#.?>S>PcO>_l5`IC""2i'(BK3f/"N_T\XqJg>g!!08<O'rk;\fF'M65RIra4M_()t7DR(nBGa59KB2DsD\4Wi+Un*E4^nn>!,Nn.A.&\9.ZR`bj8.n3HmW@8!4+"e]b6AdB>$aop:jF9T3j+tI&$+b.icku^)Bf%@faqX#$A9",%?./j<\:.sR~>endstream
+endobj
+51 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2397
+>>
+stream
+Gb!#^=]=(r(4Q"]3,`5k[+1Y37gBGi'`kJb:"<3?jV!_m']a.#$^^\`pTu1bgR-nfiu(b"OAVY3la+#0"Uk@XqD4WBI.<n[:4Y1i-U7hIi*X=In,;G^9=c_h5V16USdgA,_QdpuV`b4#-.I'#(L2k1AdJ]qk7ZBfCnQH%mRe;d(ad#kC'G(d+q4d\,u9201IhLTbRp!>nX(\##UGE<BIi-o(WqRKS:a%YPH3Zem9k$Z"/A)0!WP7V^D`!3,3sWda/F*1#Uqlo!E,$q&mXNc/WPe&<AsS")VjI9WkpO=$;U2>/nn-/cS8Z75+a3J;8PK&*B5,uf0OcVg["?T<PCITBfSY4H^3Kf<g+ed<LLeidQ6Br89lVmL"h/<;.k:r*)7KsEkL"@+Ki)]-^Jsb:NR@GCe;tb>ZltHGg;KeR)SFb9jlo19SbiEo=cM&Z!jdlS$9o0h?=G6AM]^jji"J;b`uaRXKs%1o]Q.7KR1)6oKR$CMiA:MAdBfIe8rt_N3ick@NeV(`4=5!n".I/Z_$Z2K<YS/hUocTWOZ/>O"S99f38Pin+?nZ10qV:LgpfpOHH[he1r^:+`]Hl[+CBs^KZV=<_Y:7i>%uh>1Urrq9H'km*.,tH*]A[;snU7?"T.J3!]\6o=BF%7"j0Bm/tkJp<W+@ZFFOF[!u4iGQN.%-7XbK6G(J6]&gR>&!]R&"_&ED7E]\t?>XV5G`is7qWE6kTi1.r8V/MXGK?Dg47]$.LEqkk'EL@57gPhlU-;(5nbAbs:UcDh`F*P]i:YD#1%>340fBC/;f3pS8.TQ9RcK!#ZqrC4Z:*U'(&T2(MT\C^d>$QXltk4M6TD]g]=T&C5)+#,LLUbQ>&DY79*/t4hInl.q`6"/k]#').a1HqIB&04)L&-NmI%+4QdOafCjbd1bHl=+GLl2O:0rC):fh@9ji-[r;S4k]j.\n8V:]#$e!k-&GjUPf#?Sh/Zbbj*h;(d^87NCr8XtEG_0:n(*q&Gc4^ic7hV[DhL,lU7`qCPd<7Hp)%uMP`$db)/&n:B3R.0[Ag;7(N0C>(tjB*DK%qEF;U@!t6Wi,\F/3@?^p[&$2KA5]"^iBIIK00H>fc_Wrq_3PB#"balSJNP&[W%Y:j``ot$_>C(dAeboQ\^.J6&nIMj3HQ?oW=<1SA2bOAM3_$qI`K6)m"B."8?q<!+lSZErFh(5LMG!U;l?"6Sf=po6cIVUNiZVRH]!\EXPh9g@hf>OJlk82eX@Ni2h!4m7ciXe'[9Z5G$qojLT]>$hGVobqVJ<GnocH;WVCn,XI1cda"UVf)Q#1"),tU:.G65r@]08BC-M8Negqc3-,!6NQ8J`1&&T\qG/=OX+M!g5F^Ch8/oL;c@^4_M"s!)5JPt^7V?e`G"1gV%2;3tl&*ip8#io`a?V-Q]pU$ma`NPsdfDnSf389>6j;+6>m;O8dk:M!-B;.q>&7GQFc]9s0\tmDC24i7k5kF-*Vd.G8r[+q3mMiAb)TJqSO_!"<>"9NEQpW?0[N[UrG(4cSp^Lds&3!Joao#H9t6B^JQ_l(`h+=`ZqTZ'""okIqrW#&"7#<(aRku:<KIt8HA.nE^7:mb("a:06[TfNk:Pu9D(Uc/`sVmr=N,P^`mJ31f:qdmM9I--MZ;sK@S\o,K,Hf4<OkhEfbtn.GbLr>o/Ke7P(t?Bdi^0A*:\kLR:\4uldQ=,V]a/D"@a@a:h@3dhn%4\^jJM!1e2=SfsH2M>JrhX+Y`h=mIj5/:K=h5c-F*5Z4%*,3_P)pC-JpnXl>Xo-UF9NrJItSnoYkBDYn2$o5)TQJ+IK$>PfM7(HP6AFOP6UmXD-8)6<&Qk$AtkeOt,+k8c3ZV29MUUI=c&q'"/Nf(_..e\j'T`!Rh.YjT&@Ju$:DmMml`/V"-g"t%CnXK8iohUiS^qhQm0k0T>56\>[uljaWTGshB[,)IeRK>>XkY_m+cg4"YcZ[\]L!MXEG]6rRV]Lq^DO$QoV_6Ou)GAj)5U8VkHLKk'](_gOO/]e%8D"I:\/Jll'5IMQ3Z@EVA9J+?]=;I`f&[`Hqm!?7aO5OQ15A2SR_cVUIKR/rP*,h,8$r*OU_S":`0?l<&"&g%g/I:ZQKn$8odU6qe"tl)0O6V;?62eI=\5mdZ\rnYph>Dd7+$;gEf5[j7nrJ$[4%q8.!ij;qGq6EfDhVlHQ#S<H\=cLd<d]2LMXfeJ.jhKIFNq<q6\Uq>/TptS7#lL`HS%g$prq>lL6e77iq9*Iqac&gh_&NCIPT`XHE>\Se]MhtX[X,.KKOg+!AhS;:Eq_Nff[VFLZ5O-9\,$Q/8CuFF'?*)8BGTqRjXY#oA/[o(dmV,9lDc^8XO-;Ne#K"6Vr!uraB[17[PXAAo."j$n^bU;,MXOqRa`S2asuqm"$c,%.sN0cC9k*~>endstream
+endobj
+52 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1411
+>>
+stream
+Gatm<D0+Dj&H9tYfT0`Z:aB2Ljc?qtguTlnVC?RB*KjiY=:fQ+VT.!Vhqq%T_%*[#(_SsZC@s^CB=18aT_N-mEtSTQ2MB6S"3+b/"X]%UiB>s+Hf'.&8u9#t6@I"((C5)97pX2J]`a!49IX>"U7?0P4:o4Nb4f.KKK5'U$8N(>O$*ld_'@ANpuV-9.$o8n#j7e@%#E5XJL#2TFC6E:/IHQT'TN:5(bY5p5<W=9h0agP5<cl%%`=?>`c<5@E?(T,klDAoplkm++t6:>`aR@_+MSBWN7?c?9>gEJO4"06ZY)e6+HJE!m]QD=-sPg&bZt_`:W;q*Hk+?_m9a^Z'qD(k=hi_2]2"Q('^?s)oV1;7<#I,,GuKq0j2AU>13a<!./!M?$q*\PpnFb)01MiDE@&Fh:t!e*g18S439BR4&ND0H6JMq1E$dGM\DkGNjVo&;!i'.pqkGU)K74Z^QJY$,b9.2AIeHA\C#!\+N4HX.2!HD4RIB++30j=S3)eQkpGp-a(/\ZjQ`<pHLk`V'M!o>B3,5Eh,As*140nSPRXUVFqdpXlhj@=u;ubq&B_hZA$g3J)f`&S%W7@Za#@!4e/P!H+7[7@6At3kI1=_RIZ@RV`9f<B;A7oL:c>t`<\^V07?8QqeFOj'@AlAD_i"@(!*DhAFMhCpM!Z"HR\E**D\G`,]j[-.En[UKAkL,TcbBD-EULIq<ZqPEQOI(=NZ*-O9C^9dZ,`@sKCnf;+_t8$f]0X,Z\pGEW7uJLXXn<'Y_pd$#&pTigA5Uq$Sm\HDhs&P10qp(PnBPX%?dA3Ra[)';4/-!D+3QLa:#?gL8Q@(sHNH)tf($q.PbdHjaG"(T`>NE5"&IT0e8]4,>Dbb,W\<#RB-]N)%lN@P$XSlC*Z+7>jBiqa-"i%M6mnDm'jpopL]5QCGdLZ#F^Bl%-ckYuXjg&Vb]0=PAKQQ>$mIhE(,MN?Za%-"I<@pgT6J-42@f6OZ8+N%gKGs<I9I9&3`/9aA/%BI\1cn<BV)@_UJ%_Hh)2B]]K!#e2rQ/UV9(qN*h&g62P*!"'LQ:Zb>CTNC/CJ>kO3)ledJttP"kF=F\MY&Pd)3h$Rj0II[/N]CmiLBCXNZE-!#up_H)UD0kqhS+\(3!A4Ke]Oid!BcFj]SLkAj)F*P>8S8irA"LdtlZ4*XD*3)'9SZVE;[Ss#a^ihp^A)fl\*:>N9)BPX"'So0W4<sUX%iQZtrEZZGD035'lgMBPh[t;W,e3J_*!WHF>Ed&Gk5^-!nUH#W#DK)5HOSSTDd:ED`buU#@f]pH?F/%O32O6tpGJI8e$p`J9aq2AFjn@G`fL99*MHS@%@]hj@DWsldtH!"K\*r8$(I1dRgfc)<<g+`2%8-;%//E+@UJ_*Z:mWl]Xk@R*^_$=-H9@N.f3lUL>IE5G;lT~>endstream
+endobj
+53 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2996
+>>
+stream
+Gb"/)>Ar9;'n4c<3'\S:fuE'_o!1M&Zqdps_Mtn-\jZY7ck:2:,EW<dcK=$Yb_8F4Q=Ri`qG9"<6k*ekgua"I6Abf_5A!)\>C`?4E;"h`j06/u-AdE;-+mU1^<R!a;8aal)H.CV5Zf-r)F/R4b<\UN78Y$j6oj4*L*5N46ua%D,><na78Tk#pZ'IOi"-Nt3Q-q?O\rn]"bcJD.L%0\Ys]as3,W,!aGpWA6qJP0\V66jpK+!MMg&7,q"P&ZJ&(VF:!kE\P`LV\;]u^OA5#!+'h+8CO:S)f)9"s$2^fSl/rOkYWj<n)oC>@!QIOSt$5`<_%p<&cE5R;>4tQ&Cm]K3,IK+"0?cu3l;!T23q4/>t?+*N"3_MEFI3`j!MG\8Ka+8DCiR;9B"UQUej6daTUo9)\rtJdR*R?!-"<AX`7bmfLR;IIQ*]uRg%Zt0dJsOYi:[54D&LVRkT!0rI^_l;$IV[(si'+O1@,E:_G"K4s:<NmJ.^m$m^S,TCPE;pFA3^ie6c?qB"[O^<Jn)lh.GVD'a]R2*TWl6u5_=ONJNk2DN<m+hK%8'U&5AYN-mi@F_%TZc4E^S96B6<DbUc3\9%tps;d.Eo;W$E1?!oni4U_=sLD`,Xd2jX^`L-<"HU2MomMD3)L&25M6@9CXd,;[ASnDlIN#>K;gj6o6fZlGph,p`F7p:7(E(4N?TN+%dS2lPZ9P]('0_nBZ4)e[06-sJFYpgnaC*c-4K97l`j7uN`_Ca93>MXs4WnjMn[;30)c/AtMG]&AMkdt0X2M;;^KZAa-fJ+E"Sjkbt.l9N:5):RJ:3$H"kG4,)qiHMX4@KBdEYIFr&h9N/$PZ4>$V5A-Eeuh50DT"2Qi&;3'DVOch2Ph/l5E#JfSI8OHM<Klji,at\=S2]L@b5uonp`dGqOqiZt.[UPc+k?.d@o8aGItK0n'>sF&?(R'YaR<f+2S\,rQoo9Y^Ujk4\]FWm#X/jT]j)I_RHg@(@3h2G&ATUt'O%EH;7LpbVEj160Pcj7\1(Ql7fcUlf=us3B*fa#o=%a+L,MU*b`WJ;+[2I-%L8/^d&sfoI$p@5Nl<;1jub_E2%>(k`>^#TJqG`cS;$A>B\;N]qp4NV]BSASIV&j>Kk09Og^VCmcU;U@5f9)VYP5N&'0u[RI,O&HHChn<KHK=lC-j1sAQ@=t/hk-Y5qFN/I\ld@fAO?.eE<9d_9OWVgo&VV4\"ZB.u@fnBIPr%VJCkIj=EI.o5B%HohY]siS?LW[-3\\3;;ZHD#u*g8W6ha1Mak(f\1Yu8*`]5mhB=HPFc$BNkDh^WS"o"n*3br3[a%FhRU#+3(_.F^fCqWg_Dr`Q/':@\b_+0t::-uo$i8N40)U4pBLPH:3IS^d.-a'r*c;!Et?A?50`a]gj0l=QS%DNLsbZmj+i<qu'4kO[m@BQ/9FJa+$cY50G!'-Yu8T#FURcXa,3fMO+86H;,`3u38.E7'FNGQ-,jiHgugcE0n5SkjBj-,!+FOZn$n3IHoMd5R%3(boKV;?8_liR.^]/%`U!6XdJ>P$9*s-7bj+BlRitj@2VN_LCcs_n=)GR9@RC^@rd5emTV2G/o0&$d:0J;JBtEOgMuY?[ptlFkuk9Ab40UUAT&@.DBq<3jVY/W?bJ@\CZ@\3A.&OK3i6C:i@gEk;_SIo`[O'kVXpN]euhW*Cu,Y^g_u80)<K-81;62pEK=1i;4qC_7h3K&2mPIEOpbj>=+=GltMl.L7/5,^9qfPM4PYHoBe%gZp1&DkfOr_6Zd/BbEDqRd1]VSb!<\$lk1?&+D(15'!ad9MXnC![&uotX-h7q`il+S$Q5n#VHb-R_0(_Y`ii<K=XL9Z5AYYc0uW;JpBpau-:;X.]M@l*WuuN5^f^6?1W]"PRd-7EkV_"S==b[4\803?q0.W$)_h)YZ4XgMe7^I.mUPi`HdgPVeTI)+5!`\N^"_`Z?]T3fWQL)s$/=gN4ZfR5XK[/h@r%Z2fklnAdUSd/oa%`k?DFn;p)6(gGF.5+SR=-o_c>WA\))cRF1sV<0$`='12V^]rd9ndR&Y=c=ar)--bDDk7j)WR4jT>JH./2Pjog<,F]rF#M((8qlJgsN#S^$VTRR^$ZFN\H_f_C/?deU9gRMhF>SnW;\RZm\q$<Wk2UTfC$e4N,a1-kX[C:CKY)9llb8ttj+Ea]m!BlEV2$0_?(&g4m[)u3&-.W,T\p"=eqG*URg5&@fq%_PX\2c*BLYg.)8U*p%*WA42'AKgOJD4&p&(,P':fA5@1%`eIUorjlh%:VqF=N6fb:oC-A;TiTbgHsUV+KL-,?!8qNr2k8bA9I,d4MVH9@Fl&3%3DJ=*Q:%5J;]`hkZ<II[SuO5fdJ-p&JV+Ih.^ar%1Itk+k7&2T^.r7:f.L-6Z)Hp-CmRDKbjW`t@g^BI\8fbM\f2jSAnBW1_FZeaR_;!U*5=a6BR&,>ucc4q)7oT>KK)OaRK>/'KpsC-`I2kHX"g0"_UXWN&%Ue0u11acS@#j'o=.(Kd[_pLUXQY?/%`bMp^LTP[WRdI(a!?IXe"D'G1ibq2!@&I7aXVhkmG"sjrKr)639'd;H0L5h",02-Ao:3TE5!B-uT1p%>=/34Q1\nZ&UlHeF1V"gD"CM`Aq\O0(ll"u!MR(%!q4D6iHE,(FV^Z,8X%fRMZn]Qlb:uD3B_/8Y'1Cc?_IIJ$[\<dK1<Bks!D:M"e2)f:C-KsAGm4IZV3C)eYGjR<0rY,jsWAs+fi2E1PA:FYNm=Z=\&M4e?\JUtCoRfn(7RIPh4mrWhGpP$,b^;M9k.)2WrsepMd*2q:=J+.8IaFRFPk?mih[\B9K5Wd^^W0\lM"$*W*CBc*9um:RRuZgCcGA#&f(T&s%c^>+#\"P9+tS+D4K4kFq1mW&U8(r.0p25I*J8$=*gJIV't`hu\2TLm:Vu'<s1HQm3!%KL20J3DVuK=S]>-TUhQsK]P5iJ7pq1m)]i<UtBR=,s"iX5$_TpViRJ._WHgZ9W`TSk(B1KY7@.nM)YI_(~>endstream
+endobj
+54 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2586
+>>
+stream
+GauHMgMYe+&q05P-t"+_)8lk8U+QQ7K?'=L!7$PDBk/:E`I_.>h$her6:m1,If3<0lt[SO0b?64ROtqg3`U=&=@I4;prE>G[0HD;%W?8GDuoQCi+\@kr!mW,ZS/Y<WM0qQ,ckOhbTPkIR^3FXEn3KZ,ePPJ!X^7e_9s=OZ:Kj.c[[BJb!Hj$$p=PHo)]'UM'<7;>Wt`;9]QNn+nATP84laV#Qbg_#s<gp9AqX'WK])D_ti-5n+W.Zf>#5@Y<To%1X(?C'r)tNEb$W/ars>V=u$,gMIO*RYoM%7$7_+U4<cVlGO8k@#2;%TjW:8XHE\=jmk-82Xm64:'NkpT%q3,0j#i>\^E)@hMGl&RrNg!Z=)IPF(T&(OW=S,;7C6$N\/Dj[mDSTp2rla9)9^4:)j3NB=f-s\pm]jf$-?.u6n":THb".)#/N]Nl3%-A(Qr<51#HTkJJ_7?Us.>F)".VR#*#fj1G'lt6YdafX%h>_[qIGM.]M.p_:1]2gH/3,;)Nns.UM6S'*OY\O>'oR]spL*#+m?7[[s=l$q=i*j$f8E)5iC`nM)A$[_Gd<c1VrIqH:F'Q/l'T]4D[,?mgIW.[3P84U]H]GIF!]r.<H-7sonWdG^;W@@5AA1Sd:Q,*BBZ#>gfI^TCgV;&j=?QNt+LjUO%dj]Fa;ombANjOAWh#?hbKJ3Rf&GZUh,^?dN\o"UY=E4sbBlbh8j]DME=T3\a/G[eOb9[V.&>oO"Vh=U3qV&<=2\,%p@89t[T\VlMJEg]Q-n_ffT!ut8)f)Q0?!W2q)6hk=2Pb2.K_n(P^;O8E^/k3].l1.h.Wkc8u+>P\[#&B7=ai[]#A46WB'bh``%:;U&34;)&a.][k]>6`$)oBuqVn85iT)a:$!M09h)$0U%H=_3-%r4r.rl07uE;'lVm^m\p2gErTE`lDFX]>WiZ(DoG?pA`*YA"`6_@-@qN]er8S^.-<`l8",s"`<R,]GP)[F/`,Gd\'SA_4'Ohb8qq"M/FU8#Q5*;(PBO.l04+,3d^M-1BH1Vt4,'DjngB%>=tk<NU=c)9!KV&4um+FOup4#.*a_p;Q'BXrSPTHIH&Qbd=$OE-e9r?.87e9/hc>;Ok%_Q@lJ&iF(:E0rQP8T1BL$p.XNSR4'FpU<E]Qmkf.ZLiGM$!X)9`B'>(rp[<$n1QG'D_#Kd:1GAoM[3Z1*oB_,Oh,,%05+>ti]4Z\pf6_gm):*-4jlCK=,,[#dXP0Q''j_(Sqi&'?Fc/(#&g9l,2;cC`oY\U4dm3!O.&N)oQmi?di(d0mi%@KDZOAO/4Y[L.0iQ$t;e9L>L;'c[?UB5dL0eiCRM4/78"(LOcX:lj.2-biD(G#8YM1GK<Pc$sY<(=C7nI4E]Hp_=AO"lX#0(A?`-B+8F5?NIDjpM378@b5Nd\>W*6$A>Pp-&9^J;rQ;$8Z2OD/OkUKPFe2WK;o4::!53SpPHFXbKg^a63k*ANom8f]N?(cO1nHs3P-m"DBQT^)3YEZuh%'%8=-(&9=,k,V=0Y?,-7?R%Y%Xh"1*KQd!X3C=.;V$DuD\.8e@]=8Ml]Gi3+FrDcUGNKR<pUY(/=^'$I_<lOg=os]Af9B&[_.-aC`bf\;`,J-&ke6]^lu\#&nV50u])6WGL]4UFif19@&kn77BDZ]Xe_IMb=9r?F%(HE)`fl.Y5eC7iiLlfXUIPC\e@LK0%)L@`UOeck3#^:d1n5s]5p=p8Qop5sf\Bji,/Za'N!A=h;/DomKAfU)VQ]?BUq=Q+9UiqFCim++&:cP=mP@%0Dsus=P!#kIH0Ap\?\<-q>$p4*\6`tF'$RVrMS]4EPtD<K/?Hp'i?trt96L(71PHl7j*nHs>E*f8FKn'AYJ!?&FBsk`q.ujdXRipIg@;/6>&`\dVMfuWkNjB8$PDkL)eb3)>MEiHXPjh4*f3,SDSTb#K,pN>R#4d8=6g'>)11,*^5qX<21g/@HgAk@B6:kkFchH$m0hUm1qi-$72VJ^o7_=!bI3,h7]bhPjts2aA&n2gB2WItI0.9IUE[3:c4B;%I'j.RlD)q()'44<0eKJS>0^\,Pfj0jY3)(h1JG#nncTmnO2E1;\S_9'2V-!;eXdfKB%Ug"j;_KAVk8qJL+KB]A9>.\ep;)kb*_A;ORCi>dcl>Z+\X@J"\N.8c`ml4GAUiH%R$@;<S3DmY(Y3%Od]486/0mnA'Z"1P>($S[_S07*>rbS`"mOU#P5L6b6C>II^RiuI_XLXPqu3bpM#chId=&Sc9LWQ7quOJO2,jBXiupB^2X5"Fsl4O59Rph*am\#$pD>N8P1UV6)p7hbDU>l/E7nb3]ogV';^`7d!6g6IW3AUFMo_j:7+J=A?):9k-0`9BlS:n?D0b,l<.@iOIY\X7VgE1E]@6_O2QV;mLR[dM^][>LL]<tG`@C.89e,[*O'lb!"n-1R=ZRF`2K+/'cr1W+W(eVM?#D*$5h<:/Y#HNKuY%%#bQ3WLG6Gk.Dts>kI\3KM(%Uf(GSF(T]QkSl\'g<SVbgUmO7H8h$0ddn%X7!qV[3+DnJ3)hVMkBd`rqgb2SIh5rn].aNgu(4YFr_Ck%1hhTm9nr#ReB=WUBMB)`$Rch%Y~>endstream
+endobj
+55 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2431
+>>
+stream
+Gb"/'968lH'#*s=oPN]S"QR<7HrCa$X"$,1``&?oAe,R\,;J/=@m4H'r9X^(f1<2+)j_(>.@1?k!kLVgoA^,7peTOT^'FFQ%Blr<#RTf;Lld=p^4FIMn1e<58lHT/j-g>r!u#[An/.VkTRnk/,#*1e.@3a!0S*&u/Cd<#JdJ:%.##[VmYAS-OH?]&1h\P6KkW*%#agiJ(^XSRl4?7SE',7*a@V:d/..Yooc?kG0&PQXYC:d.X+.j8p$]-aJL()M*:$I*MC8K@7\SrW:eJZ'i)5Wo$5Mg%RLMT9gSWj$GurK1>VmB7M6&3K%:#Nt>np)g_+)EN>cle+m`2^W07R<f)q7;=U&2l'I2@%6/%2>?$<,6qZ.)uM,ArP05Wah`fF<[H$0R/:gq_?o.ilpKn3:)h<"_\0"!NXTh"/R`-p_kk+$2bTC6c#J;"J]Qc.'g61*&kTC9/5)!ZI]?Asb&1LXo_#.ntH5RVdK(4KuKTc]8!VYs!CW*3P#KM1eVX-NZd2`J@!N4@p-n<'hnR>!.W1gcc"OE`V=!iZ_uS/8-bA+-T%1dkZM;QkCYQmAY(C1XlZ)(_MoMeaQY"B-TL(JJ1[t5+^e8?lj::;W?0mEDLn9Gof'N(^"-d3P(Q=dJRU`SDB0j'4dL^mjAhL/iP%=FN4E4hi68.IXfh(Ni3iRGZg!4/U!Y\5!T;%J1!2T7C^RS?+k`3]7r7`^<I.YBqR<0k"TjZi3Cp4<N*`5O>Y^^3DP=i8MYOk1Q=[H.BbU_fo^I%>S_B9Q,E+f.UECt]SKhP*NM/NM_aV-#3m6^*jY5$m<W)5\;u3.;BJh7\s0QV+RmtWIig't.0Ck6An5RVM?_1%Lr\kP>XB)q5-Yd[G)rPs!YU2SDM@,H%($[6Mf_"D=ugki>/@$U]s?UIKkCYZk3#slZd+M3KS9F?gXWIWe!bDa)RWB?(sTrsXBcuLJYtf.[>U0EhIAZa</A#^%u"`Co"$A,=Ph8D9pGr.!37#=Ru^pVn2"&an<Jt9mr)sokjER(VM2_coD)d_NWKgYh7g(M4L9HOT/D+cY,LdI;"lkknP0!J@>hJh#M[ht$5^JMiM!C_o8sOY&Eq"P:7_SNCl>AOH'adhBq(;Rf(pt0d<5)qaU62.]%NQno8:?k?h4(,n\9W2=<lHJlh\Vc?oiPrpK:?&MU+9B,"Y\>_'e+TkaI=2J?B-Yojq12cMhL9H`+%3!&NU-h'HU.HW?Hu2;Z*n;)[]eM`np(F:7n3Z.h,q+U\d$Mn^8tE)KG%Y\R^O+=)*$gSUP7TCL(`']^^Abq!J6IRi&!AtN)SA<?IiA+mDKohLdJ--)^Z(4ClZqU-:TF;pb_J+).;/23T99t'H2R/>SB*DTGu)-ikXZOU"Q)qIXFn'6;M?Z,2(K9i$Ya3Z<j#%&3kpce$8#;`\V#(+9>pS6H+[VLs1p$QX#ih]l7s&3hV:2\]#V027h`)MddK?dH#0<2`B/HYfN?0&u+E:2(5W&bfeQ?eCIl#Q@L`VZ-ob8&f;_M='"2-+*1>1XSBs'@PR?XE)7X1&,loI&u0.CP!pFospMit=PgPkR9e.DW/G@hW=6jXs?Xrle@TMI=i+e'R/Yf9pC.^RXemcZ_"hZm].(*=hd_\q_hWq&Vie0OhkkN;qfe3$t<ERFC3SYneX5V\BT<K1BA@jN$,=9<M=^aJ@.&Ue'g6,<`X^9Z$6gU*O)B$n75cL?0pA/sCX>1K"WQ.#)fu\"CE/U:=<e-nZ8\$C;E:r9.7G.&=f=j+aAMOsgjVmm_+'s-uI`nWuf]f7/NC@9hsPS3o:Bhi'q!^-i8$dH$%56)BD_:cM5J#o?-odWB"qRQL)9A&k-^ZD:7:.StlNN]:`9nKsd(j7\]?&8BSJEi)-Thhu4iU-DG@@`CD3OEM=_r='WC&q)FQ'Zk:=Qmb.LH68<-V_i*/b$uO"8(nGe!&dnpNs3esqU3N4Sd$4(HKQ\BAVaDrPK`TfhV97mgXh9!jE5OBRg]n!NS<O=_Y3,_jZTK`c(&+5^`Lg'NZ0s6"]Vjqo[lp!1kf,%[0cAm*;`H**JHEc-TYrPp/"%:8.OImB9cZQ]isQeJ,=`/GGBCL&P`iSj!1E+k5.UoiH')KStfFZL:9s'enG(:0rm8&2i7ALM6aD$8@[-*3ZW2ir6(kWD/S04\j"Grs,'3uEVpOa'r>9jJ3@@P=YD_N.Su^J7<=cKSr+:/9=S"WY19%pfFR[i'tUP(8<J#<9:+.`'FeX377tuaSDdk*"lQ$np[I)4DP4HP_g8l,8p_dsYG.EBmO!Gi6:;!?TVFun$o2iBr&t6.*D#E[\jHs;1rtjJB-q=I\fL31n+]a!eNTYEpnKj5fT$XMU[[]eRk#'l#CZr=')bumJ*b>S'=FH"C$`=o@J[fcqiAHH;b+A^GD2Yi?$7pobr[PlpA8HXGFYB7K)YhLZb\?~>endstream
+endobj
+56 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2076
+>>
+stream
+Gb!;d>Ar7S'Roe[3'\S>DQul5'I=LHK9rB<YbZF_GMOQ4^t<bQ<Yq*c]_(+MOHOucd9tE-/-."m&pZZik;sKK!l9BOY-Si#q^Dq[;kOPr$_Z;80YN/2C%#!H,=*"u%N^H5N<OQ+n;mo0pUpu[jO#B5,DZWs(uZY-3:`e''L4hHqb[oU;6]hmk6s$M]tdg-S)ldS#o3a'0c'>1Jetb\,7%No-dW(YedD)`JGVN(;g<;-4rOqZB-WfAp_'GG@/>jgZ.[3l*C"-m#f5O%NsPnn,p9_U^)]gn1_fDJ\Nsm_2Yk"SPrd7LeD0g"Q).e;\/=pHCK$I:_aFd6-hVo?go&Eqr67F>em(I,]77)(mki?+HEOPOX(5k7(H"n*Lmt&!O=(qf\fp^ZOH;0Q]"s:+il?Gu$\+A2N=cbI."j!fE//5('4?KM6RORDS.SQ(B"k@B*A]6U?7^[11X6AmK=sLp-BEPELMZD'92rWgAtJbAd[T@_cIB>%m>WK<ZSe?e0;*<@1"#UPO<G^eFG(&XH]OO936$:Gc:`LHp1os#,WH@,&C_1Jlsile@QP!+f%UVC:Yi+s&:GocCmO$tVVf*&3&bgNUt70`4'TrliYJ'W#[0gh>(9IXm5'^mhQhnTpl^de5@?IfTE!rr?2*(NiPj;:n)6DF,`Gp!EO<Bb0g"1DRN68XdqF5XSC.@IK@Z(=@LJk)RTb=1[II^<V_EUY:[Eg\GSK/]W>K-J+XW#l+?rJK\0c9Jo6rOll1O0%rU"hb3dZ'3]bnGnrV>I>I,q-q_aq8fRTT;C_2c_9Tl3qCUE7&Z22:e_fH?$@_.W7u9a4=b$Cf?q^P&!)7!rh!a5g0g4KD^F=&A%U9GFG"e7nklPue/S?gG6CkFaNR66`c58eph&G[J6a<CR^!Jqg4+P?`P1pB[dT>?"s8.W1EW9;9o_la@?EX;BHZI.dtdHqL<SnN"=&M0*491tVKE!,fB8)8.M*q0G@(CjGWXZRlLC+S6ZU1kQFs)FR%27V4SC&#CmDY13qU'3WQpj;#tuR!9mP;J2QZiDG6j\hmO8d<u5'5!Y6<aXm_9%#H,F3Z+98g@GZc_o_>!%Z0^E"(\,=bDP'A3nFnHPZ=\Z@+6QP)IOc7b@6RubW\J8depGo1=[6R``koC[9!$(/!6"*bR,2_dX5#jcL(oS"=bLT?Z(A>o(8!Zp$(OH4M>$fVZu9^J5Fh!q?]/[5HE=!20*#+dZMi6j95@e'C=,njiFqS89K-*Al1(gGGS&VJ_W-jGA>0#=ID:j=BJt>aY_4`+*C[b7@em>9DPPb:"JP;;qPjR9W?QRD5kZ/'U<DP!(b@<RDO-ZG6W26!ilY1ZpF,oQ]$RCPj&U?BOs03X!c5iO`r\jjslXaQ)"SnQ5G>(FlA%l%/2*P<XLI%p/0'f1-#/JE&AV/hfOT'@#ot2UOR"NJ'sA"]ogGuN"*cuVm4'?F;,[C*?4\9`mobElWm`nME3%gJ'Q35.^\QT;V6;$'>6\^m`fbt>uijS5,e&0N![qtmrXu`6G'gB)Zc8Y:mE?X#\P.cdO\a/KLTN/Pb]o]PpDn$U%(TkejuOjTefWmEkQ)g?jo6>U@D^Y&;g)WA1*pjk8G8$a('2XB[@-HkaY;;[nN2Pb:Pe-dM.bKS\YnT8j.Z+jedDnX&iffRC,;%)L@Y>UX6&;[;_CDAQsLWjm'3&4-)/^\*COq>OLR\`SIJl1OH3gcL=2-[B;"MWp#e\`82B9fu[/dl(9HWF>`qbd@f\LU(V#f\.2Xad:9+e7U\Yl9q+.$4dbf1UfT&Lq1*m['la78Rj2%Y=(dMB/.UWHf38uU'8p:]B60k\X<6Mor!Z[%Aql"8QBa)7,:2?);2&O';e0H>-sjkO00tlj_["Ca"CK*N0Q4SA3)M.S\q:Z>gC9&#Ah^0YDIi0Hjr-$[@&gh,GLtA]:E**uXd,Zr(j's)CG6<GMp55h](Qko_<-;2Hr(kJYg(ClZ]r$]EP,L%\[7URB("9`RT=X@VI=)Piqk<"^HO%!Fq8/n=8+dM#&I5nMR(((Bd^#cI>9/mSankGn4[S/XpOmgmtm9GISY@GKAKu56`$a~>endstream
+endobj
+57 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2502
+>>
+stream
+Gb"/(968iW'#*s=oM%q-*mYdmg_<3232MTTRH;RW(Pm`8A3n!85UH7#g[i2li4Bt0%U3_8!=i`<1#62$B$>eb?fmrd'u1>YG^IbeEL=H?P=3:[!UchK0,$ZPRW8^f)Tn!C_R*"8L1W0>5c042WC\80S8]qkO<u9Q8Mi-<KLf)M9b&i6:7M:o#uO`T$1*LB2,=ntc4d/o&AsJq-'1,"Yb:&H$55g!+^hm5l\E+H+)W-LHk29&I07sU@J[+f(cJZO7i9NN!^nMP-jSh--o)dc@8rmB1D]S8WkjIfT!)d4;-._k4:0!4Y'A4Mh9DGdU1l]6i];Yf8,p:0mqI%(rA)s-(T1qUpTMX.DX6SaR-.INjQ1oPUqoq5oqpp_ZkH*@h2ho*:n!c2)b@!-0QQB2YI%%=U(os:UroZ`o@am)E6@j^'0)d_#gp>Q_ak]%i@--DX"?'O$VZ,"n$f/f"k')%7s&<KJ'OL.rME_\=hP`8ref?gSrgYaUaCte"Ckp@!c;IQE%Eak$L(S)BnU[4Kb=WZB[,ld\d,!"kflr?C_?si:$#bn8>7Cu-Ak1ONk]3T&RXY<F2X]X-_ZjTCdO82M,1n%5OCC'!0cLI_/U_;h_#rl=pg0'GD72rcrC&*)iTCI4q/_D*H"A021?nAfSo4;j2gXQ%Y>RE/ngTr^4JZ+Y*n,=&^s\mi@Mg9#m<QX8nV3pKXBJ6iLD,%:8<lK?P+&Wjo+V#hc<Nag%B-_3Lp8+F'r)_?M80a\52/=V/\kI#X)e+gNL#h\AAHlgO$1oEF$+?fk#:_][+a^+pBg896<C,!:;*B<6GWu,X%m6`*K^JqhQH]^<Pp]5.uI?)n`r#a1UdP$/@]!ICf=;iT>oV]+lUa3Khd'7&!RQV3i=3c'K:9$"cnKG#`%/gYf!@p_,@Y5abW1Fmb1(D-9qc")S7GG1q@k=*:sK/=Od_R+GebL\7fe\21Z,dH8h7%]\;NFf:27EaV7+3djKKhI(\[T#3+,4:rq2_ud"V0iJ9)&ApoQD%SRm-L!43Uf##tJe^n;njl#m*/e5LiF80F\Fa4YF5`E9E6$ioeF42?NP",8IAh.*?Dnl=$%.sM)"i6l@Vd=T"ZG6-.BV1:Q!Y*RTfUu0ah=.7aD7c$?:\k>jA&@__E[FsEB<"pUE7Q/[WR6BMe+GB_'-=4J`3nu+j?f2=f_]hn&kPcY9("4G(B!ZPuUJc(GE%oONFBlT'/4t:9+g<hI,O-gRB#iDN3TOee!HQ`dCBPLh;9kK^,Oq3QYChYMb?)p(1)6"`JOMD5hRjO55"u-H)R:-Z>N'):;pBj[1(F(UJ&(HOm^u)S%7>'MBUH99C4SO/E&%8;'WY9o^7F.]ZhJMXmo/E&jiu99FF541qcRjG0hY<[a>Y9n$3+^^a]ZbWLAB:q^c)bIT;9$:/#ReT8dr6$R(DL&5p^'\a4Bhdk9$O@`ImhU0>iGUPOQil77q66EPe1,#>-_sK3pb.?oCEa@F/'g;E!d49./EbD*>l'jKaHQaCoG1gq6(>W?T"!ss#XB?4N,lU`lpLEr!RG/$s"u%[i\kf#S\)?,D3ZJIX?/=GTXplbtH&JT?,=&P7q!T_Sdq$d;`.,WVigeb7?*m%1CW!0&&eX+aSL^a00tW<LR2>8R\gj;p,Ol\7F!9@/^sP6Z8Isa6S]8oc4QZ-IB&.%9C>Ir^RDULY/D[/?F&D&G(9k(!&a2c,$&,8BAp,(Qf[O9D4)ZO`b))N(VLJ_I>bV)q'^bH@A=5SbVf)/iX'4jXi#/GM\m*l\nE!3gMnlo_RDoPI?Ud)9TM%;HcS5=jP>*fG`\6Z;(gQQpFGW[i/]tE"ebQM2L%EPO>M2XAF58IXMps4lBBp0T"tNW^LF^OL=1u+s>Z<\*<mA43@89k)1FgjB'_ut(b\VAT.&nn<.bE*]V:XqOHFD.D5NBN9%j#s:s+MgL%Y)EoHSmdjiNRur#B)8XQAD+HHhnm7%P;DVp,&/0UX+%dE3SC'UBBe8`d][pUOE:!rP8Vsq?]"U?iiiI6Eu&\X$n"EZsZJjO_*_9?o-.!f]jGokMr5-s)gDtA3<*(is0V(:E8Vqd/Q>8s0%sFj#,<KVZ)O09n1o.X6M6[QV^,Y(nBZr1>tE=E-!!_@K=3=n<!`8EXX$Zdr^P@,Ycb4=:Xkre.=iH<]FS/+rb)hnU\G1c?IDj!'-YGRmnT:R9A._!$J`r]^48A!9Aca\aAm2D]>Ie_]P+d#X[3^79GBB0X%D<p%5`/6-oO*=e>rk5o$_=Y.eS>"!HYlqg,;PnIVjF%.AW8AsIQocXGsef(Jd*6;lS6GBa,'=U%uAf6Dn;?Y/PK;%pHbc)NC#jRBj"f,Tc]iN<S3D``0$:fZ.9Zl+%4ha+^=QM,gGYabMB(3c!+X'HTYE"8@H4Hk!^\ol%&V!mkhh%I62Z5e5IYQM22@7T^r79na3T#+iC[Jj(VhBMGhNm"bD%c&&-l#pV2]#ut!iu>1;S:&G9/mk;%A?1+GO-EKgL<4oGD3p<t~>endstream
+endobj
+58 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1760
+>>
+stream
+Gb!;d9lo&I&A@C2lqBGR-adB1n,pm/FmV"A:?'o@HI2mC@1+MQ0Hd>AQi?\25`1jYkE7TkWBEV)j8eXWpV"O<$n2+]E6Zu7^F\=8JcXo9\-!M/#SrbG^6j>?&K4<a,9Sh</5(Mt,YDbPmXA2&,RKYiP9;;%S44qqR3XO\'4?J"+_(gR_qiL=!8rs%fHXqEng'A):LbN;VbtZgA3>d3">5]JfKf!.KaAA^6GR%>8!iE-YNFHO^5)%3?GPP6/7//fLQ+F9&K,5$$7(M(N,l^6@YtQ]j"Mqo.,0M[+uQlN[cm;5fF#pZ;T)8:Au">0r8b`)VM-<l;Rj7)a8%DAL@P2t5//[S9N/_+A0:9a<d1Ff<GQ]e1QTU#;Ao&&Qk#&g9-:&T'dTV4boY:uA5#E-m:P<=UGIKI0gQu(37+47S10"fSifaL#8octZA&+_P'16Cj<RCX7kc(o/-.t!*R.+^S;5MIRoa?/.p(@:[j&@gmnE\1g)`$^%9n`m6=Q7Wk_U2!;NC:_85"mapS6dn%M>>P3,^s<1=8U[6A[W-8J:0(`os0H7.P:96TuH-"KkbmhPMPm+rHXYO^Dc%n2EA%qQZR`bPKP,S4CJKq2Bo4Q4D:?eN`Zs=#8@A\!2"5)XRf[rJrm]1Y^IkOthO@__Fet.^qDOHuENoG%YUip44rJZou8*Rgj\615ri7o\=cl6P_1:L%!OGACoi*J]2n20m[^C9IqF)U4WN'CF6kWY<+:%nBm\0_c^\(;r,?:WAhE"<4C+^YC!pum:*Fa!f0g#SU')p8Ps&D66&>g;[4J<_$$Ee_hT]g_VZ#OP^9tkQJtg9e=XQT0\37-j,6a8c7>g]:")/jTR<oR_H:JfkAi`95'YeZl3,a2$u8daX_sdKYV;0@JrMWpTJVY.>3IGLop8]H?7Ot^@tEq4=hHW&ZVW_fUCrn`[Y),1=12e.08>+`g)+J'9!@c0K>s.eb)Pi'9L^>j"-lN3'IqXV:7#N&(Qq[s#$N8X#i16u`t-KSVO]=u&KRh*W,AC!nI.`)kR.<VIft_SgFE:TKaECXSLRA"H]#qL\XZ@N/32'9mmGe&6!i>Q:q"eKW2fXoG/^n1#j!%Il(I8pO9)1G'S93n8>d9G@fYj6iad:ZJ:?#"RHAj/c\l82<8Y7%S#U29/K`-kAEm[Xed0%BV,bJF.mZjHANk$:>nuS7^BK<\kI)io[Qu@;5W!Z,[?h>@-R4_oJ\V=ga*jtIcEYf3W)l_Og0=")qA=SMA*h6s%smbqJK-%9\Vru)J]gG']@YnMQ+qunA16[8mLEu*,_ibDZ;p\oFu$riYuT,<%?A=/2RtV$(=AmbEo^)tlFt_R:+Ok]09'O,]NsG="0I9H>3gPn)(RmO<0()Fn9(g!HJ;rTM_#F-%$GMI2?2/0FksFiemQ&fMNOPW`Z=@\DTph!b&*cJpin7mg%L*Vf)^JXOI,s0YEZZf%i7?.VF$U'UAJP.>Nb`%EdO\KZ``sKfZi$J?0T?W_!b9=%=NM9S]^u&MF5OaE`bZ;#((!2P@VP-YkmAB=&[M+L0bEd`nDK63kU']1c;_J\*,)U<n_doe`\0[W"@eH&a)BLY,uE8;iaI=6<DIhl)$beW,c:R4BcNQrl-!nV[5X\^V[<_X4FkSZ&j0Xq_VSc1fCo4Y+3)RIDnD>0[q"`VXU;NNN:4nZ&*8n8rnu"X`_U)ojqZWA%$WU0>'ZOG^%E9:D_V"SZ]pEctF5URD?E!Ih$e1pNcUZ"tI[N)*Z8Pp(,-iU>5~>endstream
+endobj
+59 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3359
+>>
+stream
+Gb"/)hc&9#&q9R^d8a7jYe*BPN.1B<B$!=R"O<*Wb);?m>DXmkOpoH^Ip^N\ABDiQbN3WF&tmC1m$[:5T'l(5Q6aPk^JLQEP3DXEHM'ahOE<Q/iE@ki?I7s(kgRVY]eG['=a">6a<sXUDIE?@bsqrJTd@Q0$7W?Y-#GR`2[ZZ@$@EJPE1G8_WCgmulUWId'NcDlLl?T%%=K+=A4[ZKSffPHOUEBV*#!u[Ehc&_QKL:=h(Is]iq2O4AFdbU:!S3]gCJE'.n_],g",1O;Kr4FY3/9_,Y7HA#TW+A[KAtG:sF?S7b:X#>pi?I(A,1ams$$oZMTm3:QF:B<Sc#Kkm-imU5p\aG\`>;Dhn%ol9%/dp%q+)YKLC@:",iYd_%Nb$B:r-fPP+[i$T+QDaWGbJSbY>AfIhuZ^o2)n%q#0Vc2T%('5ZOPdr19<L/iUV8'\MP!Z"`nln!K,H7S1L=1s,DbH)D"VD:f+8;WO3g^.j%d)ke\VdG%GuQAsUg3VjrY)Qmm=a6jch/kc6ih>fnH"+"Fp">YN0/m@bE3`(H5g\CET(-90DM9r*b:8jD_=1F7bn6R.IUP2<oCU>$1T9`dW(jD,7aN?9>mgc:9dr"19r&da/9uO5P[A@^h>GhE*tiAl]r>2@Q4]7ro<+QRSPPNS)uRDL'4n(htI*5lg#8NAOaQ-YhsgS_asf:A8JDoh;&f!^Ul1+BViKrRroTuW)X43omY4$,=aa\.M"KS!nUFY'pdnN.`bIkj$re]4(RXhAg#j2([(!^[Bit?4-mRZ[a.h*B82cUJ(kjrK"/!L4L1bS4Mf[YNHHjCE/M;Sj(ut"/6&))ML$V[pUI0"e-QFV="&9)foI6[XC?Ul'g?';Ma`QLoYHL3oPIH\o]Q%p]@2ZWqE%uT?/8iC!5*Mi,LjLWm*9h2Jp[bo,^BBgoV5]U!)C22bA@$K>ZXAj7>(X91bIlj][U#dj5N8RVjCucEP8CF`D'7,Bi-P+VP\UGg3&?RmWP,Ghjn7VPY-ta^-*NnJ@!<s7L`V9$1#VD%f#oX":"9M"2GTk7N+V&,2iZfkpu>l+RH"d)gQi?!B59+#VhIu>s!HCO\QucUoRFkPp1LBOcFKX1E<t_P:H%W2U/&hF_UO`)TVpt#[8qc/0)2SM`B8Wl*A\^4[$T>K/HP2.CGFeOuCa(ARR21.@$$AK`:'$L.EGLSiWB1=3k#)@]R=FAj<MA#H>!2%LO-b;>2VCLrhq^K8K''HCa1U>o7l.emNj!69Go>p*OTPG/CN4PU"I`=G$2QbL8-f\s7Sh]\kpbLf:m5TYh*$21(pm']7GP^/!p[o!G:EmaCC+BW*B3HsKZS:gD6933+XB`](7WbdqMWekK1a*D#^hQ>r0@oL0MPV,XUs=]`_Ton]`oR.?'/b#!mCok=SP"jYO#?Vgg[l/r6ulQ!7[4AV:l!lpCoeN?+OM`S#\TUp!&^H_!c08c@p4QfM,YZt1[2c7dA:D$j[6)6KtXf.*SI_t)(+FR[V%I<ThF!i'a\q\PuG+-\(^8A-fhdu;GJtTlW+R$!Yk]J^J1gF*1s6C%#Fe0PsH6c0^2OhZ#(`i=OoS3lWAGGL?65>TTbN8'3e`HHU1?:2Cid"_Tp#RXApM%LT5n/Tgc6')U=ese'($sEQqn^%n<AHu.#TnaIS,ImXPl@7m=FI.,Ya<!#:2,2:;iHAPhnaK2_X\T.4]@3r_Xi:TVZ+F]DZGdumf4HaP0FsK<Gi$]gQ3:l"@d\mcGOOEa9%N%aRX@8(_((.e7snr\@pFb4h>:=h*.@oCSZD8q<_^u>;pABHBH<a*t=,;%^TG9n(i6X6kB=^]n6A6.9BYU*@3#)WM8FEXpq17Z\;lhI"0$p7.F+B]%L;]9@-bn17i+^5b!=CQI[p>ml75SA^r?qA6*85>gV<<`gF?7ntAUT0fe*Qld;%U#(2d5FA-s_Ia![0`=2r%bI`^aZlco8%iOHIPiO:S/^%j3'm)@-Bj<=Z8l-In@q0h@X!JK8J/L80ZWWRo`O#@ApfoK34>.el#qJOrB/E!954-/cE+&\$\m^.i)(1@;%`Y<:=-`c-9LhTmKnAtW_HG]B_66l:JFe-Ko[2&6P$:bt&(W*-5h/I;5R(U\/HH<($cG']m#);,B.7*C,&NDuWk$ppN$DWj19$-L<5kGGR^AHbpP2.M,/TY+-R%5!3jdSp!TCJgmWIX$ULN4$j`*lgp.Lu3%8IGLa`IHUMF$&(R>(M5/h;I(F)2qJNA1l()cSspl)qt%:<odBU[*`gVU.IGBg5=d:)L[+kR37@8b>ea/M>JOUc^9,N'o2ClMiASmO*c!EMA.g`9BZ1EOqm>2*PTLj/@ctO+mtq#m_]qp^;p7YbYr8oAnojLZD,rB3BehEba$56$3iBc$Df]T!.IWMAsMpL(hBp4j$-k=/2a/'N:"uN<j39g+h<Omo?%\Qsr\\Om5'k[\_3kMX"`'d:6e8V5bZKLS5-Y9f7hBr%Q;eBLX&U4/Z&e3;'fCh&.J\>0pbjo7@Z@fB^$Q<[rt1))!`n]Shu7o;Z%3djLRT-g/_FhJO8kUB9Fm(/@cC"A6nu!BfT^T0n2jEi\Co_4r!o1%ePbl%ICTrA(`eM"?<[qo!bcedX[c,Qi:j@(\eNT]4-YXar<e1AP5bl3(/_D%,.TfBr1-d#Fpa!!O@ng"e.GnY\)=.6INNglC4c<8FHo21P2%j\NGG:[qNWVf17skVo(t%YObciNj!,d/1_qfl'8$:Yu,'N\[d"gdL4%iqmlV2EGJsUKL_Va,kIfqJL>"6`7,khHjKZhji^(qIDpZ=6DMJ;g;gTf+mH<SO(/sA9]t'QntF8fY9qM@&78k4BF)$JHq8/*LYctfC9X8C[N1[V4mjU5?=D32^;sH[G5`gccV5?-G(P+<6pr#qcmq<[K3q`>L2400@+)[3>?C<AAuT2H=$)hg[bKa)$Ra3$"`VMP8+[c(FFN<_L5+VT.]L"iT,0[L\XD#FJ?iss"c^3ht/_M4tYK#f@q[O;SOjSK@-E+H!s4#5LQ[d5N8Eom-h3nhkhHD<D]8/!'`8g`)`^)/$ooRGub>'WmtT/DC@&61A&J&Yh+YNc&AX5#_(j2"$8*Gh@CdS\@g3Mf*[>UNAY1XA`P`5EhsWMQmm8PL9&?ap-D4rA=^Q:$N:tKZh`]ENdlGn6+9Vak70+;_!pHs4p&?+N<agkrS,Kh9f\[_nBTge<C<Y)(t1=B;Z23:p7%K8&#Sar5V$nZQ->=>3p6#o=en9-EFJ;6E?sl><n.?dj,jC1#BCX@=h=Uf7QGm#+1,2?<CMZ3SS*fgc[08SN*]iJpb?+4B\tQ(HTC4O<g=#+U%,Uh](b43k"/S#^4,S,9-$@m93N84$c"bPg&~>endstream
+endobj
+60 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1931
+>>
+stream
+Gb!;d?$"IS'Rf_Z\2-7Clr(fcAR"<!'EZJm#]4bYV(\jN,Qc!nZ5ql\n!3gu1r(`]H?NoT-E<S,kM2,>F_qI/r_icfmf8r]@(r:!)6DCS3T73RJetKG;aA3%#f_FK=\,k%#YfO^-=Abu"^DTg6mb0PN3JDA^b\8EQ6nj'N?SrBYR8sr"Wi1[8n*R;p"L-4&sgO&(e]-JJRg=l8-1`j"gfY&O$Y'(o-f4@%aM4`]N\]I5CWpiY9(UH"0?rm48+E!i^=ZZE=.B>4:<%b/oc[d5/a.'KL"3XQs6?j95BDCDmZM%db[GJQ&RsUG^XSGd'diMQ6dt2Y.O4u+'8F9ipB*^"'chCcMllJhPI4&\klD%<I(s3Lu)&Jnd[AokU2gjL*;OI)MVsL*sNqK0Zs01'RnFk,=iF\9EYrS\ebUP94/o9:4p>IGS$#H0L*jY,8_aEaccE%`^bReE9$]+a[LmKd$kQsQ-/Hi/^1c]P2,DaQG1Dp*[ALJe'J[PVHJeF#Y:7:oET\GTEgl("cHjYnK>ho]7=NkkN*7IS0T@OW1/b&7o;[rrA96k(ai1Nq,P<hTd3>lN8$aL&e1IR>T<RF%(^<3s5CI?oGcpYLaXR`GMhZAh)3]-YRN8kI[!FU02[c!q1!599eb'-P0jQ1LLZX'W>K([EIM_kRi\![VY?$po$G%*BE*g>%]Ar/Eb)!+f(&4(=SX98SmQLhnamcW1S;Xb\_]'Gi">).'L:G0oYUFQfT5@HI"n365IUG-lJ*jheQ^MPVb2/H^"/rUm'qJ.7P;lSl@Gau@sC1b$g<m!i$8"Y8151:1V)EC'K3h5^6D(ck<#nML_+`mXk]o?/9h<dg.%DdCohGVNNDlO[8<lL2!O78r51-^Pe`9";u%/Gcg'p_=6XTEqc\:+6hh[B=^[Clnt7qI;6?BJmOTmEgO<of"hL]Q=lH!b1_j";KVuru]^]mT5aMZ&m@<b#c&hM3GcgS><jmbEc1C`tDg'P4IrO<Pj2j9X>o#m4/nK0e*L0+]p*G"lAkVTaNrBFo=k->@\C5Yu2U*$%KV)G%-KSHCh$[g8iS!VYaXAK"A'[,(ge!+IVITE(f3l8Ka;ip>Z1>PC>"W'ZWdZ_ak@DeG2O0RF%gO\GjhN@ikFJ[]B>\fu@S@1;>"FXaBWGXN@*[k<l(a-?\WmojhRR,F_JjjWJo'Cd9>Y5V=OUfBbXGZD3n7>&#+^+&q'%iT)k3W_ks,(Mp^I/SQUVb2-N<!oQWp5#N@D"l<RBCka0Wm(&,@?e-'eR1<A&4;#>\cFWWI(N+u?<M[qCc="\mYRQ4DBTX=c=fc>ZUg3Bq1UWl\//Ao&%9C6TUuLYX(-<Pe7n9A%B&M0YrJVJP)E_IW/1P=81'okn\aK;cKiFiDKF1\-04h=X6c5oSqt<6^u:n;9?,*/YW^ZZm1DoQTN"T0(5GL1):'WW=qOL)P#Pe,ep<2HDb3Wm1l$'PfAVaU/+2?/hEm/$i/;2IPL+S&'q_b$\A;W(="bPMo!4a*i[S`*:I=dcei-'$H6AqVZt%Asi!r-$&13q<Fj+eJu`KT#PhSDsn+k2SmNMnnVla=6b[r4`h.5!ULVk(8I(_dWDHQ)4s`aHo./&RhcM8gU#QNf;1=NQq!B?+_F:Vp]g3\9*G]/aXUBJ.4b-"mGho=otSMrbF@'XQNL\f]c/V#Q+Qb6T/<k-ps+IY@?H1Y^J#I7F@a'RVU=%?8cOHRhpu"]i/HoT"kB&BQfXHK@1l=80Xqtb`H(1OH1/6l4747R\o,?XI.%7CPu+UUVY+CpmVH!15Cj2iXmgK0/Eku58j/`GR4f>COifh5.ZA7Mj;8YZLOP4eigkWQe=FO:ZM:\NdN9*HY\pJDVt&B:/1*NlbH?Wcdo\r=>U;=UHg3e=Ra"^f+'#):c2=7#<gNFVkWABcI!R%4q"3]s!5W#rV@SF~>endstream
+endobj
+61 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2684
+>>
+stream
+Gb"/*969,O'#*[5oMKlBN#+e<W,_1B<R/h,<d$.1E$SV!7NrS1o'ZMSD#bhMb'I0UA65XuW?MKakSHE>qBHRV'`Tn3*R+RJ%cQc;!TPlH#:>:\iAFjKH[kbq%CG71#W7ha"b\<B;?cllQ\*_?Bl,\?apFt$"DK^?-<.bd'1)pBnegeElo>4h65!B0V@l\#<]ge@E$!/P!AWA#1]iBk!*0uJeA;=pU_#5M63$f@o9[;<0;%4c[i]#Q(CYf#&h?IQoa&H<&-@uF1mA)7#q-/Il=!Yb,1BP5LShnS4<#qCAWim/T&5BT7:l$,_q!\_AWdiUgi4(Gjc."cWr'$3?[V.m=/u^BB`2"<IHOaZT8_g;9]Bc%*77c^%,+Eq3\X;[>b-UGOH@o;/>n'_J-mOUZgbiq1eL_4&-t=9jpiI(A."iI[5nU6Zr9:jX_'AP>&(S0`2I'4NLL)`^u![5;egmD0UePPdl<geq)J855EJ`#CCU4EZ/*WWXQ(ZC$()$=9s!fVN,1Ok>8b*Sa3AqY#X8b4VV"^5.:sODo\c_]C=s#'e8#u4R\m3Q+eb(G#RNIIddd&;2<&K,o+LR@XbT_'C"/n+I>V+`_-cRc9E;b]*eK"u5OCk3>J`]9;5&sAkA50[>u6n&kS^O"+r"%\mU2gBqe6lRE5HIMCZGFma]Q!Rj%[_nh__>ee5@tQ9>@KW33SbCH:qr"SoBhM/d-bKFJXmG,=5Qm5e+pu#60X'7"(,rUG^nT-bN[V-nDIgCW#B`:q-h5\l:Wc['@,9j3"3<6[6$2R*BNLfhU6)Ko>$Y;QPi@Vf&1j't&10DiR[fX3cB*GDY`H6Go]m"3n+Y("$6%Qfp;BD"!<rCgRq-LYL/<=+b;`rSj0EJ]f<XrqY%4imXMBiHk"Xf0:p+TC*uYk=S45@$3cb9#WWdCu3*Q+0KZ!9k9r=oLi5L"^EG>[s3:cqE<fp%oHI<k&]Fk8rGHnjO)11EOV@\EQH\gBm@.G\e%TgS+&DEEf8MW'`m_.Fu;j(8giOiGcsncR#&67_GK[aJ6PL,/?>>4(a_Red:!^uFaF9`'=;feDGibJPuN9Pg7k-2\7k%<0)`qlV/SMtP)d<EC;X8^g:1AeZ<hBQ4E%WEbmM+I'c?VXi-oJfg')ZAj&K9`JHrnVeITp`hG!@^oRjfA5qNJb=t@.ideE64qlH8!3%e-j@b+M%KGt;/gpO-g6/MjKQmYJBjbWp);4/f,(re:hZF#S>"lRB-djUb<@Yd[E:ST\Zcgk5OCQhb]D9#?nf^h"(#rl9-37:U)Q5+EWeJd6@=+JWu#rOnN51"0=0WNjr_;U&'`hAO6Qj$rq`]!2Mft54bPAD1[3KcFkG(T4%G(s`>Wp\FtHWcc6.b/@YIAk2B[>Ca[&:Y^5ZY1=)=RN^&-dITo(+![BpVY;QCn3=V'erlk)Jup"&*g(9AD;Bi[IDAhiU/6GDTA7=D,<09R6%%GedtsRmd&a!Abm\'-To=!E)63h%"]=$Y#l5H;f+nAB-5.s."j16Z^&+OFiVM<]IN`2qesG[>UJ5LD4&P0B#-T"hX`\/pUgDQRZ8.^RgUR/%i%=H37!bn+G?hKg+)--<is/W,uCI`AVCRp>>AN^iT`O[q^<n;Rm8Jj<U\r&-^^f^eA>,0;j^rEOD"^eF5Uu;&B4HC(o!32n3$Q,W0KDS#Fa!j#`DU"O,6cr/'=PSi[d_LBf*YCC769'L,8U>+.!S(EDa`6r7Ks"b23o'7kinU0*O`\&4B24L&P#"IQ6[(o57(0Pj4W$%&f*$a7pfLa&"t<:lOBj/hh?Yj2H'dIR!1EI;^k1*6W&tbSli":&L]Pg*6Ai9H=nY:+?qLQj==rW83cLdh[D=*BdpXp^&"*@aTHIGSC:+I;bRf:1D((>O+ihfFO$uRBRpV0mQHG1@5YL`r`_Kqa13U8>JN`Q@cHr,)mA7h/88_;m5gf@<r%i%S_aZk`;*HAIoC]^YU)ZdoV<o?Vs#ba.]Q)rfETn\o'IRH7lYtI`]iUH,%dEhQM$jpT#&3_Bn(#r?6+NIRDkshs_B3Drd)R)sK>sO\<i8m(8R0&@KA+h[fZ)R9F[^f,A3R0B2l&J!%6g9m?l/d4#!_A`&T,*K/s)/[*4b2sEC9a5>L^6TP.;md7p^:Vr_&jm%c8;FOh*UHFRciZTg\QArU1k/SkChZn?dXSOo5!O'VL3n<^kpse[uQBu5C0uEN:);G!3"8`D&0B`X0MrWjg#e]G!>b8leI;jHE"(%1fm7<s!iGIaTSnEr_JJpeAb_n?6;r/DH0hUCShPYTWE0tj?Cj6TTF^&JRruanV30-Ps*"q\i=ZVQiCFd2Eiq<6`07UcQ"7MD#a7iUX`H-<+^tZNFSQKUY;UDF9mBM9Rmg<$`GD3?I]0`pB]A,?H8k8)/eCn-E]C7ar##QnpSSh>cGL`._^=F]^^ubg59=Zi*rT:?(a#o:"UW=MOlgpQf_(>HOJ]pclf4A9XoUUe`mH`W&b\L#Kp0h8T.;u8jX6m+bmfi)-deN@I<A\E;^$*pp-lAaoQB#EFZc-E:SYF=f.Mp,1d!O<RUZsrU5jLkR`LHhl,Yhbd7q:?-->?`%,Y(BGs5W3fC&(OQ/OR4JZkO_:;-NO07gI2nc\R#tB10"6Sp-5@])PiDSG4=<r^>c$53(;;I5dZL^.sm%I3rSY9"8RW229uf!U*-arr~>endstream
+endobj
+62 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1476
+>>
+stream
+Gatm:9lo&I&A@C2m#2Hq1,0,d?XRcS,:CaGNBbqdU'jX\(-E:&",,_6q^t-+U1emWVmS*T";gsl0(qGb!QAC]rYHN(TBG^m3<R90^&f(6)!2VgRnk(PKI0%T(^SA8b>TN7NAI#T\XQP0$c7S<"UN6WVf;o\/r7TT'Gt7U,SC,I_<UtE!-$"MiXt`F4c)VMZNLQs=e%/g3R;1\J]Vm6lUgMA=@A<3MI=/Lj,;U"bL>cQhr+@S4.+pCr4UG/(Ga!eEmBgV8=[UYja^JHM?sf5(l](T5D3/^27PL9dM8me.l]>C-t0F3Ns^=r4ZV-6[]n\(#3XUoosDKZqs3UX6[i7LKP%stoFUJmY#]kJW`H0@Y`FUS;`XEGGT>?`QApqKMb$<OQLBlcLkJ6C4?S<>m*6(d9aD5\8-7Vr8#&`8Pc*P/i#i(,8[gCW:XT5t$Vp7L)8Uu)i"Z+^j_i'^_L:(]K70Sr)ekW2M-6%:h@-i!iG:_//Rakh/C.-+Ie6')36+eSCm-tWBdUE_;rDZ,n+-kCp6bYIg;S"pN5<+YL^)qCnfU%5KZA;BgJS]P6M,A%:P4GO+_`kIL[CiJ`lPVRhkrTNTFAD'Y+9iW[>%RG,IIU=%*Y:M<C0P9U+C$o'Ph8fEI<5KG^%N=Wrl[Ba6EYo;as+6=YLCoRHS7BE6l-8Y:0;kETAESWD'-c;q-#geeT<sK);OspgbVMV3`,PU6pP5i6L3t=gc=oF/r:EbNW1jUF_X)6Xs*'gm7XWOSA+&EC;)UiAPhdFRTm>?PQP_B5+U0VKA+tGO]+fXFe;;B+aJ4T^X87VKS#Oc:?fseAr,(AJ*/%#+:Z<i7V<11;YMg;N8T*;NTEOVMdeW;hY_08F,SW9RU.AAo&0INu5=P9rTX#bT/U#K;Z+mFZE(O*NTB>\dclA]#%cc%N6;iKWrhGgJUW;eBNd3&KZ(c<aCZ6s58!o`r%K9IA$t^%&9D)dAdZP=dR^Cb!@a<C[n4hN,5&&rRfn8PjPuFrd=5H&'62\g8GV]d:[8!\h^!%?2clH/anq?R6J3`29+P4]5(t0Ah92Fi\hDgBjV_AYP>\!I<Dtg,#j!OXVP1sc/JNj"D@N,:@jsgUA\p82rP>h5+i/(F:^D;Gp1Sc87kH+FXA$qSEWK.iZ`f'FYWEIf#@,W@irU3T-8-X/kZ-Slf-_[S?;I!AV+DL7U+EF7UQs+>F<h\Yq1X%R;]C44lBGc6'nDLSG1%XfG&18-!e-(03g0r^Oe_&(`GW9-o(&T`>BW>7=fhc"UpVQ_YLl3br,^A2[-OMiG49Mjq3$'^`V9F'XZIda!94X\q"uR>Y!70@@0p;)mgseF"LUCg0j2b]2DCj\>,1G`XUa5m;>Q[g,q=r]X2oO*-tOiFr%.%N[99=e`F`L<=n4I7tF!mKe'u`dqW^P1Y!#sNP`Gmng;F"Nd:g&D\>QW%$c[Ys%_Rc^fMf<5CZ\m>gS&?@Ic?Cg?Sq~>endstream
+endobj
+63 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2377
+>>
+stream
+Gb!#]>BAQ-&q8H9fU4p&l*4W$#[[Gk\9=#k:?*ako;%ca,LI-&?;t7ZSpu65!Dk%Q.jq*,gc?[B+L/Q9mXB\j)Z^rY$1kjQ!F@G;nkO^sY]p<00b5&oE4_M85%.]OU%Em*Ll9=Z-@@K)5#e"C!FEi8(e,[%>VaF7!5'^j@2/JZQr#9^+]Jb1r\Q>6,Qpf)Kug6+?KfQt"-YM0ZiCl`a?pN;*!Lutfio&GBhp0[j=n9^rU=bhs7lc@hnF]](KgT')P&+.G#T`@%Y/iYMmro>U,a\CgC[\aTkJ7SM9t1S.bF'f8]q0QWhn,fDUP]p]XsckV,c?e;YgFLc0b2X>o2pTqo]g`B28&Kr:e8*DT^rn>pi()-J:YEKe?78ioZU<N0=MWdh!oCE#qDq)H`rKMS*@5:5mKTLp%[/+k-_ap"(\<5]Z*2-:'t3N%i"&F.>f(1GY1Go(@POP6ECcY0TVe$Pgfm1e2Rh;XWOZ?-]H%>F#"LoHSDRM/-9fVF;3WRNUmN%WI)`7W,O\np(f#QudB'lf1*k?&SqAWLG,!5+"\^4,Fp"eoS1e\64&s^[+!p+fb#P*8t9rP9&di7Z>7*_9e"T+8%+]pKW8\Ef"m4$AbbXF(-5ZTNp?QO[)3^m`eiKXuBHXYNO)1UM,)rJTd,F^k@`8abhda$b79]+u2_b=mda1LL(ihDM".@mLb;.(VL?7![ii;PgBe`F-8=LUaY-mq7G%FeYsA-lP9>Bf$'^?g<:c<G'<oE;*S4KT?c/#3W$OT*OY]dIdR?O%#*"YeVE[bWI?:FS<LSFe%f>"oQN@f?&RaERDnLfKDo>Mq!LsRIlP9f?VajnVb+]`!M3if1eVHb3'LsS)a@]6+L#u,;conFWXZ4lo-9X;R@racq][?T9+W"RnB&?&_\[^mQk(MRVECX;j2',MHX/)^q>4(Tq$APK58-FlN-1*\/B(R2or&Ro."XAI,/&1(#?^#$\fWaSPUHBXXC*pMh,-Y?)gMiB:o`rb(.ht145R0f,$qR3;^og`-c8O-C-m&FL>Qm+]?jK:DmpC]!KX)'p`thpdQ""hi78\qk9CLWJL'_uP>Hn]G(Q3=E281:/PI[*;<gmmaq@<\:tcf\S"B"%\k5/,<##5L&<fu4<J3fR9*kBsOK&O+'otsWXMZ-[1>atYmb7)QDlAFhcrZK3<;c0g/?Rkp/Ug@Dmg:O@dC$L:Zq5\AB('HNos]4BFO.mR%5!B"kd"0D?eLf^a!3J&OjAD^N//`VBYYiUjH8rE+cum[!ji2Z28Z-FN9]7h.'(TMRom(?chDJ8.&8t>P:&H4IabWp9?.ucjHmXj%6UEE^c*2*OC^->:FQ2d*g.PM@N5A,)mNQDc;W1l;$4W5\AMua'qBu<W;Cb^W6pAMCqK(Cro*gn!j3"]fbOnDArn@D:(I&Ef]ig8[(;99<s'9h_EENMb`lnsp`i5VV:<6V3>e6Q_G(fTLoY@NAfE[I*YuY"@H>Ms$bX@dL3pjZ9*Tt8j!UItd+mRQ'%rh67NT7.DPs:Wapm/tZPr$sf\(U#h!R^ug%@nHfh*KumGT2SAO</)2$o9%bZp^D:;FY$QgkQ-d'A$WX2l4m%;]PFrr-V%o!%Y04A]Or7&+%(WBBgIgndS">Er?GI(:0JlF.mHJ5BN)nS%rGe0Mq%L']Ki[c]R/$u$@4?FKV2VMc4Q)Arn(T=^mSh7PkQIS6-:fYD:u)Tg]6O<sBFN^$CM/oKWr]\-?-B@bP%j/RC9nJ]f%f/2lBil:?_m=e[YnSUiI@[#<=+--2]#3F:-M)S"=]7u+8[kph*"Qtm-]<(o`RB?kaFgc:*lN32Kjbd"gg*3ZJKQU=n&#<sJNIPm6qSP`_KBq%pkAP@ZQW96218Jm#6!VTI*rh'obKHbh^;?j.A[SR#%!GMXYq\pZ3*8qp9Qp,'OFn\JNOQN:("YF!FCHr*\5B;=)RaY!7<`O?"JeIa?jp\P^i3Pp[a!j>\:A^*-*-/0V/%>L[4A9p!RK[g1&>`r1la4MPfK`c$CZ&A4.Mk9k8+tdo^NNW<O^M]8o&h&&H'1/6l>G%^f`Q1X"r#U,&Y[&$i$6.dp`aq#-2&V7;m*j>L[NDT]is<0QND\Y=V`hNk4Zgk<p39oU3@+g<*q4J!72uXnt42aHI=i5[2d!9Gm:NhV7==;$JA>foK22'u]E_f3f_%D2-1H<0:Z10dd[>05Z]bC8uO7@MkH8f]X%=n`]FIJ+U^4JN9q)mT5iPX%0T!mZSDo!B$S@-tE7Oior'LZTH@cn/,$C(lkIbMKO8nrJ,:dF$/DQe?,5M$i=o9HaZ4hH)LD7IqA?NV^qFX%f^i%pp@WpQ](\$m4\13[A+^6Ht.?%>ubdB37!fR0VZl8S\3o!*@CdgL45P(~>endstream
+endobj
+64 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3417
+>>
+stream
+Gb".>gMYb*p>'(qJ:4BZ;FMiW8cn_*9p<"A\M`mc0L/qYRs*;D-!-FLgTTL%;PN:*Oqh%s@"I^a1.<7Uqh9eP@,kUg5%cBr2cD[r-U9(R(I/t`Ja!?.9h1gGQL4N4Fhk9bRfj]^_B$tbO=`s/35.h/5OcLuWC:[E""3Ri5O^WDM_O;*5%F^15E?K[$D-?O$ph;7jnP?l/m+?aN_@.pB](!F\2aVPMT?5B_CX;I%&PNl?^tEZ9Q&`o_sR>n@/:2,5Kb&t7\8XK!@=lRQK(#W9`]HXD;9(L&$Zur$F\@;,AD+\V=S_.6tl_#ffaCJ=@>pd5"o:T7p0064lm`Ths0C#H;:O(g!r!/2*0@_,l`62heAN1U:EgP8AkrsbHE0++PerU"6Dq`kA'LRjk7'YCt)kgY0@$GWJ)Rn@utZ]6::6J7IK4cMdi>;jj02W_,j/Y?DD5DU]qb&;_-eo1Gh]3P_+;NQ_re!KL9Hk_8RU(LY4e<SNU/_FO^BiLph.WiRIF>\E/mh6_E#GJ-V*;d,c,i(ZAC>-X^*e2T.T5(?\'qN-`id(uGa-R#T;i]d[iX!mBU6Qq^fmAp=/:6]Cer7s[]'C=aT:ghA[PEVC;7o`G(@hdHL%4c[lK/BNV5U\^*)L8Lh!ba&*r/8m1^)jWL)L)t(aDY"sqTL#[T%#F#>_W?UMJY&k7fSh-:AgI12K1ZRF/h!%q?^3kjf0jZ8+dur[PU*1?!OL-p*@4cr0h8MM9I\!gE#Nk0lP7r:8\F2GBsqb)\QumLMGksc.0WaFWeYt;.'CHI=(+4qB]XP.7^qR.cG:7D8P[Ra1Pg%F*+a>pDYJ%6;$/??!QD2Ch0[?=GCp*_,nY1@n"AK&Y)/j#$c:9iI&eu,9Wm6$\9\B=PBUXhP/->Tc!PGca2R\g"]"u8[[Tg8*@cn_A;U4m7)^RrA_9D[pFpj_@$a4>.6d3X$r]ZQ!E`t<nYHdW-B")0mE,"ojQoLR^H9'1d`9HK^_K;&/9dpXQ-^C);E*$$`_*)42Q:XM+\66d'Id8WhH9OO8;D2p3u!"dJH_Dq9WY<.]+kn>;45GN<]n.]5Yg5q6ODm'G:ShUp27mO)+l;mL(`cba/O9V'!0e-^Ir4WLN,5Pgu#*%NO"#Yeeo1c<_spIjos4Ri#l;J4WZg.8Ms=G0<!GF3E226245@R;sDk[+fqK&.Ot)ur@-W@#6]ojWi_YU_Tnm,1h03_PsURVL(:O',D'Pt4;SQapb/&1J\jHQ$LLHr;"[Zqo+4.G=(sS=`1_S%*O=:O9Wc,ZP@@Q#%b.4.,Y2i2<q)R;k#LAMga#aZ^/:fB`k"gHYlYUB7Tq=@*'DSoXeA^7g4@u7)5GX'G:(DpTq)L6O4frKK0'=S&K>e?E*n")B8N`IXK>1X(L%b(2<TtQ"OJ0n'NJo*QN<m0Wq]@aLmHb\EW0<L<nB/Yl<E'80J4HZopn#3<Wn(q/>h+j#d,758JI)+(-H[JHG"37Z7*tl6CqUrVJ4#%1!$g97f+4kT2oS,VZ*qG,Wc:R@;SibSpg.eg!jk+oj21.%RrldTXk"&H!9@6eY&dKr!T#i-\iGhi-q$=)InDU]qj]YBK"&^fqZVR,k,`*`\<f-F-.PDn3H!J/u)#a=Ag7Z<6M-Z^W`;+&=@/B`FC>VK]4WfXL%OB7]Wt!<BbG^`q-,W6^=-eW-oN>FcugENN"[s)Ge3ucbj9?%dSN[$EcFa'I$E&r,*d]LPfq,N/BuEk."AB(j%&*lc1R#dDq68)*F.'/;cVp*esXB36\*cKPI(bpftO"dM?7j**2S`k`'AQOY,!t<Q8H[El'<W-UT#"%]c.Fp)n,M1R^s48jPU@(uE;BocWBdl[Pbm[!WGSVbQT/3ir..,]K.u(dp1$AZ[JsXQ/Mc.C+S`*sfJUI/"t!-]3YV8kr[7QcHB"8+-(I54\tUr_4`^-\6_2Mo&S4p&;sb[YJOai!C[L<'P_g(5o?6[]tBl"EBkW:LTL3YgA2gJp\orKf"G"WI5lj\jJS'mLVp6%s?XP+R3RC&>;3rjtN!uSE,[nSthfEP!>gliql!Rf3XL-FcOHf8]jGn*'Or5D?\5_bkL/e%dV^k_g$7(Jn9M0>4cCd`u2TsLFCb<MB.H7HU^OGXeJ5K<kpgL$]Hj;)Dm:deaG2&Cr5sV&ZIS';\#i^mn>%-a#sECs01@J5D\1B-Qb48*)_3rD,fM)<@G'@8CSA6NW+^lI@=T0VKAHJ,)^'hB7jCP_r*]i[.t7mK#>1eO/5LWG`meMP_?;Bn.L.p^,]ojI@DP#E.&>\"]bZ;%U$\W1_/<>^0A/V^Z#2gXk2C<mm[Edq2ac8Xr8*i3/lh!o`>t=/QRGf#&"*@^Q@B1@](qlDnWTgQ8TMdDUq-dh'm29iQt7QZ8I?RH:i?H)cLcjVYCp.EbM<eh3u2h4V\+E)'%0?S2Vg7<)91XS,BR,K$qeWUc?Sk.1X42D9?mQ))PDkO"/=O>?'K=o,jUXWG.GMigKf?rWRJl]n#sK%f63D@K*`S@8>;E=4hUT*I&3"XtF#>-s;j5^?5L%cQkWef4N7/9+]0K):Ol<^3)_U>C5fc[dPjh[XZi$)[p1o_)]g?4.Z<d&dL>pmOO178T'#"IZlp=>O`LQlHEe^p8$f[(AD)Cq1RKmp&*\\D(ei<'upY?R76EqDGSKjLL0&Hit:PulG24NqgA\cj61F:4e=Z:K.(8KY`'[n7,1Z6a<)Eb-R7=BAE*D!S==PJ*%(F(n\V6<gtZRi.!!AsoZ?bF4Jd9&>HQrXX$0k9`>X@5^2@8=W6U8]J$0sC6s)UrA2$VodO6Q]V>(eV@3joBnb0Y4pQc+,cpW`RZZ*V7D?R)j;HNEJQY/!*iA+Y%B&]MTm#B!3rb\Zq0$n>ZHNKV:IZ"ib'f[b;1'YI>p7s<ZZ]kL9q(K/0%T:<1/:?XnQ%K"kT/J.dGGl"4Wb1rk*=I*C[T9mZT(@Qb$KWoSh@Gq/GCk"j@0aO,.;ai>\`?l^,K]<bXSt45qZdRADtnB[(B0'Q6G:V)Ab;IXg$E\I)lQ8McYTd7aBf^R_B]VtG/..gj9V,k08EC.Ko!\l:!0:02@gJ:g4Sub'N*:'5Ro's\)JiA5nX):4[d'%.L_Br*Y2Hq%abXWqhF'0"GQX*<%d:aAJp9(E$";;oDA3M,PHU%A*jlMWj59j-B8M``Ooj-R:W,6UMoX@N%j:2a:daXf10><,YN31)YY`FLFJ?=6[@\u?Y.np#dikcQEJ_V;\Ji+gP6qc;A:=CbI4IQg:q66*(-+;iVb>r#p:P+2>\TBi:?5L!dBuDH(R]WOEU"s&S;3(98Fa-mfa_;h>:l/.Fj?j?!Z8oBnEB%]t1f"V>Im9gRE>I]'73kVq$]8)lkNg>XMD"##1!90.)pcWlAd:BWbaGVi=+3;%GQ8>$J$.gGHH)NaVKdLt2iN~>endstream
+endobj
+65 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2937
+>>
+stream
+Gau`U=a-?+(4Ol=\8UDL>IYH+-#\ZFmc?Eb@r(5NK3o0>b9R?!9AK@;F)Md9[,<p#B#][]$L7':>mbX\plCojGQ[GI!>efW\:DO#E7])<E=MNYjR^;u.L:\8%LX-b4`IpoqTOS44itJK*$,5k!!*an@'1#X(cXhFHb^XSAY9)Q2*Cdl0`hLQNZnd<bMI4@:\Y8:+ad@2E'b/JW!"kG!o>E;Q,9Am>Ua*dJ[=\<qjZ:+DsuZYO&rR\#`E&G@r'0"*#T*dHuN?PL.hSf;%+?1b2H$gTQ!uV4fS]FA\Mp=3ls1f/FTFp;4W*^nE4V6Q'>8XpVQO\lIK9Sm<-f_kO3Telbk77PPs@@]ZWEa86.dP':fWsS=oOSLjCic#Ps;SqdJujj"ohQgFtU<@PW%\;><HGoKk\%+:nTce=D":P8"-5hL6"="@e4-F^i@Q1_:l5iImfV'4[aZ,gc4o2r-_C*I;d^0%G4ZQ)f:95!!\t)3B;4D"j'2>LSh_*Q:AfF(4-jIhC),-M%==>=^ApBfnRV8@P"sTsS-<OQ+,u4HIscpHBpXoX7BrnRS+3JYhXu_EiIoZf,Ra07Xfm8u6;aZ#&YdlfjdF(f)!q%b?NGT6--c4\cOjcf?)!`B?DlN0XS#BXq-rPIpO.FT;BX6B[P$WuP55\lnu99/@d^#7>gi`@*R^N]BB5:ein+TI(f%csZ,#pANa8"h]TIW<-W&;<ecl%<5^%`K*`Ul5E\AdKokcX!Cn:&Zmp(9MrC-DKN:Y-N6<"[./*%KU\Wn%gdd`g#uo8?m['e]8J1XLCn-WZ73=;iX@HgW*/@nE=#j*H^HfE^^P>llP:*QSUbFYRE30k8LG-2.GRZKQ_"DAFAWeLXscX!$\cZLna5b98qfO3n.H]&pa)JaQ3Ajl/PTXJ`07tj:?gI=lNg=B<l6i\a#hPnf_UUNq6oe<Y-/@/fRBY:GLR[GUocl63&Us6#O+!18YXCBS>RgQk4M!l[M!$(\YSN^q72AIOG1I!Zo?_ndh8FgBL#YGA>&rTFBK7]$)UL0;A1\OU?E)E]J93;6tQ9eG_W^!G;FIlUC?l\k*^D$?tYig8$Ung11^sUMK@;,#qPHu!H?q=>D]Uj_^`eYLljkS=31%l%L[6RD1DLOQT<in$2>-u8X.b=`9cL.r@:hCWQ,cK;GiK4f>VSSSJeEhk566#KUs?A@%!2W)i]5NW04`KkR"8NB/-f8L/R^kUaT>3>t/\ka&UHlPBh><Vi;:/J&\1,/>GhTY=Q*<0ZJ7]ZVQ$hLO/1hB8A$uP:4u$jI1J0acgk%:93:r_4;*b`AfZbnl;thob#bibPGuI!Vq#&00e`&q-UrL(\iF!eg=$R2gU,J#-@e9/MSC+*SPeL5ZB"3PjV$':l3BimhYME0BRf(o!a,J8_%hgZ_DtE^.cmG%))buc.b7W.;'&G+t<Oa\lCHO"hs@8=WrQ'\i.McdH?#jo(X1?W-:\r78nYQ&rfe,;F8oL&E1<1liQ!FTsf/f<7\XnIru78H%>YG1f]_'WhPtF1j=;_pLeQSX=VMidV.JOk#E-BYV)]^8SY=_n.G>sTJ@'*hQXq7M3=$D\C.mh6pJV(VgOUS=\Una4`K7N>".!%1<5W0)LYH8puq>i2m+'@(&9qLM<b41qALEE9pB2OYX23,I?'.Q!%s0L<RWi9R$J"u9J[p,h1<&Df&?!5/&9FMoO2he\G^i-p$W2+.?6m%_+)SY5ph;tYo:_HiW9TJ0/pgXdYrU0-$&:?$@-D,eYI=e6WDYu>;bHK0ka3)'2f.t/R')nmJY2k3m(Jm"bG29CFdrTb@(i!mF9^b"iWp[IB?b:^0buN(PTjj:O;9lH1UfAM5*[%=WZIne2K:AE''PLcNr2l[^2qOcDDF([549B[V'f"3LnlDdN/g7_R840j!';\jY!Jp9=gp_QDG]a*=X6"1p]b8Z*dll?Kgg#/nJlq-+I@[FA0;Feg=gA'#kbNUbQWmSo-k2o`@G%UJ0)SKX)QNIAi11C'q#=-*g^SNYg-,QGR<LGM#^&a7a,'YXK5occM3_*\@t\]F>/#0!SOFU##r79&@hM>BF`Q\sdf]+uY^Wo!a>22ifIU*5tU$<0Pbt2gjX6:XaHjKu4UcUNTc--RZ5jWPKXB1<f0,_DW-g*se8mMB*^tfcu_Cr&sM9$K#6Oqi24BisZk,o591tVk]foimAnMeM06K2CB,29cXgo*MNF28ZiTaZkFm\8sLcQ6GhJ#6Ei%QEDf3LhkMA!(K;DOL<#l!aSY7I..^e*edT-EY3KOb$B,AcE4?]KA*.?_D)Z7a8_NgSE`=*79Eq%5#6?"%2]'p?N/?X$@]sb#7?N%`<%eM$=5P/7$d=FR1g_VMU/NH^+\L?)#93Q;BMG)<B&CiAI0>F%]-E?a\4Nqn+NY+-KJQ[)fFr(79R6_/K`>M.[X^BF823$A.>hDI(!*$;BFgHY"E@Jn8PGCjM4V[X[kQ8ef%=X)'=t*')_GEYq`b%*bZnDp"7_fTC!ZR0g-PUHK^_Lr`[T:A5<s@'nbZZjp4kL'Ijk0+Y2f<sM!rEWk7Um+!XEg^l4`q=q0RuE\hV<akP<9Gf6BD"cRG:m:/Nb8e2UbTqo"c98UUF"?MZ93)7k9KA/koNkeV<I*UIlNjVdcO3r5'T(63KG0CqABG`_X39Okh4T_Z0:dV';B]+(:O;!\0\p"^`O9ggRl(,(@RpJ0.]Z??#<al,'Jq?L2j5L`I@%_,YJei5fTPXuk&'7`)*djp(-rH0!sTBL)q+aQ%-HN=gUUFA\YaR;U8BnGo1L4H3A$$Q=Ceqs>5Im6-keq9_!:]5iW1H76Bqs%\XjXe)"OW>mBVhV"W,gso(0R1BVDR71!_3P[&,O0-,>f2?Z7e[`q>(^J[#F4u`qKhW2=8%4)/XAtpI^.El0[Cr!T(e/ZF&/5IS&apjm\tVM!gEWaoOAm2~>endstream
+endobj
+66 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2990
+>>
+stream
+Gb"/)CN%rs(B(CCEIemedPd;7PK]aQ<*)g7.#qf:+,W$+(n$L$8<c_EDR7*,mlX-<eAJFVB7\%UM<PUbk2(/$BC=!2!QAthIngaZ^Pq.).0IRur"5;A'#m9UN&uN4#ZY<S,nLtl(24mbbCF?KVO\E386?]u+bZ'n:1XD\$:u'<)AlmLKIVX+JWJ]2X8i_2;+<n5V^F7L4A\:&&#<Z"+s'<T![l"hbU^5d_?<_6#T,4f2]TK@k[4>c"tj7HJak*)IqNBc5al^]`0gs_80oM'!G>7D-et$*W'EYr[[8RE%5+sJom0N[Q78>7=$j1%R,'*.epi!,bOP_;\.7HhdQRL,3VLe8q6kaK3(3q%?Z4+L=f*9Rf1B/iP'Lma$,*/Ze=30ocqZ-*\fhV1TJVH_DBPXI,*I(%4O?-S&?Q3B6E$usrS)-H#>VgI3e9Y3Kb.OI3?1UJ0g+MBd]+J1H3)'TkC.3h:uF=?k17%fZ<YB%p$ug?6RKuFD<P2_mE-*J[%Gi9YpdDXf\\tbZKcB[1HGl`/NPX"c4(KMf[*$%Af?q]0Pc?u1_i\F<<KRA?>DtTck<?M'SgFHr-a/0nM0LB)=^d3%\[L38Vc<lF8Y8`\=_n>,_407#D7Xs(f8kM#j6Ygq+Oe!n3!1H%W`!+*0FZa&tu<(l2W?N%VN_96AM$G%jUhgc`q1'i)RtYY8Z7+jXb)3%5)Q1MjbO57nf+iKXCrl-4g;I='E3kltg'[Yg/@C^.'2Af>Dehaua^^_(%sCl,p`[SCW8.3m`*@&+aM3ECo3EdWe0i:H`=BXiY`!H^H((Ft+CTH<3mYVY!d`fU_SHRNJt<9tCT2c#3pW,pptkH(]IQTI/V0$kgso$H(GN*=U1AHSB^#59#V6VnhLg0_Y4L_>22\";6Ifo,#.N7_9%$kbs]mb-j]laKWaSg<_7r5_*CFRs7e/(0J60A?hTD7?Y:5iKl++?,FOarmZ@JMp5^2jD^Z??#-TQ\+6'^GHJfcnV*pC?WkJT0/p^Of0\Et@?O8e<OV8.M>$nlLV/#))?Y7T#@'PEmdplM#)`bs=k4ckK<UqD1/`70_)4l&0oM+mW\*Mc_F:#!\9*R,cGIg[5<Jj^Oq/X7no7;-Z:mG7m[&;k8V1lC"JZG70$fYJ]tc=P1^i*o4I#0iqk6(+WQC^"DNN=FQ#kndUF!BQ\fU:;q.uNC3+f4L@TF4iKL[AJE=qdP60nXdAqr/d\*RakRotkIMDZ.bf,2]AM:=cA8NO[WZA>b6\;o%nL%elrY*SF7d%QrU_3,MmLAOk;fWU$u#al:dG_&k&Q$Eke.\(7-`R\DCF3/WCF>mS?LtBUdJ]/WR=^V[Co,.M(dku_^Rj9R>(ZDB<42]AXR,#W<'m+;RGa`^ts-ui%Z=Q)'k!6hcf!?@Yh>YA2%"0R&)M;3&/mhpJ+`MH8UVtSuM%NrJ-mX;gE`=[-8e5g'/4VV>*Gme:8UA"=fhiiWBpt97RV9d.+8-UV7F?*NE#I.5+;a3CFs1dhF\l<8O4^TG7'f,ioa4"[)G&A8+CS>K;3aH,SokV;V)GX`*ghqGO"l8[#[U#5RPeoY\PZMND1"YQ?Nm-c1Ug._6YUX`qKo$;)'Wh-"^U"5":s<WiLJk=0/HmHZ!G+LXP0o7@Z/3O?HhOfP@]#\KekdbqEe-b"qm+*K\6\mrre@+GLbVhRJR0u.PgiE71Se.)N'o12=@bSRu^GPll-cVg"NcO7CVd!<UG'6H.1,I%_eUabt2oAVR1i`,I%KKA84-443hI.*4O*sAC?W&iCE*\bdtN%CJFIe5DJJ%*S'3D<S-dr<$1S-?F6oIifBf0i4Q%8P.%O)Uoe5Yk@'dXID6UD!Hm:q+-p":+Ou"]enmK[R>ZE^HoatWGRiRH&:[ld$X9-+$,gTD)d?N+)s?%#eY(>*@K4jKB;a*!L'PaqXc,"?FM6%$=ZO-hc31=QcuK]&LpmFID?k@bCV^Kp/$OqT@#r&<C`P\Jp0]iuZiP8frfr!`h't?=.B=qqg,D$DoGa]:SAhtZ]Oc+o_C\R0Sj@j;:0;1iAa^=Id+=$`oZ:jYc>t78Zhs<IR+WkHhQL5X\L[Z\K]gZ/=V;O-Vt[7K]67a_[sS4*F_uYO_1)@X'7=T@Z'M#GjQTJ6bn$pKNq>e[>SPlX_n&D0XqBGA`)'KdXK^0[bL-*ts*E%/J5"uldOrOiDi;&ZNr9bB\KSOna.Ij9D^W`I.S`3H5&F@M9t-BKH1Um,J,XfH42$g6^,]`6/boJ8;%'j*nd9q4L4$64\bGL:bVq9-2<EEBFl)eqhMj27qSPOPB;=u=B>:l+f53Trn#r>\l`MHl0((dq&U0bmEN9"f]_ap6]K<>&OfuKsrfhDgUpiq,:9`*,r]i<tW\4!7"H1.1+]I2B]>I)Yq.&5jIqaE`6LC<.WB$!F-WS]FLZtQ+^+LZ<b\8d9TtdO_:lJ64+RHRM&@K)1o@WpnC+WUqqJ<rTQ,&phq_"g@PuF8BoBPn&\Wc76crdT\@P9`d4=_/oTu'J^G;.'jM*mH_I/&p?Y!bB#"jKaC8bj/n=_$i/%\jNV&/q<MX"Q_Y1@E%0S#)>%.R&g1?3RBV?PeOhY+Qr_>Uq]I82lm0bu_Em]\A2c]XM(6f\)OtaiVY!o'`.(L#1q7ZB!`Ci=LU9@F:D#bOj8(S\_oGHb5[u([lj(gLYq]QfNES1\Vt^7&Eb?"a#nC'de<\<PZK<H87es?Y<>8ek-KQa4OMK05u8G$BZOclk5cCCV,7H)-E@YkspW]_kGf!8#Y9OW?Vo1T0qc,Y]>LD\(s?+rig^hAA,Wl41kK-[XNG=DT;sqs5sSGlD"TEHK_S'#`8keM.H?G(YjoN+-0[@`;4\<gWQYgI];uIs*m*)a/,+UE$rH[YHh\DeF#Q+reAh:%2OsL_@OS*Zo/J"Amf?_\T"b.#?;RdUjoLFq=.e1I(d+ih^J@<\:8RqD<@l;PoQYfa"uk#eYld^'t@q^UW\CArRQEbk<G&4i@Y~>endstream
+endobj
+67 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2299
+>>
+stream
+GauHL>BeOc&:XAWQo@\XDtg!VL!r5=&>5OY6L[!`W;Ef]QUDrh7[FhclT;Ga=E5scC"hWMdRlUqDg#bo!69TJY42_Skn8Gk/jMs0^'EUO&!gjI\t"2;0s8DjHGFdD7H=Oa^)(`1MX+CL?H>MO7NmFi1<I30]I7<!'_if<:b's<'GfR*0QR:@"AG#4W+F;fd$K:f-=u+L!A'CrLIr\1,S7)@4"3KNm3r4^%F!-ncS(;3T:Nm]bK$jb!6ZI?@r'0"*#2&="(7_o+t`o,BT<MAEWfGl-lS"HTk\ODjQek0P!"A\@\pFc<H;m6fAjjAUaR`q8O%agQd,K=]eA.;l'nr,SN+jrZJQbI43=i'akC?,@ab>u$X6CqW&Mb9TV"WV+,3%cJFao;Kn4rHX2l5LiL\ojL%q)[&45d64h`M2'I9%EILmcX:'gGQ1"/Z3LlnBAOg"Mt\0slWF?f+d02tJthAjq>2W's4SM,j>(?_.fl!)+"?.8_-Tl'nn`4)Dc+XB#?Na?,k)CGoE;E%0oLF9>TOQ^P?@u0Z;F:Y4r*LRTd1,j"T\^S+ZR7g]N;HEJtgDT+*Nf_Cdd]53D(oKK???3;c+<a8eEgiVgm(2W?27FgNNEiA!qAKAPLp)Y5;f^0e51g5/`['fE%!4Q=49XepA^n2tW9RjG$KYd[qtf/MS1K_0>9m@ACsB=-5,b\S('\$PaemkNPUs'ml_iq2Nqb/H1(VU#j!s]gfL`g[b',8B6d8nNB5P6=Rf)B-Kq#a*l[[,V)ACo/D7WKJj=e"Zq)!OA_#<lV[^\%n#(AdCs)E_;JErI-]I]oF8&0i5DChc9AcB72o@0l16,a]<2R4FAp6W3E=8,O1Et92a=;P9@rB"@f;Z$Is!k9*H2jlV,s(L/Z8A'GUeGM7pil5T(b$gB[&"P]kT]f%<VE+SR`b[1QcBfNg/%ijTI"A:g9F<_UKX*@%A_5fCkQarK*H"%5(,fO8`,T*reO'?)(&gBj<jn>JAcc!3F&s>tG5JokVsnT0g-]VP>%1Q^%#E`,L^0IGpap]nH7@O=jMT4<GPn,6*T+]?4XCTcW2RmiAkkQ3#SoI;_:Qoqa+HBE#;$it52CHo[k"'TMR`2J,(-?.5gs$h+0%"OV%^t+o(r`3p[F(_\lr&*[H>:3)L'nQ!i,6pH\K[h&0`6m&h7iscXrV6cb)gA!Pj94Hsb6.B/L=tK4mM4gN@;'kG\6NcVP\TCkP;AL$HBA8?:Q0SMb6JRJ1gY0oWA>747$$RF>F**B'IpRi.L-dg[GQ-*ZGP=@U2ZD)C%I/;(3U6Lk)p6BX\oFpbU_;7B$pel'AY:]lFMEG$9%'nruu/`[FBTRp9&D;rOrq<Nqb4Fn<uNb3A^C]UMdP+Fng2N)EN<s.k$>HCUWY:Qd;@Ipp\Q,9+"SO/UU/Q\#-)n=g$"4ma47>O)uX&DE"h!Yn>Chl%V<4*+;5@QHS9#i.<E0?Z94Y5&beDf<)#)n>iMKo@&"s3n0K"oP=CE%RjB9^1MVpi_^YEC=F<H6>!/p`U360LTkZ[41$W(`pim$Qg#3f=ml1^J:^U#Qg46H;'.pJtBdi7)hW('99;5Rmu:TgY\Bdpo#@h/0=hHh_;FN<'_^%=SWe7>2TJd#*4?fO>HUBo3IJ16=Al"=2!nfl9N/.fpUA2=5#ucfr=SR.kje#lfNr>sHK<WuMM8,eG++G=sg2TZCQgA,-GDqN2lY7F4KN,rk2E=+&hOF<?2!XoVc=^\GgAoS1[(XRe!LaA"@%3n#r9q5D\V29-W/W/feKd-*;bR(-nt^uW>=n&:jY`O6ab9$J.na(7<89%]NW8>$fYg.!d*2MMnr3Vs\R?.X%\f2\EYBi`dk^8VIGY*0KrPS!7do>Ueh"'"KA'&9S5Q4u^AeL@o>(foupWn$,SRYG`iI&J#VG+G(tA8o(WK"j9,I0\(n@<qhV?*Ji*$K'R3,bLm-UR+!@q**-UVR#DPN!G@`P]/8)<K\\?o4\4A`jt)].B`3q`Y9M37=fS/3np.@P\<g[@$L2qJCiq)ZDeF5jIBNr8nc&GJ@!h+(de!$,c&P)At;lJp52W.GR6!#kiC.`!9[jn96ZD_]0cVRl@DRYfhPdM`AaSS!@3*C3;*Z5b$d6d@&OJLMthAsV+L!q30n0g/TQdtc.YBtpe!]*M+eX)DYUA(iSF3$e\ae\F.]rBCX8*L4/f`[l\fBR\0Qc#`.Fu(<0b]>>E`4H[>A-</WmMWAMe/jQe)+<JF8>)jd'p5]@:p?C_?BJp$D--Xo$5F&uW5JIp1LZI(o\A>Tn*::dW"bDgZ@_J,~>endstream
+endobj
+68 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2101
+>>
+stream
+Gb"/(>Ar7S'Roe[3"H,R[L:!b`()a\edQ8^-=26(Gu5U$;.`J#/8*/@h]XFGo%cirD&CiuOsuRWqON\618+E/\`[W5n9,)XB+,W4i>jUD,Rc?aFP-KA,?2W:QU%LCb\/+mbD9m]a1WI'9NW:((h1VoV_S<f@M5/$"!^Kq=N++6E;-s,'QAkaZ5QCgT#b%*8-.[3P)98pgdj7'L#W;:)qet7Jg`&N%&_Ie3;mqZ\9dlUY26pFi<'Kq>D]a4bBej#9LV4BP(n!B.>jk876QS:<+Hcpgn8A#=VeL<;3_kVS<Ps!Z)#O6;E,a<SRpoaJfCj;34nbM62_kUn'd>Up,2+LNNE/+;;Xs-hds92?=iAs1QTIsU^YsO0c_)Y(+lF-&gX2.12Rq#XJdhYRtVYJ-RdB"+:r#DbT/g2f`X:rH8u9O@]+nC7a5NjFk#oJ';O*@)OCW1_7nMk;oSn%@5Je_:"&#U.;t->nt(etBkQ^D`-04TCuQg";9VF1'C,m:,K#%KQ-iMiDq^CEpbYg7?pbU0R;IWL@+>P=2AM0sTn1`Nl*LkU["KPiE<t"_pBWY9CXVeenL&1N:b-80UF:PB:HuWZm5H;@hL,pNZ)&:ua&a'5$KE"ML*)9!<<)=q#0#Fp_hc0_gD5j0n#9m*D<lF[=oUja%RVHEj3md(#K1o4XOgZCPP9`g"Eu"#"JI>O>T".%\cKYo7iLa6*)Sqp*b^Q-h?iXO1WtYk`nGCC":CL2H:\"??\?<,NGD&EL@DeHQt<a<[Z`\f(<Q*7=IRX`?(n?Wg03?[EOgl+_sW?K4^iGt1sdeS:m6-^m1R*E_=iR#_=hG;I2KW/7`olo!aj6VIm(KT7Kmc%l12=6'dWJma_1r(;)(rtd\F6uM=ho5CML1j)N1,<B?;S#=qn^nTBEO1)4/IpY6Q/TgP96Ek393jT+m@4+CUGoj*<\d^L^b"aZ*Q8%sLke,(r+4a.\c&[!&QK\0BR?P0TkWJ@G#S:N]4HgUT#$3sOW+&]h7I"#3J;gob-VdjXWbO>Nu\-+HLF"Y-JP+53I4-!YQ&KM,Z4N>-9.e^EusXYtQ\C?)JrAQ*GNlrS%.=b/61!i+Tg>`Xk4]>0^p5,GY*\FKaeEG,jVAo_geTB*+RN@^T8XlRc"5JfYP[m`dE=Jd.a/F;^/2\s]KC=NVVhZ[')$;!4;k[.C;DLglZNO\q,Su487VN8h9J#l(!(0CS/Xu09R[MD>@^EK@q;;SQ"`HbXp#W]abQ/D@i.WJr$?T3]VMutge0m0$+<$YF!bF"iP[=3[3*4KMmF]%YME'-g"rcm(^2do$dg+r99=iZdCZApAZi&#''aG:Wb6OO3(85Vc'/s?,o1gDBR1Dh:'/`EA'"qsNOM>L$Ni\i*-/5_o/]Udr?e#H9mYL6R];'3)%E[!,(06c``.&TXjWPUg[1s'\'O^OqJ_$)Rt(#P^'n<?mD$.mLKFe?sbA>:bF"+"$!_3KrJH:opHT1p6WWeY/KhZt)Gg#g5\pqR!R^)G`WXstGc`\rukQGOU9OHd]ihLqC/kBSu/2P[[6d=JAr59/F#)NKFVdDI#u3fs%gR6ssT9];S9+&[U[WY:Tf.;fauH+1r1D(4N]JVO7r%EE0<)pKa5%RM1-"\CoT$'I(>>!1XXq.=F3^rm6t"fg:/]H[&&_WHE.Go8FLUjNK:=2PE(8T7c?p7*E(;ZbU\)jCRoK?%M\5KL)Zme5X6Bb"RfE*eQJ_sq-G^<QBQ*2`\,"5I=4?,5263(_8uR*QOca#5(+0`#QqiT>=e`>nGj?Bs9t%1etad$g"CHS)u/le7Z_o=R[g>;8R<9JFVeIm,2Zd,+eAqJi_YCkj`6]Ei9X$H(R$[?'s?c"WVJONbPWnM)IOD_]uMpE3R?](Kl]rIY%j2P*7=I`CD"LHiY<BA,@<@rh_')fM!]/eQ?-4Ag7!@ae)sS_9PD]'u,2#'P`;&@B9dqUj?__,f$9LTO;V[[I\bCo7A>^-f0:@&t*:d9=@clqqTr6_j&3e9IeBrm5?U"cIcRD1?4UrL]G"=,,0Uh0t8+oo=A9.J3Yl/H:iJ(3^R^gs2?MPc(mY+XPImdJgTgYBF9N88^J-J_jas\-(I~>endstream
+endobj
+69 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1962
+>>
+stream
+Gb!;eD,91O&H:Nn1"&[<lj?GQ3,e\r$\_"WPV(EW-WN3qe.ch"VsC/6_6:VYPEr's/6<#C%T%c+N1YB@B#]!CGkaqf24Xbq)T)Ic"j14t%?qM9_c,b.45W-<$f[On+C='T,QpG$*dJor8OilD$'!sjL=g!hGru/"`$A*P&1F6d*sXM;$.g7[%Y-i5!fN/idh<dX/.-n](@cnV8Q`i,$(Mt=BW^=t$M@!+I342"fK&?l0=leR4q'WiLZ(0/I]tWZL2>lE$)9chKEjX0(uQrrLD)RcW95C%dY&L3C2dVPnKKPbY2R0Tr.'Z&h+BZkmN!`TPV?QT"@n+0hQ?7aqVF;PlF2ES]ZAeK2Xq8tIBCLeQV(k*E[7eNQ(ZtTL'.BBUWkJ\5)DBT8fki7ikY.!^)ht[]s@bH"+ips"/g&2eu0"Ea26(D0Sg_T$(!>A1MI;Q`Jc'NYQ<dYJ:I:l@rLqj7lg3R6S=Su>aTNFB5U8/cdkM!,.CX9i3d8_k9Q]lKK7F'8]8stkiipIaQu'%Ic*?F#uGNjiJCoefn0\<+ULMN#:o7Q;Y]4g0S$O:)K7?M;QF4mU6*9-)Ogs^!'<^`e_[W-4Y?[%XlMT'@G:5_-,XNk:3Etj0[Dg>*TY"79H"m\3l7NhA)f1'bPFL;l=9JUSqLDa04SV3\7V*KY*imW.uc8rRcaF3'lRKQ`Q?o+Y8M%sX7WTjW563RQK[:RMFW_*S2h?pcIIp]@d[1oVuYhIEL#.2Q[^"I07G:TYtI,KoD'D5B(J]^^`aA;ZB3%;dTbWjmJU&A,Ea/EQ>j84!/ZeTfI@qPa4t+<K1G,q,*c5T5)!A%6l2\e(bp@L2Su`1Wql)G#I"fHYWn[.WN2hq?IW#tAHgqX0D$_MhSF-D_<"8g]P7o,$mYDckE/RooA!!Gk>f<P-c84\5/ORA:Ia3YD-gUU#)Nr8n*Ipn`cAdi"b'>n=%`?@Z^:J^Y%;DFfXG]>lOPU#;4ibOBoJA]Ypf2]p<E%68[+mLNMK<\!E):AC)5_Kb)E^)$`aO:bF]09,SUSkU99a`,L@qJT`>C!/l[[C+8D-T9[TFAPZ@]"G#<gOd*kgIgKYV`B8ZibS+s+ZH=!YBAoYK*l#+c1Xq=a;Z%kbVK?\;jr?Hf5\fInqrRiEoSS+e-P\VAb3U[\>I9mK\]cC](_$t[b1d%h[/(jh7_.Q0XX6A7uVckTS/7?`>q+<dJms+8[nc&ImF0EuWhNm'rDk-]A3/kiDG#TAtG19sV;25OC[MEM:2]=0K#i,P=gSWR/rNt(<6JKT:D]saKa@oq'HD)/LA"`qT]O@aMWH;@YU^:i/YC<mPS`76W<m73N;g"oB*(sdI/>mG?AjS`Bl)/Bdk.3Bp#'6JLVHV/h)LK`?IO;uklE,Fq;fF#i<G$90BhEI_Y"'f`5N3UJ2)VZje9u];L2j!2*Jtd:fA\t-E2Bjs_Ep*Mr?X#7Z+YPs%Dl03"m(-<?M)P/'tBiG/ab$dcPe+i9PD%f]>JItjqna0g>oSTf]pbE19ZgHh0Qu+Jga9k0rIt*[2P0&Q(AO(8<N9_"!rmpEH@BQ1N&74?G*gg]Yej8<dR=s[aa+PM`^QcZt_&;hS(iR)lu2f_J#=u\7siUb>O_UJ[U85S[u0_;g"12.=,t(l*PfmK0et!Is0C+590K`_J!R79RV">H4M+PZCjC#3?%8EVA+lN:#$nJP.O7kPGc%F;RIuRCG+XAHAm64@>806NVA$t3qY_bmXW7tBs=nI#9d`n?'r^MI>]fY<FUNGF/'(AEq"A+*NbS.X-.LDXW7Ot%8@?E,r_Zj+hUarjJ[\7/;5jbJ2nD<d[eK2eLPfOCgT``=>!9_<MhsK_)7;633IP@09iPcpEG*9l$qE]kNmfK"g/?4i_GDG-Hn]HUQna?N5l"fN46n`;b!#8CO;S'I^g*f@Z6GJ)>pjKjBlsUpCOR$I`^Q(X"QKIG+eFcVX/9H~>endstream
+endobj
+70 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3621
+>>
+stream
+Gb".>fl#Qap0D#[^dSj3Ng\S1j\=?2Ea^>u/YGA&(Rh(/-5<G"ESS=DkKK#T;A*Oe;=dVk78+/'k3UjH+X7^#BBjEF,36L;o(J4Y`lW<gR'\-,?B^<3kg,A[D9q7*=Oa7mGDO3Xku*;tb>Cm-B/.a(4lT=VE@P6<IF%J3f-/@I6?oq/nq\iG*@V,]\<`*kr#33o4bpX-YrHs(c%tJ&?NLf>*&b$ia;,-sQ7[e5dhNa-?[TGUgmrp=GOJn&l";dM'd;.eCuQ$jB=:GaBhP(=!`3\?!;h!X'nFBoUR;-sj>P?H<ER7D9$[!qYZXfB:D*CV3PCCCU*MP_\E*3U5:?,F>!FZ(p??A>g!iIiSNaco/7$3c-nXI-l0Pah>#IQ29gKdB-g#<H_%i8/WU%$.YWSB^?ZrjHS^K5`*8:N^n8(P]j=--'_C9[eQ,&6SOB>81B%W8-BXl)7hm#,e-nTD!i,c@aV'fXm8@,cYM6_8cca2*ud0d3[BBsJDgI;j^Oe6_HS,"]3`9meh0?o)sSh[NZheFEbU")D"!X$J`*/4Qj*q1*,ZpU=9,;T=<8ie3SEZI^[&=X=8*I`co&K]%b6\M)=fg69K32-C9J\QM^rep4f!/qsh?lTr&5s8%/YU.*7P_If3ceIR;F[=-T!7&AI/`BOhV__utCHd/Yfq<:(ER35m22l^;N11FMD[*Td)CQ_pQEOI7MJIrOmh&8T&kWdAM*P0N\l-Y8=[F;O6n%.f+/V=o<3N5:,4V*`U"O1(+h2,9MGks#-jA0pl3G$\'K9IU;.87hGjTecUYBCfPHY+ZjR&erfJ--dUMPS:n(r[Pl<k>J!O8[jpYK@q4(nUsLsWE>4g[l?RMjh+3t1MGTZ6'h@WG4]-<D9BVY<L!p%-?.UA/p2n8s=oe;+[gJj9[ZdD9K&hX3_SFSp!mR&elOWZ[083Wkm87cB[Z0$8K&NE5?j.*Zjq4pC##S0^HYO1%KoQ)'*fU,F2m(<Y#k]/80%"jhmt,,?UIetdMF2[I.pj.@i/=9*'P"NWWn><W]Qa4ph&id+n6OhTY2+-;lV?MLIYgl+Z\IW3\o+'`Q!BqTG#<^VZ"k[Es7*laJkbJqH036];67KVG)"H7)%+:%cVkT]6Qn5ggaK\Lf=]ai-BRS9m+e=/:[For-G,*cD1WE8;upoY\B34Pio@:lN"Mu.2+OJuuK!:L!%A1KA/]#"LNKpW_]F0Z.=Br&rh]]O!qIp"&M=#,h-fT\a")YG(a^cL+Co.dY,5ipN(?Dp"a)R?c0;\#Jd1<90F>/e=T46r\!lRX-R!3t)FCZ"in;X9k^Cpi((p"9i=9R\@*8paNgH?VVUn90D]8oe*T.S`p=CMrG27^QQ)*:#a6cs<mjc!*V7DPA1E&gQOgHMZtX9L,bFNr0LIe%!Vs5m0lmQ7Ka$^E::7O=mT4(e+OHF`#n5!>M0+1/<QYE2Z?6hu437cJum<._rZN<T/IRL`]P!jJ--9+:r#4>Iu._19Z`F6N+BIL>cTqM/DS>VEm#8lt,KD*b(CpaZISO8Q[99:6L./K/b';OmI=U/2<ORn93hW1LusdM[h%.$rI5L`Y1<f^20[j'*i%-c4E$BA<>J(bgJ7=X4_9/@O.TsOkCR$Q[%0j#0Napl^+aOLh79qo/L$-L6dt%OUN\jEV^uMIn4_DFFWiF!5CLJQGfbMgufh=4h?.4"8q1MBMF%MmbX/^RgYeMALmIs(8mQ!"VeIBg.<'"PeZQ/a.dOj9?&>iHAK`a90V'D:3<IQLa_RMSqN+$%WIRUO`[i8i^A.0muKb;9\/OcT(91>0Sb(/h[[4'hs2E/4h?9%"!$AmBU]YS\TeUZ"S0Vc3Wqhu6d9-50[Ee94G][r>NS4S`P^9R\d.ti+o9ALI"C#/J8.&pBF1bl[":dqF_DRoB,0LY[d"baZ@#XuHciSD1QH#j9o><N?dg8.k(]2>F2j@7_Y1NnbQ!<k9"sX*8&MBCWd12T-(.i1b_%:%8WZ.t&r/TT%W_@=f:GUIE<k`XMq$Rrl!cP/nR;>0j]FkdjILR=rl5su1O3KMduSiJ*90GYr,JLaSP4e:ib8/ibL[&q=%!o4>if+rk87TSitsP5O&/K"Bo)_BJ[t#`E"`%u`,R?@qS3-2"6(LE5I-\r77l"28_`/@cX0[$_&S[;KeirR4hRD3ni0t0J>=(E6!2-bj/.iHBkoIWoS(mPg@,SPD]NfL3.bH@c5Q_8J"HsMVKZ)d#"ZLPm^uSk2N2sEOScj`,4)d,ZX(`1Af0OY<0?%*TY8saZ`pcH!72c"S%H/T,S&(`m-V]aR8UM/h+@:6R9'&pSQRi$PE>7@j!2BPck=PJduK4TB$ct?\b6aqh[J4am^h+O(&V[jc3oDC"2]=>B]ag!0K4'H.fA*=Wb)9ESbmY2ZukgVQ+@OG/M7l.USB[tRH&ECjI&[<*BiPB[\\`]m#0i/l!!(bCA(L.n;tZOn5fb6(R'<71T!3Q/Q&h&/S@!-o>b\C;`I0-Wq0%#:p60%H^X0u.8H.fgDtm:roY#Fh6bnf4(AO_pS_uu52G!h+Y?u.dRi!"*j<TA5cZPnYcQ;RhC[TL[23AC9e(@f)`ZXMl*dT7SOn]jdhKL/FF&J1I^GZWT@ZRfhX6\49RjKYM7PS)Rgr^b@_at9>E+=8Oc0Fp]cS4#HoS^nUOJt=n-Af^raFE,gL_8sO\kij<\jUu)>SF880Y<NO/Loh,>S>8e?_WqC]GAg$MuuVNA!/4lI3!dAK:)*[7'nI_1D&mr&Om=FZ54N$jA^DL$Pp?DY%\P0(o0=R'#Bs57Oq%mnqtbOEF/#%a<FjE;7VAITiUJRm=)hh9-X2.hWR"X/"j#Pa;ODo%&XB;QlEaU"W=emr?k2Wn!Os"`NX-G6gkgYSjJpPN\@ehTmj[^#bf:&F^I@^sXM]Wrt_>a1OIV<i[W#8[s&>%(i+:U/T8NI<':[f?:?+`qqNp_Qj6sJ>Zt,;9^Z_+YDI;Np7#,kH[*f"U8H4L>:Zk.A4$!&3:(TmZ=oZ#ZC"EcRXXK#SM8InW6hFcLF7ui(7IMa"(89!_gn7<>q3]D?)"%?tETA-=9&r/<#2aHe7;aO-=o5ec2J`m2Mu)Ikg0ZH`2>nQ:+i_]TCTsPVb^!E,QVq,B[0HKA\0c61Y?dDqX-h6<2;2c#+q&QWhILOAJ0qZfej<V0'-SP-2k+JtjJO!d3u\WqBOI7'.Y=aC#lbccpY.FoDV^EtoW)'j,r'Vl4K4]>9q!,k3W<1ZZbbZ5XEa^SfIKGn,Y8g'#ifWZ[b:5H@>SCc2KsKXHdgBuB"1%+R.an?'-BcI+CD%3do2:+$$GJ+9=PEj;>K*s2L8MFcLL41p,,jYgZHX=W3b_C[gs/Xk]+9IE-;ls=`:@2K_Jr/`%Fl_$NB56pus+FgQbGTJ*4kZKK@b[+KmFmP^b'd=>mT,uB+)JofiXFCGK(j-AsIYsg[XgVs\D[3OGSaGhZDcK[>i&i<a"`/-3H8T7rKhT>a[]"1ZZ8Z9[3DnG+Ql#Vk[i&lu#DXFp^))GYYR7D2W%<#_>4k#?!I1($`]tg'Pi=s)7pdYJkmJSW5ZIaWgPp^([i<(@he:Lk4Z#"ol)HB*0Yaa]Ck7&(V.nFDg?p^+a7!+@)>tXXdHqb~>endstream
+endobj
+71 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2022
+>>
+stream
+Gb!;d?#SIU'Rf_Z\3M`-/S^$9.#I64i2"Iq+C/:)gE,LN?t@u'.uPl'V<u%TV7pE:/PlkmJ@11N[3j5Y^#rX,M?1]2XSGO#!1,4G\7*04XL>nI&[8j#ldb(VK[<Of/qD<%Z6TLg+q`90ghr:-OG$2n8<B&L:.5R8O[LO9"H9Q-OJ)fT@Jb/p!-!`ckRitqGp6e;it)LZYm;5/KI6gmi8Q_IFX/&*=?o1b"L'r&q<dk@`I.L@2(X6*!iu("HKnSu2Y%\482pue+<hL+jaaCb'GimN@5L6Bj:l3ce6q8%VG8XOF1?8V+CqK-pDRA`B/dhq's)Zp_p,J-kM<Z5`p;MWq=S\MNW&jO;nOWMDp:c7Q-n:44<hC.--2Qb3\X;[I[l-P+>K^4nrO&"6Q.603",aA3Whne&eop+)nPWfB/8D07urkL5rKi2l=%E1Ua$^/3D#t7&PSAlSq%ot*DI[ZS;5KSR?qVl.(?H;[jS.<*)1j6g)`!m\uc-8P)ptEH=B4(Qt&64dLmeGr?uq&2A)R73:AO58^Kqp6A?!_M'D((L?PB]K';/JKQJt3#SAo"L<#CoOapjX+X@HrrZO^05A$*s=o=g#o4YI<3h_@miFi%Yp='$\qL#T@TE`-.Uua7C8,2^@hV?jW?U%)u!mD^G8OR(Ak=fi?]J9G2Zo.mY^c8!bg[kFB0/i$6Z=]n&S+PK>r`p:\56]Rs0Sk`@*e.a@hP_8Sf**Lc,%0E2!f1WL`]/HOpL0QE:N30$HNf<D2fPhJ#%"97Y,fTLpNW7`K>Hs]&B'.ORJ/k+(fc;<`7L*@2NVQ*J>RaW`Idsm)E'&u>?3u,!eGVueq3&12[E7E$&l,gJ9A!Ib8D@OE4*0P1_)8MGIWi/+,W`l\r5hEZ1nR0c.NMk3o+T7Ipfk;Klto[C^nj#C-5CA,c>MS10kB+7LgcfX!?*^^-:7rBb,Ede+NOfjr6:T2_=+_ob1+VbnPW;e/:^_"'4"AIo'cB67S]MWOGf+QF4U1IB9is)5o!G1]2!]G.JY&=,a&Y?r.Ud0]/h'_G.!*1ShJ)FR;\B8UK)u7l6sMGV?3=T<c>%4>hi8i&SGeig*Duq)h71?)I2b+dLTE6B=Tkp%"QL.<\9/o!gksVm;:p_<>GS)6tZ,m95pIb2Il)@rHPf%"G;IdS"pibn##c%4#m+-J.n\QpA5AgMKG(<EWpL,]+%JS15VA$^\0ZZET`g29+`h?8\P.Hc3k[mZ$L(ch-rUZWL*?TF]cq;-,)#-%9W<Mo&k].%J7CZ@4PI_)N@V$To'8(BOXGF=^gF6Qb*!=4L#nZ$2RM<E\@$$fedKLV<Ud?<=A1@Fs"0S\raPgl&BGqk_OqcWV]T(dg%-0jC!NWo]nse=!$dgAu]$GBKe<1H8%G4LgV#1>ojiDXG`@PT1+JSJk;M/F%alq9'=MP3s%%0NYZ]RQJQ31c3of\N`bjlO7*f%D'R@qMR9;#$C3(gtN08;>?\3k7%&4eEIhl+1YHXTi+g;_52T!0AJ,;A!r'Cg7(R=VC>a$TORJ<4H$F7*a>E@.<Tu_mV>^9Nc3G7d7Ar(HEO>"aoQ`@7\re57h_XR`er1?$mp9<?1jJ3I6JVN%n5BB,\UASp>G.p%A]gbj,r%pNR9]hIEB)"m!G;^8Fe@@O%e"7DZ!A2mP=/k$?`Q$QJNLkk"0MP)OIn_+(_F[C%lWX$,"V;n,1g[E6X:B\6@.tdrj(hC:`o.it\Wt/B=cnliD#Sroh#(^)j&S)R3dDr->XN273.FW%)$lMc+/oGLWBh*#H1;Po0sQB]e2'Yu5E9ah%)Tao."`U9U&>O)F+[Dmn+T)S36"o,,fsd:es\K4H0XDX_Q9?(#gsQ(,(mDN<=.7t^1I+FfGX@/#Vk3T$TH1u:JsAh"nE0ft'&5u?2Cm8+XeUrM@0#N\/5b2g/BFSY(TTt*pb(OtQ?nFqWS89Ret[Z2&km<Gf&:NGonK8*2#4hkis'k#p"qVWm%m_$P=lJJdS\OM[9qu00O^@V>a%e&lC9ORE%:1eYI~>endstream
+endobj
+72 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 6969
+>>
+stream
+GauHQ>BegkP()#dkdSr5eo4uImY?3eHq?Fj'5(k#m+FON@3jK;9T]Z8T(0SQWp2Z:8JF]jHpY&gm]+!#I40IoZioFY:XJ:L*Fh<?Z^5S6'9ZXN@R<#B?!jlrf4TT'2;D:a2/B_^_R6HWXmUGWQClLc9\W$=lR]AI2NmBdBkJCN\sA1B-tSBLbFX.Yb8DajXD85ZE'\lHD(@]c)C[ab"DaNL)EIo9Tn*K?bZ][7N)kgAhm)dr2t)70\9e+F?2a\6G5XM7rX2=,!u^B$:(#IT7N:a)A0Aj1&6S61>_+)#X8*$,A%sW4\!rl[F>7F3Q62A(PP+QPce_s?GWT36f'K/J48/Bj+"tM$3ZR&T;YMiE1VCWq\$`qOMts:8D*MB'qcV=LZ!jLLoUEa=^c[Hk\."pC3mKgRQ_C[=/#UQj(caZL8S]4u"DasJ(Z1P-)3\=6_aT[2P*2]%C*'gZ6B/@XENL+WTiFpZiGnU.C9+!Jb\#CCeh?G=bM1!ojd5+AEE>!q44n^[#p&2)[uD!&"/"4OTliCrGg%th%(*W.dn]^Mi+rUO[V8rsKsWu#26+ni_f!at!PE,IP[)\FRO'+HZ6UI)hge0Ubg*jhpr[([Nfn;*3(T[XVm##CnJhPEfp=KKN^oW0jl`\f'ka.?0JYW@W0XpmnGsuUI[j.i"r81OdQ2k(aN.p4GUh\I;^"h%PQLH>`t]qS7P/T/O%dgr9[QO)RKD#il"ZYgd3t!l@#>^i41G]7`-mVA&NfGOVu3c..hifcicNTM.U'Va,olDjl>_LIQ=/K*1:Wo@F;psFL)T8$0AicqMt8qhb-n6=h0Ue+=-g\0'@?^5#e:B_cn/5L2YN9ICDaHMIBQhM^(3Z'ZW@s0Dglt[p$U'>F.E4%rBIGKCu77Sa%!noj>FpYKE<^5Lm-c[*M@!0[_!eG)VBiEDDIdW%"O,8_KWR']\ffgZPD7Q_Yp1C]3hgIW0m!*gX@<[QBb(kS>Lq?;keE#]eFC15k!+MQ"koW3U_\\!8bc$:M"K]S83C_@?D#%1<bTI,B=&1TL"pkco$DZ>=*sm7W9[V5_TZQ_?Sge+V53:(lc6NjMQ1TL^/#D09\(<1u]nlh+%_ETdo#OB/9V;TE*AD^iL!\j&uc>Q#83f3&3L+F@/c?%_Y+LeYnsPKSn+uiVTT`5CKTZcR;NTkN7&0^uPVfE#>OA:;ZrKr/YaPE-J%GH#9BkUlFo9A!3rEnrHj8]:$n>q<`4V03JfoN=U/De(#@qFKnt(q*M>>rFX`daLZlAF-Qd4RiEJ,m+%HE+.GGS_1_dI(H.b3>>BX:@AE)bApQ\0d7p0o_lTTCT(f;9jEj\Nf8InBI@<hQK^%[d%ckep3/cYBYff6_d&YNmVXrR,*ue0TS_mIfqkqPJ9muIhh]TdF&/!^DYednX2H=S_pBOqgg;eV0Ek>\+!;6KE$ST>*i?q`$k-(9oq?iRS[tqJ5(L`*u,'i-$P'^Du]PnaF6V/jiaX"(KP3aoG+uGr6dV!jsfa@7n_D_a;9<?pg]mZ]lSXdRZ,]%OO^K@X/#nm[6rXO<=$@<l>.N-V^\PgU?#aiIWpMr%h]GWY9M<i?M8@!]8:"K9@`U[p-"S)QV;;UUJH*;GUdNKMFYf2<#T``J=`]nmEBbV^3fTC[9Gj(:OlDHGJ\,Inc]IOF3m$N3G4PkZlMGqG>kR4&'6s1p049Wm(mg,of78Q_V+p'UA<WIUt8q]/u.#R%I53'&F$&J\.,^2_uTIVqY)#E4SZ^nrkTWQ,OrmBh[378I?i@"U:o>AhYn)p`)MtMs%mdJh!"lKYF8$^@hNf[qI<K\)I2X%>t7=qL9&8OGm:uT661B07@+4'Bk2d\N<X,hb5m-BcQYLFo1OMGFG]3L"HBIuV7[\]_bGe>AU%HK;^?f[rjLKod2SAaC7-WS$QOi^$K-3[2h_YU:Sc]b/PL281=JYpG-f[D)U#?$S-?qRpI2DI&#5mN^G[i'9?/h`i'f"G19!e^EV^0[mA(b`Q"2I1/HZdm5^X;7HrK)MVbY`Oo1LeV3:r)*eqK-h#koN:a:Q6lAmE=_\=Sb;3!?S_Ic8`IQ4oMJY6oMO1coMP,Q=eUms!mq5`Ld$&WkX3sZ-6rfC#N[0+,[IYUFM[]i2#8U>0Oi(tfjX)sSOUa$SDN7"B#3\M[p]4='E<=Vp58ga0!6[+3"#XQ]cXu7f3eC)F96bp:$uA*b!;X$Dh5=9B0.k?6Xq(n%nno74A:&N,,)e8?sjSg.t8#RH7R'LLr7;&ZA;bEMk%`Ei[7`$Pka:@,QS*LeQ\2YTrPmMm)Z7ZncAa:5ftfG++F^ACiSnAF6MAZ+"j^VNBhJls*(`YhY\.\YqN$HYPmk#*Db)gThs6M^-!Vi+pMfs/j[YnQ]N*=".)\#E65I5/fB^=VTZJ[>em2E%CcOb\f-o=8%@&0O%ZT*E!`]_9h5]OP&VP0U9<.a&.`C,")t4K?EB0I9?',L9@ntmDgj\I/d8qLj3kgt;$%E\."TK^'ehp."-'QQ?tsrj9\q%8Yo<`XY's:!\dFhG9JVc=<P9\M(TL)8C3]tVWM`<-%\t*9-t"goWX=>&SG_]R+,3#+*!)GDb5On].HjY?LI[5_Kct,4_@RFUJK^il$n5K!OO=7pb%)>e?%=*#!t<$2ehEm]Jfu?/%3755iO,BdM'3^6SVNo;.lMo1q#68.+VgMJ+!$*#B9+_CaY!DEjR^#kZcg)q"T>]q,0;a2p?_JPSH+Itk#\n2#4s#F_38%/6Gf4=U\t(mEJXZK5mXXOe!\9GHodGl24u@%*Nule#kAjj;,Yd\6nZJ::?$6[P:HSg:[/3'8Oa/jRQr/jb%Gf"6HW=OP^8e:iBYO?O*E^<lPb)G1_8!]d1IcFdq!nhSUUjuq0ZWg$4?HIiZi?]!Y_plJI.52!#'bQ^a*Fs9Me(>&LmmH0EIQ:%)=.=!1:R*:m<dXR%u0]$*P(<8.5N_0HQUUY'>ILq#66XVYK283BAi#cUSjr^K@U>aatquiV\js(RNpI!0r/i6W$FR$C*_pP@0&7Sqo-g%oJ03n6GV:OGdk09"=@^Pr'4*ObI<__5[fQP,*Ip<i@:t$C+LbP;o;0MD63'8g*OiW"bOS=jY31nIg==g:!S?i@&AcQo'tL/7jem$h2!l*oJ8KTWIZV"s5Bf9kakFI&%.7[GlbC<d[/8.o)>:ih!GV]V)@j>1&#A+S_Vb)'*M8)S=r)2]@(>$^C=hP(42?@&J4#cc&Jl-`To!o=FDZ0.XabXEMeoOFB/HpqTjqi$1C%'@?l>#u%.Y"7Q?_WPHPY6S=6>pu'":nDP*jm4BTY"YU/I/1I3j#]&eJX=OhfCDo`(k#('S9oH+U@=<7eM+`/h!%<^@s7I@h8@E$-CM[.J:qINd/_`Nrj-Kh$>,&02S#L2V"mT97J\&j6rX+@T-0eZ;:L-Ut:tKfkBL6/6KfW"8-XEuCMpsV5N^ocq:tOON;5b/_iUkCSr]A+bPXNl:rT\ba"9k>;Jt="W_#.6[j,'0,4\3dBT]u4_H9,1q:G@?)F9Ca#eP<,\`Dq8kaB2jYXu]4uB.C&&4&SC@2rpuQ+Q]!2a$&?7-]391;I2"(o@7-]?A"_C2XImPG&.]sMB4*s?n01uNik?U/FEU"3cNMFQ^fmu&5mW4UnnQkZo!>tQ=dp(91,5V1nKnsVVn97>1&#A&E%6J8LIg.0b69YW=Rp_V$W[!4Z_M7pAj,V>lClSBDG62#oXnGGkUuj*bMt\M-bKX-N9kpaj#(C(AZd.`piOHqHsT>fVQ2[&;P%m<1/W#p;W57_A#[cQB]]p9JgpgKH33dU1kb3R)f4p09&*E:\8X$:QIS'OaKpf,KJ6\fWmmh\JHhLAY>mi97]J64`JKL1o:V+,Z92ZL2IN`8.dF*Q)CIT.VNP-<\tsSKLF8;dRdMV+H_u0cgaOO""io#N^PYl9),16+.I_.dkf5$RsFkNqSMM#O'm"D9)lEf^Fc$!#K_jgQEjtrV(>__.>P"3PSG\hlld1#X>DMW;PbjDg=o.f&65s_=].F^Z-q9e&s219Q)9+s@m2"F;Q"!#j-%h_!YVUOGE^icmt[T6;"JW?,huMa)-[m/K>i8CLBlrZ^D,<f2\.lYk#q8j4A-9RB.4&/1X%geO7:B"'F")%f8:n#L9QG[juM[`%6-,hq"\am!>C\5Z%iR;&H(bM'2p'`^uo6:&3!)cK=Iqu+A]bJ\-;,`'\74d%"ie/KgFQ.E`!:`+C+Q78lVmu[uLk1U0sOuUjT%KSZsCclL5t_9EQ`aHpAOemE*5<Ybn=Q*PR/IINf%1h,kF2b9[^BHa1r7"r8,lA0AaP`'\.1KafT?E.N]YDSSRH7kD#dSqRr_@%lggd=fF\&>@ks*GZE/]AWQF)Mj'+M:4u@S/*7ud]sBj(<cB.I>c36pbLIcEYkM-_fHW&^<736iE;S9dt>W(nfqrrGk2eYV?d?haMk[38K=m^;WTAXg7(Zc&?;b>,j@WqJOnFU=]l_Bd56r*bi<a\Kl'VP],2@Xh0cW%HsTS9_CL2dYLe]97g>ih90XC,RB\S*[Obk.lpX8L'52(W;S\A;)HrM%6]3kLd%Ut+ZtK\$[-3=#(7h@s79@j_FKK4C@L.]l:I?L8Z%51Z)F)9[:`Fe*fA!D4_GEdT*97AsJ=otNqO=\`VB3AGq#i\,ME3<BqD!FP$o1i^ZnPMZ1_qmE[);fUd8p(l_&dW:Qp4;<T2]qJ-gbarK18p]dTM_c<0\<M<h+:"BbG%c:0O#Pnu';D:5D3`RaTOPZs*^Rf>g@RT]oUQOW)DBA'5LKe6YhV:k>Uc0*N[OO$bBQeNsG:>3Nb$$U%mtKdN[#B[9Wc>qjfNX_:%1#a:KcWfsU<!;CQ-cgdBu"&ge3Sj"_m7cXQ5$t@XqG-f"d'R+,5*"5DR5ZkespJ&>2b$OuW5._R-OROeq,]j/$3]^TR"+EdS?LgJ"*ceM)n3aST8X6FaCMtF87!(^sB1_nm79F%i8k`,M_O:[,Nd3`O,d]ZG589IVic`:QBMP2s@m?bX'p!<$@Os0l/PFk2Hh#NN"C<"]'Y#BDQPLe:d\&;PNXWS-O98fm8E-J"oXqPm"YWU%MC'U'E(>.Z3pDM2"S1"93?EB4i2+E?o;+lHG^MBZ]1:@ZBJj^XI/33.P<P'3Xm^0)"bl>R6Qom<:rq*B.<\"G-A=@P*JQnt<hYU6LKl[R:^C,dWKIuJm7ekdKIgg$/4gYX9%X^j/Y.6W`/0)3(1I\(SO+LA:DaFmAUQYNl$lng^7m>&)gT@3<r.XiaH!*rD8fE-]gulS3,2Mme;bA\QO.CCph@PH5E2/0eJQ5]T,-5Rdt/D61gMW#O;PnYkNQ\^ZdTE+Bm0P9m34E9oW78<nb?mjPo*gC4#ZB6Vb$'ch@an0KH*e*7#4)D-3B"P"2&Vj"ZLnlF&<D*"rB;9%BoP?D[dR+Gelm_8\._u^l>DYBK'Is>sUrl0jJgJ3R$1*]c6,!'^-coN-d&A\K/jP[h[`Sm_q).JSaaHY.5dW\][Zf(PlZBG\0%1R4Y\fes"=di0a%$Y0F$qQoiVIG;[(h+hQMM5V@8C><[@jF3%N)4?mP9@U:](e+H:=q<HHCFO"4=:0j.@gf;J@?'3ms%9&b..^Rf/M9U42f5-APAm8-S[UPD:5pY2.O)-<b\Z8inDFbsq"c(lmb\!_BV62u/P>]VHIImH6Dfp1aLuTjL(-RsTeeO=KpYq<XTTOB=,&8BbFlnc[TTDlUONi;@DM^Sq4al*$lnMhf[@-R7Z16&CY)-YJ]WjYN2E$[T5'lq.)=4u?p@#Id5L2'bnD+7!d`l78=t_h`ULu:dh*:YkJ*Q26)pS4trVU^,gZl=F9Y05DF[[>:JiP_Vin.5CZ)MDH1LuL"Ji%?qcFBu)j0i?Sc&aV;'jkc,]%@GE@U5)7q@Kg^S<,3Y]9qUXq(c*V0(/1h$p*Om*9PWtb]O-]IL44QJ%80Y%^/D;mqfuA1r:29_qd0IAf>)2NH-NYg.A'l80bdIjcafk)9\8KHiOPU+piYpHt?+Fr&C6Ak03AQ_a`:nDcZ1Qa^u1jkV==:q)mKeX7#JD[GkeCS(/3sQFrS\B&D4hRgN[!bM0#&Qg<_o13\#2\u_pUAQ:$/X'skj.ajV_]miMbI7Cbo`qJO4eI/*o_X^aAEga(X8@Gfb?*^aD5DXs2m+N$A^pgYYT8Rm\h[,RsrgeQ*3<Tg%R^Q0)mO/53e$Y1nS9IfkqA-'Q[(C(dBr^4#Q0QM1;^utXOh.rgn@OSpTCUk1C%o?KCZC=Vq4$]*p,!L[mJACprBpfpCjI#XZZ3g*_a_Jc]S3M3VVW0BQtjh6\2S;O]q6$$SP%UC2nt%Z@_NsR@P\[)M.='OXt7$9Q*ek]g2:![\_Z\K[g:*uh7j-f@q!^h%##R9e&mK?`>;X(Khr:u,JKYqGLJMA]eiS%;6Fl2?MYT>'@.,[BO*I0jN`+(WFk!UXq7CI-MPtHrc0sr`'-oYEW=g-QE+Q#:V)`*4&%+&7>J%^qhkj]p=S8ki$d/eZZmWZG.@D[2S:Ig6,?X]UtUlu2E'_T;/qfggp\'n.&ZM"6:*L;Ecmdn:W@:&O;GRgenFu\qd8^fqYP]%?4N+j\t<p#6uflLjbq[iN,c?XNRN:SbMqs!AR@#Y.3<*+l#7U!OlA%'2?p;F9-%A3*[h!d7g4t,X7bK7CVP6n$O"!LJ?_+.bO+rNVp4K=2=rg7a;?4@V<r80d=5B3KT<i$[a`::X]=(Nm+k+ah>60BqLRHsk7t>pJ5%#]4#3W`Y/5XkWAEMY_>]qWVbK^t*Hgf\W<[a%Xs1!V*P'>AIlCrJf-I[a8tXC9_?BOiQ[a;6ru60EXu8%`^_2^'Giptn^@YjFhW<=<L&ZXPn?rI\4JLKGX5:_:5P%#.YbXTQ!o'FuQ*KkL7W]HIpf".1J$_pI/Y:hP_)]E(:!*=<=Xk*eKsBJYYsKoS'r8.l4Kq.%'GZkpIMoCW.\mE#'6n]os"Z&<jT~>endstream
+endobj
+73 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2324
+>>
+stream
+Gb!#]?#SIU(V]XI31!g(;#CkN$@$dBV9.F7?*_rsn,`du`F]`?[cC&d]Dh[J;A(:dr^*K?DFe>rjEVf;oC27-!QG),rHGsWpiQrC2$:j,q?SVp!DIFiC-)/G+]Kr1"!BFt/.R680SjBJ`R?)b5S9kmX?]WX3"7&;@RX69Ktms-6:h?7L;u4d$c!o0dNHJfGnR';7hQ*j;'6a<R)]5j5i^LJ2'b6t-AW(`JE[ERS#b;U\+f?/iVrdO0`;F/2o]=u+hK]Xk"J60!ZAq@"'Ug$%1[@p'aPKa@:i%>mYZCsR9+*o_.>>7OsO,>eaVPb`H>@K(!Ln>_=`6TI+pc]c1C4]+hndfd`?fc35iGQZc@0]ZRXMK?9b/&:W:DE@Q;_1/D:P#,Y1=;'R*t.8l?6+r@#>,3t<O#"GNMEV>GF?UeBX1LV#k1TI^?T>F<<#lG7GY8K>kn(`NXp^c_@<1Je/MTf35TQ9&A#`?N&FT#j*%ot(-ZgA^Nh,Rk$"Mf;@[P!0%%3Vq-KqLULSep_4#9s,N-mTO%dlS^#K3;OR=WA$Zo4;A[<mDY14SmDNB/<m?C/GMf[EVp0]kknA&na2npeAe35JPAM]VBPAj:`H>ESJg"pEFsP95l2nn<dV6mR>D5R\Y+U*)2&Eq?br4\>AI>SR-.VKZV@J-C+?>BqVk>7#TQh/[F!bPq<F[#"6oLGUSp]ti37R1rL5'Zg?A)M!"T.JfREn2SV`.g=lo5k>o\M05tE\faSuOP808p4jUiK^!#7B,^b3o9G0IGhN0"q`Jl:])DA2_.A-LhfkId`cnDR^>AVo*Q`Umc6rTX7k6<_Z`3ln/H7S@GKe:+,TK$FT.b*pgR@)Crad'AZdr.8rL6V/'Q>X%-YR;P>Q6X/S9qHKKeErV-&s&g:*ph.Zb*97W5=X?j4Z>(`ToOXK+eA#qMlpWQkA4Ioe,!&?on+%*D^C08Y29-nh169<Th5PBF2GD!A'!c6\p8B^AVq&j&)^.HnK6%d+aCaqjCT[QWh!&r$;P%7Xo/'VH9,k,m6fjn?lq#d28mpd9s)Yn'+Q%";;N@S)e>e<o;9+Yk(9gE&10ln7H?\h\cOoA3'EVCto?@VDbI'e[%=So)o#/2n$$7FNI8P;TUF%"P[>E2R8'6kqVN^.5FI!c9^RP"?):`^f8#UtW6`?X*8e3^l?2AYcHVC<Hb8J2,=0!UcftB3Ej3'o)F12kTo'@O?h*IJmSKZ[KkU=e8Tn>@*n1u?5j:@VV7rj`7OC.96>,?/TeBN[o?K[,g'Gl&0(4)J1GYU.s^;=_OOuf%;E="^]%kdJH2j;)Siq1gDe)>_.;sHm^(`9ab1-Ma9`IC"$Nl&p0S$;[S[s.lPq[H[[:5a*3jEGnX?hFM'4T@J?Y/-(?Yc7Q72ltG*K?dkmigasU_Es5+TYJoqA+ioh8[_@/NEGXZ\hL1M9Rf.+jWGV^Dh@rsgR?B$iJmt"Z>dj(K5Z.!/5+kQlH`"pj1s5m)S8i&r6mW7EB"LQS<%qhIY\#GP=;[=\UMW38cQbRHbIl0*/=oW;BOX_WAA/anAgaS.%ECa=d8o\%2-\CN/;rseE[=cBG!ET):!C%cCB@(^X!/R.IM\T0I62=Sb'"qj%WHW_P`#6pXkgg[];P`mWZ)m9_Zgfh0DZZG7@5(6p>#%]qkP([T7aWL(s@RLgkQjC0G_u*\*AR4lS;8\mhiP(TKWp1i9g5YDig$Hc0UOFN&f<bfP-kW[YNZE8Y;+FB*o'Wj(,V`GrWs95R*7p+*As<hL"N'j02['chPAq9h9X%_UlfSQ"af6a#9+KFYZDeGm'8TOcF)H3A53l`n3UOKJU]/.RfM])tn'LHXRf"9s-\m'ZE#6:;Yjk*p^AK99'FlODW-9O'kUgT)npKJR4P^rD=l_:cldf[2gIPK"sKVQLRi`o[q&`Wif(D'%gk`S0L3\_3XL);.9D$P$mSId2t,p7n#R)GWVu!o'%R&MV+.e0I@JgHaL/9gb_oC7:lnBm[6E)f+*ZckHp`gSB+^[uP'=?AQfW8TRVFL#bd.2!!sBoj&o?mJJ581)0Cf6c1*$b>];?;InV>FjBa;F_^hYC3\I.fJm6-(.D]$B6n:g=8BioBJ*@oPnYm__Y(46]P6foi;PljbNB"P;f4XD9]s`V6]Gj[OB,QDX=8EpB\;UE1ba&HP*OregHLjk!e*eCpR;Bh2[Q3C>@qIPM/-GHIu.++3u%gV,STs)l_1\c/L"b!#YhGG;2HMuig7G=0-T!q)(lo9=]f5+9i9ElZmC:<C2OkFC@<RE],.Tm1Vq_19tJnpSS*kV.an.>)`r,erc-#ShEZe:^OcJ%#Q~>endstream
+endobj
+xref
+0 74
+0000000000 65535 f 
+0000000061 00000 n 
+0000000156 00000 n 
+0000000263 00000 n 
+0000000375 00000 n 
+0000000458 00000 n 
+0000000720 00000 n 
+0000000830 00000 n 
+0000001035 00000 n 
+0000001150 00000 n 
+0000001227 00000 n 
+0000001510 00000 n 
+0000001716 00000 n 
+0000001822 00000 n 
+0000002105 00000 n 
+0000002311 00000 n 
+0000002517 00000 n 
+0000002800 00000 n 
+0000003006 00000 n 
+0000003212 00000 n 
+0000003495 00000 n 
+0000003701 00000 n 
+0000003907 00000 n 
+0000004113 00000 n 
+0000004396 00000 n 
+0000004602 00000 n 
+0000004885 00000 n 
+0000005091 00000 n 
+0000005374 00000 n 
+0000005580 00000 n 
+0000005786 00000 n 
+0000006069 00000 n 
+0000006275 00000 n 
+0000006558 00000 n 
+0000006764 00000 n 
+0000007047 00000 n 
+0000007253 00000 n 
+0000007536 00000 n 
+0000007742 00000 n 
+0000008025 00000 n 
+0000008231 00000 n 
+0000008301 00000 n 
+0000008636 00000 n 
+0000008915 00000 n 
+0000011608 00000 n 
+0000013721 00000 n 
+0000017483 00000 n 
+0000019085 00000 n 
+0000022839 00000 n 
+0000026535 00000 n 
+0000029532 00000 n 
+0000030905 00000 n 
+0000033394 00000 n 
+0000034897 00000 n 
+0000037985 00000 n 
+0000040663 00000 n 
+0000043186 00000 n 
+0000045354 00000 n 
+0000047948 00000 n 
+0000049800 00000 n 
+0000053251 00000 n 
+0000055274 00000 n 
+0000058050 00000 n 
+0000059618 00000 n 
+0000062087 00000 n 
+0000065596 00000 n 
+0000068625 00000 n 
+0000071707 00000 n 
+0000074098 00000 n 
+0000076291 00000 n 
+0000078345 00000 n 
+0000082058 00000 n 
+0000084172 00000 n 
+0000091233 00000 n 
+trailer
+<<
+/ID 
+[<dc380b19e88c02f9e3414437239d6bc1><dc380b19e88c02f9e3414437239d6bc1>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 41 0 R
+/Root 40 0 R
+/Size 74
+>>
+startxref
+93649
+%%EOF

--- a/GOTO_MARKET/01_ICP_ET_SEGMENTS.md
+++ b/GOTO_MARKET/01_ICP_ET_SEGMENTS.md
@@ -1,0 +1,92 @@
+# ICP et Segments
+
+## ICP principal
+
+PME de 10 a 200 employes, avec une partie des equipes sur le terrain, en horaires variables ou multi-sites.
+
+Acheteur typique :
+
+- dirigeant-proprietaire ;
+- DRH ou responsable administratif ;
+- comptable interne ou cabinet partenaire ;
+- responsable operations ou chantier.
+
+## Douleurs prioritaires
+
+- feuille de presence papier difficile a verifier ;
+- pointage WhatsApp non fiable ;
+- heures supplementaires contestees ;
+- retard ou absence decouverts trop tard ;
+- preparation paie manuelle ;
+- litiges employes sur "j'etais la" ;
+- manque de preuve en cas de controle.
+
+## Segments a attaquer d'abord
+
+| Rang | Segment | Pourquoi maintenant | Message d'ouverture |
+| --- | --- | --- | --- |
+| 1 | BTP / chantiers | Equipes terrain, fraude et absences couteuses | "Combien de temps perdez-vous a verifier qui etait vraiment sur site ?" |
+| 2 | Securite / gardiennage | Horaires repetitifs, postes fixes, retards visibles | "Vos agents pointent-ils au bon endroit et a la bonne heure ?" |
+| 3 | Industrie / ateliers | Besoin de presence temps reel et discipline horaire | "Votre responsable sait-il qui est present avant 9h ?" |
+| 4 | Commerce / distribution | Plannings, shifts, retards, turnover | "La presence magasin est-elle fiable sans appeler tout le monde ?" |
+| 5 | Services terrain | Equipes mobiles, besoin manager leger | "Vos interventions terrain generent-elles une preuve de presence ?" |
+
+## Signaux d'achat
+
+Un prospect est prioritaire si au moins 3 signaux sont vrais :
+
+- plus de 15 employes ;
+- plusieurs sites ou equipes mobiles ;
+- preparation paie mensuelle > 4 heures ;
+- outils actuels : papier, Excel, WhatsApp ;
+- problemes recents de retard, absence ou heures supplementaires ;
+- dirigeant implique directement dans le suivi ;
+- materiel ZKTeco deja present ou besoin biometrie ;
+- croissance rapide de l'equipe.
+
+## Mauvais fit temporaire
+
+- moins de 5 employes sans douleur de pointage ;
+- entreprise qui veut uniquement un SIRH complet paie/juridique ;
+- grand compte avec appel d'offres long ;
+- besoin de paie locale complexe non validee ;
+- client qui refuse tout usage mobile ou toute discipline de pointage.
+
+## Persona 1 - Dirigeant PME
+
+Ce qu'il veut :
+
+- savoir si l'equipe travaille vraiment ;
+- eviter les conflits de fin de mois ;
+- payer juste ;
+- ne pas passer ses dimanches sur Excel.
+
+Phrase qui parle :
+
+> "En fin de mois, vous n'avez plus a deviner. Vous avez un rapport propre."
+
+## Persona 2 - Responsable RH/Admin
+
+Ce qu'elle veut :
+
+- centraliser les presences ;
+- reduire les corrections ;
+- avoir une trace propre ;
+- eviter les relances manuelles.
+
+Phrase qui parle :
+
+> "Vous passez de collecter les presences a controler les exceptions."
+
+## Persona 3 - Comptable
+
+Ce qu'il veut :
+
+- donnees fiables ;
+- export mensuel ;
+- moins de questions avant paie ;
+- justification en cas de litige.
+
+Phrase qui parle :
+
+> "Le rapport mensuel devient votre base de paie, pas une chasse aux informations."

--- a/GOTO_MARKET/02_OFFRES_PRICING_PACKAGING.md
+++ b/GOTO_MARKET/02_OFFRES_PRICING_PACKAGING.md
@@ -1,0 +1,72 @@
+# Offres, Pricing et Packaging
+
+## Principe
+
+Le pricing doit etre simple a expliquer au telephone. La premiere vente doit porter sur le controle de presence, puis les modules RH s'ajoutent quand le client voit deja la valeur.
+
+## Packaging recommande
+
+| Offre | Cible | Promesse | Inclus | Prix indicatif |
+| --- | --- | --- | --- | --- |
+| Starter Pointage | 10-30 employes | Savoir qui est present chaque jour | pointage, dashboard, historique, support email | 29 EUR/mois |
+| Business Controle | 30-100 employes | Controler anomalies et preparer le mois | Starter + anomalies, geofence, rapport mensuel CSV/PDF, support prioritaire | 79 EUR/mois |
+| Terrain Plus | 100-200 employes | Piloter plusieurs sites | Business + multi-sites, feature flags, onboarding accompagne | 199 EUR/mois |
+| Enterprise | >200 employes | Deploiement adapte | SLA, integrations, assistance migration, clauses specifiques | sur devis |
+
+## Offre d'entree recommandee
+
+Pour les 90 prochains jours :
+
+> Pilote 14 jours - Pointage et rapport mensuel.
+
+Conditions :
+
+- configuration accompagnee ;
+- 1 manager ;
+- 1 equipe pilote ;
+- objectif de 20 pointages minimum ;
+- bilan ROI a J+14 ;
+- conversion automatique vers Starter ou Business.
+
+## Garantie commerciale
+
+Formulation possible :
+
+> Si au bout de 14 jours vous n'avez pas identifie au moins une source de temps perdu ou d'erreur de presence, vous ne continuez pas.
+
+Cette garantie force une demo centree valeur et evite les conversations abstraites.
+
+## Preuves a collecter pendant le pilote
+
+- nombre de pointages ;
+- nombre d'anomalies ;
+- retards detectes ;
+- sorties manquantes ;
+- pointages hors zone ;
+- temps economise estime ;
+- export mensuel genere ;
+- avis manager en une phrase.
+
+## Upsell naturel
+
+Ne pas vendre l'upsell trop tot. Declencheurs :
+
+- le client a plusieurs sites ;
+- il demande des exports comptables ;
+- il veut limiter la fraude ;
+- il veut activer des alertes manager ;
+- il veut plus de langues ou plus d'utilisateurs.
+
+## Objections prix
+
+"C'est cher."
+
+Reponse :
+
+> Si une seule erreur de paie ou une demi-journee non justifiee coute plus que l'abonnement, le logiciel est rentable. On le verifie sur vos donnees pendant le pilote.
+
+"Excel suffit."
+
+Reponse :
+
+> Excel est correct pour stocker. Il ne prouve pas qui etait la, ou, et a quelle heure. Leopardo RH apporte la preuve et le rapport.

--- a/GOTO_MARKET/03_PLAYBOOK_VENTE.md
+++ b/GOTO_MARKET/03_PLAYBOOK_VENTE.md
@@ -1,0 +1,95 @@
+# Playbook Vente
+
+## Objectif de la vente
+
+Obtenir un pilote de 14 jours, pas convaincre le prospect de toute la vision Leopardo RH.
+
+## Message d'ouverture LinkedIn
+
+Bonjour [Prenom],
+
+Je travaille sur Leopardo RH, une app de pointage et controle presence pour PME terrain.
+
+Question simple : aujourd'hui, vos presences sont suivies plutot par papier, Excel, WhatsApp ou badgeuse ?
+
+Je demande car on aide des dirigeants a reduire les erreurs de fin de mois avec un rapport automatique.
+
+## Message WhatsApp court
+
+Bonjour [Prenom], je vous contacte pour Leopardo RH.
+
+On aide les PME a suivre les presences employes depuis mobile et a sortir un rapport mensuel propre pour la paie.
+
+Si vous utilisez encore papier/Excel/WhatsApp, je peux vous montrer en 10 minutes comment un pilote marche.
+
+## Structure demo 20 minutes
+
+1. 3 minutes - comprendre la methode actuelle.
+2. 4 minutes - montrer pointage employe.
+3. 4 minutes - montrer dashboard manager.
+4. 4 minutes - montrer anomalies et rapport mensuel.
+5. 3 minutes - proposer pilote 14 jours.
+6. 2 minutes - prochaines actions.
+
+## Questions de qualification
+
+- Combien d'employes doivent pointer ?
+- Combien de sites ou equipes ?
+- Comment preparez-vous la paie aujourd'hui ?
+- Qui corrige les retards et absences ?
+- Combien de temps prend la consolidation mensuelle ?
+- Avez-vous deja eu un litige sur presence ou heures sup ?
+- Qui decide si on lance un pilote ?
+
+## Script de closing pilote
+
+> Le plus simple est de ne pas debattre dans le vide. On configure une equipe pilote, vous faites pointer pendant 14 jours, puis on regarde ensemble les anomalies et le rapport. Si la valeur n'est pas claire, on arrete.
+
+## Objections
+
+### "Mes employes ne vont pas accepter."
+
+Reponse :
+
+> On commence avec une equipe pilote. L'objectif n'est pas de surveiller pour surveiller, c'est d'eviter les erreurs de paie et les discussions de fin de mois. Les employes y gagnent aussi une trace claire.
+
+### "On a deja une badgeuse."
+
+Reponse :
+
+> Parfait. Leopardo RH peut etre positionne comme couche de pilotage : anomalies, rapport, manager mobile, multi-site. La question est : vos donnees de badgeuse deviennent-elles vraiment actionnables ?
+
+### "On verra plus tard."
+
+Reponse :
+
+> Je comprends. Pour savoir si ca vaut le coup de le remettre a plus tard : combien d'heures votre equipe perd-elle chaque fin de mois sur les presences ?
+
+### "Envoyez une brochure."
+
+Reponse :
+
+> Je peux envoyer une fiche, mais la meilleure brochure c'est votre methode actuelle comparee a un rapport automatique. On peut faire une demo courte et vous decidez apres.
+
+## Suivi apres demo
+
+J+0 :
+
+- recap besoin ;
+- lien creation compte ou checklist ;
+- date bilan J+14.
+
+J+3 :
+
+- verifier que les premiers pointages existent ;
+- corriger friction onboarding.
+
+J+7 :
+
+- envoyer capture des premieres anomalies ou presences.
+
+J+14 :
+
+- bilan ROI ;
+- choix plan ;
+- prochaines etapes.

--- a/GOTO_MARKET/04_CANAUX_ACQUISITION.md
+++ b/GOTO_MARKET/04_CANAUX_ACQUISITION.md
@@ -1,0 +1,97 @@
+# Canaux d'Acquisition
+
+## Priorite canal
+
+| Canal | Role | Pourquoi | KPI |
+| --- | --- | --- | --- |
+| Vente directe LinkedIn/WhatsApp | Obtenir les 30 prochains clients | Rapide, apprend le terrain | demos qualifiees/semaine |
+| Partenaires ZKTeco/integrateurs | Acces PME deja equipees | Douleur pointage deja connue | leads partenaires/mois |
+| SEO local | Construire demande entrante | Durable et peu couteux | pages indexees, leads organiques |
+| Lead magnets | Capturer prospects froids | Utile pour RH/comptables | taux conversion visiteur-lead |
+| Ads test | Valider messages | Budget controle | cout demo qualifiee |
+
+## LinkedIn
+
+Cibles :
+
+- fondateurs PME ;
+- DRH ;
+- responsables operations ;
+- cabinets comptables ;
+- integrateurs IT locaux.
+
+Cadence :
+
+- 20 invitations ciblees/jour ;
+- 10 messages de qualification/jour ;
+- 3 posts/semaine ;
+- 1 cas client/semaine des qu'il existe.
+
+## WhatsApp
+
+Usage :
+
+- relance chaude ;
+- partage demo courte ;
+- diffusion lead magnet ;
+- relation partenaire.
+
+Regle :
+
+- jamais spam massif ;
+- message court ;
+- une seule question ou un seul CTA.
+
+## Partenariats
+
+Partenaires naturels :
+
+- revendeurs badgeuses ;
+- installateurs ZKTeco ;
+- cabinets comptables PME ;
+- consultants RH ;
+- agences IT locales.
+
+Offre partenaire :
+
+- 15% de commission recurrente pendant 12 mois ;
+- ou frais fixe par client active ;
+- support demo fourni ;
+- fiche une page "pointage + rapport mensuel".
+
+## SEO
+
+Pages a creer en priorite :
+
+- Logiciel de pointage en Algerie ;
+- Gestion presence PME Maroc ;
+- Rapport mensuel pointage pour paie ;
+- Alternative Excel pointage employes ;
+- Pointage mobile pour chantier ;
+- Badgeuse vs application mobile.
+
+Chaque page doit inclure :
+
+- probleme concret ;
+- capture produit ;
+- exemple de rapport ;
+- CTA demo/pilote ;
+- FAQ objections.
+
+## Ads test
+
+Ne pas depenser gros avant d'avoir une page et un message convertissant.
+
+Test initial :
+
+- 5 USD/jour pendant 7 jours ;
+- FR + AR ;
+- Algerie, Maroc, Tunisie ;
+- 2 angles : "temps economise" et "fraude/erreurs reduites" ;
+- objectif : demande demo, pas trafic simple.
+
+Decision :
+
+- couper si aucun lead qualifie ;
+- garder si cout demo qualifiee acceptable ;
+- appeler vite les leads entrants.

--- a/GOTO_MARKET/05_PRODUCTION_CREATIVE_IA_FIRST.md
+++ b/GOTO_MARKET/05_PRODUCTION_CREATIVE_IA_FIRST.md
@@ -1,0 +1,133 @@
+# Production Creative IA-First
+
+Ce document transforme le PDF inspirant `Leopardo_RH_Production_Creative.pdf` en consignes utilisables dans `GOTO_MARKET`.
+
+## Voix de marque
+
+Leopardo RH doit rester :
+
+- humain : parler a des gerants reels ;
+- direct : phrases courtes, preuves concretes ;
+- confiant : promettre un test mesurable, pas des miracles ;
+- local : Maghreb, Turquie, PME terrain ;
+- visible : vrais ecrans, vrais chiffres, vrais rapports.
+
+## Regles de contenu
+
+A faire :
+
+- montrer le produit ;
+- montrer les chiffres ;
+- raconter des situations PME ;
+- adapter culturellement FR, AR, TR, EN ;
+- garder un message par visuel ;
+- relire les textes arabes avec un locuteur natif ;
+- utiliser les captures app comme preuve centrale.
+
+A eviter :
+
+- photos IA generiques ;
+- jargon RH enterprise ;
+- textes arabes non verifies ;
+- traductions mot a mot ;
+- videos avatar trop rapides ;
+- promesses de conformite juridique non validees.
+
+## Stack recommandee
+
+| Besoin | Outil | Usage |
+| --- | --- | --- |
+| Scripts | ChatGPT / Claude | posts, emails, video, landing |
+| Traduction | DeepL + relecture humaine | FR vers AR/TR/EN |
+| Video avatar | Synthesia / HeyGen | demos et shorts sans tournage |
+| Voix | ElevenLabs | voix off natives par langue |
+| Montage | CapCut Web | sous-titres, formats shorts |
+| Design | Canva | posts, PDF, lead magnets |
+| Visuels | Midjourney / Ideogram | fonds, mockups, statiques |
+
+## Supports prioritaires
+
+1. Demo produit 3 minutes FR + AR.
+2. Short 30 secondes "3 secondes pour pointer".
+3. PDF lead magnet "Checklist pointage PME".
+4. Page landing "Pointage mobile PME".
+5. Sequence email pilote 14 jours.
+6. 10 posts LinkedIn FR, dont 3 adaptes AR.
+
+## Scripts a produire
+
+### Video demo 3 minutes
+
+Structure :
+
+- probleme : fin de mois, presences eparpillees ;
+- solution : pointage mobile ;
+- preuve : dashboard manager ;
+- controle : anomalies et rapport ;
+- CTA : pilote 14 jours.
+
+Phrase centrale :
+
+> Chaque mois, vous ne reconstituez plus les presences. Vous controlez seulement les exceptions.
+
+### Short 30 secondes
+
+Accroche :
+
+> 3 secondes pour pointer. 2 heures economisees chaque semaine.
+
+Plan :
+
+- employe pointe ;
+- manager voit le statut ;
+- anomalie detectee ;
+- rapport pret.
+
+## Naming des assets
+
+Format :
+
+- `video_demo_pointage_fr.md`
+- `video_demo_pointage_ar.md`
+- `post_linkedin_erreurs_paie_fr.md`
+- `lead_magnet_checklist_pointage_fr.pdf`
+- `email_pilote_j03_fr.md`
+- `ads_pointage_30s_fr.md`
+
+Langues :
+
+- `fr`
+- `ar`
+- `tr`
+- `en`
+
+## Prompts utiles
+
+### Posts LinkedIn
+
+```text
+Tu es expert en vente B2B SaaS pour PME du Maghreb. Ecris 10 posts LinkedIn pour Leopardo RH, app de pointage mobile et controle presence.
+Ton : humain, direct, local, pas corporate.
+Chaque post : accroche max 8 mots, 5 a 8 lignes aerees, une situation concrete, un CTA leger.
+Themes : erreurs de paie, retard, Excel, WhatsApp, chantier, rapport mensuel, manager terrain, anomalies.
+```
+
+### Landing page
+
+```text
+Genere une landing page FR pour Leopardo RH.
+Cible : dirigeant PME 10-100 employes, equipes terrain.
+Promesse : pointage mobile, anomalies, rapport mensuel.
+Sections : hero, probleme, solution, demo, preuves, prix, FAQ, CTA.
+Style : phrases courtes, concret, aucune promesse juridique non verifiee.
+```
+
+### Adaptation arabe
+
+```text
+Adapte ce texte en arabe naturel pour un gerant PME au Maghreb.
+Ne traduis pas mot a mot.
+Garde les chiffres en 1,2,3.
+Ton : direct, respectueux, simple.
+Signale les passages qui doivent etre relus par un locuteur natif.
+```

--- a/GOTO_MARKET/06_CALENDRIER_90_JOURS.md
+++ b/GOTO_MARKET/06_CALENDRIER_90_JOURS.md
@@ -1,0 +1,62 @@
+# Calendrier 90 Jours
+
+## Objectif 90 jours
+
+Passer de 10 clients payants a un systeme capable de generer regulierement des demos qualifiees et des pilotes de 14 jours.
+
+Objectif quantifie :
+
+- 120 prospects qualifies ;
+- 40 demos ;
+- 25 pilotes ;
+- 15 nouveaux clients payants ;
+- 5 preuves client exploitables.
+
+## Semaines 1 a 4 - Preuve et fondation
+
+| Semaine | Livrable principal | Sortie attendue |
+| --- | --- | --- |
+| S1 | Interview des 10 clients payants | douleurs, mots clients, chiffres ROI |
+| S2 | 5 mini-cas clients anonymises | page ou PDF interne |
+| S3 | Landing pointage FR | page prete conversion demo |
+| S4 | Demo produit FR + AR | video courte et script demo |
+
+## Semaines 5 a 8 - Prospection repetable
+
+| Semaine | Livrable principal | Sortie attendue |
+| --- | --- | --- |
+| S5 | Liste 300 prospects | segments BTP, securite, industrie |
+| S6 | Sequence LinkedIn/WhatsApp | messages et relances |
+| S7 | Lead magnet checklist pointage | PDF + formulaire |
+| S8 | Premier partenariat ZKTeco/comptable | 5 partenaires contactes |
+
+## Semaines 9 a 12 - Conversion et contenu
+
+| Semaine | Livrable principal | Sortie attendue |
+| --- | --- | --- |
+| S9 | Sequence email pilote 14 jours | J0, J3, J7, J14 |
+| S10 | Pages SEO prioritaires | 3 pages publiees |
+| S11 | Ads test FR/AR | 2 angles, budget limite |
+| S12 | Rapport bilan GTM | KPI, apprentissages, decisions |
+
+## Cadence hebdomadaire
+
+Chaque semaine :
+
+- 100 nouveaux contacts ou enrichissements ;
+- 25 messages personnalises ;
+- 5 demos proposees ;
+- 2 contenus publies ;
+- 1 amelioration de support vente ;
+- 1 revue KPI le vendredi.
+
+## Definition "fait"
+
+Un livrable est fait s'il peut etre utilise par vente ou produit sans explication orale.
+
+Exemples :
+
+- un script demo doit etre lisible par une autre personne ;
+- une page doit avoir CTA, preuve et formulaire ;
+- un cas client doit inclure probleme, solution, resultat ;
+- un asset AR doit etre relu avant diffusion.

--- a/GOTO_MARKET/07_KPI_PILOTAGE.md
+++ b/GOTO_MARKET/07_KPI_PILOTAGE.md
@@ -1,0 +1,85 @@
+# KPI et Pilotage
+
+## North Star
+
+Nombre de PME qui generent un rapport mensuel de presence exploitable.
+
+Pourquoi : ce KPI relie adoption produit, valeur manager et conversion payante.
+
+## Funnel
+
+| Etape | KPI | Cible 90 jours |
+| --- | --- | --- |
+| Prospection | prospects qualifies | 120 |
+| Interesse | demos realisees | 40 |
+| Activation | pilotes lances | 25 |
+| Usage | clients avec 20 pointages | 20 |
+| Valeur | rapports mensuels generes | 15 |
+| Conversion | nouveaux clients payants | 15 |
+
+## KPI activation produit
+
+- temps creation entreprise ;
+- temps ajout premier manager ;
+- temps ajout 5 employes ;
+- premier pointage ;
+- 20e pointage ;
+- premiere anomalie vue ;
+- premier rapport mensuel exporte.
+
+## KPI vente
+
+- taux reponse prospection ;
+- taux demo bookee ;
+- taux show demo ;
+- taux demo vers pilote ;
+- taux pilote vers payant ;
+- cycle de vente moyen ;
+- revenu mensuel moyen par client.
+
+## KPI contenu
+
+- vues landing ;
+- taux visiteur vers lead ;
+- taux lead vers demo ;
+- posts qui generent conversations ;
+- cout par lead qualifie ;
+- cout par demo qualifiee.
+
+## Rituel hebdomadaire
+
+Chaque vendredi :
+
+1. Compter les demos, pilotes, conversions.
+2. Lire les objections exactes.
+3. Identifier le segment qui repond le mieux.
+4. Garder un message gagnant, couper un message faible.
+5. Decider une seule amelioration produit ou support.
+
+## Tableau de bord minimal
+
+Colonnes CRM simples :
+
+- entreprise ;
+- pays ;
+- segment ;
+- nombre employes ;
+- douleur principale ;
+- canal ;
+- statut ;
+- prochaine action ;
+- date prochaine action ;
+- plan probable ;
+- notes.
+
+Statuts :
+
+- prospect ;
+- contacte ;
+- repondu ;
+- demo planifiee ;
+- demo faite ;
+- pilote lance ;
+- payant ;
+- perdu ;
+- a relancer.

--- a/GOTO_MARKET/08_ASSETS_ET_INSPIRATION.md
+++ b/GOTO_MARKET/08_ASSETS_ET_INSPIRATION.md
@@ -46,6 +46,16 @@ GOTO_MARKET/
     case_studies/
     sales_decks/
     ads/
+  public/
+    brand/
+    landing/
+    social/
+    video/
+    press/
+    partners/
+    ads/
+    content_calendar/
+    metrics/
 ```
 
 ## Assets prioritaires a produire

--- a/GOTO_MARKET/08_ASSETS_ET_INSPIRATION.md
+++ b/GOTO_MARKET/08_ASSETS_ET_INSPIRATION.md
@@ -1,0 +1,72 @@
+# Assets et Inspiration
+
+## Document inspirant ajoute
+
+Le document source fourni par l'utilisateur doit etre conserve ici :
+
+- `00_inspiration/Leopardo_RH_Production_Creative.pdf`
+
+Il inspire surtout :
+
+- l'approche IA-first ;
+- la production multilingue FR, AR, TR, EN ;
+- les regles de voix de marque ;
+- les videos sans tournage ;
+- les posts sociaux ;
+- les lead magnets ;
+- le calendrier de production 90 jours.
+
+## Decision importante
+
+Le PDF parlait d'un dossier `/marketing/`. Dans ce repo, la strategie creee ici utilise `GOTO_MARKET/` pour eviter de reduire le sujet a la communication.
+
+`GOTO_MARKET/` inclut :
+
+- positionnement ;
+- vente ;
+- canaux ;
+- offre ;
+- onboarding ;
+- contenu ;
+- KPI ;
+- assets.
+
+## Bibliotheque a remplir
+
+Structure recommandee :
+
+```text
+GOTO_MARKET/
+  00_inspiration/
+  assets/
+    README.md
+    screenshots/
+    videos/
+    lead_magnets/
+    case_studies/
+    sales_decks/
+    ads/
+```
+
+## Assets prioritaires a produire
+
+1. 5 captures produit FR.
+2. 5 captures produit AR apres verification RTL.
+3. 1 video demo pointage FR.
+4. 1 video demo pointage AR.
+5. 1 PDF checklist pointage PME.
+6. 1 fiche offre Starter/Business.
+7. 5 mini-cas clients anonymises.
+
+## Regle de qualite
+
+Chaque asset doit montrer au moins un de ces elements :
+
+- vrai ecran produit ;
+- chiffre ROI ;
+- rapport mensuel ;
+- anomalie detectee ;
+- situation PME locale ;
+- preuve client.
+
+Un asset qui ne montre rien de concret reste brouillon.

--- a/GOTO_MARKET/09_TEMPLATES_OPERATIONNELS.md
+++ b/GOTO_MARKET/09_TEMPLATES_OPERATIONNELS.md
@@ -1,0 +1,84 @@
+# Templates Operationnels
+
+## Fiche mini-cas client
+
+```text
+Client :
+Pays :
+Segment :
+Nombre employes :
+Methode avant Leopardo RH :
+Douleur principale :
+Fonction utilisee :
+Resultat mesure :
+Citation client :
+Capture disponible :
+Autorisation diffusion : oui / non / anonymise
+```
+
+## Interview client 20 minutes
+
+Questions :
+
+- Comment suiviez-vous les presences avant Leopardo RH ?
+- Quelle etait la partie la plus penible en fin de mois ?
+- Combien de temps cela prenait-il ?
+- Quelle anomalie ou erreur revenait souvent ?
+- Qu'est-ce qui a change depuis l'utilisation ?
+- Quelle fonctionnalite montrez-vous en premier a un autre dirigeant ?
+- Qu'est-ce qui bloque encore ?
+- Acceptez-vous une citation anonymisee ?
+
+## CRM minimal CSV
+
+```csv
+entreprise,pays,segment,nombre_employes,contact,role,canal,douleur,statut,prochaine_action,date_prochaine_action,plan_probable,notes
+```
+
+## Checklist lancement pilote
+
+- Entreprise creee.
+- Manager principal cree.
+- 5 employes minimum ajoutes.
+- Langue configuree.
+- Regle de pointage expliquee.
+- Premier pointage teste.
+- Date bilan J+14 fixee.
+- Objectif pilote note.
+
+## Email recap apres demo
+
+Objet : Recap Leopardo RH - pilote pointage
+
+Bonjour [Prenom],
+
+Merci pour l'echange.
+
+Ce que j'ai compris :
+
+- equipe : [nombre] employes ;
+- methode actuelle : [papier / Excel / WhatsApp / badgeuse] ;
+- probleme principal : [douleur] ;
+- objectif du pilote : [objectif].
+
+Prochaine etape proposee : lancer un pilote 14 jours sur une equipe, puis regarder ensemble les presences, anomalies et rapport mensuel.
+
+Je vous envoie la checklist de configuration.
+
+## Revue hebdomadaire GTM
+
+```text
+Semaine :
+Prospects ajoutes :
+Messages envoyes :
+Reponses :
+Demos faites :
+Pilotes lances :
+Clients signes :
+Objection la plus frequente :
+Message qui a le mieux marche :
+Segment qui a le mieux repondu :
+Action a couper :
+Action a amplifier :
+Decision produit/support :
+```

--- a/GOTO_MARKET/10_VIABILITE_ET_REPOSITIONNEMENT.md
+++ b/GOTO_MARKET/10_VIABILITE_ET_REPOSITIONNEMENT.md
@@ -1,0 +1,102 @@
+# Viabilite et Repositionnement
+
+## Principe fondateur
+
+Leopardo RH existe pour utiliser la technologie afin de creer une plateforme qui repond a des besoins reels de son temps et qui gagne de l'argent.
+
+C'est simple, mais non negociable :
+
+- utile pour les clients ;
+- vendable par une equipe commerciale ;
+- rentable pour l'entreprise ;
+- moderne dans l'experience et la distribution ;
+- capable de changer quand le marche donne un signal clair.
+
+## Role de `GOTO_MARKET`
+
+Ce dossier est le centre de reflexion sur la viabilite globale du projet.
+
+Il doit aider a decider :
+
+- quoi vendre ;
+- a qui vendre ;
+- pourquoi maintenant ;
+- quel probleme prioriser ;
+- quel module couper, renforcer ou repositionner ;
+- quel canal merite du temps ou de l'argent ;
+- quelle promesse est vraiment crue par le marche.
+
+## Mentalite
+
+Ne pas avoir peur de :
+
+- deranger les habitudes internes ;
+- repositionner le produit ;
+- repositionner l'offre ;
+- moderniser le discours ;
+- remoderniser l'interface ;
+- couper les idees qui ne vendent pas ;
+- renforcer les idees qui creent du cash et de la valeur ;
+- viser le haut niveau sans attendre une permission.
+
+Le respect du projet ne consiste pas a figer la premiere version. Il consiste a le rendre assez vivant pour survivre au marche.
+
+## Questions de viabilite
+
+Chaque mois, repondre franchement :
+
+1. Qui paie vraiment aujourd'hui ?
+2. Quel probleme paie-t-il pour resoudre ?
+3. Quelle fonctionnalite cree le plus vite le moment "je comprends" ?
+4. Quelle fonctionnalite cree le plus vite le moment "je paie" ?
+5. Quel segment a le cycle de vente le plus court ?
+6. Quel segment a le meilleur potentiel de revenu ?
+7. Quel canal ramene des conversations de qualite ?
+8. Quelle promesse attire mais ne convertit pas ?
+9. Quelle partie du produit semble moderne ?
+10. Quelle partie semble deja fatiguee ?
+
+## Repositionnement autorise
+
+Le repositionnement est une preuve d'intelligence, pas un aveu d'echec.
+
+Signaux qui justifient un repositionnement :
+
+- les demos interessent mais ne convertissent pas ;
+- les clients utilisent surtout une seule fonctionnalite ;
+- un segment paie plus vite qu'un autre ;
+- le message actuel attire les mauvais prospects ;
+- un concurrent occupe mieux la promesse RH generale ;
+- le marche repond mieux a "controle terrain" qu'a "SIRH complet" ;
+- la technologie ouvre une opportunite plus forte que l'idee initiale.
+
+## Revue mensuelle "top de top"
+
+Format court :
+
+```text
+Mois :
+MRR :
+Nouveaux clients :
+Clients perdus :
+Segment gagnant :
+Promesse gagnante :
+Canal gagnant :
+Fonctionnalite qui vend :
+Fonctionnalite ignoree :
+Decision de repositionnement :
+Decision de modernisation :
+Action cash des 30 prochains jours :
+```
+
+## Definition de la victoire
+
+Leopardo RH gagne si :
+
+- les clients comprennent la valeur en moins de 5 minutes ;
+- les equipes adoptent le pointage sans formation lourde ;
+- les managers voient des anomalies utiles ;
+- les rapports economisent du temps reel ;
+- le produit se vend avec une promesse simple ;
+- le revenu augmente sans complexite inutile ;
+- l'equipe ose ameliorer, repositionner et moderniser avant que le marche ne la force.

--- a/GOTO_MARKET/11_SYSTEME_PUBLICATION_PUBLIQUE.md
+++ b/GOTO_MARKET/11_SYSTEME_PUBLICATION_PUBLIQUE.md
@@ -1,0 +1,100 @@
+# Systeme de Publication Publique
+
+## Objectif
+
+Structurer tous les fichiers utiles pour presenter Leopardo RH au public via les reseaux sociaux, le site, les partenaires, les ads, les videos et les supports presse.
+
+Ce systeme doit permettre de produire, stocker, relire, publier et mesurer les contenus sans perdre le message central.
+
+## Message public central
+
+Leopardo RH aide les PME terrain a suivre les presences, detecter les anomalies et produire un rapport mensuel exploitable pour la paie.
+
+Formule courte :
+
+> Pointage mobile, controle terrain, rapport mensuel.
+
+## Architecture publique
+
+```text
+GOTO_MARKET/public/
+  README.md
+  brand/
+  landing/
+  social/
+    linkedin/
+    whatsapp/
+    instagram_facebook/
+  video/
+  press/
+  partners/
+  ads/
+  content_calendar/
+  metrics/
+```
+
+## Cycle de vie d'un contenu
+
+1. Idee : noter le probleme client et le canal cible.
+2. Brouillon : creer le fichier dans le bon dossier.
+3. Relecture : verifier promesse, ton, preuves et langue.
+4. Asset : ajouter capture, video, visuel ou PDF si necessaire.
+5. Publication : noter date, canal et lien.
+6. Mesure : noter vues, reponses, leads, demos.
+7. Recyclage : transformer les contenus qui marchent en ads, landing ou script demo.
+
+## Regles de nommage
+
+Format general :
+
+```text
+YYYY-MM-DD_canal_theme_lang_statut.md
+```
+
+Exemples :
+
+- `2026-05-10_linkedin_excel_pointage_fr_draft.md`
+- `2026-05-12_whatsapp_pilote_14j_fr_ready.md`
+- `2026-05-15_instagram_3secondes_pointage_ar_ready.md`
+- `2026-05-18_video_demo_pointage_fr_script.md`
+
+Statuts :
+
+- `draft`
+- `review`
+- `ready`
+- `published`
+- `archived`
+
+## Definition d'un contenu pret
+
+Un contenu est pret si :
+
+- une seule idee principale ;
+- une douleur client explicite ;
+- une preuve ou un exemple concret ;
+- un CTA clair ;
+- langue relue ;
+- pas de promesse juridique fragile ;
+- fichier range au bon endroit ;
+- canal cible indique.
+
+## Priorite des canaux
+
+1. LinkedIn : construire autorite B2B et conversations dirigeant/DRH.
+2. WhatsApp : convertir les prospects chauds et partenaires.
+3. Landing page : transformer l'interet en demande demo.
+4. Video courte : expliquer vite le pointage et les anomalies.
+5. Partenaires : multiplier la distribution locale.
+6. Ads : amplifier uniquement les messages deja valides.
+
+## Banque de themes
+
+- Excel ne prouve pas la presence.
+- WhatsApp ne remplace pas un rapport.
+- Les retards invisibles coutent cher.
+- Le manager doit voir les exceptions, pas refaire toute la paie.
+- Le pointage terrain doit etre simple pour l'employe.
+- Un rapport mensuel propre vaut plus qu'un tableur improvise.
+- La tech utile est celle qui fait gagner du temps et de l'argent.
+- Leopardo RH commence par le controle terrain, puis grandit avec l'entreprise.

--- a/GOTO_MARKET/README.md
+++ b/GOTO_MARKET/README.md
@@ -1,0 +1,45 @@
+# GOTO_MARKET - Leopardo RH
+
+Derniere mise a jour : 2026-05-07
+
+Ce dossier est le centre de gravite go-to-market de Leopardo RH. Il ne s'appelle pas `marketing` volontairement : son role n'est pas seulement de produire du contenu, mais de relier produit, ventes, onboarding, preuves client et croissance.
+
+## Objectif
+
+Transformer les 10 premiers clients payants en machine commerciale repetable :
+
+- servir de centre de reflexion global sur la viabilite du projet ;
+- verifier regulierement que la technologie repond a un besoin reel de son temps ;
+- assumer que le but est aussi de gagner de l'argent avec une plateforme utile ;
+- autoriser les repositionnements, modernisations et remises en question quand le marche l'exige ;
+- prouver vite le ROI du pointage et du controle terrain ;
+- vendre aux PME qui ont deja une douleur visible ;
+- documenter les scripts, offres, canaux et KPI ;
+- produire des supports IA-first sans perdre la voix locale de Leopardo RH ;
+- donner a chaque agent ou membre equipe un point d'entree clair.
+
+## Ordre de lecture
+
+1. `00_STRATEGIE_GO_TO_MARKET.md` - strategie globale et priorites.
+2. `01_ICP_ET_SEGMENTS.md` - clients cibles et signaux d'achat.
+3. `02_OFFRES_PRICING_PACKAGING.md` - offres, packaging et preuves de valeur.
+4. `03_PLAYBOOK_VENTE.md` - prospection, demo, objections, closing.
+5. `04_CANAUX_ACQUISITION.md` - canaux d'acquisition et tests.
+6. `05_PRODUCTION_CREATIVE_IA_FIRST.md` - contenu inspire du PDF source.
+7. `06_CALENDRIER_90_JOURS.md` - execution semaine par semaine.
+8. `07_KPI_PILOTAGE.md` - metriques et rituels.
+9. `08_ASSETS_ET_INSPIRATION.md` - bibliotheque et document inspirant.
+10. `09_TEMPLATES_OPERATIONNELS.md` - CRM, pilote, interviews, recap demo.
+11. `10_VIABILITE_ET_REPOSITIONNEMENT.md` - boussole business, modernisation et decisions dures.
+
+## Regle simple
+
+Chaque action go-to-market doit repondre a une question :
+
+> Est-ce que cela aide une PME a comprendre, tester ou acheter Leopardo RH plus vite ?
+
+Si la reponse est non, ce n'est pas prioritaire.
+
+## Boussole
+
+Le projet n'a pas vocation a proteger une idee ancienne par orgueil. Il doit utiliser la tech pour creer une plateforme qui repond a des besoins actuels, vendable, rentable, et capable de se repositionner autant de fois que necessaire pour aller au meilleur niveau.

--- a/GOTO_MARKET/README.md
+++ b/GOTO_MARKET/README.md
@@ -31,6 +31,13 @@ Transformer les 10 premiers clients payants en machine commerciale repetable :
 9. `08_ASSETS_ET_INSPIRATION.md` - bibliotheque et document inspirant.
 10. `09_TEMPLATES_OPERATIONNELS.md` - CRM, pilote, interviews, recap demo.
 11. `10_VIABILITE_ET_REPOSITIONNEMENT.md` - boussole business, modernisation et decisions dures.
+12. `11_SYSTEME_PUBLICATION_PUBLIQUE.md` - structure des fichiers publics, reseaux sociaux, landing, videos, partenaires et ads.
+
+## Dossiers actifs
+
+- `00_inspiration/` - documents source et inspirations.
+- `assets/` - supports commerciaux selectionnes.
+- `public/` - contenus et fichiers destines a presenter Leopardo RH au public.
 
 ## Regle simple
 

--- a/GOTO_MARKET/assets/README.md
+++ b/GOTO_MARKET/assets/README.md
@@ -1,0 +1,14 @@
+# Assets GOTO_MARKET
+
+Ce dossier stocke les supports commerciaux et creatifs exploitables.
+
+## Sous-dossiers recommandes
+
+- `screenshots/` - captures produit par langue.
+- `videos/` - scripts, storyboards et exports.
+- `lead_magnets/` - guides, checklists, calculateurs.
+- `case_studies/` - mini-cas clients.
+- `sales_decks/` - supports demo et pitch.
+- `ads/` - copies, visuels, learnings.
+
+Les fichiers lourds doivent rester utiles et nommes clairement. Eviter les exports brouillons non selectionnes.

--- a/GOTO_MARKET/public/README.md
+++ b/GOTO_MARKET/public/README.md
@@ -1,0 +1,35 @@
+# Public - Presentation de Leopardo RH
+
+Ce dossier stocke les fichiers destines a presenter Leopardo RH au public.
+
+Il couvre :
+
+- reseaux sociaux ;
+- site et landing pages ;
+- videos ;
+- supports partenaires ;
+- ads ;
+- kit presse ;
+- calendrier editorial ;
+- suivi de performance.
+
+## Sous-dossiers
+
+- `brand/` - message public, ton, bio, slogans, elements de marque.
+- `landing/` - copies de pages publiques et CTA.
+- `social/` - contenus LinkedIn, WhatsApp, Instagram/Facebook.
+- `video/` - scripts, storyboards, shorts et demos.
+- `press/` - kit presse, communiques, presentation courte.
+- `partners/` - one-pagers et messages revendeurs/integrateurs.
+- `ads/` - tests paid, copies, audiences, resultats.
+- `content_calendar/` - calendrier editorial et planning publication.
+- `metrics/` - suivi des performances par canal.
+
+## Regle
+
+Tout fichier public doit dire clairement :
+
+- qui on aide ;
+- quel probleme on resout ;
+- pourquoi maintenant ;
+- quelle action faire ensuite.

--- a/GOTO_MARKET/public/ads/ADS_TEST_PLAN_FR_AR.md
+++ b/GOTO_MARKET/public/ads/ADS_TEST_PLAN_FR_AR.md
@@ -1,0 +1,57 @@
+# Ads Test Plan FR/AR
+
+## Objectif
+
+Tester les messages publics avant d'augmenter les budgets.
+
+## Budget initial
+
+- 5 USD par jour ;
+- 7 jours ;
+- FR et AR ;
+- Algerie, Maroc, Tunisie ;
+- objectif : demande demo ou formulaire pilote.
+
+## Angles a tester
+
+### Angle 1 - Temps economise
+
+Message :
+
+Arretez de reconstruire les presences chaque fin de mois.
+
+CTA :
+
+Lancer un pilote 14 jours.
+
+### Angle 2 - Preuve terrain
+
+Message :
+
+Excel calcule, mais il ne prouve pas la presence terrain.
+
+CTA :
+
+Voir Leopardo RH en demo.
+
+### Angle 3 - Rapport mensuel
+
+Message :
+
+Pointage mobile aujourd'hui, rapport mensuel demain.
+
+CTA :
+
+Recevoir un exemple de rapport.
+
+## KPI
+
+- cout par lead ;
+- taux lead vers demo ;
+- taux demo vers pilote ;
+- cout par pilote ;
+- qualite des conversations.
+
+## Decision
+
+Ne garder un angle que s'il genere des conversations qualifiees, pas seulement des clics.

--- a/GOTO_MARKET/public/brand/BRAND_PUBLIC_GUIDE.md
+++ b/GOTO_MARKET/public/brand/BRAND_PUBLIC_GUIDE.md
@@ -1,0 +1,64 @@
+# Brand Public Guide
+
+## Positionnement public
+
+Leopardo RH est une plateforme de pointage mobile et controle terrain pour PME.
+
+## Phrase courte
+
+Pointage mobile, controle terrain, rapport mensuel.
+
+## Phrase longue
+
+Leopardo RH aide les PME a suivre les presences de leurs equipes, detecter les anomalies et preparer un rapport mensuel fiable pour la paie.
+
+## Promesse
+
+En 14 jours, une PME doit voir plus clairement qui etait present, quelles anomalies existent, et combien de temps elle peut economiser en fin de mois.
+
+## Ton
+
+- concret ;
+- direct ;
+- local ;
+- professionnel ;
+- ambitieux ;
+- anti-jargon.
+
+## A dire
+
+- "presence terrain" ;
+- "rapport mensuel" ;
+- "anomalies de pointage" ;
+- "moins d'Excel, moins de WhatsApp" ;
+- "preuve claire pour manager et comptable" ;
+- "pilote 14 jours".
+
+## A eviter
+
+- "solution RH revolutionnaire" ;
+- "100% conforme partout" sans verification ;
+- "intelligence artificielle" si elle n'apporte pas de preuve concrete ;
+- slogans abstraits sans capture produit ;
+- promesses trop larges avant la preuve pointage.
+
+## Bios reseaux
+
+### LinkedIn
+
+Leopardo RH aide les PME terrain a suivre les presences, detecter les anomalies et produire des rapports mensuels fiables pour la paie. Pointage mobile. Controle terrain. ROI visible.
+
+### Instagram/Facebook
+
+Pointage mobile et controle presence pour PME. Moins d'Excel, moins de WhatsApp, plus de preuves.
+
+### WhatsApp Business
+
+Leopardo RH - Pointage mobile, anomalies et rapport mensuel pour PME.
+
+## CTA standards
+
+- Demander une demo.
+- Lancer un pilote 14 jours.
+- Recevoir la checklist pointage.
+- Voir un exemple de rapport mensuel.

--- a/GOTO_MARKET/public/content_calendar/CALENDRIER_PUBLIC_30_JOURS.md
+++ b/GOTO_MARKET/public/content_calendar/CALENDRIER_PUBLIC_30_JOURS.md
@@ -1,0 +1,55 @@
+# Calendrier Public 30 Jours
+
+## Objectif
+
+Publier pendant 30 jours sans improviser, avec un message coherent.
+
+## Semaine 1 - Probleme
+
+| Jour | Canal | Theme | Format |
+| --- | --- | --- | --- |
+| J1 | LinkedIn | Excel ne prouve pas | post opinion |
+| J2 | WhatsApp | question methode actuelle | message direct |
+| J3 | Instagram/Facebook | carrousel pointage | 5 slides |
+| J4 | LinkedIn | WhatsApp n'est pas un systeme | post |
+| J5 | Video | short 30s pointage | script + reel |
+
+## Semaine 2 - Solution
+
+| Jour | Canal | Theme | Format |
+| --- | --- | --- | --- |
+| J6 | LinkedIn | manager voit les exceptions | post |
+| J7 | Landing | page pointage FR | copy |
+| J8 | WhatsApp | invitation demo | message |
+| J9 | Instagram/Facebook | anomalie visible | visuel |
+| J10 | LinkedIn | pilote 14 jours | post |
+
+## Semaine 3 - Preuve
+
+| Jour | Canal | Theme | Format |
+| --- | --- | --- | --- |
+| J11 | LinkedIn | mini-cas client | post |
+| J12 | Press | description produit | kit |
+| J13 | Video | demo rapport mensuel | script |
+| J14 | WhatsApp | relance apres demo | message |
+| J15 | Instagram/Facebook | avant/apres Excel | carrousel |
+
+## Semaine 4 - Conversion
+
+| Jour | Canal | Theme | Format |
+| --- | --- | --- | --- |
+| J16 | LinkedIn | cout des erreurs | post |
+| J17 | Ads | test temps economise | ad |
+| J18 | Partners | one-pager partenaire | PDF/copy |
+| J19 | WhatsApp | pilote 14 jours | message |
+| J20 | LinkedIn | tech utile et rentable | post |
+
+## Recyclage
+
+Les posts qui generent des reponses deviennent :
+
+- script video ;
+- ad test ;
+- section landing ;
+- email partenaire ;
+- mini-guide PDF.

--- a/GOTO_MARKET/public/landing/PUBLIC_LANDING_COPY_FR.md
+++ b/GOTO_MARKET/public/landing/PUBLIC_LANDING_COPY_FR.md
@@ -1,0 +1,85 @@
+# Landing Page Publique - FR
+
+## Hero
+
+### H1
+
+Suivez les presences de vos equipes terrain sans Excel ni WhatsApp.
+
+### Sous-titre
+
+Leopardo RH aide les PME a faire pointer leurs employes, detecter les anomalies et generer un rapport mensuel clair pour la paie.
+
+### CTA
+
+Lancer un pilote 14 jours
+
+### CTA secondaire
+
+Voir un exemple de rapport
+
+## Probleme
+
+Chaque fin de mois, beaucoup de PME reconstruisent les presences a partir de feuilles papier, messages WhatsApp, appels et fichiers Excel.
+
+Resultat :
+
+- retards difficiles a prouver ;
+- sorties manquantes ;
+- heures supplementaires discutees ;
+- paie preparee dans l'urgence ;
+- manager fatigue par les corrections.
+
+## Solution
+
+Avec Leopardo RH :
+
+- l'employe pointe depuis mobile ;
+- le manager suit les presences en temps reel ;
+- les anomalies sont visibles ;
+- le rapport mensuel est pret pour la paie.
+
+## Preuve a afficher
+
+Ajouter ici :
+
+- capture pointage employe ;
+- capture dashboard manager ;
+- capture anomalies ;
+- exemple rapport mensuel PDF/CSV.
+
+## Offre pilote
+
+Testez Leopardo RH pendant 14 jours sur une equipe.
+
+Objectif du pilote :
+
+- configurer une equipe ;
+- obtenir au moins 20 pointages ;
+- identifier les anomalies ;
+- generer un premier rapport ;
+- decider avec des donnees reelles.
+
+## FAQ
+
+### Est-ce que les employes doivent etre formes ?
+
+Non. Le pointage doit rester simple : ouvrir l'app, pointer, confirmer.
+
+### Est-ce que cela remplace Excel ?
+
+Pour le suivi presence, oui. Excel peut rester utile pour d'autres analyses, mais il ne prouve pas une presence terrain.
+
+### Est-ce adapte aux petites equipes ?
+
+Oui si la douleur de pointage existe. Le meilleur fit commence autour de 10 employes.
+
+### Peut-on tester sur une seule equipe ?
+
+Oui. C'est meme la methode recommandee.
+
+## CTA final
+
+Arretez de reconstruire le mois a la main.
+
+Lancez un pilote 14 jours et regardons vos donnees ensemble.

--- a/GOTO_MARKET/public/metrics/PUBLICATION_METRICS.md
+++ b/GOTO_MARKET/public/metrics/PUBLICATION_METRICS.md
@@ -1,0 +1,50 @@
+# Publication Metrics
+
+## Objectif
+
+Mesurer les contenus publics par conversations et opportunites, pas seulement par vues.
+
+## Tableau de suivi
+
+```csv
+date,canal,fichier,lien_public,theme,langue,vues,reactions,commentaires,messages_recus,leads,demos,pilotes,notes
+```
+
+## KPI par canal
+
+### LinkedIn
+
+- vues ;
+- commentaires utiles ;
+- messages entrants ;
+- demos demandees.
+
+### WhatsApp
+
+- reponses ;
+- demos planifiees ;
+- pilotes lances.
+
+### Instagram/Facebook
+
+- vues reels ;
+- clics ;
+- messages ;
+- cout lead si ads.
+
+### Landing
+
+- visiteurs ;
+- taux conversion ;
+- demandes demo ;
+- sources trafic.
+
+## Revue hebdomadaire
+
+Questions :
+
+- Quel contenu a cree une vraie conversation ?
+- Quel message a attire les mauvais prospects ?
+- Quel canal merite plus d'effort ?
+- Quel contenu doit devenir une landing ou une ad ?
+- Quelle objection revient dans les commentaires ?

--- a/GOTO_MARKET/public/partners/ONE_PAGER_PARTENAIRE_FR.md
+++ b/GOTO_MARKET/public/partners/ONE_PAGER_PARTENAIRE_FR.md
@@ -1,0 +1,42 @@
+# One-Pager Partenaire FR
+
+## Pour qui
+
+Revendeurs badgeuses, integrateurs IT, cabinets comptables, consultants RH.
+
+## Ce que Leopardo RH apporte
+
+Une plateforme simple pour aider les PME a suivre les presences, detecter les anomalies et produire un rapport mensuel.
+
+## Pourquoi c'est utile pour vos clients
+
+Vos clients ont souvent deja le probleme :
+
+- presences papier ;
+- fichiers Excel ;
+- messages WhatsApp ;
+- badgeuses non exploitees ;
+- paie mensuelle difficile.
+
+Leopardo RH transforme ces donnees en controle manager et rapport exploitable.
+
+## Offre partenaire
+
+Proposer un pilote 14 jours a vos clients PME.
+
+Vous pouvez :
+
+- identifier le besoin ;
+- introduire Leopardo RH ;
+- accompagner la mise en place ;
+- recevoir une commission ou un revenu partenaire selon accord.
+
+## Message court a envoyer
+
+Bonjour [Prenom],
+
+Nous pouvons vous proposer Leopardo RH, une solution de pointage mobile et rapport mensuel pour PME.
+
+L'idee est simple : tester sur une equipe pendant 14 jours et mesurer si cela reduit le temps perdu en fin de mois.
+
+Souhaitez-vous une demo courte ?

--- a/GOTO_MARKET/public/press/PRESS_KIT.md
+++ b/GOTO_MARKET/public/press/PRESS_KIT.md
@@ -1,0 +1,44 @@
+# Press Kit - Leopardo RH
+
+## Description courte
+
+Leopardo RH est une plateforme de pointage mobile et controle terrain pour PME.
+
+## Description longue
+
+Leopardo RH aide les PME a suivre les presences de leurs equipes, detecter les anomalies et produire des rapports mensuels exploitables pour la paie. La plateforme vise les entreprises qui gerent encore leurs presences avec papier, Excel, WhatsApp ou des outils difficiles a consolider.
+
+## Positionnement
+
+Pointage mobile, controle terrain, rapport mensuel.
+
+## Public cible
+
+- PME 10-200 employes ;
+- BTP ;
+- securite ;
+- industrie ;
+- commerce ;
+- services terrain.
+
+## Fonctions a presenter
+
+- pointage arrivee/depart ;
+- dashboard manager ;
+- anomalies ;
+- rapport mensuel ;
+- onboarding pilote ;
+- multilingue FR/AR/TR/EN.
+
+## Citation fondateur a valider
+
+"Notre objectif est simple : utiliser la technologie pour aider les PME a gagner du temps, reduire les erreurs et piloter leurs equipes avec des donnees claires."
+
+## Assets a ajouter
+
+- logo ;
+- captures produit ;
+- video demo ;
+- portrait fondateur ;
+- exemples rapport ;
+- fiche produit PDF.

--- a/GOTO_MARKET/public/social/instagram_facebook/README.md
+++ b/GOTO_MARKET/public/social/instagram_facebook/README.md
@@ -1,0 +1,28 @@
+# Instagram et Facebook
+
+Ces canaux servent a rendre le probleme visible, recycler les messages LinkedIn et tester des formats courts.
+
+## Formats
+
+- carrousel 5 slides ;
+- reel 30 secondes ;
+- capture produit avant/apres ;
+- stat visuelle ;
+- temoignage court ;
+- annonce pilote 14 jours.
+
+## Regles visuelles
+
+- un seul message par visuel ;
+- capture produit quand possible ;
+- texte court ;
+- contraste fort ;
+- CTA simple ;
+- version AR relue avant publication.
+
+## Nommage
+
+```text
+YYYY-MM-DD_instagram_theme_lang_statut.md
+YYYY-MM-DD_facebook_theme_lang_statut.md
+```

--- a/GOTO_MARKET/public/social/instagram_facebook/carousel_5_slides_pointage_fr.md
+++ b/GOTO_MARKET/public/social/instagram_facebook/carousel_5_slides_pointage_fr.md
@@ -1,0 +1,34 @@
+# Carrousel FR - 5 Slides - Pointage PME
+
+## Slide 1
+
+Votre paie depend-elle encore d'Excel ?
+
+## Slide 2
+
+Excel calcule.
+
+Mais il ne prouve pas qui etait present.
+
+## Slide 3
+
+Avec Leopardo RH, l'employe pointe depuis mobile.
+
+Le manager voit la presence en temps reel.
+
+## Slide 4
+
+Les anomalies deviennent visibles :
+
+- retard ;
+- sortie manquante ;
+- pointage hors zone ;
+- heures douteuses.
+
+## Slide 5
+
+Fin de mois plus claire.
+
+Rapport pret pour la paie.
+
+CTA : Demander un pilote 14 jours.

--- a/GOTO_MARKET/public/social/linkedin/2026-05_batch_posts_fr.md
+++ b/GOTO_MARKET/public/social/linkedin/2026-05_batch_posts_fr.md
@@ -1,0 +1,77 @@
+# Batch LinkedIn FR - Mai 2026
+
+## Post 01 - Excel ne prouve pas
+
+Excel peut additionner des heures.
+
+Mais Excel ne prouve pas qu'un employe etait vraiment present, au bon endroit, au bon moment.
+
+C'est la difference entre un tableau et un systeme de controle terrain.
+
+Pour une PME avec 20, 50 ou 100 employes, cette difference devient visible chaque fin de mois :
+
+- retards discutes ;
+- sorties oubliees ;
+- heures supplementaires floues ;
+- paie corrigee a la main.
+
+Leopardo RH commence par une chose simple : rendre la presence visible.
+
+## Post 02 - Le manager doit voir les exceptions
+
+Un bon outil RH ne doit pas donner plus de travail au manager.
+
+Il doit lui dire quoi regarder.
+
+Qui est en retard.
+Qui n'a pas pointe la sortie.
+Quel pointage semble hors zone.
+Quel rapport est pret pour la paie.
+
+Le manager ne doit pas reconstruire le mois.
+
+Il doit controler les exceptions.
+
+## Post 03 - 14 jours suffisent
+
+On n'a pas besoin de 6 mois pour savoir si un outil de pointage apporte de la valeur.
+
+En 14 jours, une PME peut deja voir :
+
+- si les employes pointent ;
+- si le manager consulte ;
+- si des anomalies sortent ;
+- si le rapport mensuel aide vraiment.
+
+C'est pour ca que Leopardo RH se vend mieux par pilote que par promesse.
+
+Les donnees parlent plus vite que les slides.
+
+## Post 04 - WhatsApp n'est pas un systeme
+
+WhatsApp est pratique pour communiquer.
+
+Mais ce n'est pas un systeme de presence.
+
+Un message peut etre oublie.
+Une photo peut arriver tard.
+Une heure peut etre contestee.
+Une conversation peut se perdre.
+
+Quand vient la paie, le manager a besoin d'un rapport clair, pas d'une chasse aux messages.
+
+Leopardo RH transforme le pointage en donnees exploitables.
+
+## Post 05 - Tech utile
+
+La meilleure technologie n'est pas celle qui impressionne.
+
+C'est celle qui fait gagner du temps, evite une erreur, ou aide a prendre une decision.
+
+Pour Leopardo RH, la question reste simple :
+
+Est-ce que le manager voit mieux son terrain ?
+Est-ce que le comptable prepare mieux le mois ?
+Est-ce que le dirigeant gagne du temps ?
+
+Si oui, la tech sert le business.

--- a/GOTO_MARKET/public/social/linkedin/README.md
+++ b/GOTO_MARKET/public/social/linkedin/README.md
@@ -1,0 +1,32 @@
+# LinkedIn
+
+LinkedIn sert a creer l'autorite, provoquer des conversations B2B et obtenir des demos.
+
+## Cadence
+
+- 3 posts par semaine.
+- 20 invitations ciblees par jour.
+- 10 messages de qualification par jour.
+- 1 cas client ou preuve produit par semaine.
+
+## Formats prioritaires
+
+- probleme concret ;
+- mini-cas client ;
+- capture produit commentee ;
+- opinion business ;
+- checklist pratique ;
+- comparaison avant/apres.
+
+## Nommage
+
+```text
+YYYY-MM-DD_linkedin_theme_lang_statut.md
+```
+
+## CTA possibles
+
+- "Je peux vous envoyer la checklist."
+- "Je peux vous montrer le rapport en demo."
+- "Commentez POINTAGE et je vous l'envoie."
+- "On peut tester sur une equipe pendant 14 jours."

--- a/GOTO_MARKET/public/social/whatsapp/README.md
+++ b/GOTO_MARKET/public/social/whatsapp/README.md
@@ -1,0 +1,25 @@
+# WhatsApp
+
+WhatsApp sert aux conversations chaudes, aux relances, aux partenaires et aux prospects deja identifies.
+
+## Regles
+
+- Message court.
+- Une seule idee.
+- Une seule question.
+- Pas de spam.
+- Toujours proposer une demo ou un fichier utile.
+
+## Nommage
+
+```text
+YYYY-MM-DD_whatsapp_theme_lang_statut.md
+```
+
+## Usage
+
+- relance apres contact ;
+- envoi checklist ;
+- invitation demo ;
+- suivi pilote ;
+- message partenaire.

--- a/GOTO_MARKET/public/social/whatsapp/messages_prospection_fr.md
+++ b/GOTO_MARKET/public/social/whatsapp/messages_prospection_fr.md
@@ -1,0 +1,31 @@
+# Messages WhatsApp FR
+
+## Premier contact
+
+Bonjour [Prenom], je vous contacte pour Leopardo RH.
+
+On aide les PME a suivre les presences employes depuis mobile et a sortir un rapport mensuel propre pour la paie.
+
+Vous suivez vos presences aujourd'hui plutot par papier, Excel, WhatsApp ou badgeuse ?
+
+## Relance demo
+
+Bonjour [Prenom], je reviens vers vous rapidement.
+
+Je peux vous montrer en 10 minutes comment une equipe pointe, comment le manager voit les anomalies, et comment le rapport mensuel sort.
+
+Quel moment vous arrange cette semaine ?
+
+## Envoi checklist
+
+Comme promis, voici la checklist pour evaluer si votre suivi presence actuel vous coute du temps en fin de mois.
+
+Si 3 points ou plus vous parlent, un pilote Leopardo RH peut etre utile.
+
+## Apres demo
+
+Merci pour l'echange.
+
+Le plus simple maintenant : on teste sur une equipe pendant 14 jours, puis on regarde les pointages, anomalies et rapport ensemble.
+
+Je peux vous aider a configurer le pilote.

--- a/GOTO_MARKET/public/video/README.md
+++ b/GOTO_MARKET/public/video/README.md
@@ -1,0 +1,23 @@
+# Video
+
+Ce dossier stocke les scripts, storyboards et plans de videos publiques.
+
+## Formats
+
+- demo produit 3 minutes ;
+- short 30 secondes ;
+- tutoriel pointage ;
+- temoignage client ;
+- video partenaire ;
+- video ads 15 secondes.
+
+## Nommage
+
+```text
+YYYY-MM-DD_video_theme_lang_script.md
+YYYY-MM-DD_video_theme_lang_storyboard.md
+```
+
+## Regle
+
+Chaque video doit montrer un ecran produit ou un resultat concret.

--- a/GOTO_MARKET/public/video/script_short_30s_pointage_fr.md
+++ b/GOTO_MARKET/public/video/script_short_30s_pointage_fr.md
@@ -1,0 +1,35 @@
+# Script Video 30s - Pointage FR
+
+## Objectif
+
+Expliquer en 30 secondes pourquoi Leopardo RH remplace le suivi presence manuel.
+
+## Script
+
+Vous suivez encore les presences avec Excel, papier ou WhatsApp ?
+
+Le probleme, ce n'est pas seulement le temps perdu.
+
+C'est la preuve.
+
+Avec Leopardo RH, l'employe pointe depuis mobile.
+
+Le manager voit les presences et les anomalies.
+
+En fin de mois, le rapport est pret pour la paie.
+
+Leopardo RH.
+
+Pointage mobile, controle terrain, rapport mensuel.
+
+## Visuels
+
+1. Feuille Excel ou papier.
+2. Ecran pointage employe.
+3. Dashboard manager.
+4. Liste anomalies.
+5. Rapport mensuel.
+
+## CTA
+
+Lancer un pilote 14 jours.


### PR DESCRIPTION
## Summary
- Add root GOTO_MARKET folder as the global viability and go-to-market center for Leopardo RH.
- Include GTM strategy, ICP, packaging, sales playbook, acquisition channels, 90-day calendar, KPI, operational templates, and viability/repositioning guidance.
- Preserve the provided creative inspiration PDF under GOTO_MARKET/00_inspiration without creating a marketing folder.

## Validation
- Created from a clean worktree based on origin/main.
- Staged only AGENTS.md, CHANGELOG.md, and GOTO_MARKET/.
- Documentation-only change; no application tests run.