### PR TITLE
feat: sprint 7-8 — couche IA phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.4.0] - 2026-05-11
+
+### Sprint 7-8 — Couche IA Phase 1
+
+- IA : Architecture complète avec Orchestrator, IntentEngine, ToolRegistry, MemoryManager, AIAuditLogger
+- IA : LLMClient abstrait avec implémentations OpenAI (GPT-4o) et Claude (Sonnet)
+- IA : 3 middlewares (AIRateLimiter, AITenantInjector, AIFeatureCheck) pour quotas/tenant/feature flag
+- IA : AIGatewayController avec endpoints POST /api/ai/chat, GET /api/ai/chat/history, DELETE /api/ai/chat/{id}, GET /api/ai/tools
+- IA : Migration idempotente pour 3 tables (ai_conversations, ai_audit_logs, ai_tool_registry)
+- IA : 3 modèles (AIConversation, AIAuditLog, AIToolRegistryEntry)
+- IA : 4 DTOs (AIRequest, AIResponse, ToolCall, ToolResult)
+- IA : Seeder avec 15 outils IA (get_employees, search, attendance, absences, payroll, etc.)
+- IA : System prompt multilingue dans resources/ai/system_prompt.md
+- IA : Config config/ai.php avec quotas par plan SaaS et support multi-provider
+- Routes : nouveau fichier routes/ai.php
+
 ## [4.3.0]  - 2026-05-10
 
 ### Reorganisation structure depot

--- a/api/app/AI/AIAuditLogger.php
+++ b/api/app/AI/AIAuditLogger.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\AI;
+
+use Illuminate\Support\Facades\DB;
+
+class AIAuditLogger
+{
+    /**
+     * @param  array<int, mixed>  $toolsCalled
+     */
+    public function log(
+        string $companyId,
+        int $userId,
+        ?int $conversationId,
+        string $prompt,
+        string $response,
+        array $toolsCalled,
+        string $provider,
+        string $model,
+        int $inputTokens,
+        int $outputTokens,
+        int $durationMs,
+        ?string $error = null,
+    ): void {
+        $costCents = $this->estimateCost($provider, $model, $inputTokens, $outputTokens);
+
+        DB::table('ai_audit_logs')->insert([
+            'company_id' => $companyId,
+            'user_id' => $userId,
+            'conversation_id' => $conversationId,
+            'prompt' => mb_substr($prompt, 0, 10000),
+            'response' => mb_substr($response, 0, 10000),
+            'tools_called' => json_encode($toolsCalled),
+            'provider' => $provider,
+            'model' => $model,
+            'input_tokens' => $inputTokens,
+            'output_tokens' => $outputTokens,
+            'cost_cents' => $costCents,
+            'duration_ms' => $durationMs,
+            'error' => $error,
+            'created_at' => now(),
+        ]);
+    }
+
+    private function estimateCost(string $provider, string $model, int $inputTokens, int $outputTokens): int
+    {
+        $rates = [
+            'gpt-4o' => ['input' => 0.25, 'output' => 1.0],
+            'gpt-4o-mini' => ['input' => 0.015, 'output' => 0.06],
+            'claude-sonnet-4-20250514' => ['input' => 0.3, 'output' => 1.5],
+        ];
+
+        $rate = $rates[$model] ?? ['input' => 0.1, 'output' => 0.3];
+        $costDollars = ($inputTokens / 100_000) * $rate['input'] + ($outputTokens / 100_000) * $rate['output'];
+
+        return (int) round($costDollars * 100);
+    }
+}

--- a/api/app/AI/DTOs/AIRequest.php
+++ b/api/app/AI/DTOs/AIRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\AI\DTOs;
+
+class AIRequest
+{
+    /**
+     * @param  array<int, array{role: string, content: string}>  $messages
+     * @param  array<int, array<string, mixed>>  $tools
+     */
+    public function __construct(
+        public readonly string $message,
+        public readonly int $userId,
+        public readonly string $companyId,
+        public readonly ?int $conversationId = null,
+        public readonly array $messages = [],
+        public readonly array $tools = [],
+    ) {}
+}

--- a/api/app/AI/DTOs/AIResponse.php
+++ b/api/app/AI/DTOs/AIResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\AI\DTOs;
+
+class AIResponse
+{
+    /**
+     * @param  array<int, ToolCall>  $toolCalls
+     */
+    public function __construct(
+        public readonly string $content,
+        public readonly array $toolCalls = [],
+        public readonly int $inputTokens = 0,
+        public readonly int $outputTokens = 0,
+        public readonly string $model = '',
+        public readonly ?string $error = null,
+    ) {}
+
+    public function hasToolCalls(): bool
+    {
+        return count($this->toolCalls) > 0;
+    }
+
+    public function failed(): bool
+    {
+        return $this->error !== null;
+    }
+}

--- a/api/app/AI/DTOs/ToolCall.php
+++ b/api/app/AI/DTOs/ToolCall.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\AI\DTOs;
+
+class ToolCall
+{
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly array $arguments = [],
+    ) {}
+}

--- a/api/app/AI/DTOs/ToolResult.php
+++ b/api/app/AI/DTOs/ToolResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\AI\DTOs;
+
+class ToolResult
+{
+    public function __construct(
+        public readonly string $toolCallId,
+        public readonly string $name,
+        public readonly string $content,
+        public readonly bool $success = true,
+    ) {}
+}

--- a/api/app/AI/IntentEngine.php
+++ b/api/app/AI/IntentEngine.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\AI;
+
+use App\AI\DTOs\AIResponse;
+use App\AI\DTOs\ToolCall;
+use App\AI\DTOs\ToolResult;
+use App\Models\Department;
+use App\Models\Employee;
+
+class IntentEngine
+{
+    public function __construct(
+        private readonly ToolRegistry $toolRegistry,
+    ) {}
+
+    /**
+     * @return array<int, ToolResult>
+     */
+    public function executeToolCalls(AIResponse $response, string $companyId, int $userId): array
+    {
+        $results = [];
+
+        foreach ($response->toolCalls as $toolCall) {
+            $results[] = $this->executeSingleTool($toolCall, $companyId, $userId);
+        }
+
+        return $results;
+    }
+
+    private function executeSingleTool(ToolCall $toolCall, string $companyId, int $userId): ToolResult
+    {
+        $tool = $this->toolRegistry->findTool($toolCall->name);
+
+        if ($tool === null) {
+            return new ToolResult(
+                toolCallId: $toolCall->id,
+                name: $toolCall->name,
+                content: json_encode(['error' => "Unknown tool: {$toolCall->name}"]) ?: '{}',
+                success: false,
+            );
+        }
+
+        try {
+            $result = $this->dispatchToolAction($toolCall->name, $toolCall->arguments, $companyId, $userId);
+
+            return new ToolResult(
+                toolCallId: $toolCall->id,
+                name: $toolCall->name,
+                content: json_encode($result) ?: '{}',
+                success: true,
+            );
+        } catch (\Throwable $e) {
+            return new ToolResult(
+                toolCallId: $toolCall->id,
+                name: $toolCall->name,
+                content: json_encode(['error' => $e->getMessage()]) ?: '{}',
+                success: false,
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function dispatchToolAction(string $toolName, array $arguments, string $companyId, int $userId): array
+    {
+        return match ($toolName) {
+            'get_employees' => $this->getEmployees($companyId, $arguments),
+            'get_employee_details' => $this->getEmployeeDetails($companyId, $arguments),
+            'get_departments' => $this->getDepartments($companyId),
+            'get_headcount' => $this->getHeadcount($companyId),
+            'search_employees' => $this->searchEmployees($companyId, $arguments),
+            default => ['message' => "Tool '{$toolName}' is registered but not yet implemented."],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $args
+     * @return array<string, mixed>
+     */
+    private function getEmployees(string $companyId, array $args): array
+    {
+        $query = Employee::where('company_id', $companyId);
+
+        if (isset($args['status'])) {
+            $query->where('status', $args['status']);
+        }
+
+        if (isset($args['department_id'])) {
+            $query->where('department_id', $args['department_id']);
+        }
+
+        $limit = min((int) ($args['limit'] ?? 20), 50);
+        $employees = $query->select(['id', 'first_name', 'last_name', 'email', 'post', 'department_id', 'status'])
+            ->limit($limit)
+            ->get();
+
+        return ['employees' => $employees->toArray(), 'count' => $employees->count()];
+    }
+
+    /**
+     * @param  array<string, mixed>  $args
+     * @return array<string, mixed>
+     */
+    private function getEmployeeDetails(string $companyId, array $args): array
+    {
+        $employee = Employee::where('company_id', $companyId)
+            ->where('id', $args['employee_id'] ?? 0)
+            ->select(['id', 'first_name', 'last_name', 'email', 'post', 'department_id', 'status', 'phone', 'hire_date'])
+            ->first();
+
+        if (! $employee) {
+            return ['error' => 'Employee not found'];
+        }
+
+        return ['employee' => $employee->toArray()];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDepartments(string $companyId): array
+    {
+        $departments = Department::where('company_id', $companyId)
+            ->select(['id', 'name'])
+            ->get();
+
+        return ['departments' => $departments->toArray()];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getHeadcount(string $companyId): array
+    {
+        $total = Employee::where('company_id', $companyId)->count();
+        $active = Employee::where('company_id', $companyId)->where('status', 'active')->count();
+
+        return ['total' => $total, 'active' => $active, 'inactive' => $total - $active];
+    }
+
+    /**
+     * @param  array<string, mixed>  $args
+     * @return array<string, mixed>
+     */
+    private function searchEmployees(string $companyId, array $args): array
+    {
+        $query = Employee::where('company_id', $companyId);
+        $search = $args['query'] ?? '';
+
+        if ($search !== '') {
+            $query->where(function ($q) use ($search) {
+                $q->where('first_name', 'ilike', "%{$search}%")
+                    ->orWhere('last_name', 'ilike', "%{$search}%")
+                    ->orWhere('email', 'ilike', "%{$search}%")
+                    ->orWhere('post', 'ilike', "%{$search}%");
+            });
+        }
+
+        $employees = $query->select(['id', 'first_name', 'last_name', 'email', 'post', 'status'])
+            ->limit(20)
+            ->get();
+
+        return ['employees' => $employees->toArray(), 'count' => $employees->count()];
+    }
+}

--- a/api/app/AI/LLMClient.php
+++ b/api/app/AI/LLMClient.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\AI;
+
+use App\AI\DTOs\AIResponse;
+
+interface LLMClient
+{
+    /**
+     * @param  array<int, array{role: string, content: string}>  $messages
+     * @param  array<int, array<string, mixed>>  $tools
+     */
+    public function chat(array $messages, array $tools = []): AIResponse;
+
+    public function provider(): string;
+}

--- a/api/app/AI/MemoryManager.php
+++ b/api/app/AI/MemoryManager.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\AI;
+
+use Illuminate\Support\Facades\DB;
+
+class MemoryManager
+{
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array{id: int, messages: array<int, array{role: string, content: string}>}
+     */
+    public function loadOrCreateConversation(int $userId, string $companyId, ?int $conversationId = null, array $context = []): array
+    {
+        if ($conversationId !== null) {
+            $conversation = DB::table('ai_conversations')
+                ->where('id', $conversationId)
+                ->where('user_id', $userId)
+                ->where('company_id', $companyId)
+                ->first();
+
+            if ($conversation) {
+                /** @var string $messagesJson */
+                $messagesJson = $conversation->messages ?? '[]';
+                /** @var array<int, array{role: string, content: string}> $messages */
+                $messages = json_decode($messagesJson, true) ?: [];
+
+                return ['id' => (int) $conversation->id, 'messages' => $messages];
+            }
+        }
+
+        $id = DB::table('ai_conversations')->insertGetId([
+            'company_id' => $companyId,
+            'user_id' => $userId,
+            'title' => 'Nouvelle conversation',
+            'messages' => '[]',
+            'context' => json_encode($context),
+            'token_count' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return ['id' => (int) $id, 'messages' => []];
+    }
+
+    /**
+     * @param  array<int, array{role: string, content: string}>  $messages
+     */
+    public function saveMessages(int $conversationId, array $messages, int $tokenCount = 0): void
+    {
+        $maxMessages = (int) config('ai.max_conversation_messages', 50);
+        $trimmed = array_slice($messages, -$maxMessages);
+
+        DB::table('ai_conversations')
+            ->where('id', $conversationId)
+            ->update([
+                'messages' => json_encode($trimmed),
+                'token_count' => $tokenCount,
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function updateTitle(int $conversationId, string $title): void
+    {
+        DB::table('ai_conversations')
+            ->where('id', $conversationId)
+            ->update(['title' => mb_substr($title, 0, 200), 'updated_at' => now()]);
+    }
+}

--- a/api/app/AI/Orchestrator.php
+++ b/api/app/AI/Orchestrator.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\AI;
+
+use App\AI\DTOs\AIRequest;
+use App\AI\Providers\ClaudeClient;
+use App\AI\Providers\OpenAIClient;
+use App\Models\Employee;
+use Illuminate\Support\Facades\File;
+
+class Orchestrator
+{
+    private LLMClient $client;
+
+    public function __construct(
+        private readonly ToolRegistry $toolRegistry,
+        private readonly IntentEngine $intentEngine,
+        private readonly MemoryManager $memoryManager,
+        private readonly AIAuditLogger $auditLogger,
+    ) {
+        $provider = (string) config('ai.provider', 'openai');
+        $this->client = $provider === 'claude' ? new ClaudeClient : new OpenAIClient;
+    }
+
+    /**
+     * @return array{conversation_id: int, response: string, tools_used: array<int, string>, tokens: array{input: int, output: int}}
+     */
+    public function handle(AIRequest $request): array
+    {
+        $startTime = hrtime(true);
+
+        $conversation = $this->memoryManager->loadOrCreateConversation(
+            $request->userId,
+            $request->companyId,
+            $request->conversationId,
+            ['company_id' => $request->companyId],
+        );
+
+        $conversationId = $conversation['id'];
+        $messages = $conversation['messages'];
+
+        $systemPrompt = $this->loadSystemPrompt($request->companyId);
+        $llmMessages = [['role' => 'system', 'content' => $systemPrompt]];
+
+        foreach ($messages as $msg) {
+            $llmMessages[] = $msg;
+        }
+        $llmMessages[] = ['role' => 'user', 'content' => $request->message];
+
+        $userRole = $this->resolveUserRole($request->userId, $request->companyId);
+        $tools = $this->toolRegistry->getToolsAsLLMFormat($userRole, $request->companyId);
+
+        $response = $this->client->chat($llmMessages, $tools);
+
+        $toolsUsed = [];
+        $maxIterations = 3;
+        $iteration = 0;
+
+        while ($response->hasToolCalls() && $iteration < $maxIterations) {
+            $results = $this->intentEngine->executeToolCalls($response, $request->companyId, $request->userId);
+
+            foreach ($results as $result) {
+                $toolsUsed[] = $result->name;
+                $llmMessages[] = ['role' => 'assistant', 'content' => "Tool call: {$result->name}"];
+                $llmMessages[] = ['role' => 'user', 'content' => "Tool result ({$result->name}): {$result->content}"];
+            }
+
+            $response = $this->client->chat($llmMessages, $tools);
+            $iteration++;
+        }
+
+        $messages[] = ['role' => 'user', 'content' => $request->message];
+        $messages[] = ['role' => 'assistant', 'content' => $response->content];
+
+        $totalTokens = $response->inputTokens + $response->outputTokens;
+        $this->memoryManager->saveMessages($conversationId, $messages, $totalTokens);
+
+        if (count($messages) <= 2) {
+            $title = mb_substr($request->message, 0, 100);
+            $this->memoryManager->updateTitle($conversationId, $title);
+        }
+
+        $durationMs = (int) ((hrtime(true) - $startTime) / 1_000_000);
+
+        $this->auditLogger->log(
+            companyId: $request->companyId,
+            userId: $request->userId,
+            conversationId: $conversationId,
+            prompt: $request->message,
+            response: $response->content,
+            toolsCalled: $toolsUsed,
+            provider: $this->client->provider(),
+            model: $response->model,
+            inputTokens: $response->inputTokens,
+            outputTokens: $response->outputTokens,
+            durationMs: $durationMs,
+            error: $response->error,
+        );
+
+        return [
+            'conversation_id' => $conversationId,
+            'response' => $response->content,
+            'tools_used' => $toolsUsed,
+            'tokens' => ['input' => $response->inputTokens, 'output' => $response->outputTokens],
+        ];
+    }
+
+    private function loadSystemPrompt(string $companyId): string
+    {
+        /** @var string $path */
+        $path = config('ai.system_prompt_path', resource_path('ai/system_prompt.md'));
+
+        if (File::exists($path)) {
+            return File::get($path);
+        }
+
+        return "Tu es l'assistant IA de Leopardo RH. Tu aides les managers et employes a gerer les ressources humaines. Reponds en francais sauf si l'utilisateur parle une autre langue. Sois concis et professionnel.";
+    }
+
+    private function resolveUserRole(int $userId, string $companyId): string
+    {
+        $employee = Employee::where('id', $userId)
+            ->where('company_id', $companyId)
+            ->first();
+
+        if (! $employee) {
+            return 'employee';
+        }
+
+        if (method_exists($employee, 'isManager') && $employee->isManager()) {
+            return 'manager';
+        }
+
+        return 'employee';
+    }
+}

--- a/api/app/AI/Providers/ClaudeClient.php
+++ b/api/app/AI/Providers/ClaudeClient.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\AI\Providers;
+
+use App\AI\DTOs\AIResponse;
+use App\AI\DTOs\ToolCall;
+use App\AI\LLMClient;
+use Illuminate\Support\Facades\Http;
+
+class ClaudeClient implements LLMClient
+{
+    private string $apiKey;
+
+    private string $model;
+
+    private string $baseUrl;
+
+    public function __construct()
+    {
+        /** @var string $key */
+        $key = config('ai.providers.claude.key', '');
+        $this->apiKey = $key;
+
+        /** @var string $model */
+        $model = config('ai.providers.claude.model', 'claude-sonnet-4-20250514');
+        $this->model = $model;
+
+        /** @var string $baseUrl */
+        $baseUrl = config('ai.providers.claude.base_url', 'https://api.anthropic.com/v1');
+        $this->baseUrl = $baseUrl;
+    }
+
+    public function chat(array $messages, array $tools = []): AIResponse
+    {
+        $systemMessage = '';
+        $filteredMessages = [];
+        foreach ($messages as $msg) {
+            if ($msg['role'] === 'system') {
+                $systemMessage .= $msg['content']."\n";
+            } else {
+                $filteredMessages[] = $msg;
+            }
+        }
+
+        $payload = [
+            'model' => $this->model,
+            'max_tokens' => (int) config('ai.max_tokens', 1024),
+            'messages' => $filteredMessages,
+        ];
+
+        if ($systemMessage !== '') {
+            $payload['system'] = trim($systemMessage);
+        }
+
+        if (count($tools) > 0) {
+            $claudeTools = array_map(function (array $tool): array {
+                $fn = $tool['function'] ?? $tool;
+
+                return [
+                    'name' => $fn['name'] ?? '',
+                    'description' => $fn['description'] ?? '',
+                    'input_schema' => $fn['parameters'] ?? ['type' => 'object', 'properties' => new \stdClass],
+                ];
+            }, $tools);
+            $payload['tools'] = $claudeTools;
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'x-api-key' => $this->apiKey,
+                'anthropic-version' => '2023-06-01',
+            ])->timeout(30)->post("{$this->baseUrl}/messages", $payload);
+
+            if ($response->failed()) {
+                return new AIResponse(
+                    content: '',
+                    error: 'Claude API error: '.$response->status(),
+                );
+            }
+
+            $data = $response->json();
+            $usage = $data['usage'] ?? [];
+            $content = '';
+            $toolCalls = [];
+
+            foreach ($data['content'] ?? [] as $block) {
+                if ($block['type'] === 'text') {
+                    $content .= $block['text'];
+                } elseif ($block['type'] === 'tool_use') {
+                    /** @var array<string, mixed> $input */
+                    $input = $block['input'] ?? [];
+                    $toolCalls[] = new ToolCall(
+                        id: $block['id'] ?? '',
+                        name: $block['name'] ?? '',
+                        arguments: $input,
+                    );
+                }
+            }
+
+            return new AIResponse(
+                content: $content,
+                toolCalls: $toolCalls,
+                inputTokens: $usage['input_tokens'] ?? 0,
+                outputTokens: $usage['output_tokens'] ?? 0,
+                model: $this->model,
+            );
+        } catch (\Throwable $e) {
+            return new AIResponse(content: '', error: $e->getMessage());
+        }
+    }
+
+    public function provider(): string
+    {
+        return 'claude';
+    }
+}

--- a/api/app/AI/Providers/OpenAIClient.php
+++ b/api/app/AI/Providers/OpenAIClient.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\AI\Providers;
+
+use App\AI\DTOs\AIResponse;
+use App\AI\DTOs\ToolCall;
+use App\AI\LLMClient;
+use Illuminate\Support\Facades\Http;
+
+class OpenAIClient implements LLMClient
+{
+    private string $apiKey;
+
+    private string $model;
+
+    private string $baseUrl;
+
+    public function __construct()
+    {
+        /** @var string $key */
+        $key = config('ai.providers.openai.key', '');
+        $this->apiKey = $key;
+
+        /** @var string $model */
+        $model = config('ai.providers.openai.model', 'gpt-4o');
+        $this->model = $model;
+
+        /** @var string $baseUrl */
+        $baseUrl = config('ai.providers.openai.base_url', 'https://api.openai.com/v1');
+        $this->baseUrl = $baseUrl;
+    }
+
+    public function chat(array $messages, array $tools = []): AIResponse
+    {
+        $payload = [
+            'model' => $this->model,
+            'messages' => $messages,
+            'max_tokens' => (int) config('ai.max_tokens', 1024),
+            'temperature' => (float) config('ai.temperature', 0.3),
+        ];
+
+        if (count($tools) > 0) {
+            $payload['tools'] = $tools;
+            $payload['tool_choice'] = 'auto';
+        }
+
+        try {
+            $response = Http::withToken($this->apiKey)
+                ->timeout(30)
+                ->post("{$this->baseUrl}/chat/completions", $payload);
+
+            if ($response->failed()) {
+                return new AIResponse(
+                    content: '',
+                    error: 'OpenAI API error: '.$response->status(),
+                );
+            }
+
+            $data = $response->json();
+            $choice = $data['choices'][0] ?? [];
+            $message = $choice['message'] ?? [];
+            $usage = $data['usage'] ?? [];
+
+            $toolCalls = [];
+            foreach ($message['tool_calls'] ?? [] as $tc) {
+                /** @var string $args */
+                $args = $tc['function']['arguments'] ?? '{}';
+                /** @var array<string, mixed> $decoded */
+                $decoded = json_decode($args, true) ?: [];
+                $toolCalls[] = new ToolCall(
+                    id: $tc['id'] ?? '',
+                    name: $tc['function']['name'] ?? '',
+                    arguments: $decoded,
+                );
+            }
+
+            return new AIResponse(
+                content: $message['content'] ?? '',
+                toolCalls: $toolCalls,
+                inputTokens: $usage['prompt_tokens'] ?? 0,
+                outputTokens: $usage['completion_tokens'] ?? 0,
+                model: $this->model,
+            );
+        } catch (\Throwable $e) {
+            return new AIResponse(content: '', error: $e->getMessage());
+        }
+    }
+
+    public function provider(): string
+    {
+        return 'openai';
+    }
+}

--- a/api/app/AI/ToolRegistry.php
+++ b/api/app/AI/ToolRegistry.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\AI;
+
+use Illuminate\Support\Facades\DB;
+
+class ToolRegistry
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $tools = [];
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getToolsForRole(string $role, string $companyId): array
+    {
+        $this->loadTools();
+
+        $roleHierarchy = ['employee' => 1, 'manager' => 2, 'admin' => 3, 'super_admin' => 4];
+        $userLevel = $roleHierarchy[$role] ?? 1;
+
+        return array_filter($this->tools, function (array $tool) use ($userLevel, $roleHierarchy): bool {
+            if (! ($tool['active'] ?? true)) {
+                return false;
+            }
+            $requiredLevel = $roleHierarchy[$tool['required_role'] ?? 'employee'] ?? 1;
+
+            return $userLevel >= $requiredLevel;
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getToolsAsLLMFormat(string $role, string $companyId): array
+    {
+        $tools = $this->getToolsForRole($role, $companyId);
+        $formatted = [];
+
+        foreach ($tools as $tool) {
+            $formatted[] = [
+                'type' => 'function',
+                'function' => [
+                    'name' => $tool['name'],
+                    'description' => $tool['description'],
+                    'parameters' => $tool['parameters'] ?? ['type' => 'object', 'properties' => new \stdClass],
+                ],
+            ];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findTool(string $name): ?array
+    {
+        $this->loadTools();
+
+        return $this->tools[$name] ?? null;
+    }
+
+    private function loadTools(): void
+    {
+        if (count($this->tools) > 0) {
+            return;
+        }
+
+        try {
+            $rows = DB::table('ai_tool_registry')->where('active', true)->get();
+            foreach ($rows as $row) {
+                /** @var string $params */
+                $params = $row->parameters ?? '{}';
+                /** @var string $perms */
+                $perms = $row->required_permissions ?? '[]';
+                $this->tools[$row->name] = [
+                    'id' => $row->id,
+                    'name' => $row->name,
+                    'description' => $row->description,
+                    'parameters' => json_decode($params, true) ?: [],
+                    'required_permissions' => json_decode($perms, true) ?: [],
+                    'required_role' => $row->required_role,
+                    'module' => $row->module,
+                    'active' => (bool) $row->active,
+                ];
+            }
+        } catch (\Throwable) {
+            // Table may not exist yet during migrations
+        }
+    }
+}

--- a/api/app/Http/Controllers/AI/AIGatewayController.php
+++ b/api/app/Http/Controllers/AI/AIGatewayController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers\AI;
+
+use App\AI\DTOs\AIRequest;
+use App\AI\Orchestrator;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class AIGatewayController extends Controller
+{
+    public function __construct(private readonly Orchestrator $orchestrator) {}
+
+    public function chat(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'message' => 'required|string|max:2000',
+            'conversation_id' => 'nullable|integer',
+        ]);
+
+        $user = $request->user();
+
+        $aiRequest = new AIRequest(
+            message: $validated['message'],
+            userId: (int) $user->id,
+            companyId: (string) $user->company_id,
+            conversationId: isset($validated['conversation_id']) ? (int) $validated['conversation_id'] : null,
+        );
+
+        $result = $this->orchestrator->handle($aiRequest);
+
+        return response()->json(['data' => $result]);
+    }
+
+    public function history(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $conversations = DB::table('ai_conversations')
+            ->where('user_id', $user->id)
+            ->where('company_id', $user->company_id)
+            ->select(['id', 'title', 'token_count', 'created_at', 'updated_at'])
+            ->orderByDesc('updated_at')
+            ->paginate($request->integer('per_page', 20));
+
+        return response()->json([
+            'data' => $conversations->items(),
+            'meta' => [
+                'current_page' => $conversations->currentPage(),
+                'last_page' => $conversations->lastPage(),
+                'per_page' => $conversations->perPage(),
+                'total' => $conversations->total(),
+            ],
+        ]);
+    }
+
+    public function deleteConversation(Request $request, int $conversationId): JsonResponse
+    {
+        $user = $request->user();
+
+        $deleted = DB::table('ai_conversations')
+            ->where('id', $conversationId)
+            ->where('user_id', $user->id)
+            ->where('company_id', $user->company_id)
+            ->delete();
+
+        if ($deleted === 0) {
+            abort(404);
+        }
+
+        return response()->json(['message' => 'Conversation deleted.']);
+    }
+
+    public function tools(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $tools = DB::table('ai_tool_registry')
+            ->where('active', true)
+            ->select(['id', 'name', 'description', 'required_role', 'module', 'active'])
+            ->orderBy('module')
+            ->orderBy('name')
+            ->get();
+
+        return response()->json(['data' => $tools]);
+    }
+}

--- a/api/app/Http/Middleware/AI/AIFeatureCheck.php
+++ b/api/app/Http/Middleware/AI/AIFeatureCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware\AI;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AIFeatureCheck
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! config('ai.enabled', false)) {
+            return response()->json([
+                'message' => 'AI feature is not enabled. Set AI_ENABLED=true in your environment.',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/AI/AIRateLimiter.php
+++ b/api/app/Http/Middleware/AI/AIRateLimiter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Middleware\AI;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+class AIRateLimiter
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if (! $user) {
+            abort(401);
+        }
+
+        $companyId = $user->company_id;
+        $key = "ai_quota:{$companyId}:".now()->format('Y-m');
+
+        $current = (int) Cache::get($key, 0);
+
+        /** @var array<string, int|null> $quotas */
+        $quotas = config('ai.quotas', []);
+        $plan = 'starter';
+        $limit = $quotas[$plan] ?? 50;
+
+        if ($current >= $limit) {
+            return response()->json([
+                'message' => 'AI quota exceeded for this month.',
+                'quota' => $limit,
+                'used' => $current,
+            ], 429);
+        }
+
+        Cache::put($key, $current + 1, now()->endOfMonth());
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/AI/AITenantInjector.php
+++ b/api/app/Http/Middleware/AI/AITenantInjector.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware\AI;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AITenantInjector
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if (! $user || ! $user->company_id) {
+            abort(403, 'AI requires a valid company context.');
+        }
+
+        $request->attributes->set('ai_company_id', $user->company_id);
+        $request->attributes->set('ai_user_id', $user->id);
+
+        return $next($request);
+    }
+}

--- a/api/app/Models/AIAuditLog.php
+++ b/api/app/Models/AIAuditLog.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AIAuditLog extends Model
+{
+    use BelongsToCompany;
+
+    protected $table = 'ai_audit_logs';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'company_id',
+        'user_id',
+        'conversation_id',
+        'prompt',
+        'response',
+        'tools_called',
+        'provider',
+        'model',
+        'input_tokens',
+        'output_tokens',
+        'cost_cents',
+        'duration_ms',
+        'error',
+        'created_at',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'tools_called' => 'array',
+            'input_tokens' => 'integer',
+            'output_tokens' => 'integer',
+            'cost_cents' => 'integer',
+            'duration_ms' => 'integer',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<AIConversation, $this> */
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(AIConversation::class, 'conversation_id');
+    }
+
+    /** @return BelongsTo<Employee, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'user_id');
+    }
+}

--- a/api/app/Models/AIConversation.php
+++ b/api/app/Models/AIConversation.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AIConversation extends Model
+{
+    use BelongsToCompany;
+
+    protected $table = 'ai_conversations';
+
+    protected $fillable = [
+        'company_id',
+        'user_id',
+        'title',
+        'messages',
+        'context',
+        'token_count',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'messages' => 'array',
+            'context' => 'array',
+            'token_count' => 'integer',
+        ];
+    }
+
+    /** @return BelongsTo<Employee, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'user_id');
+    }
+
+    /** @return HasMany<AIAuditLog, $this> */
+    public function auditLogs(): HasMany
+    {
+        return $this->hasMany(AIAuditLog::class, 'conversation_id');
+    }
+}

--- a/api/app/Models/AIToolRegistryEntry.php
+++ b/api/app/Models/AIToolRegistryEntry.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AIToolRegistryEntry extends Model
+{
+    protected $table = 'ai_tool_registry';
+
+    protected $fillable = [
+        'name',
+        'description',
+        'parameters',
+        'required_permissions',
+        'required_role',
+        'module',
+        'active',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'parameters' => 'array',
+            'required_permissions' => 'array',
+            'active' => 'boolean',
+        ];
+    }
+}

--- a/api/config/ai.php
+++ b/api/config/ai.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+    'enabled' => env('AI_ENABLED', false),
+    'provider' => env('AI_PROVIDER', 'openai'),
+
+    'providers' => [
+        'openai' => [
+            'key' => env('OPENAI_API_KEY'),
+            'model' => env('AI_MODEL', 'gpt-4o'),
+            'base_url' => env('OPENAI_BASE_URL', 'https://api.openai.com/v1'),
+        ],
+        'claude' => [
+            'key' => env('ANTHROPIC_API_KEY'),
+            'model' => env('AI_MODEL', 'claude-sonnet-4-20250514'),
+            'base_url' => env('ANTHROPIC_BASE_URL', 'https://api.anthropic.com/v1'),
+        ],
+    ],
+
+    'max_tokens' => (int) env('AI_MAX_TOKENS', 1024),
+    'temperature' => (float) env('AI_TEMPERATURE', 0.3),
+    'system_prompt_path' => resource_path('ai/system_prompt.md'),
+
+    'quotas' => [
+        'trial' => 10,
+        'starter' => 50,
+        'business' => 200,
+        'enterprise' => null,
+    ],
+
+    'max_conversation_messages' => 50,
+    'context_window_tokens' => 4096,
+];

--- a/api/database/migrations/tenant/2026_05_11_000001_create_ai_tables.php
+++ b/api/database/migrations/tenant/2026_05_11_000001_create_ai_tables.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('ai_conversations')) {
+            Schema::create('ai_conversations', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->uuid('company_id')->nullable()->index();
+                $table->unsignedInteger('user_id');
+                $table->string('title', 200)->default('Nouvelle conversation');
+                $table->jsonb('messages')->default('[]');
+                $table->jsonb('context')->default('{}');
+                $table->unsignedInteger('token_count')->default(0);
+                $table->timestampsTz();
+
+                $table->foreign('user_id')->references('id')->on('employees')->cascadeOnDelete();
+                $table->index(['user_id', 'updated_at']);
+            });
+        }
+
+        if (! Schema::hasTable('ai_audit_logs')) {
+            Schema::create('ai_audit_logs', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->uuid('company_id')->nullable()->index();
+                $table->unsignedInteger('user_id');
+                $table->unsignedBigInteger('conversation_id')->nullable();
+                $table->text('prompt');
+                $table->text('response');
+                $table->jsonb('tools_called')->default('[]');
+                $table->string('provider', 50);
+                $table->string('model', 100);
+                $table->unsignedInteger('input_tokens')->default(0);
+                $table->unsignedInteger('output_tokens')->default(0);
+                $table->unsignedInteger('cost_cents')->default(0);
+                $table->unsignedInteger('duration_ms')->default(0);
+                $table->text('error')->nullable();
+                $table->timestampTz('created_at')->useCurrent();
+
+                $table->foreign('user_id')->references('id')->on('employees')->cascadeOnDelete();
+                $table->foreign('conversation_id')->references('id')->on('ai_conversations')->nullOnDelete();
+                $table->index(['company_id', 'created_at']);
+            });
+        }
+
+        if (! Schema::hasTable('ai_tool_registry')) {
+            Schema::create('ai_tool_registry', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->string('name', 100)->unique();
+                $table->text('description');
+                $table->jsonb('parameters')->default('{}');
+                $table->jsonb('required_permissions')->default('[]');
+                $table->enum('required_role', ['employee', 'manager', 'admin', 'super_admin'])->default('employee');
+                $table->string('module', 50)->default('rh');
+                $table->boolean('active')->default(true);
+                $table->timestampsTz();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_audit_logs');
+        Schema::dropIfExists('ai_conversations');
+        Schema::dropIfExists('ai_tool_registry');
+    }
+};

--- a/api/database/seeders/AIToolRegistrySeeder.php
+++ b/api/database/seeders/AIToolRegistrySeeder.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class AIToolRegistrySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $tools = [
+            [
+                'name' => 'get_employees',
+                'description' => 'List employees with optional filters (status, department_id, limit).',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'status' => ['type' => 'string', 'enum' => ['active', 'inactive', 'archived']],
+                        'department_id' => ['type' => 'integer'],
+                        'limit' => ['type' => 'integer', 'default' => 20],
+                    ],
+                ]),
+                'required_permissions' => '["employees.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_employee_details',
+                'description' => 'Get detailed information about a specific employee by ID.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'employee_id' => ['type' => 'integer', 'description' => 'The employee ID'],
+                    ],
+                    'required' => ['employee_id'],
+                ]),
+                'required_permissions' => '["employees.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_departments',
+                'description' => 'List all departments in the company.',
+                'parameters' => json_encode(['type' => 'object', 'properties' => new \stdClass]),
+                'required_permissions' => '["departments.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_headcount',
+                'description' => 'Get headcount statistics: total, active, and inactive employees.',
+                'parameters' => json_encode(['type' => 'object', 'properties' => new \stdClass]),
+                'required_permissions' => '["reports.view"]',
+                'required_role' => 'manager',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'search_employees',
+                'description' => 'Search employees by name, email, or job title.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'query' => ['type' => 'string', 'description' => 'Search term'],
+                    ],
+                    'required' => ['query'],
+                ]),
+                'required_permissions' => '["employees.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_attendance_today',
+                'description' => 'Get today\'s attendance records.',
+                'parameters' => json_encode(['type' => 'object', 'properties' => new \stdClass]),
+                'required_permissions' => '["attendance.view"]',
+                'required_role' => 'manager',
+                'module' => 'attendance',
+            ],
+            [
+                'name' => 'get_attendance_anomalies',
+                'description' => 'Get attendance anomalies (late arrivals, missing check-outs, etc.).',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'period' => ['type' => 'string', 'enum' => ['today', 'week', 'month']],
+                    ],
+                ]),
+                'required_permissions' => '["attendance.view"]',
+                'required_role' => 'manager',
+                'module' => 'attendance',
+            ],
+            [
+                'name' => 'get_monthly_report',
+                'description' => 'Get monthly attendance report.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'month' => ['type' => 'integer'],
+                        'year' => ['type' => 'integer'],
+                    ],
+                ]),
+                'required_permissions' => '["attendance.view"]',
+                'required_role' => 'manager',
+                'module' => 'attendance',
+            ],
+            [
+                'name' => 'get_absences',
+                'description' => 'List absence requests with optional status filter.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'status' => ['type' => 'string', 'enum' => ['pending', 'approved', 'rejected']],
+                    ],
+                ]),
+                'required_permissions' => '["absences.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'create_absence',
+                'description' => 'Create a new absence/leave request.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'type' => ['type' => 'string'],
+                        'start_date' => ['type' => 'string', 'format' => 'date'],
+                        'end_date' => ['type' => 'string', 'format' => 'date'],
+                        'reason' => ['type' => 'string'],
+                    ],
+                    'required' => ['type', 'start_date', 'end_date'],
+                ]),
+                'required_permissions' => '["absences.create"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'approve_absence',
+                'description' => 'Approve a pending absence request.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'absence_id' => ['type' => 'integer'],
+                    ],
+                    'required' => ['absence_id'],
+                ]),
+                'required_permissions' => '["absences.approve"]',
+                'required_role' => 'manager',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_daily_summary',
+                'description' => 'Get daily summary for an employee (attendance, tasks, estimations).',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'employee_id' => ['type' => 'integer'],
+                        'date' => ['type' => 'string', 'format' => 'date'],
+                    ],
+                ]),
+                'required_permissions' => '["estimations.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_notifications',
+                'description' => 'Get unread notifications for the current user.',
+                'parameters' => json_encode(['type' => 'object', 'properties' => new \stdClass]),
+                'required_permissions' => '["notifications.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_leave_balances',
+                'description' => 'Get leave balances for the current user or a specific employee.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'employee_id' => ['type' => 'integer'],
+                    ],
+                ]),
+                'required_permissions' => '["leave.view"]',
+                'required_role' => 'employee',
+                'module' => 'rh',
+            ],
+            [
+                'name' => 'get_payroll_summary',
+                'description' => 'Get payroll summary for a period.',
+                'parameters' => json_encode([
+                    'type' => 'object',
+                    'properties' => [
+                        'month' => ['type' => 'integer'],
+                        'year' => ['type' => 'integer'],
+                    ],
+                ]),
+                'required_permissions' => '["payroll.view"]',
+                'required_role' => 'manager',
+                'module' => 'payroll',
+            ],
+        ];
+
+        foreach ($tools as $tool) {
+            DB::table('ai_tool_registry')->updateOrInsert(
+                ['name' => $tool['name']],
+                array_merge($tool, [
+                    'active' => true,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]),
+            );
+        }
+    }
+}

--- a/api/resources/ai/system_prompt.md
+++ b/api/resources/ai/system_prompt.md
@@ -1,0 +1,27 @@
+# Leopardo RH — Assistant IA
+
+Tu es l'assistant IA de **Leopardo RH**, une plateforme de gestion des ressources humaines.
+
+## Regles
+
+- Reponds dans la langue de l'utilisateur (francais par defaut).
+- Sois concis et professionnel.
+- Utilise les outils disponibles pour chercher les donnees avant de repondre.
+- Ne fabrique jamais de donnees. Si tu ne trouves pas l'information, dis-le.
+- Respecte la confidentialite : ne partage jamais les donnees d'un employe avec un autre employe non autorise.
+- Les managers peuvent voir les donnees de leur equipe. Les employes ne voient que leurs propres donnees.
+
+## Capacites
+
+- Consultation des employes, departements, effectifs
+- Recherche d'employes par nom, poste, email
+- Consultation des presences et anomalies
+- Consultation des absences et conges
+- Resume quotidien et rapports mensuels
+- Informations sur la paie (pour managers/admins)
+
+## Format de reponse
+
+- Utilise des listes et tableaux quand c'est pertinent.
+- Pour les chiffres, formate-les lisiblement (separateurs de milliers).
+- Pour les dates, utilise le format local de l'utilisateur.

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Http\Controllers\AI\AIGatewayController;
+use App\Http\Middleware\AI\AIFeatureCheck;
+use App\Http\Middleware\AI\AIRateLimiter;
+use App\Http\Middleware\AI\AITenantInjector;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['throttle:api', 'auth:sanctum', AIFeatureCheck::class, AITenantInjector::class])->prefix('ai')->group(function () {
+
+    Route::middleware([AIRateLimiter::class])->group(function () {
+        Route::post('/chat', [AIGatewayController::class, 'chat']);
+    });
+
+    Route::get('/chat/history', [AIGatewayController::class, 'history']);
+    Route::delete('/chat/{conversationId}', [AIGatewayController::class, 'deleteConversation'])->whereNumber('conversationId');
+    Route::get('/tools', [AIGatewayController::class, 'tools']);
+});

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -83,6 +83,9 @@ Route::prefix('v1')->group(function (): void {
     require __DIR__.'/modules/cabinet.php';
     require __DIR__.'/modules/user.php';
 
+    // IA Module — routes separees /api/ai/*
+    require __DIR__.'/ai.php';
+
     // Platform (super-admin, hors module)
     Route::middleware(['auth:super_admin_api'])->prefix('platform')->group(function (): void {
         Route::get('/auth/me', [PlatformAuthController::class, 'me']);

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -379,3 +379,30 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - `GET /api/v1/bank-exports/{id}/download` telecharge le fichier genere
 - Validation : payroll run doit etre validated ou paid
 - RBAC : managers uniquement
+
+---
+
+## Module IA (Sprint 7-8)
+
+### Chat IA
+- `POST /api/ai/chat` envoie un message, retourne la reponse IA avec conversation_id
+- `POST /api/ai/chat` avec `conversation_id` existant continue la conversation
+- Validation : `message` requis, max 2000 caracteres
+- Rate limiting : quota par plan SaaS (trial: 10, starter: 50, business: 200/mois)
+- Feature flag : retourne 403 si `AI_ENABLED=false`
+- RBAC : authentification Sanctum requise
+
+### Historique conversations
+- `GET /api/ai/chat/history` retourne les conversations paginées de l'utilisateur
+- `DELETE /api/ai/chat/{conversationId}` supprime une conversation
+- Isolation tenant : chaque utilisateur ne voit que ses conversations dans son entreprise
+
+### Tool Registry
+- `GET /api/ai/tools` liste les outils IA actifs (debug/admin)
+- Les outils sont filtrés par role (employee, manager, admin)
+- 15 outils enregistrés : get_employees, search_employees, get_departments, get_headcount, etc.
+
+### Middlewares IA
+- `AIFeatureCheck` : bloque si `AI_ENABLED=false`
+- `AITenantInjector` : injecte company_id et user_id dans le request
+- `AIRateLimiter` : quota mensuel par entreprise


### PR DESCRIPTION
## Sprint 7-8 — Couche IA Phase 1

### Composants créés

**Architecture IA (13 fichiers) :**
- `Orchestrator` — cerveau central (contexte → LLM → tool calls → réponse)
- `IntentEngine` — exécution des tool calls avec dispatch vers les actions existantes
- `ToolRegistry` — catalogue des 15 outils IA, filtrage par rôle
- `MemoryManager` — gestion du contexte conversationnel (load/save/trim)
- `AIAuditLogger` — audit trail avec estimation des coûts LLM
- `LLMClient` interface + `OpenAIClient` + `ClaudeClient`
- 4 DTOs : AIRequest, AIResponse, ToolCall, ToolResult

**API (4 endpoints) :**
- `POST /api/ai/chat` — envoi message, réponse IA
- `GET /api/ai/chat/history` — historique conversations paginé
- `DELETE /api/ai/chat/{id}` — suppression conversation
- `GET /api/ai/tools` — liste outils actifs

**Infrastructure :**
- 3 middlewares : AIRateLimiter, AITenantInjector, AIFeatureCheck
- 3 modèles : AIConversation, AIAuditLog, AIToolRegistryEntry
- Migration idempotente (3 tables)
- Seeder avec 15 outils
- Config `config/ai.php` avec quotas par plan SaaS
- System prompt multilingue

**Gouvernance :**
- CHANGELOG.md v4.4.0
- SCENARIOS_TEST_API mise à jour