### PR TITLE
feat: add admin login password toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ Procedure recommandee :
 - Le dashboard plateforme ne doit plus inventer ses routes d'auth. Le backend expose `/api/v1/platform/auth/login`, `/me`, `/logout`; il n'existe pas de refresh token `/admin/auth/refresh`.
 - `PlatformAuthController` retourne maintenant aussi `role=super_admin` et `two_fa_enabled` pour eviter les hypothese cote frontend.
 - Si un compte super-admin a le 2FA active, l'API renvoie `202 TWO_FA_REQUIRED`; le frontend doit traiter ce cas comme une etape de login et non comme un succes silencieux.
+- Le login admin supporte maintenant un toggle afficher / masquer le mot de passe. Si cette zone evolue encore, garder les labels ARIA synchronises avec l'etat visible/cache et couvrir la regression dans Playwright.
 - La vitrine publique `web/` a maintenant un vrai rail de locale client (`FR/EN/TR/AR`) sur la landing page. Pour les prochaines evolutions, reutiliser ce socle au lieu de rehardcoder des textes dans chaque composant.
 - Desormais, quand `web/**` change, les checks de lint/build doivent partir via `web-marketing-ci.yml`; ne pas se reposer uniquement sur le workflow admin.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.109] - 2026-05-08
+
+### Plateforme admin - Confort de login
+
+- Admin : ajout d'un toggle afficher / masquer le mot de passe sur l'ecran de login, avec labels ARIA dynamiques et conservation du flux 2FA existant.
+- Tests : ajout d'un scenario Playwright dedie pour verifier le changement de type `password` <-> `text` sans casser les selecteurs du login admin.
+
 ## [4.1.108] - 2026-05-08
 
 ### CI - Gates proportionnees au perimetre modifie

--- a/admin-dashboard/e2e/login-smoke.spec.js
+++ b/admin-dashboard/e2e/login-smoke.spec.js
@@ -8,6 +8,6 @@ test('login screen loads for administrators', async ({ page }) => {
     page.getByRole('heading', { name: /Administration Leopardo RH/i }),
   ).toBeVisible()
   await expect(page.getByLabel(/Adresse email/i)).toBeVisible()
-  await expect(page.getByLabel(/Mot de passe/i)).toBeVisible()
+  await expect(page.locator('#password')).toBeVisible()
   await expect(page.getByRole('button', { name: /Se connecter/i })).toBeVisible()
 })

--- a/admin-dashboard/e2e/login-ux.spec.js
+++ b/admin-dashboard/e2e/login-ux.spec.js
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test'
 test('password visibility toggle works on the admin login form', async ({ page }) => {
   await page.goto('/login')
 
-  const passwordInput = page.getByLabel(/Mot de passe/i)
+  const passwordInput = page.locator('#password')
   const toggleButton = page.getByRole('button', { name: /Afficher le mot de passe/i })
 
   await passwordInput.fill('MotDePasseTresSecret123')

--- a/admin-dashboard/e2e/login-ux.spec.js
+++ b/admin-dashboard/e2e/login-ux.spec.js
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+test('password visibility toggle works on the admin login form', async ({ page }) => {
+  await page.goto('/login')
+
+  const passwordInput = page.getByLabel(/Mot de passe/i)
+  const toggleButton = page.getByRole('button', { name: /Afficher le mot de passe/i })
+
+  await passwordInput.fill('MotDePasseTresSecret123')
+  await expect(passwordInput).toHaveAttribute('type', 'password')
+
+  await toggleButton.click()
+  await expect(passwordInput).toHaveAttribute('type', 'text')
+  await expect(page.getByRole('button', { name: /Masquer le mot de passe/i })).toBeVisible()
+
+  await page.getByRole('button', { name: /Masquer le mot de passe/i }).click()
+  await expect(passwordInput).toHaveAttribute('type', 'password')
+})

--- a/admin-dashboard/src/views/auth/LoginView.vue
+++ b/admin-dashboard/src/views/auth/LoginView.vue
@@ -30,19 +30,31 @@
           </div>
           <div>
             <label for="password" class="sr-only">Mot de passe</label>
-            <input
-              id="password"
-              v-model="form.password"
-              name="password"
-              type="password"
-              autocomplete="current-password"
-              required
-              :class="[
-                'relative block w-full border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6',
-                requiresTwoFactor ? '' : 'rounded-b-md'
-              ]"
-              placeholder="Mot de passe"
-            />
+            <div class="relative">
+              <input
+                id="password"
+                v-model="form.password"
+                name="password"
+                :type="showPassword ? 'text' : 'password'"
+                autocomplete="current-password"
+                required
+                :class="[
+                  'relative block w-full border-0 py-1.5 pr-12 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6',
+                  requiresTwoFactor ? '' : 'rounded-b-md'
+                ]"
+                placeholder="Mot de passe"
+              />
+              <button
+                type="button"
+                class="absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 transition hover:text-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                :aria-label="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+                :title="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+                @click="showPassword = !showPassword"
+              >
+                <EyeSlashIcon v-if="showPassword" class="h-5 w-5" aria-hidden="true" />
+                <EyeIcon v-else class="h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
           </div>
           <div v-if="requiresTwoFactor">
             <label for="two-factor-code" class="sr-only">Code de verification</label>
@@ -141,7 +153,12 @@
 <script setup>
 import { reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { LockClosedIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
+import {
+  LockClosedIcon,
+  ExclamationTriangleIcon,
+  EyeIcon,
+  EyeSlashIcon,
+} from '@heroicons/vue/24/outline'
 import { useAuthStore } from '@/stores/auth'
 
 const router = useRouter()
@@ -157,6 +174,7 @@ const form = reactive({
 const isLoading = ref(false)
 const error = ref('')
 const requiresTwoFactor = ref(false)
+const showPassword = ref(false)
 
 async function handleLogin() {
   if (isLoading.value) return

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS.md
@@ -58,6 +58,7 @@ Donner une base de scenarios stable pour le dashboard `admin-dashboard/`, avec u
 - prevention du double submit sur action critique
 - messages d'erreur stables
 - saisie du code 2FA sans perdre l'email deja renseigne
+- toggle afficher / masquer le mot de passe visible, accessible au clavier et coherent avec les labels ARIA
 
 ## Artefacts obligatoires
 


### PR DESCRIPTION
## Summary
- add an accessible show/hide password toggle to the admin login form
- keep the existing 2FA flow intact
- add a focused Playwright scenario and update the admin scenario doc

## Validation
- git diff --check
- GitHub Actions on PR