### PR TITLE
feat: expose platform plans api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ Procedure recommandee :
 - Les dashboards super-admin doivent consommer ce contrat avant d'ajouter un billing complet ; il donne deja les signaux minimaux pour relancer un client, aider l'onboarding ou proposer un module Business.
 - La vue portefeuille `GET /api/v1/platform/companies/health` doit rester compacte : resume MRR/risques en haut, puis une action prioritaire par client. Eviter d'en faire un export lourd ; le detail appartient au health d'une seule company.
 - Le contrat abonnement `GET/PATCH /api/v1/platform/companies/{company}/subscription` est volontairement fournisseur-agnostique : plan/statut/dates/notes seulement. Brancher Stripe/PayPal/local PSP plus tard derriere ce contrat, pas dans le premier lot.
+- `GET /api/v1/platform/plans` fournit le catalogue a utiliser par l'admin-dashboard pour les formulaires d'abonnement ; ne pas hardcoder les `plan_id` cote frontend.
 
 ### 2026-05-07 - Dossier Go-To-Market racine
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.114] - 2026-05-08
+
+### Plateforme - Catalogue plans API
+
+- API : ajout de `GET /api/v1/platform/plans` pour exposer au super-admin le catalogue des plans disponibles.
+- API : le catalogue plans retourne prix mensuel/annuel, plafond employes, features, jours d'essai et statut actif afin d'alimenter les formulaires d'abonnement.
+- Tests : ajout d'une couverture Feature verifiant l'ordre par prix et le decodage des features de plan.
+
 ## [4.1.113] - 2026-05-08
 
 ### Plateforme - Contrat abonnement client

--- a/api/app/Http/Controllers/Api/V1/PlatformPlanController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformPlanController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class PlatformPlanController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $plans = DB::table('plans')
+            ->orderBy('price_monthly')
+            ->orderBy('id')
+            ->get()
+            ->map(fn ($plan): array => [
+                'id' => (int) $plan->id,
+                'name' => $plan->name,
+                'price_monthly' => (float) $plan->price_monthly,
+                'price_yearly' => (float) $plan->price_yearly,
+                'max_employees' => $plan->max_employees !== null ? (int) $plan->max_employees : null,
+                'features' => $this->decodeFeatures($plan->features ?? null),
+                'trial_days' => (int) $plan->trial_days,
+                'is_active' => (bool) $plan->is_active,
+            ])
+            ->values();
+
+        return new JsonResponse([
+            'data' => [
+                'items' => $plans,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeFeatures(mixed $features): array
+    {
+        if (is_array($features)) {
+            return $features;
+        }
+
+        if (! is_string($features) || $features === '') {
+            return [];
+        }
+
+        $decoded = json_decode($features, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\V1\PlatformCompanyFeatureController;
 use App\Http\Controllers\Api\V1\PlatformCompanyHealthController;
 use App\Http\Controllers\Api\V1\PlatformCompanyRequestController;
 use App\Http\Controllers\Api\V1\PlatformCompanySubscriptionController;
+use App\Http\Controllers\Api\V1\PlatformPlanController;
 use App\Http\Controllers\Api\V1\TranslationCatalogController;
 use App\Http\Controllers\Web\PlatformCompanyController;
 use Illuminate\Support\Facades\Route;
@@ -87,6 +88,7 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/auth/2fa/setup', [PlatformAuthController::class, 'setup2fa']);
         Route::post('/auth/2fa/enable', [PlatformAuthController::class, 'enable2fa']);
         Route::post('/auth/2fa/disable', [PlatformAuthController::class, 'disable2fa']);
+        Route::get('/plans', PlatformPlanController::class);
         Route::get('/companies', [PlatformCompanyController::class, 'index']);
         Route::post('/companies', [PlatformCompanyController::class, 'store']);
         Route::get('/companies/health', [PlatformCompanyHealthController::class, 'index']);

--- a/api/tests/Feature/PlatformPlanApiTest.php
+++ b/api/tests/Feature/PlatformPlanApiTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SuperAdmin;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class PlatformPlanApiTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_super_admin_can_list_platform_plans_for_subscription_forms(): void
+    {
+        DB::table('plans')->insert([
+            [
+                'id' => 1,
+                'name' => 'Business',
+                'price_monthly' => 149,
+                'price_yearly' => 1490,
+                'max_employees' => 100,
+                'features' => json_encode(['rh' => true, 'finance' => true]),
+                'trial_days' => 14,
+                'is_active' => true,
+            ],
+            [
+                'id' => 2,
+                'name' => 'Starter',
+                'price_monthly' => 29,
+                'price_yearly' => 290,
+                'max_employees' => 10,
+                'features' => json_encode(['rh' => true]),
+                'trial_days' => 14,
+                'is_active' => true,
+            ],
+        ]);
+
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+        $response = $this->getJson('/api/v1/platform/plans');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.items.0.name', 'Starter');
+        $response->assertJsonPath('data.items.0.price_monthly', 29);
+        $response->assertJsonPath('data.items.0.max_employees', 10);
+        $response->assertJsonPath('data.items.0.features.rh', true);
+        $response->assertJsonPath('data.items.1.name', 'Business');
+        $response->assertJsonPath('data.items.1.features.finance', true);
+    }
+
+    private function superAdmin(): SuperAdmin
+    {
+        return SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => fake()->unique()->safeEmail(),
+            'password_hash' => Hash::make('password123'),
+        ]);
+    }
+}

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -99,3 +99,4 @@ Quand un domaine gagne une feature significative, ajouter:
 - Le contrat health plateforme (`/api/v1/platform/companies/{company}/health`) est une surface v5.0 critique : il soutient adoption, retention et upsell, et doit rester teste avec isolation tenant et auth super-admin.
 - La vue portefeuille health (`/api/v1/platform/companies/health`) est critique pour le pilotage commercial : elle doit garder MRR, repartition des risques et next action par client dans la CI backend.
 - Le contrat abonnement plateforme (`/api/v1/platform/companies/{company}/subscription`) est critique pour la commercialisation : il doit rester fournisseur-agnostique et valider plan, statut et dates avant toute integration paiement.
+- Le catalogue plans plateforme (`/api/v1/platform/plans`) doit rester teste afin que l'admin-dashboard ne hardcode jamais les `plan_id` ou les limites de packaging.

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -152,6 +152,7 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - Aucun contrat admin ne doit reintroduire des routes `/admin/auth/*` inexistantes
 - `GET /api/v1/platform/companies/{company}/health` retourne plan/MRR, features, adoption pointage 30 jours, onboarding, anomalies et next actions
 - `GET /api/v1/platform/companies/health` retourne le portefeuille client avec MRR total, repartition des risques et prochaine action par company
+- `GET /api/v1/platform/plans` retourne le catalogue des plans pour alimenter les formulaires d'abonnement super-admin
 - `GET/PATCH /api/v1/platform/companies/{company}/subscription` lit et met a jour plan, statut, dates d'abonnement et notes client
 - Le health client classe clairement le risque (`low`, `medium`, `high`) et reste reserve au guard `super_admin_api`
 - Les metriques health ne doivent jamais lire les donnees d'un autre tenant ni dependre d'un `current_company` applicatif
@@ -195,6 +196,7 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - Contrats JSON critiques pour le mobile
 - Contrats d'auth plateforme et cas `TWO_FA_REQUIRED`
 - Contrat health plateforme pour adoption, retention et upsell client
+- Contrat catalogue plans plateforme pour eviter les `plan_id` hardcodes cote frontend
 - Contrat abonnement plateforme pour upgrade, suspension, expiration et notes client
 - Health endpoint
 


### PR DESCRIPTION
## Summary
- add super-admin plan catalog endpoint for subscription forms
- expose pricing, employee caps, feature map, trial days and active flag
- cover plan ordering and feature decoding with Feature tests

## Validation
- git diff --check
- local PHP tests not run: php is not available in this Windows PATH