### PR TITLE
fix: remove invalid Vercel env schema metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Le statut externe `Vercel` peut echouer immediatement vers une page de configura
 
 Le workflow GitHub `Build & Deploiement` a aussi porte une integration `vercel/action@v4` introuvable cote Actions. Si ce workflow redevient rouge pour `Unable to resolve action vercel/action`, conserver seulement le job de build jusqu'a ce qu'une integration Vercel valide soit configuree.
 
+Pour le frontend `web/`, ne pas declarer dans `vercel.json` un bloc `env` avec des objets de description. Vercel attend des chaines de caracteres si `env` est present. Si les variables sont deja gerees dans le dashboard Vercel, supprimer completement ce bloc du fichier pour eviter l'erreur `env.<VAR> should be string`.
+
 ### Main local divergent
 
 Le poste local peut avoir un `main` divergent (`ahead`/`behind`). Dans ce cas :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.105] - 2026-05-08
+
+### Web - Compatibilite Vercel
+
+- Web : suppression du bloc `env` invalide de `web/vercel.json` qui cassait les builds Vercel avec l'erreur `env.NEXT_PUBLIC_API_URL should be string`.
+- Ops : les variables `NEXT_PUBLIC_*`, `NEXTAUTH_*` et secrets web doivent rester configurees dans le dashboard Vercel, pas decrites comme objets metadata dans `vercel.json`.
+
 ## [4.1.104] - 2026-05-08
 
 ### Backend - Migrations publiques Render hors transaction
@@ -1705,4 +1712,3 @@ docs(erd): unify manager_id and remove supervisor_id from employees
 - Initialisation de la conception technique.
 - Premier ERD et schÃ©ma SQL de base.
 - Structure initiale des dossiers.
-

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -3,38 +3,6 @@
   "devCommand": "npm run dev",
   "installCommand": "npm ci",
   "framework": "nextjs",
-  "env": {
-    "NEXT_PUBLIC_API_URL": {
-      "description": "API endpoint URL"
-    },
-    "NEXT_PUBLIC_GA_ID": {
-      "description": "Google Analytics 4 ID"
-    },
-    "NEXT_PUBLIC_MIXPANEL_TOKEN": {
-      "description": "Mixpanel token for analytics"
-    },
-    "SENDGRID_API_KEY": {
-      "description": "SendGrid API key for email"
-    },
-    "NEXT_PUBLIC_SITE_URL": {
-      "description": "Site URL for SEO and canonical URLs"
-    },
-    "NEXT_PUBLIC_SITE_NAME": {
-      "description": "Site name for metadata"
-    },
-    "NEXT_PUBLIC_ENVIRONMENT": {
-      "description": "Environment name (staging, production)"
-    },
-    "NEXTAUTH_SECRET": {
-      "description": "NextAuth secret for authentication"
-    },
-    "NEXTAUTH_URL": {
-      "description": "NextAuth URL"
-    },
-    "NEXT_PUBLIC_SENTRY_DSN": {
-      "description": "Sentry DSN for error tracking"
-    }
-  },
   "regions": ["cdg1"],
   "functions": {
     "api/**": {


### PR DESCRIPTION
## Summary
- remove the invalid object-based env metadata from web/vercel.json
- keep web environment variables managed in the Vercel dashboard
- document the rule in AGENTS.md and CHANGELOG.md

## Validation
- PowerShell JSON parse on web/vercel.json