### PR TITLE
fix: remove stale Vercel functions pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Le statut externe `Vercel` peut echouer immediatement vers une page de configura
 
 Le workflow GitHub `Build & Deploiement` a aussi porte une integration `vercel/action@v4` introuvable cote Actions. Si ce workflow redevient rouge pour `Unable to resolve action vercel/action`, conserver seulement le job de build jusqu'a ce qu'une integration Vercel valide soit configuree.
 
+Dans `web/vercel.json`, ne declarer un bloc `functions` que si le pattern correspond vraiment aux fonctions Vercel generees par le projet. Le pattern historique `api/**` casse les deploys du frontend Next.js avec `The pattern "api/**" defined in functions doesn't match any Serverless Functions`, car les route handlers reels vivent sous `web/src/app/api/**`.
+
 Pour le frontend `web/`, ne pas declarer dans `vercel.json` un bloc `env` avec des objets de description. Vercel attend des chaines de caracteres si `env` est present. Si les variables sont deja gerees dans le dashboard Vercel, supprimer completement ce bloc du fichier pour eviter l'erreur `env.<VAR> should be string`.
 
 ### Main local divergent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.106] - 2026-05-08
+
+### Web - Pattern Vercel functions corrige
+
+- Web : suppression du bloc `functions.api/**` de `web/vercel.json`, qui ne correspondait plus a la structure Next.js actuelle et faisait echouer Vercel avec `The pattern "api/**" defined in functions doesn't match any Serverless Functions`.
+- Ops : dans ce projet, les route handlers Next sont sous `web/src/app/api/**`; ne pas garder de pattern `functions` Vercel s'il n'est pas aligne sur les vraies fonctions generees.
+
 ## [4.1.105] - 2026-05-08
 
 ### Web - Compatibilite Vercel

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -4,11 +4,6 @@
   "installCommand": "npm ci",
   "framework": "nextjs",
   "regions": ["cdg1"],
-  "functions": {
-    "api/**": {
-      "maxDuration": 60
-    }
-  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- remove the stale \\unctions.api/**\\ block from \\web/vercel.json\\
- keep the Vercel config aligned with the actual Next.js app router structure
- document the pitfall in \\CHANGELOG.md\\ and \\AGENTS.md\\

## Validation
- JSON parse of \\web/vercel.json\\
- local web build not run successfully on this Windows host because \\
pm ci\\ tripped over a partial \\
ode_modules\\ cleanup and \\
ext\\ is unavailable without a clean install; GitHub/Vercel should be treated as source of truth for this hotfix