### PR TITLE
Provision companies from approved requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,7 @@ Procedure recommandee :
 - Le cockpit `admin-dashboard` doit consommer les contrats plateforme reels (`/platform/companies/health`, `/platform/companies/{id}/health`, `/subscription`, `/plans`) avant toute nouvelle statistique mockee.
 - La page Support admin sert maintenant d'intake demandes clients via `/platform/company-requests`; ne pas y remettre de tickets mockes tant qu'un vrai module support n'a pas son API dediee.
 - Le dashboard d'accueil admin doit rester une synthese des contrats plateforme existants. Eviter les endpoints `/admin/dashboard/*` tant qu'ils n'existent pas cote API.
+- Approuver une `company_request` doit declencher le provisioning partage via `CompanyProvisioningService` et remplir `approved_company_id`; ne pas se limiter a changer le statut.
 
 ### 2026-05-07 - Dossier Go-To-Market racine
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.118] - 2026-05-08
+
+### Plateforme - Provisioning depuis demandes clients
+
+- API : l'approbation `PATCH /api/v1/platform/company-requests/{id}` provisionne maintenant la company, cree le manager principal et lie `approved_company_id`.
+- API : l'approbation accepte un `plan_id` optionnel et utilise le premier plan actif par defaut pour eviter une validation commerciale bloquee.
+- Tests : ajout d'un scenario feature couvrant approbation, creation company, manager principal et invitation.
+
 ## [4.1.117] - 2026-05-08
 
 ### Admin dashboard - Accueil cockpit

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanyRequestController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanyRequestController.php
@@ -3,12 +3,21 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Models\Company;
 use App\Models\CompanyRequest;
+use App\Models\SuperAdmin;
+use App\Services\CompanyProvisioningService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 
 class PlatformCompanyRequestController extends Controller
 {
+    public function __construct(
+        private readonly CompanyProvisioningService $companyProvisioningService,
+    ) {}
+
     public function index(Request $request): JsonResponse
     {
         $query = CompanyRequest::with('user:id,first_name,last_name,email')
@@ -78,12 +87,17 @@ class PlatformCompanyRequestController extends Controller
 
     public function updateStatus(Request $request, int $id): JsonResponse
     {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+        }
+
         $validated = $request->validate([
             'status' => ['required', 'in:approved,rejected'],
             'admin_notes' => ['nullable', 'string', 'max:2000'],
+            'plan_id' => ['nullable', 'integer', Rule::exists('plans', 'id')],
         ]);
 
-        $companyRequest = CompanyRequest::findOrFail($id);
+        $companyRequest = CompanyRequest::with('user:id,first_name,last_name,email,phone')->findOrFail($id);
 
         if (! $companyRequest->isPending()) {
             return new JsonResponse([
@@ -92,9 +106,22 @@ class PlatformCompanyRequestController extends Controller
             ], 422);
         }
 
+        $approvedCompany = null;
+        if ($validated['status'] === 'approved') {
+            /** @var SuperAdmin $superAdmin */
+            $superAdmin = $request->user('super_admin_api');
+            $approvedCompany = $this->provisionCompanyFromRequest(
+                companyRequest: $companyRequest,
+                superAdmin: $superAdmin,
+                planId: $validated['plan_id'] ?? null,
+                notes: $validated['admin_notes'] ?? null,
+            );
+        }
+
         $companyRequest->update([
             'status' => $validated['status'],
             'admin_notes' => $validated['admin_notes'] ?? null,
+            'approved_company_id' => $approvedCompany?->id,
             'reviewed_at' => now(),
         ]);
 
@@ -102,9 +129,55 @@ class PlatformCompanyRequestController extends Controller
             'data' => [
                 'id' => $companyRequest->id,
                 'status' => $companyRequest->status,
+                'approved_company_id' => $companyRequest->approved_company_id,
                 'admin_notes' => $companyRequest->admin_notes,
                 'reviewed_at' => $companyRequest->reviewed_at?->toIso8601String(),
             ],
         ]);
+    }
+
+    private function provisionCompanyFromRequest(
+        CompanyRequest $companyRequest,
+        SuperAdmin $superAdmin,
+        ?int $planId,
+        ?string $notes,
+    ): Company {
+        $resolvedPlanId = $planId
+            ?? DB::table('plans')->where('is_active', true)->orderBy('id')->value('id')
+            ?? DB::table('plans')->orderBy('id')->value('id');
+
+        if (! $resolvedPlanId) {
+            abort(422, 'Aucun plan actif disponible pour approuver cette demande.');
+        }
+
+        $managerName = trim($companyRequest->manager_name ?: $companyRequest->user?->fullName() ?: 'Manager principal');
+        $nameParts = preg_split('/\s+/', $managerName, 2) ?: ['Manager'];
+
+        $email = $companyRequest->email ?: $companyRequest->user?->email;
+        if (! $email) {
+            abort(422, 'Un email de contact est requis pour approuver cette demande.');
+        }
+
+        $country = strtoupper((string) ($companyRequest->country ?: 'DZ'));
+        if (strlen($country) !== 2) {
+            $country = 'DZ';
+        }
+
+        $result = $this->companyProvisioningService->provisionSharedCompany([
+            'name' => $companyRequest->company_name,
+            'sector' => $companyRequest->sector ?: 'Non precise',
+            'country' => $country,
+            'city' => $companyRequest->city ?: 'Non precise',
+            'email' => $email,
+            'phone' => $companyRequest->phone ?: $companyRequest->user?->phone,
+            'plan_id' => $resolvedPlanId,
+            'notes' => $notes ?: $companyRequest->description,
+            'manager_first_name' => $nameParts[0] ?: 'Manager',
+            'manager_last_name' => $nameParts[1] ?? 'Principal',
+            'manager_email' => $companyRequest->user?->email ?: $email,
+            'manager_phone' => $companyRequest->manager_phone ?: $companyRequest->user?->phone ?: $companyRequest->phone,
+        ], $superAdmin);
+
+        return $result['company'];
     }
 }

--- a/api/tests/Feature/PlatformCompanyRequestProvisioningTest.php
+++ b/api/tests/Feature/PlatformCompanyRequestProvisioningTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\UserInvitationMail;
+use App\Models\CompanyRequest;
+use App\Models\SuperAdmin;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class PlatformCompanyRequestProvisioningTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+        $this->setUpCompanyRequestTables();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownCompanyRequestTables();
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_approving_company_request_provisions_company_and_manager_invitation(): void
+    {
+        Mail::fake();
+
+        DB::table('plans')->insert([
+            'id' => 1,
+            'name' => 'Starter',
+            'price_monthly' => 29,
+            'price_yearly' => 290,
+            'trial_days' => 14,
+            'is_active' => true,
+        ]);
+
+        $superAdmin = SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => 'admin@leopardo-rh.com',
+            'password_hash' => Hash::make('admin'),
+        ]);
+
+        $user = User::query()->create([
+            'first_name' => 'Nadia',
+            'last_name' => 'Bensaid',
+            'email' => 'nadia@example.com',
+            'phone' => '+213555000111',
+            'password_hash' => Hash::make('secret'),
+        ]);
+
+        $companyRequest = CompanyRequest::query()->create([
+            'user_id' => $user->id,
+            'company_name' => 'Terrain Plus',
+            'sector' => 'BTP',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'manager_name' => 'Nadia Bensaid',
+            'manager_phone' => '+213555000111',
+            'email' => 'contact@terrain-plus.dz',
+            'phone' => '+213555000222',
+            'description' => 'Besoin de controler les pointages chantier.',
+            'status' => 'pending',
+        ]);
+
+        $response = $this
+            ->actingAs($superAdmin, 'super_admin_api')
+            ->patchJson("/api/v1/platform/company-requests/{$companyRequest->id}", [
+                'status' => 'approved',
+                'admin_notes' => 'Client pilote prioritaire.',
+            ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.status', 'approved');
+        $this->assertNotNull($response->json('data.approved_company_id'));
+
+        $this->assertDatabaseHas('company_requests', [
+            'id' => $companyRequest->id,
+            'status' => 'approved',
+            'admin_notes' => 'Client pilote prioritaire.',
+        ]);
+
+        $this->assertDatabaseHas('companies', [
+            'name' => 'Terrain Plus',
+            'email' => 'contact@terrain-plus.dz',
+            'plan_id' => 1,
+            'schema_name' => 'shared_tenants',
+        ]);
+
+        DB::statement('SET search_path TO shared_tenants,public');
+
+        $this->assertDatabaseHas('employees', [
+            'email' => 'nadia@example.com',
+            'role' => 'manager',
+            'manager_role' => 'principal',
+        ]);
+
+        DB::statement('SET search_path TO public');
+
+        Mail::assertSent(UserInvitationMail::class, function (UserInvitationMail $mail): bool {
+            return $mail->employee->email === 'nadia@example.com'
+                && $mail->employee->role === 'manager'
+                && str_contains($mail->activationUrl, '/activate/');
+        });
+    }
+
+    private function setUpCompanyRequestTables(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+
+            return;
+        }
+
+        if (! Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table): void {
+                $table->id();
+                $table->string('first_name');
+                $table->string('last_name');
+                $table->string('email')->unique();
+                $table->string('phone')->nullable();
+                $table->string('password_hash')->nullable();
+                $table->string('provider')->default('email');
+                $table->string('preferred_language', 2)->default('fr');
+                $table->string('status')->default('active');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('company_requests')) {
+            Schema::create('company_requests', function (Blueprint $table): void {
+                $table->id();
+                $table->foreignId('user_id')->nullable();
+                $table->string('company_name');
+                $table->string('sector')->nullable();
+                $table->string('country')->nullable();
+                $table->string('city')->nullable();
+                $table->string('email')->nullable();
+                $table->string('phone')->nullable();
+                $table->text('description')->nullable();
+                $table->string('status')->default('pending');
+                $table->uuid('approved_company_id')->nullable();
+                $table->text('admin_notes')->nullable();
+                $table->timestamp('reviewed_at')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    private function tearDownCompanyRequestTables(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+
+            return;
+        }
+
+        Schema::dropIfExists('company_requests');
+        Schema::dropIfExists('users');
+    }
+}

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -103,3 +103,4 @@ Quand un domaine gagne une feature significative, ajouter:
 - Le cockpit admin v5.0 doit afficher les donnees reelles du portefeuille, du detail health, des abonnements et des plans. Toute regression `admin-dashboard/**` sur ces vues doit rester couverte par build/Playwright.
 - L'intake demandes clients de l'admin-dashboard doit rester branche sur `/api/v1/platform/company-requests` : filtres statut, compteurs et actions approuver/rejeter font partie du parcours commercial critique.
 - L'accueil admin v5.0 ne doit plus dependre d'endpoints mockes `/admin/dashboard/*`; il synthetise les contrats plateforme existants pour garder un premier ecran exploitable.
+- L'approbation d'une demande client doit verifier le provisioning complet : company publique, manager principal tenant, invitation et `approved_company_id`.


### PR DESCRIPTION
## Summary
- make approved platform company requests provision a shared company through CompanyProvisioningService
- link approved_company_id and keep rejected requests as status-only decisions
- add feature coverage for company, manager and invitation provisioning

## Checks
- git diff --check
- php artisan test --filter=PlatformCompanyRequestProvisioningTest (blocked locally: php is not available in PATH)