### PR TITLE
⚡ Bolt: Optimize Platform Health report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.1.119] - 2026-05-08
+
+### ⚡ Bolt - Optimisation de performance plateforme
+
+- API : optimisation de `PlatformCompanyHealthService` par l'implémentation d'un cache au niveau de l'instance pour les plans, éliminant les requêtes N+1 lors de la génération du rapport de santé du portefeuille.
+
 ## [4.1.118] - 2026-05-08
 
 ### Plateforme - Provisioning depuis demandes clients

--- a/api/app/Services/PlatformCompanyHealthService.php
+++ b/api/app/Services/PlatformCompanyHealthService.php
@@ -215,15 +215,35 @@ class PlatformCompanyHealthService
     }
 
     /**
+     * @var array<int, object|null>
+     */
+    private array $plansCache = [];
+
+    /**
      * @return array<string, mixed>
      */
     private function plan(Company $company): array
     {
-        $plan = DB::table('plans')->where('id', $company->plan_id)->first();
+        $planId = $company->plan_id;
+
+        if ($planId === null) {
+            return [
+                'id' => null,
+                'name' => null,
+                'price_monthly' => null,
+                'price_yearly' => null,
+            ];
+        }
+
+        if (! array_key_exists($planId, $this->plansCache)) {
+            $this->plansCache[$planId] = DB::table('plans')->where('id', $planId)->first();
+        }
+
+        $plan = $this->plansCache[$planId];
 
         return [
-            'id' => $company->plan_id,
-            'name' => $plan->name ?? null,
+            'id' => $planId,
+            'name' => $plan?->name ?? null,
             'price_monthly' => isset($plan->price_monthly) ? (float) $plan->price_monthly : null,
             'price_yearly' => isset($plan->price_yearly) ? (float) $plan->price_yearly : null,
         ];


### PR DESCRIPTION
- Optimized PlatformCompanyHealthService by implementing an instance-level cache for subscription plans.
- This eliminates N+1 database queries on the plans table when generating reports for a portfolio of companies.
- The implementation is safe for MVP as it is mono-scope, low-risk, under 50 lines, and uses instance-level state to avoid cross-test interference.
- Verified via PlatformCompanyHealthApiTest in SQLite environment.
- Rollback: Revert the changes in PlatformCompanyHealthService.php.

---
*PR created automatically by Jules for task [16294364592425311002](https://jules.google.com/task/16294364592425311002) started by @kitokoh*