### PR TITLE
[codex] add acquisition launch support pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,8 @@ Procedure recommandee :
 - Les prochaines actions GTM doivent rester connectees au wedge produit prioritaire : pointage, anomalies, rapport mensuel, onboarding et ROI client mesurable.
 - `GOTO_MARKET/` est aussi le centre de reflexion sur la viabilite globale : utiliser la tech pour repondre a un besoin actuel, gagner de l'argent, et ne pas hesiter a repositionner ou moderniser le produit/offre quand le marche l'exige.
 - Les fichiers destines a presenter Leopardo RH au public doivent aller dans `GOTO_MARKET/public/` avec un sous-dossier par canal : `social/`, `landing/`, `video/`, `press/`, `partners/`, `ads/`, `content_calendar/`, `metrics/`.
+- Le pack de lancement acquisition vit dans `GOTO_MARKET/12_PACK_LANCEMENT_ACQUISITION.md` et les supports associes (`public/email`, `public/lead_magnets`, `public/owned_channels`, etc.).
+- La vision "Leopardo RH peut aussi aider une entreprise a gerer et automatiser son marketing" est documentee dans `GOTO_MARKET/product_marketing_automation/`, mais elle n'est pas implementee dans le depot et ne doit pas distraire du wedge pointage tant qu'il n'est pas solidement vendu.
 
 ### 2026-05-07 - Federation de PR ouvertes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Docs : integration du document inspirant `Leopardo_RH_Production_Creative.pdf` comme source de production creative IA-first, sans creer de dossier nomme `marketing`.
 - Docs : ajout d'une boussole de viabilite et repositionnement pour rappeler que le projet doit utiliser la tech afin de repondre a des besoins actuels, generer du revenu et accepter les modernisations necessaires.
 - Docs : ajout de `GOTO_MARKET/public/` pour structurer les contenus publics de presentation sur LinkedIn, WhatsApp, Instagram/Facebook, landing pages, videos, presse, partenaires, ads, calendrier editorial et metriques.
+- Docs : ajout d'un pack lancement acquisition avec scripts video, sequence email pilote, lead magnet checklist, messages WhatsApp, posts LinkedIn, copies ads et playbook owned channels.
+- Produit : documentation d'une future brique `product_marketing_automation/`, non implementee, pour cadrer l'idee d'aider les entreprises clientes a gerer et automatiser leur marketing.
 
 ## [4.1.98] - 2026-05-07
 

--- a/GOTO_MARKET/12_PACK_LANCEMENT_ACQUISITION.md
+++ b/GOTO_MARKET/12_PACK_LANCEMENT_ACQUISITION.md
@@ -1,0 +1,67 @@
+# Pack Lancement Acquisition
+
+## Objectif
+
+Ce pack regroupe les supports minimum pour lancer l'acquisition depuis nos propres canaux.
+
+But :
+
+- presenter Leopardo RH publiquement ;
+- obtenir des conversations qualifiees ;
+- convertir vers une demo ;
+- lancer des pilotes 14 jours ;
+- collecter les preuves de valeur ;
+- reutiliser les meilleurs contenus en ads ou partenaires.
+
+## Supports produits dans ce lot
+
+| Support | Dossier | Usage |
+| --- | --- | --- |
+| Script demo 3 minutes | `public/video/` | YouTube, LinkedIn, landing |
+| Storyboard demo | `public/video/` | Canva, Synthesia, CapCut |
+| Script short 15s | `public/video/` | Reels, ads, shorts |
+| Sequence email pilote | `public/email/` | activation et conversion |
+| Lead magnet checklist | `public/lead_magnets/` | capture leads |
+| Posts LinkedIn supplementaires | `public/social/linkedin/` | autorite et conversations |
+| Messages WhatsApp broadcast | `public/social/whatsapp/` | acquisition directe |
+| Ads copy FR/EN + briefs AR/TR | `public/ads/` | tests paid |
+| Plan owned channels | `public/owned_channels/` | acquisition sans dependance externe |
+| Roadmap marketing automation | `product_marketing_automation/` | futur module produit |
+
+## Sequence de lancement recommandee
+
+1. Publier la landing FR.
+2. Publier 3 posts LinkedIn probleme.
+3. Envoyer 50 messages WhatsApp qualifies.
+4. Diffuser le lead magnet checklist.
+5. Publier la video short 15s.
+6. Programmer 8 emails pilote.
+7. Lancer 2 ads test seulement apres les premiers retours organiques.
+8. Reprendre les objections et enrichir la landing.
+
+## Regle d'acquisition
+
+On ne cherche pas des vues pour flatter l'ego.
+
+On cherche :
+
+- reponses ;
+- demos ;
+- pilotes ;
+- clients ;
+- revenu ;
+- apprentissage marche.
+
+## Message de campagne
+
+Campagne principale :
+
+> Arretez de reconstruire les presences en fin de mois.
+
+Sous-message :
+
+> Leopardo RH transforme le pointage terrain en anomalies visibles et rapport mensuel exploitable.
+
+CTA :
+
+> Lancer un pilote 14 jours.

--- a/GOTO_MARKET/README.md
+++ b/GOTO_MARKET/README.md
@@ -32,12 +32,14 @@ Transformer les 10 premiers clients payants en machine commerciale repetable :
 10. `09_TEMPLATES_OPERATIONNELS.md` - CRM, pilote, interviews, recap demo.
 11. `10_VIABILITE_ET_REPOSITIONNEMENT.md` - boussole business, modernisation et decisions dures.
 12. `11_SYSTEME_PUBLICATION_PUBLIQUE.md` - structure des fichiers publics, reseaux sociaux, landing, videos, partenaires et ads.
+13. `12_PACK_LANCEMENT_ACQUISITION.md` - supports de lancement pour acquisition via nos propres canaux.
 
 ## Dossiers actifs
 
 - `00_inspiration/` - documents source et inspirations.
 - `assets/` - supports commerciaux selectionnes.
 - `public/` - contenus et fichiers destines a presenter Leopardo RH au public.
+- `product_marketing_automation/` - vision produit future pour automatiser le marketing des entreprises clientes.
 
 ## Regle simple
 

--- a/GOTO_MARKET/product_marketing_automation/README.md
+++ b/GOTO_MARKET/product_marketing_automation/README.md
@@ -1,0 +1,75 @@
+# Module Futur - Marketing Automation
+
+## Statut
+
+Non implemente dans ce depot a ce jour.
+
+Ce dossier documente une direction produit future : Leopardo RH ne doit pas seulement aider une entreprise a gerer ses RH. A terme, la plateforme peut aussi l'aider a structurer, automatiser et mesurer son marketing.
+
+## Pourquoi c'est coherent
+
+Une PME a deux besoins vitaux :
+
+- gerer son equipe ;
+- gagner des clients.
+
+Si Leopardo RH devient une plateforme de gestion moderne pour PME, la brique marketing automation peut devenir un avantage fort :
+
+- centraliser les contacts ;
+- envoyer des campagnes ;
+- automatiser les relances ;
+- suivre les leads ;
+- connecter RH, operations et croissance ;
+- aider une entreprise a mieux vendre depuis ses propres canaux.
+
+## Vision produit
+
+Permettre a une entreprise cliente de :
+
+- importer ses contacts ;
+- segmenter prospects et clients ;
+- creer des campagnes email/WhatsApp ;
+- planifier des posts ;
+- suivre les reponses ;
+- automatiser les relances ;
+- mesurer leads, demos, ventes ;
+- generer des contenus avec IA assistee.
+
+## MVP possible
+
+Phase 1 :
+
+- CRM simple contacts ;
+- tags et segments ;
+- templates messages ;
+- historique d'interactions ;
+- export CSV.
+
+Phase 2 :
+
+- sequences email ;
+- rappels de relance ;
+- calendrier contenu ;
+- tracking des sources ;
+- tableau de bord acquisition.
+
+Phase 3 :
+
+- integration WhatsApp Business ;
+- integration Brevo/Mailchimp ;
+- IA pour proposer messages et posts ;
+- scoring leads ;
+- automation multi-etapes.
+
+## Limites a respecter
+
+- Ne pas melanger donnees RH sensibles et campagnes marketing sans separation stricte.
+- Respecter consentement, opt-in, desinscription et lois locales.
+- Ne pas envoyer de spam.
+- Garder une distinction claire entre gestion RH interne et acquisition client.
+
+## Decision actuelle
+
+La priorite implementation reste le wedge pointage, anomalies et rapport mensuel.
+
+La brique marketing automation est documentee maintenant pour guider la vision, mais ne doit pas distraire l'equipe avant que le coeur RH/terrain convertisse fortement.

--- a/GOTO_MARKET/product_marketing_automation/ROADMAP.md
+++ b/GOTO_MARKET/product_marketing_automation/ROADMAP.md
@@ -1,0 +1,44 @@
+# Roadmap Marketing Automation
+
+## Hypothese
+
+Les PME qui utilisent Leopardo RH pour mieux gerer leurs equipes pourraient aussi vouloir mieux gerer leur acquisition.
+
+Mais cette hypothese doit etre validee avant implementation.
+
+## Questions de validation
+
+- Les clients actuels demandent-ils de l'aide marketing ?
+- Utilisent-ils deja WhatsApp, Facebook ou email pour vendre ?
+- Ont-ils une base contacts ?
+- Ont-ils une personne responsable commercial/marketing ?
+- Paieraient-ils pour automatiser relances et campagnes ?
+- Preferent-ils une integration Brevo/WhatsApp ou un module interne ?
+
+## Critere go
+
+Lancer un MVP seulement si :
+
+- 5 clients payants demandent clairement cette brique ;
+- au moins 3 acceptent de tester ;
+- le module peut etre vendu ou augmenter la retention ;
+- la separation des donnees RH/marketing est claire.
+
+## Critere no-go temporaire
+
+Reporter si :
+
+- le pointage n'est pas encore assez vendu ;
+- les clients veulent surtout paie/absence ;
+- le module cree trop de complexite produit ;
+- les contraintes legal/consentement ne sont pas maitrisees.
+
+## Premier artefact a construire sans code
+
+Avant toute implementation :
+
+- un template CRM Google Sheet ;
+- une sequence WhatsApp/email ;
+- un calendrier contenu ;
+- un dashboard metriques simple ;
+- un test avec 3 PME.

--- a/GOTO_MARKET/public/README.md
+++ b/GOTO_MARKET/public/README.md
@@ -22,6 +22,9 @@ Il couvre :
 - `press/` - kit presse, communiques, presentation courte.
 - `partners/` - one-pagers et messages revendeurs/integrateurs.
 - `ads/` - tests paid, copies, audiences, resultats.
+- `email/` - sequences d'acquisition, pilote et conversion.
+- `lead_magnets/` - checklists, guides et supports de capture lead.
+- `owned_channels/` - playbooks pour acquerir depuis nos propres canaux.
 - `content_calendar/` - calendrier editorial et planning publication.
 - `metrics/` - suivi des performances par canal.
 

--- a/GOTO_MARKET/public/ads/ADS_COPY_LAUNCH_FR_EN_AR_TR.md
+++ b/GOTO_MARKET/public/ads/ADS_COPY_LAUNCH_FR_EN_AR_TR.md
@@ -1,0 +1,61 @@
+# Ads Copy Launch FR/EN + Briefs AR/TR
+
+## FR - Angle temps
+
+Titre : Arretez de reconstruire les presences
+
+Texte : Vos presences sont encore dans Excel, WhatsApp ou sur papier ? Leopardo RH aide vos employes a pointer depuis mobile et vos managers a sortir un rapport mensuel clair.
+
+CTA : Lancer un pilote 14 jours
+
+## FR - Angle preuve
+
+Titre : Excel calcule. Il ne prouve pas.
+
+Texte : Pour les equipes terrain, le pointage doit etre clair, visible et exploitable. Testez Leopardo RH sur une equipe pendant 14 jours.
+
+CTA : Voir la demo
+
+## EN - Time angle
+
+Headline: Stop rebuilding attendance every month
+
+Body: Leopardo RH helps SMEs track mobile attendance, detect anomalies and generate monthly reports for payroll.
+
+CTA: Start a 14-day pilot
+
+## EN - Proof angle
+
+Headline: Excel calculates. It does not prove presence.
+
+Body: Give managers a clear view of attendance, anomalies and monthly reporting.
+
+CTA: Book a demo
+
+## AR - Brief
+
+Adapter les angles FR en arabe naturel pour dirigeants PME Maghreb.
+
+Ne pas traduire mot a mot.
+
+Conserver :
+
+- Excel / WhatsApp / papier ;
+- pointage mobile ;
+- rapport mensuel ;
+- pilote 14 jours.
+
+Validation native obligatoire avant publication.
+
+## TR - Brief
+
+Adapter pour PME turques.
+
+Conserver :
+
+- mobil devam takibi ;
+- saha kontrolu ;
+- aylik rapor ;
+- 14 gunluk pilot.
+
+Validation native recommandee.

--- a/GOTO_MARKET/public/email/BREVO_SETUP.md
+++ b/GOTO_MARKET/public/email/BREVO_SETUP.md
@@ -1,0 +1,60 @@
+# Brevo Setup - Acquisition et Pilote
+
+## Listes
+
+- `Prospects - GTM`
+- `Leads - Checklist Pointage`
+- `Demos - Planifiees`
+- `Pilotes - 14 jours`
+- `Clients - Payants`
+
+## Attributs contact
+
+```text
+FIRSTNAME
+LASTNAME
+COMPANY
+COUNTRY
+LANGUAGE
+SEGMENT
+EMPLOYEE_COUNT
+SOURCE
+STATUS
+PILOT_START_DATE
+PILOT_END_DATE
+PLAN_INTEREST
+```
+
+## Automations
+
+### Lead magnet
+
+Trigger : formulaire checklist.
+
+Action :
+
+- envoyer checklist ;
+- attendre 1 jour ;
+- proposer demo ;
+- si clic demo, tag `demo_intent`.
+
+### Pilote 14 jours
+
+Trigger : statut `pilot_started`.
+
+Action :
+
+- J0 bienvenue ;
+- J1 premier pointage ;
+- J3 premiers signaux ;
+- J7 milieu pilote ;
+- J10 rapport ;
+- J13 bilan ;
+- J14 conversion ;
+- J17 question ouverte.
+
+## Regle
+
+Ne pas automatiser a l'aveugle.
+
+Toute sequence doit ramener vers une conversation humaine si le prospect repond, clique plusieurs fois ou demande une demo.

--- a/GOTO_MARKET/public/email/SEQUENCE_PILOTE_14J_FR.md
+++ b/GOTO_MARKET/public/email/SEQUENCE_PILOTE_14J_FR.md
@@ -1,0 +1,126 @@
+# Sequence Email Pilote 14 Jours - FR
+
+## J0 - Bienvenue
+
+Objet : Votre pilote Leopardo RH commence
+
+Bonjour [Prenom],
+
+Votre pilote Leopardo RH peut commencer.
+
+L'objectif est simple : tester le pointage sur une equipe, detecter les premieres anomalies et verifier si le rapport mensuel vous fait gagner du temps.
+
+Premiere etape : configurer l'entreprise, ajouter un manager et inviter quelques employes.
+
+CTA : Configurer mon pilote
+
+## J1 - Premier pointage
+
+Objet : Avez-vous fait le premier pointage ?
+
+Bonjour [Prenom],
+
+Le premier objectif est d'obtenir un pointage reel.
+
+Un employe.
+
+Une arrivee.
+
+Une confirmation.
+
+Des que ce premier pointage existe, le pilote devient concret.
+
+CTA : Faire le premier test
+
+## J3 - Premiers signaux
+
+Objet : Les premiers signaux apparaissent
+
+Bonjour [Prenom],
+
+Apres quelques jours, regardez deja :
+
+- qui pointe vraiment ;
+- qui oublie ;
+- quelles heures semblent inhabituelles ;
+- si le manager consulte le tableau de bord.
+
+Le but n'est pas d'avoir un mois parfait.
+
+Le but est de voir si Leopardo RH rend le terrain plus lisible.
+
+CTA : Voir le tableau de bord
+
+## J7 - Milieu pilote
+
+Objet : Milieu du pilote : que voit-on ?
+
+Bonjour [Prenom],
+
+Nous sommes au milieu du pilote.
+
+C'est le bon moment pour comparer avec votre ancienne methode :
+
+- moins d'appels ?
+- moins de messages ?
+- moins de verification manuelle ?
+- plus de visibilite ?
+
+Si vous voulez, on peut regarder ensemble vos premiers resultats.
+
+CTA : Planifier un point rapide
+
+## J10 - Rapport
+
+Objet : Preparez votre premier rapport
+
+Bonjour [Prenom],
+
+Le rapport mensuel est l'une des pieces les plus importantes du pilote.
+
+Il doit vous aider a discuter avec le manager, les RH ou le comptable sur une base claire.
+
+Regardez surtout les anomalies et les donnees manquantes.
+
+CTA : Generer un rapport
+
+## J13 - Bilan demain
+
+Objet : Bilan du pilote demain
+
+Bonjour [Prenom],
+
+Demain, nous pouvons faire le bilan du pilote.
+
+Les questions sont simples :
+
+- avez-vous gagne du temps ?
+- avez-vous vu des anomalies utiles ?
+- le rapport aide-t-il la paie ?
+- voulez-vous continuer sur une equipe plus large ?
+
+CTA : Confirmer le bilan
+
+## J14 - Conversion
+
+Objet : Continuer avec Leopardo RH
+
+Bonjour [Prenom],
+
+Votre pilote de 14 jours arrive a la fin.
+
+Si Leopardo RH vous a aide a mieux voir les presences, reduire les verifications et preparer le rapport, le prochain pas est simple : passer sur l'offre adaptee a votre equipe.
+
+CTA : Choisir mon plan
+
+## J17 - Derniere relance humaine
+
+Objet : Question simple
+
+Bonjour [Prenom],
+
+Question directe : qu'est-ce qui vous empeche de continuer avec Leopardo RH aujourd'hui ?
+
+Votre reponse nous aide a ameliorer le produit, l'offre ou l'accompagnement.
+
+CTA : Repondre a cet email

--- a/GOTO_MARKET/public/lead_magnets/CHECKLIST_POINTAGE_PME_FR.md
+++ b/GOTO_MARKET/public/lead_magnets/CHECKLIST_POINTAGE_PME_FR.md
@@ -1,0 +1,52 @@
+# Lead Magnet - Checklist Pointage PME
+
+## Titre
+
+Checklist pointage PME : 21 questions pour savoir si votre suivi presence vous coute trop cher.
+
+## Introduction
+
+Si vos presences sont suivies avec papier, Excel, WhatsApp ou plusieurs outils non connectes, cette checklist vous aide a voir ou le temps se perd.
+
+## Section 1 - Collecte
+
+- Vos employes pointent-ils tous au meme endroit ?
+- Les arrivees et departs sont-ils horodates ?
+- Les oublis de sortie sont-ils visibles rapidement ?
+- Le manager voit-il les presences en temps reel ?
+- Les donnees sont-elles centralisees ?
+
+## Section 2 - Controle
+
+- Pouvez-vous identifier les retards sans relire tout le mois ?
+- Pouvez-vous voir les pointages hors zone ?
+- Pouvez-vous reperer les heures trop repetitives ?
+- Les corrections manuelles sont-elles tracees ?
+- Les anomalies sont-elles separees des donnees normales ?
+
+## Section 3 - Paie
+
+- Combien de temps prend la preparation mensuelle ?
+- Le comptable recoit-il un rapport propre ?
+- Les heures supplementaires sont-elles faciles a verifier ?
+- Les absences sont-elles discutees avec preuve ?
+- Les donnees exportees sont-elles exploitables ?
+
+## Section 4 - Management
+
+- Le dirigeant sait-il qui est present aujourd'hui ?
+- Le manager controle-t-il les exceptions seulement ?
+- Les employes comprennent-ils la regle de pointage ?
+- Le systeme reduit-il les conflits ?
+- Le process reste-t-il simple pour une nouvelle recrue ?
+- Pouvez-vous tester sur une seule equipe ?
+
+## Score
+
+Si vous cochez 7 problemes ou plus, votre suivi presence merite probablement un pilote.
+
+## CTA
+
+Demandez un pilote Leopardo RH de 14 jours.
+
+Objectif : 20 pointages, premieres anomalies, premier rapport mensuel.

--- a/GOTO_MARKET/public/lead_magnets/LANDING_LEAD_MAGNET_COPY_FR.md
+++ b/GOTO_MARKET/public/lead_magnets/LANDING_LEAD_MAGNET_COPY_FR.md
@@ -1,0 +1,38 @@
+# Landing Lead Magnet - Checklist Pointage PME
+
+## H1
+
+Votre suivi presence vous coute-t-il trop cher ?
+
+## Sous-titre
+
+Telechargez la checklist gratuite pour evaluer votre methode actuelle : papier, Excel, WhatsApp, badgeuse ou application.
+
+## Ce que vous allez verifier
+
+- si vos presences sont fiables ;
+- si les anomalies sont visibles ;
+- si la paie est preparee proprement ;
+- si vos managers perdent trop de temps ;
+- si un pilote 14 jours peut etre utile.
+
+## Formulaire
+
+Champs :
+
+- prenom ;
+- email professionnel ;
+- entreprise ;
+- pays ;
+- nombre employes ;
+- methode actuelle de pointage.
+
+## CTA
+
+Recevoir la checklist
+
+## Apres formulaire
+
+Merci. La checklist arrive par email.
+
+Si vous cochez 7 problemes ou plus, demandez une demo Leopardo RH.

--- a/GOTO_MARKET/public/owned_channels/OWNED_CHANNELS_PLAYBOOK.md
+++ b/GOTO_MARKET/public/owned_channels/OWNED_CHANNELS_PLAYBOOK.md
@@ -1,0 +1,42 @@
+# Owned Channels Playbook
+
+## Objectif
+
+Gagner plus de clients depuis nos propres canaux avant de dependre fortement des plateformes payantes.
+
+## Canaux propres
+
+- site officiel ;
+- blog ;
+- email list ;
+- WhatsApp Business ;
+- base prospects ;
+- contenu LinkedIn fondateur ;
+- reseau partenaires ;
+- webinars ;
+- fichiers PDF lead magnets.
+
+## Systeme hebdomadaire
+
+Chaque semaine :
+
+- 2 posts LinkedIn fondateur ;
+- 1 post LinkedIn page entreprise ;
+- 1 broadcast WhatsApp qualifie ;
+- 1 email a la base prospects ;
+- 10 relances demo ;
+- 1 contenu preuve produit ;
+- 1 mise a jour landing ou FAQ.
+
+## Entonnoir
+
+Contenu public -> lead magnet -> email -> demo -> pilote 14 jours -> client payant.
+
+## Regles
+
+- Construire une base email des maintenant.
+- Ne jamais laisser un lead sans prochaine action.
+- Recycler les bons posts en emails.
+- Recycler les bonnes objections en FAQ.
+- Recycler les bonnes demos en videos.
+- Mesurer les conversations, pas seulement les vues.

--- a/GOTO_MARKET/public/social/linkedin/2026-05_batch_posts_acquisition_fr.md
+++ b/GOTO_MARKET/public/social/linkedin/2026-05_batch_posts_acquisition_fr.md
@@ -1,0 +1,95 @@
+# Batch LinkedIn Acquisition FR
+
+## Post 06 - Le cout invisible
+
+Le cout du pointage manuel n'apparait pas toujours dans la comptabilite.
+
+Il apparait dans les appels.
+
+Dans les messages.
+
+Dans les corrections.
+
+Dans les dimanches passes a reconstruire le mois.
+
+Dans les discussions avec les employes.
+
+Leopardo RH ne vend pas juste un logiciel.
+
+On vend du temps recupere et des decisions plus claires.
+
+## Post 07 - Le pilote est la preuve
+
+Un prospect n'a pas besoin de nous croire.
+
+Il peut tester.
+
+Une equipe.
+
+14 jours.
+
+20 pointages.
+
+Quelques anomalies.
+
+Un rapport.
+
+Apres ca, la conversation devient concrete.
+
+Soit la valeur est visible.
+
+Soit on apprend quoi ameliorer.
+
+## Post 08 - Marketing automation futur
+
+Aujourd'hui, Leopardo RH commence par le pointage et le controle terrain.
+
+Mais la vision est plus large.
+
+Une PME n'a pas seulement besoin de gerer ses employes.
+
+Elle doit aussi communiquer, relancer, vendre et automatiser une partie de son marketing.
+
+Notre direction est claire : construire une plateforme utile, moderne et rentable pour les besoins reels des entreprises.
+
+On commence par la douleur la plus concrete.
+
+Puis on etend.
+
+## Post 09 - Moins de promesses
+
+Le marche n'a pas besoin de grandes promesses.
+
+Il a besoin de resultats visibles.
+
+Un employe pointe.
+
+Une anomalie remonte.
+
+Un manager comprend.
+
+Un rapport sort.
+
+Un dirigeant gagne du temps.
+
+C'est exactement le type de technologie que nous voulons construire.
+
+## Post 10 - Nos propres canaux
+
+Une entreprise moderne doit apprendre a vendre depuis ses propres canaux.
+
+LinkedIn.
+
+WhatsApp.
+
+Email.
+
+Site.
+
+Partenaires.
+
+Videos.
+
+Chaque canal doit ramener vers la meme chose : une conversation qualifiee, une demo, un pilote, un client.
+
+C'est la discipline GTM que nous construisons pour Leopardo RH.

--- a/GOTO_MARKET/public/social/whatsapp/broadcast_acquisition_fr.md
+++ b/GOTO_MARKET/public/social/whatsapp/broadcast_acquisition_fr.md
@@ -1,0 +1,41 @@
+# Broadcast WhatsApp Acquisition FR
+
+## Broadcast 01 - Checklist
+
+Bonjour [Prenom],
+
+Nous avons prepare une checklist gratuite pour savoir si votre suivi presence vous coute trop de temps en fin de mois.
+
+Elle couvre papier, Excel, WhatsApp, badgeuse et pointage mobile.
+
+Je peux vous l'envoyer ?
+
+## Broadcast 02 - Demo courte
+
+Bonjour [Prenom],
+
+Leopardo RH permet a une PME de faire pointer ses employes depuis mobile, voir les anomalies et sortir un rapport mensuel.
+
+Je peux vous montrer le fonctionnement en 10 minutes cette semaine.
+
+Quel jour vous arrange ?
+
+## Broadcast 03 - Pilote 14 jours
+
+Bonjour [Prenom],
+
+Le plus simple pour juger Leopardo RH est un pilote 14 jours sur une equipe.
+
+Objectif : 20 pointages, premieres anomalies, premier rapport.
+
+Souhaitez-vous tester ?
+
+## Broadcast 04 - Partenaire
+
+Bonjour [Prenom],
+
+Nous cherchons des partenaires locaux qui travaillent avec des PME : comptables, integrateurs IT, revendeurs badgeuses, consultants RH.
+
+Leopardo RH peut etre propose comme solution de pointage mobile et rapport mensuel.
+
+Ouvert a en discuter ?

--- a/GOTO_MARKET/public/video/demo_3min_pointage_fr_script.md
+++ b/GOTO_MARKET/public/video/demo_3min_pointage_fr_script.md
@@ -1,0 +1,98 @@
+# Script Demo 3 Minutes - FR
+
+## Usage
+
+Video principale pour YouTube, LinkedIn, landing page et demo commerciale.
+
+## Slide 1 - Accroche
+
+Vous gerez une equipe terrain.
+
+Chaque fin de mois, vous devez savoir qui etait present, qui etait en retard, qui a oublie de pointer, et quelles heures doivent etre payees.
+
+Si ces informations sont dans Excel, WhatsApp ou sur papier, vous perdez du temps.
+
+## Slide 2 - Probleme
+
+Le probleme n'est pas seulement administratif.
+
+C'est un probleme de preuve.
+
+Un manager ne peut pas piloter correctement son equipe si les presences arrivent trop tard, dans trop d'endroits, et sans controle clair.
+
+## Slide 3 - Leopardo RH
+
+Leopardo RH est une plateforme de pointage mobile et controle terrain pour PME.
+
+L'employe pointe son arrivee et son depart.
+
+Le manager voit les presences.
+
+Les anomalies remontent.
+
+Le rapport mensuel devient exploitable pour la paie.
+
+## Slide 4 - Pointage employe
+
+L'employe ouvre l'application.
+
+Il appuie sur pointer l'arrivee.
+
+L'heure est enregistree.
+
+Le manager n'a pas besoin d'appeler, verifier un message ou attendre une feuille.
+
+## Slide 5 - Controle manager
+
+Sur son tableau de bord, le manager voit l'etat de l'equipe.
+
+Qui est present.
+
+Qui est absent.
+
+Qui est en retard.
+
+Quelles donnees doivent etre verifiees.
+
+## Slide 6 - Anomalies
+
+Leopardo RH aide a reperer les exceptions :
+
+- sortie manquante ;
+- pointage trop rapproche ;
+- pointage hors zone ;
+- retard ;
+- heure repetitive ;
+- correction manuelle.
+
+Le manager ne reconstruit plus tout le mois.
+
+Il controle ce qui merite attention.
+
+## Slide 7 - Rapport mensuel
+
+En fin de mois, Leopardo RH permet de produire un rapport clair.
+
+Ce rapport sert de base de discussion entre manager, RH et comptable.
+
+Moins d'oubli.
+
+Moins de conflit.
+
+Moins de temps perdu.
+
+## Slide 8 - Pilote 14 jours
+
+Le plus simple est de tester sur une equipe.
+
+Pendant 14 jours, vous configurez vos employes, vous collectez les pointages, vous regardez les anomalies et vous genereez un premier rapport.
+
+Ensuite, vous decidez avec vos propres donnees.
+
+## Slide 9 - CTA
+
+Leopardo RH.
+
+Pointage mobile, controle terrain, rapport mensuel.
+
+Demandez une demo ou lancez un pilote 14 jours.

--- a/GOTO_MARKET/public/video/demo_3min_pointage_storyboard.md
+++ b/GOTO_MARKET/public/video/demo_3min_pointage_storyboard.md
@@ -1,0 +1,31 @@
+# Storyboard Demo 3 Minutes
+
+## Style
+
+- sobre ;
+- ecrans produit en priorite ;
+- fond Slate 900 ;
+- accent Emerald ;
+- sous-titres actifs ;
+- rythme lent ;
+- une idee par scene.
+
+## Scenes
+
+| Scene | Visuel | Texte ecran | Asset requis |
+| --- | --- | --- | --- |
+| 1 | manager devant tableau ou bureau | Fin de mois complique ? | visuel sobre ou mockup |
+| 2 | Excel + WhatsApp + papier | Trop de sources, pas assez de preuves | montage Canva |
+| 3 | telephone employe | Pointer en quelques secondes | capture mobile |
+| 4 | dashboard manager | Presence visible en temps reel | capture dashboard |
+| 5 | liste anomalies | Les exceptions remontent | capture anomalies |
+| 6 | rapport mensuel | Une base claire pour la paie | capture rapport |
+| 7 | checklist pilote | Testez sur une equipe | capture checklist |
+| 8 | logo + CTA | Pilote 14 jours | logo + URL |
+
+## Exports
+
+- 16:9 YouTube/LinkedIn ;
+- 9:16 Reels/Shorts ;
+- sous-titres FR ;
+- versions AR/TR/EN apres validation.

--- a/GOTO_MARKET/public/video/short_15s_ads_fr.md
+++ b/GOTO_MARKET/public/video/short_15s_ads_fr.md
@@ -1,0 +1,27 @@
+# Script Short 15s - Ads FR
+
+## Format
+
+9:16, sous-titres obligatoires.
+
+## Script
+
+Encore des presences sur Excel ou WhatsApp ?
+
+Avec Leopardo RH, vos employes pointent depuis mobile.
+
+Le manager voit les anomalies.
+
+Et le rapport mensuel est pret pour la paie.
+
+Leopardo RH.
+
+Lancez un pilote 14 jours.
+
+## Visuels
+
+- 0-3s : Excel/WhatsApp/papier.
+- 3-6s : pointage mobile.
+- 6-10s : anomalies manager.
+- 10-13s : rapport mensuel.
+- 13-15s : CTA.

--- a/GOTO_MARKET/public/video/translation_briefs_ar_tr_en.md
+++ b/GOTO_MARKET/public/video/translation_briefs_ar_tr_en.md
@@ -1,0 +1,45 @@
+# Briefs Traduction Video AR/TR/EN
+
+## Regle
+
+Ne jamais publier une version AR ou TR sans relecture native.
+
+## EN - Adaptation courte
+
+Use simple business English for MENA SMEs.
+
+Core line:
+
+> Mobile attendance, field control, monthly reports.
+
+CTA:
+
+> Start a 14-day pilot.
+
+## TR - Brief
+
+Adapter pour PME turques avec ton professionnel simple.
+
+Eviter les mots trop corporate.
+
+Conserver le sens :
+
+- pointage mobile ;
+- controle terrain ;
+- anomalies ;
+- rapport mensuel ;
+- pilote 14 jours.
+
+## AR - Brief
+
+Adapter pour gerants PME Maghreb.
+
+Ton :
+
+- direct ;
+- respectueux ;
+- naturel ;
+- pas arabe litteraire trop froid si le canal est social ;
+- verifier RTL dans Canva/CapCut.
+
+Garder les chiffres en 14, 3, 30.


### PR DESCRIPTION
## Summary
- Add a concrete acquisition launch pack under GOTO_MARKET with video scripts, email pilot sequence, lead magnet copy, WhatsApp broadcasts, LinkedIn posts, ads copy, and owned-channel playbook.
- Document the future marketing automation product direction separately under GOTO_MARKET/product_marketing_automation, clearly marked as not implemented in this repository yet.
- Update GOTO_MARKET, CHANGELOG, and AGENTS guidance so future work keeps public communication assets structured and connected to acquisition.

## Validation
- Rebased branch on latest origin/main after PR #325 was merged.
- Documentation-only change; no application tests run.