### PR TITLE
feat: expose platform portfolio health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ Procedure recommandee :
 - Pour aller vers v5.0 commercial, chaque nouvelle brique plateforme doit aider a piloter adoption, retention ou upsell. `GET /api/v1/platform/companies/{company}/health` est le contrat de reference pour lire plan/MRR, usage pointage 30 jours, onboarding, anomalies et next actions.
 - Le score health doit rester explicable et conservateur : ne pas le remplacer par une logique opaque tant qu'on n'a pas de donnees churn reelles.
 - Les dashboards super-admin doivent consommer ce contrat avant d'ajouter un billing complet ; il donne deja les signaux minimaux pour relancer un client, aider l'onboarding ou proposer un module Business.
+- La vue portefeuille `GET /api/v1/platform/companies/health` doit rester compacte : resume MRR/risques en haut, puis une action prioritaire par client. Eviter d'en faire un export lourd ; le detail appartient au health d'une seule company.
 
 ### 2026-05-07 - Dossier Go-To-Market racine
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.112] - 2026-05-08
+
+### Plateforme - Portefeuille clients
+
+- API : ajout de `GET /api/v1/platform/companies/health` pour donner au super-admin une vue portefeuille des clients.
+- API : le portefeuille agrège nombre de clients, clients actifs, MRR, repartition des risques et prochaine action prioritaire par client.
+- Tests : ajout d'un scenario Feature couvrant un client sain upsellable et un client suspendu dans la vue portefeuille.
+
 ## [4.1.111] - 2026-05-08
 
 ### Plateforme - Pilotage adoption client

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanyHealthController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanyHealthController.php
@@ -6,9 +6,17 @@ use App\Http\Controllers\Controller;
 use App\Models\Company;
 use App\Services\PlatformCompanyHealthService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class PlatformCompanyHealthController extends Controller
 {
+    public function index(Request $request, PlatformCompanyHealthService $healthService): JsonResponse
+    {
+        return new JsonResponse($healthService->portfolio(
+            limit: $request->integer('limit', 50),
+        ));
+    }
+
     public function __invoke(string $companyId, PlatformCompanyHealthService $healthService): JsonResponse
     {
         $company = Company::query()->findOrFail($companyId);

--- a/api/app/Services/PlatformCompanyHealthService.php
+++ b/api/app/Services/PlatformCompanyHealthService.php
@@ -17,6 +17,52 @@ class PlatformCompanyHealthService
     /**
      * @return array<string, mixed>
      */
+    public function portfolio(int $limit = 50): array
+    {
+        $companies = Company::query()
+            ->latest()
+            ->limit(max(1, min(100, $limit)))
+            ->get();
+
+        $items = $companies
+            ->map(function (Company $company): array {
+                $health = $this->build($company)['data'];
+
+                return [
+                    'company' => $health['company'],
+                    'plan' => $health['plan'],
+                    'subscription' => $health['subscription'],
+                    'health_score' => $health['adoption']['health_score'],
+                    'risk_level' => $health['adoption']['risk_level'],
+                    'employees_active' => $health['adoption']['employees']['active'],
+                    'attendance_logs_30d' => $health['adoption']['attendance']['logs_30d'],
+                    'last_punch_at' => $health['adoption']['attendance']['last_punch_at'],
+                    'critical_anomalies_30d' => $health['adoption']['anomalies']['critical_30d'],
+                    'next_action' => $health['next_actions'][0] ?? null,
+                ];
+            })
+            ->values();
+
+        return [
+            'data' => [
+                'summary' => [
+                    'companies' => $items->count(),
+                    'active_companies' => $items->where('company.status', 'active')->count(),
+                    'mrr' => round((float) $items->sum(fn (array $item): float => (float) ($item['subscription']['mrr'] ?? 0)), 2),
+                    'risk' => [
+                        'high' => $items->where('risk_level', 'high')->count(),
+                        'medium' => $items->where('risk_level', 'medium')->count(),
+                        'low' => $items->where('risk_level', 'low')->count(),
+                    ],
+                ],
+                'items' => $items,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     public function build(Company $company): array
     {
         return $this->withTenantSearchPath($company, function () use ($company): array {

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -88,6 +88,7 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/auth/2fa/disable', [PlatformAuthController::class, 'disable2fa']);
         Route::get('/companies', [PlatformCompanyController::class, 'index']);
         Route::post('/companies', [PlatformCompanyController::class, 'store']);
+        Route::get('/companies/health', [PlatformCompanyHealthController::class, 'index']);
         Route::get('/companies/{company}/health', PlatformCompanyHealthController::class);
         Route::get('/companies/{company}/features', [PlatformCompanyFeatureController::class, 'show']);
         Route::patch('/companies/{company}/features', [PlatformCompanyFeatureController::class, 'update']);

--- a/api/tests/Feature/PlatformCompanyHealthApiTest.php
+++ b/api/tests/Feature/PlatformCompanyHealthApiTest.php
@@ -124,6 +124,66 @@ class PlatformCompanyHealthApiTest extends TestCase
         $response->assertJsonPath('data.next_actions.0.key', 'reactivate_subscription');
     }
 
+    public function test_super_admin_can_view_portfolio_health_summary(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-08 10:00:00', 'UTC'));
+
+        DB::table('plans')->insert([
+            ['id' => 1, 'name' => 'Starter', 'price_monthly' => 29, 'price_yearly' => 290, 'trial_days' => 14, 'is_active' => true],
+            ['id' => 2, 'name' => 'Pro', 'price_monthly' => 99, 'price_yearly' => 990, 'trial_days' => 14, 'is_active' => true],
+        ]);
+
+        $healthy = Company::factory()->create([
+            'plan_id' => 2,
+            'timezone' => 'UTC',
+            'metadata' => [
+                'attendance_geofence' => [
+                    'lat' => 36.7525,
+                    'lng' => 3.0420,
+                    'radius_meters' => 100,
+                ],
+            ],
+        ]);
+        $risky = Company::factory()->suspended()->create([
+            'plan_id' => 1,
+            'timezone' => 'UTC',
+        ]);
+
+        $employee = Employee::factory()->create(['company_id' => $healthy->id, 'salary_base' => 173330]);
+
+        app()->instance('current_company', $healthy);
+        AttendanceLog::factory()->create([
+            'company_id' => $healthy->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-08',
+            'check_in' => Carbon::parse('2026-05-08 08:00:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-08 17:00:00', 'UTC'),
+        ]);
+        app()->forgetInstance('current_company');
+
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+        $response = $this->getJson('/api/v1/platform/companies/health?limit=10');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.summary.companies', 2);
+        $response->assertJsonPath('data.summary.active_companies', 1);
+        $response->assertJsonPath('data.summary.mrr', 128);
+        $response->assertJsonPath('data.summary.risk.high', 1);
+        $response->assertJsonPath('data.summary.risk.low', 1);
+
+        $items = collect($response->json('data.items'));
+        $healthyItem = $items->firstWhere('company.id', $healthy->id);
+        $riskyItem = $items->firstWhere('company.id', $risky->id);
+
+        $this->assertSame('low', $healthyItem['risk_level']);
+        $this->assertSame('prepare_upsell', $healthyItem['next_action']['key']);
+        $this->assertSame('high', $riskyItem['risk_level']);
+        $this->assertSame('reactivate_subscription', $riskyItem['next_action']['key']);
+
+        Carbon::setTestNow();
+    }
+
     private function superAdmin(): SuperAdmin
     {
         return SuperAdmin::query()->create([

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -97,3 +97,4 @@ Quand un domaine gagne une feature significative, ajouter:
 - Le contrat d'auth plateforme (`/api/v1/platform/auth/*`, `role=super_admin`, `two_fa_enabled`, `202 TWO_FA_REQUIRED`) fait maintenant partie du perimetre admin critique et doit rester documente et teste.
 - Les extensions attendance qui rendent la valeur terrain visible (impact business des anomalies, actions manager recommandees, rapport mensuel avec estimation paie, checklist go-live) font partie des scenarios API critiques et doivent rester couvertes par `Tests - Leopardo RH`.
 - Le contrat health plateforme (`/api/v1/platform/companies/{company}/health`) est une surface v5.0 critique : il soutient adoption, retention et upsell, et doit rester teste avec isolation tenant et auth super-admin.
+- La vue portefeuille health (`/api/v1/platform/companies/health`) est critique pour le pilotage commercial : elle doit garder MRR, repartition des risques et next action par client dans la CI backend.

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -151,6 +151,7 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - `POST /api/v1/platform/auth/logout` invalide le token courant sans exiger de mecanisme de refresh fantome
 - Aucun contrat admin ne doit reintroduire des routes `/admin/auth/*` inexistantes
 - `GET /api/v1/platform/companies/{company}/health` retourne plan/MRR, features, adoption pointage 30 jours, onboarding, anomalies et next actions
+- `GET /api/v1/platform/companies/health` retourne le portefeuille client avec MRR total, repartition des risques et prochaine action par company
 - Le health client classe clairement le risque (`low`, `medium`, `high`) et reste reserve au guard `super_admin_api`
 - Les metriques health ne doivent jamais lire les donnees d'un autre tenant ni dependre d'un `current_company` applicatif
 


### PR DESCRIPTION
## Summary
- add super-admin portfolio health endpoint for MRR, risk distribution and next actions
- reuse per-company health scoring for compact portfolio rows
- add Feature coverage for healthy and suspended clients in the portfolio view

## Validation
- git diff --check
- local PHP tests not run: php is not available in this Windows PATH