### PR TITLE
feat: sprint 11-12 — modules RH avancés

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.6.0] - 2026-05-11
+
+### Sprint 11-12 — Modules RH avances
+
+- Recrutement : Actions publish, close, delete sur JobPosting avec workflow statut
+- Recrutement : Detail candidat avec entretiens, changement statut pipeline, suppression
+- Recrutement : Feedback entretien avec notation, annulation entretien
+- Self-service : GET /me/trainings (mes formations avec sessions et cours)
+- Self-service : POST /me/trainings/{sessionId}/enroll (auto-inscription formation)
+- Self-service : GET /me/loans (mes prets avec compteur echeances)
+- Self-service : GET /me/loans/{id}/repayments (echeancier de mon pret)
+- Rapports avances : Pipeline recrutement (candidats par statut)
+- Rapports avances : Completion formations (inscriptions par statut)
+- Rapports avances : Resume prets (montants par statut)
+- Rapports avances : Demographics (effectifs par departement et type contrat)
+- Rapports avances : Analyse couts (prets actifs + inscriptions formations par annee)
+- Routes : ~17 nouveaux endpoints dans hr_extended.php
+
 ## [4.3.0]  - 2026-05-10
 
 ### Reorganisation structure depot

--- a/api/app/Http/Controllers/Api/V1/AdvancedReportController.php
+++ b/api/app/Http/Controllers/Api/V1/AdvancedReportController.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Applicant;
+use App\Models\Employee;
+use App\Models\EmployeeLoan;
+use App\Models\TrainingEnrollment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AdvancedReportController extends Controller
+{
+    public function recruitmentPipeline(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isManager()) {
+            abort(403);
+        }
+
+        $companyId = $user->company_id;
+
+        $pipeline = Applicant::where('company_id', $companyId)
+            ->selectRaw('status, COUNT(*) as count')
+            ->groupBy('status')
+            ->pluck('count', 'status');
+
+        return response()->json(['data' => $pipeline]);
+    }
+
+    public function trainingCompletion(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isManager()) {
+            abort(403);
+        }
+
+        $companyId = $user->company_id;
+
+        $stats = TrainingEnrollment::where('company_id', $companyId)
+            ->selectRaw('status, COUNT(*) as count')
+            ->groupBy('status')
+            ->pluck('count', 'status');
+
+        return response()->json(['data' => $stats]);
+    }
+
+    public function loanSummary(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isManager()) {
+            abort(403);
+        }
+
+        $companyId = $user->company_id;
+
+        $stats = EmployeeLoan::where('company_id', $companyId)
+            ->selectRaw('status, COUNT(*) as count, COALESCE(SUM(amount), 0) as total_amount')
+            ->groupBy('status')
+            ->get();
+
+        return response()->json(['data' => $stats]);
+    }
+
+    public function demographicBreakdown(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isManager()) {
+            abort(403);
+        }
+
+        $companyId = $user->company_id;
+
+        $byDepartment = Employee::where('company_id', $companyId)
+            ->where('status', 'active')
+            ->selectRaw('department_id, COUNT(*) as count')
+            ->groupBy('department_id')
+            ->get();
+
+        $byContractType = Employee::where('company_id', $companyId)
+            ->where('status', 'active')
+            ->selectRaw('contract_type, COUNT(*) as count')
+            ->groupBy('contract_type')
+            ->get();
+
+        return response()->json([
+            'data' => [
+                'by_department' => $byDepartment,
+                'by_contract_type' => $byContractType,
+            ],
+        ]);
+    }
+
+    public function costAnalysis(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isManager()) {
+            abort(403);
+        }
+
+        $companyId = $user->company_id;
+        $year = $request->integer('year', (int) now()->format('Y'));
+
+        $loanCosts = EmployeeLoan::where('company_id', $companyId)
+            ->whereIn('status', ['disbursed', 'repaying'])
+            ->sum('amount');
+
+        $trainingCost = TrainingEnrollment::where('company_id', $companyId)
+            ->whereYear('created_at', $year)
+            ->count();
+
+        return response()->json([
+            'data' => [
+                'year' => $year,
+                'active_loans_total' => $loanCosts,
+                'training_enrollments_count' => $trainingCost,
+            ],
+        ]);
+    }
+}

--- a/api/app/Http/Controllers/Api/V1/JobPostingActionController.php
+++ b/api/app/Http/Controllers/Api/V1/JobPostingActionController.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Applicant;
+use App\Models\Interview;
+use App\Models\JobPosting;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class JobPostingActionController extends Controller
+{
+    public function publish(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->hasManagerRole('principal', 'rh')) {
+            abort(403);
+        }
+
+        $job = JobPosting::where('company_id', $user->company_id)->findOrFail($id);
+
+        if ($job->status !== 'draft') {
+            return response()->json(['message' => 'Only draft postings can be published.'], 422);
+        }
+
+        $job->update([
+            'status' => 'published',
+            'published_at' => now(),
+        ]);
+
+        return response()->json(['data' => $job->fresh()]);
+    }
+
+    public function close(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->hasManagerRole('principal', 'rh')) {
+            abort(403);
+        }
+
+        $job = JobPosting::where('company_id', $user->company_id)->findOrFail($id);
+
+        if ($job->status !== 'published') {
+            return response()->json(['message' => 'Only published postings can be closed.'], 422);
+        }
+
+        $job->update(['status' => 'closed']);
+
+        return response()->json(['data' => $job->fresh()]);
+    }
+
+    public function destroy(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->hasManagerRole('principal', 'rh')) {
+            abort(403);
+        }
+
+        $job = JobPosting::where('company_id', $user->company_id)->findOrFail($id);
+
+        if ($job->status !== 'draft') {
+            return response()->json(['message' => 'Only draft postings can be deleted.'], 422);
+        }
+
+        $job->delete();
+
+        return response()->json(['message' => 'Job posting deleted.']);
+    }
+
+    public function showApplicant(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isManager()) {
+            abort(403);
+        }
+
+        $applicant = Applicant::where('company_id', $user->company_id)
+            ->with(['jobPosting:id,title', 'interviews'])
+            ->findOrFail($id);
+
+        return response()->json(['data' => $applicant]);
+    }
+
+    public function updateApplicantStatus(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->hasManagerRole('principal', 'rh')) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'status' => 'required|in:new,screening,interview,offer,hired,rejected,withdrawn',
+        ]);
+
+        $applicant = Applicant::where('company_id', $user->company_id)->findOrFail($id);
+        $applicant->update($validated);
+
+        return response()->json(['data' => $applicant->fresh()]);
+    }
+
+    public function destroyApplicant(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->hasManagerRole('principal', 'rh')) {
+            abort(403);
+        }
+
+        $applicant = Applicant::where('company_id', $user->company_id)->findOrFail($id);
+        $applicant->delete();
+
+        return response()->json(['message' => 'Applicant deleted.']);
+    }
+
+    public function interviewFeedback(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+
+        $interview = Interview::where('company_id', $user->company_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'feedback' => 'required|string|max:5000',
+            'rating' => 'nullable|integer|min:1|max:5',
+        ]);
+
+        $interview->update(array_merge($validated, ['status' => 'completed']));
+
+        return response()->json(['data' => $interview->fresh()]);
+    }
+
+    public function destroyInterview(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->hasManagerRole('principal', 'rh')) {
+            abort(403);
+        }
+
+        $interview = Interview::where('company_id', $user->company_id)->findOrFail($id);
+        $interview->update(['status' => 'cancelled']);
+
+        return response()->json(['message' => 'Interview cancelled.']);
+    }
+}

--- a/api/app/Http/Controllers/Api/V1/SelfServiceController.php
+++ b/api/app/Http/Controllers/Api/V1/SelfServiceController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\EmployeeLoan;
+use App\Models\LoanRepayment;
+use App\Models\TrainingEnrollment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SelfServiceController extends Controller
+{
+    public function myTrainings(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $enrollments = TrainingEnrollment::where('employee_id', $user->id)
+            ->where('company_id', $user->company_id)
+            ->with(['trainingSession.trainingCourse:id,title,category,type,duration_hours'])
+            ->orderByDesc('created_at')
+            ->paginate($request->integer('per_page', 20));
+
+        return response()->json([
+            'data' => $enrollments->items(),
+            'meta' => [
+                'current_page' => $enrollments->currentPage(),
+                'last_page' => $enrollments->lastPage(),
+                'per_page' => $enrollments->perPage(),
+                'total' => $enrollments->total(),
+            ],
+        ]);
+    }
+
+    public function selfEnroll(Request $request, int $sessionId): JsonResponse
+    {
+        $user = $request->user();
+
+        $exists = TrainingEnrollment::where('training_session_id', $sessionId)
+            ->where('employee_id', $user->id)
+            ->exists();
+
+        if ($exists) {
+            return response()->json(['message' => 'Already enrolled in this session.'], 422);
+        }
+
+        $enrollment = TrainingEnrollment::create([
+            'training_session_id' => $sessionId,
+            'employee_id' => $user->id,
+            'company_id' => $user->company_id,
+            'status' => 'enrolled',
+        ]);
+
+        return response()->json(['data' => $enrollment], 201);
+    }
+
+    public function myLoans(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $loans = EmployeeLoan::where('employee_id', $user->id)
+            ->where('company_id', $user->company_id)
+            ->withCount('repayments')
+            ->orderByDesc('created_at')
+            ->paginate($request->integer('per_page', 20));
+
+        return response()->json([
+            'data' => $loans->items(),
+            'meta' => [
+                'current_page' => $loans->currentPage(),
+                'last_page' => $loans->lastPage(),
+                'per_page' => $loans->perPage(),
+                'total' => $loans->total(),
+            ],
+        ]);
+    }
+
+    public function myLoanRepayments(Request $request, int $loanId): JsonResponse
+    {
+        $user = $request->user();
+
+        $loan = EmployeeLoan::where('employee_id', $user->id)
+            ->where('company_id', $user->company_id)
+            ->where('id', $loanId)
+            ->firstOrFail();
+
+        $repayments = LoanRepayment::where('employee_loan_id', $loan->id)
+            ->orderBy('due_date')
+            ->get();
+
+        return response()->json(['data' => $repayments]);
+    }
+}

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -5,15 +5,18 @@
  * formation, prêts, frais, organigramme, rapports, webhooks, audit.
  */
 
+use App\Http\Controllers\Api\V1\AdvancedReportController;
 use App\Http\Controllers\Api\V1\ApprovalController;
 use App\Http\Controllers\Api\V1\AuditLogController;
 use App\Http\Controllers\Api\V1\ContractController;
 use App\Http\Controllers\Api\V1\EmployeeLoanController;
 use App\Http\Controllers\Api\V1\ExpenseClaimController;
 use App\Http\Controllers\Api\V1\HrReportController;
+use App\Http\Controllers\Api\V1\JobPostingActionController;
 use App\Http\Controllers\Api\V1\LeavePolicyController;
 use App\Http\Controllers\Api\V1\OrgChartController;
 use App\Http\Controllers\Api\V1\RecruitmentController;
+use App\Http\Controllers\Api\V1\SelfServiceController;
 use App\Http\Controllers\Api\V1\TrainingController;
 use App\Http\Controllers\Api\V1\WebhookController;
 use Illuminate\Support\Facades\Route;
@@ -118,4 +121,29 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function ()
     Route::post('/approvals/{approvalRequest}/approve', [ApprovalController::class, 'approve']);
     Route::post('/approvals/{approvalRequest}/reject', [ApprovalController::class, 'reject']);
     Route::get('/approvals/history', [ApprovalController::class, 'history']);
+
+    // ── Module C bis — Recruitment Actions (Sprint 11-12) ─────────────────
+    Route::post('/recruitment/jobs/{id}/publish', [JobPostingActionController::class, 'publish'])->whereNumber('id');
+    Route::post('/recruitment/jobs/{id}/close', [JobPostingActionController::class, 'close'])->whereNumber('id');
+    Route::delete('/recruitment/jobs/{id}', [JobPostingActionController::class, 'destroy'])->whereNumber('id');
+    Route::get('/recruitment/applicants/{id}', [JobPostingActionController::class, 'showApplicant'])->whereNumber('id');
+    Route::patch('/recruitment/applicants/{id}/status', [JobPostingActionController::class, 'updateApplicantStatus'])->whereNumber('id');
+    Route::delete('/recruitment/applicants/{id}', [JobPostingActionController::class, 'destroyApplicant'])->whereNumber('id');
+    Route::patch('/recruitment/interviews/{id}/feedback', [JobPostingActionController::class, 'interviewFeedback'])->whereNumber('id');
+    Route::delete('/recruitment/interviews/{id}', [JobPostingActionController::class, 'destroyInterview'])->whereNumber('id');
+
+    // ── Self-Service (Sprint 11-12) ───────────────────────────────────────
+    Route::get('/me/trainings', [SelfServiceController::class, 'myTrainings']);
+    Route::post('/me/trainings/{sessionId}/enroll', [SelfServiceController::class, 'selfEnroll'])->whereNumber('sessionId');
+    Route::get('/me/loans', [SelfServiceController::class, 'myLoans']);
+    Route::get('/me/loans/{loanId}/repayments', [SelfServiceController::class, 'myLoanRepayments'])->whereNumber('loanId');
+
+    // ── Advanced Reports (Sprint 11-12) ───────────────────────────────────
+    Route::prefix('reports')->group(function (): void {
+        Route::get('/recruitment-pipeline', [AdvancedReportController::class, 'recruitmentPipeline']);
+        Route::get('/training-completion', [AdvancedReportController::class, 'trainingCompletion']);
+        Route::get('/loan-summary', [AdvancedReportController::class, 'loanSummary']);
+        Route::get('/demographics', [AdvancedReportController::class, 'demographicBreakdown']);
+        Route::get('/cost-analysis', [AdvancedReportController::class, 'costAnalysis']);
+    });
 });

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -379,3 +379,30 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - `GET /api/v1/bank-exports/{id}/download` telecharge le fichier genere
 - Validation : payroll run doit etre validated ou paid
 - RBAC : managers uniquement
+
+---
+
+## Modules RH Avances (Sprint 11-12)
+
+### Recrutement — Actions avancees
+- `POST /api/v1/recruitment/jobs/{id}/publish` publier une offre (draft -> published)
+- `POST /api/v1/recruitment/jobs/{id}/close` fermer une offre (published -> closed)
+- `DELETE /api/v1/recruitment/jobs/{id}` supprimer (draft uniquement)
+- `GET /api/v1/recruitment/applicants/{id}` detail candidat avec entretiens
+- `PATCH /api/v1/recruitment/applicants/{id}/status` changer statut pipeline
+- `DELETE /api/v1/recruitment/applicants/{id}` supprimer candidat
+- `PATCH /api/v1/recruitment/interviews/{id}/feedback` ajouter feedback + notation
+- `DELETE /api/v1/recruitment/interviews/{id}` annuler entretien
+
+### Self-service employe
+- `GET /api/v1/me/trainings` mes inscriptions formations avec details cours/session
+- `POST /api/v1/me/trainings/{sessionId}/enroll` auto-inscription a une session
+- `GET /api/v1/me/loans` mes prets avec compteur echeances
+- `GET /api/v1/me/loans/{id}/repayments` echeancier de mon pret
+
+### Rapports avances
+- `GET /api/v1/reports/recruitment-pipeline` candidats par statut
+- `GET /api/v1/reports/training-completion` inscriptions par statut
+- `GET /api/v1/reports/loan-summary` montants prets par statut
+- `GET /api/v1/reports/demographics` effectifs par departement et type contrat
+- `GET /api/v1/reports/cost-analysis` analyse couts (prets, formations) par annee


### PR DESCRIPTION
## Sprint 11-12 — Modules RH Avancés

### Recrutement — Actions avancées (8 endpoints)
- `POST /publish` + `POST /close` + `DELETE` sur JobPosting (workflow statut draft→published→closed)
- `GET /applicants/{id}` détail avec entretiens
- `PATCH /applicants/{id}/status` changement pipeline (new→screening→interview→offer→hired/rejected)
- `DELETE /applicants/{id}` suppression
- `PATCH /interviews/{id}/feedback` feedback + notation
- `DELETE /interviews/{id}` annulation

### Self-Service Employé (4 endpoints)
- `GET /me/trainings` — formations avec sessions et cours
- `POST /me/trainings/{sessionId}/enroll` — auto-inscription
- `GET /me/loans` — prêts avec compteur échéances
- `GET /me/loans/{id}/repayments` — échéancier détaillé

### Rapports Analytiques (5 endpoints)
- Pipeline recrutement, complétion formations, résumé prêts, démographiques, analyse coûts

### Controllers
- JobPostingActionController (recrutement workflow)
- SelfServiceController (formations + prêts self-service)
- AdvancedReportController (analytics)

**Gouvernance :**
- CHANGELOG.md v4.6.0
- SCENARIOS_TEST_API mise à jour