### PR TITLE
feat: sprint 17-18 — IA avancée (Voice, Agents, Analytics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@
 - Rapports avances : Analyse couts (prets actifs + inscriptions formations par annee)
 - Routes : ~17 nouveaux endpoints dans hr_extended.php
 
+## [4.9.0] - 2026-05-11
+
+### Sprint 17-18 — IA avancee (Voice, Agents, Analytics)
+
+- Voice IA : VoiceController (transcribe, synthesize, command pipeline complet)
+- Voice IA : Support 4 langues (FR/AR/TR/EN) avec Whisper STT + Edge TTS
+- Voice IA : Integration Deepgram (STT) et ElevenLabs (TTS) en alternative
+- Voice IA : Pipeline audio-in -> transcription -> IA -> synthese -> audio-out
+- Agents : AgentRunner (multi-step tool calling autonome, max 10 etapes)
+- Agents : AgentController (run task, list workflows predefinis)
+- Agents : 3 workflows predefinis (paie, rapport hebdo, onboarding employe)
+- Analytics IA : AIAnalyticsController (usage, costs, tools, errors)
+- Analytics IA : Usage par tenant, couts par periode/provider, outils top, taux erreur
+- Config : config/ai.php enrichi avec voice providers et agent settings
+- Routes : ~9 nouveaux endpoints dans routes/ai.php
+
 ## [4.5.0] - 2026-05-11
 
 ### Sprint 9-10 — Tracking vehicules (Integration Traccar)

--- a/api/app/AI/AgentRunner.php
+++ b/api/app/AI/AgentRunner.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\AI;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+class AgentRunner
+{
+    private int $maxSteps;
+
+    private AIOrchestrator $orchestrator;
+
+    public function __construct(AIOrchestrator $orchestrator, int $maxSteps = 10)
+    {
+        $this->orchestrator = $orchestrator;
+        $this->maxSteps = $maxSteps;
+    }
+
+    /**
+     * @param  User  $user
+     * @return array<string, mixed>
+     */
+    public function execute($user, string $task, ?string $conversationId = null): array
+    {
+        $steps = [];
+        $currentMessage = $task;
+        $currentConversationId = $conversationId;
+
+        for ($i = 0; $i < $this->maxSteps; $i++) {
+            $response = $this->orchestrator->handle($user, $currentMessage, $currentConversationId);
+            $currentConversationId = $response['conversation_id'] ?? $currentConversationId;
+
+            $step = [
+                'step' => $i + 1,
+                'input' => $currentMessage,
+                'response' => $response['response'] ?? '',
+                'tool_called' => $response['tool_called'] ?? null,
+                'tool_result' => $response['tool_result'] ?? null,
+            ];
+            $steps[] = $step;
+
+            if (empty($response['tool_called'])) {
+                break;
+            }
+
+            $currentMessage = 'Continue with the result of the previous tool call. The tool returned: '.json_encode($response['tool_result'] ?? []);
+        }
+
+        Log::info('Agent completed', [
+            'task' => $task,
+            'steps' => count($steps),
+            'user_id' => $user->id,
+        ]);
+
+        return [
+            'task' => $task,
+            'conversation_id' => $currentConversationId,
+            'steps' => $steps,
+            'total_steps' => count($steps),
+            'final_response' => end($steps)['response'] ?? '',
+        ];
+    }
+}

--- a/api/app/Http/Controllers/AI/AIAnalyticsController.php
+++ b/api/app/Http/Controllers/AI/AIAnalyticsController.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Http\Controllers\AI;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class AIAnalyticsController extends Controller
+{
+    public function usage(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from' => 'nullable|date',
+            'to' => 'nullable|date',
+        ]);
+
+        $from = $validated['from'] ?? now()->subDays(30)->toDateString();
+        $to = $validated['to'] ?? now()->toDateString();
+
+        $usage = DB::table('ai_audit_logs')
+            ->whereBetween('created_at', [$from, $to.' 23:59:59'])
+            ->selectRaw('company_id, count(*) as total_requests, sum(total_tokens) as total_tokens, sum(cost) as total_cost')
+            ->groupBy('company_id')
+            ->orderByDesc('total_requests')
+            ->get();
+
+        return response()->json([
+            'data' => $usage,
+            'meta' => ['from' => $from, 'to' => $to],
+        ]);
+    }
+
+    public function costs(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from' => 'nullable|date',
+            'to' => 'nullable|date',
+            'group_by' => 'nullable|in:day,week,month',
+        ]);
+
+        $from = $validated['from'] ?? now()->subDays(30)->toDateString();
+        $to = $validated['to'] ?? now()->toDateString();
+        $groupBy = $validated['group_by'] ?? 'day';
+
+        $dateFormat = match ($groupBy) {
+            'week' => 'YYYY-IW',
+            'month' => 'YYYY-MM',
+            default => 'YYYY-MM-DD',
+        };
+
+        $costs = DB::table('ai_audit_logs')
+            ->whereBetween('created_at', [$from, $to.' 23:59:59'])
+            ->selectRaw("to_char(created_at, '{$dateFormat}') as period, provider, sum(cost) as total_cost, count(*) as requests, sum(total_tokens) as total_tokens")
+            ->groupBy('period', 'provider')
+            ->orderBy('period')
+            ->get();
+
+        return response()->json([
+            'data' => $costs,
+            'meta' => ['from' => $from, 'to' => $to, 'group_by' => $groupBy],
+        ]);
+    }
+
+    public function tools(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from' => 'nullable|date',
+            'to' => 'nullable|date',
+        ]);
+
+        $from = $validated['from'] ?? now()->subDays(30)->toDateString();
+        $to = $validated['to'] ?? now()->toDateString();
+
+        $tools = DB::table('ai_audit_logs')
+            ->whereBetween('created_at', [$from, $to.' 23:59:59'])
+            ->whereNotNull('tool_called')
+            ->selectRaw('tool_called, count(*) as call_count, avg(response_time_ms) as avg_response_ms')
+            ->groupBy('tool_called')
+            ->orderByDesc('call_count')
+            ->get();
+
+        return response()->json([
+            'data' => $tools,
+            'meta' => ['from' => $from, 'to' => $to],
+        ]);
+    }
+
+    public function errors(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from' => 'nullable|date',
+            'to' => 'nullable|date',
+        ]);
+
+        $from = $validated['from'] ?? now()->subDays(30)->toDateString();
+        $to = $validated['to'] ?? now()->toDateString();
+
+        $total = DB::table('ai_audit_logs')
+            ->whereBetween('created_at', [$from, $to.' 23:59:59'])
+            ->count();
+
+        $errors = DB::table('ai_audit_logs')
+            ->whereBetween('created_at', [$from, $to.' 23:59:59'])
+            ->where('status', 'error')
+            ->count();
+
+        $recentErrors = DB::table('ai_audit_logs')
+            ->whereBetween('created_at', [$from, $to.' 23:59:59'])
+            ->where('status', 'error')
+            ->orderByDesc('created_at')
+            ->limit(20)
+            ->get(['id', 'company_id', 'user_id', 'provider', 'error_message', 'created_at']);
+
+        $successRate = $total > 0 ? round((($total - $errors) / $total) * 100, 1) : 100;
+
+        return response()->json([
+            'data' => [
+                'total_requests' => $total,
+                'total_errors' => $errors,
+                'success_rate' => $successRate,
+                'recent_errors' => $recentErrors,
+            ],
+            'meta' => ['from' => $from, 'to' => $to],
+        ]);
+    }
+}

--- a/api/app/Http/Controllers/AI/AgentController.php
+++ b/api/app/Http/Controllers/AI/AgentController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\AI;
+
+use App\AI\AgentRunner;
+use App\AI\AIOrchestrator;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AgentController extends Controller
+{
+    public function run(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'task' => 'required|string|max:2000',
+            'conversation_id' => 'nullable|string',
+            'max_steps' => 'nullable|integer|min:1|max:20',
+        ]);
+
+        $orchestrator = app(AIOrchestrator::class);
+        $agent = new AgentRunner($orchestrator, $validated['max_steps'] ?? 10);
+
+        $result = $agent->execute(
+            $request->user(),
+            $validated['task'],
+            $validated['conversation_id'] ?? null,
+        );
+
+        return response()->json(['data' => $result]);
+    }
+
+    public function workflows(): JsonResponse
+    {
+        $workflows = [
+            [
+                'id' => 'prepare_payroll',
+                'name' => 'Preparer la paie du mois',
+                'description' => 'Collecte les donnees, calcule la paie, genere un resume',
+                'steps' => ['Collecter les donnees de pointage', 'Verifier les absences', 'Calculer les salaires', 'Generer le resume'],
+            ],
+            [
+                'id' => 'weekly_report',
+                'name' => 'Rapport hebdomadaire',
+                'description' => 'Anomalies, absences, effectifs de la semaine',
+                'steps' => ['Collecter les anomalies', 'Compter les absences', 'Resume des effectifs', 'Generer le rapport'],
+            ],
+            [
+                'id' => 'new_employee_onboarding',
+                'name' => 'Onboarding nouvel employe',
+                'description' => 'Creer le profil, affecter le departement, envoyer les accreditations',
+                'steps' => ['Creer le profil employe', 'Affecter au departement', 'Configurer les acces', 'Envoyer notification'],
+            ],
+        ];
+
+        return response()->json(['data' => $workflows]);
+    }
+}

--- a/api/app/Http/Controllers/AI/VoiceController.php
+++ b/api/app/Http/Controllers/AI/VoiceController.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Http\Controllers\AI;
+
+use App\AI\AIOrchestrator;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class VoiceController extends Controller
+{
+    public function transcribe(Request $request): JsonResponse
+    {
+        $request->validate([
+            'audio' => 'required|file|mimes:wav,mp3,webm,ogg,m4a|max:10240',
+            'language' => 'nullable|in:fr,ar,tr,en',
+        ]);
+
+        $audio = $request->file('audio');
+        $language = $request->input('language', 'fr');
+
+        $provider = config('ai.voice.stt_provider', 'whisper');
+        $text = $this->speechToText($audio, $language, $provider);
+
+        return response()->json([
+            'data' => [
+                'text' => $text,
+                'language' => $language,
+                'provider' => $provider,
+            ],
+        ]);
+    }
+
+    public function synthesize(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'text' => 'required|string|max:2000',
+            'language' => 'nullable|in:fr,ar,tr,en',
+            'voice' => 'nullable|string|max:50',
+        ]);
+
+        $provider = config('ai.voice.tts_provider', 'edge_tts');
+        $audioUrl = $this->textToSpeech(
+            $validated['text'],
+            $validated['language'] ?? 'fr',
+            $validated['voice'] ?? null,
+            $provider,
+        );
+
+        return response()->json([
+            'data' => [
+                'audio_url' => $audioUrl,
+                'provider' => $provider,
+            ],
+        ]);
+    }
+
+    public function command(Request $request): JsonResponse
+    {
+        $request->validate([
+            'audio' => 'required|file|mimes:wav,mp3,webm,ogg,m4a|max:10240',
+            'language' => 'nullable|in:fr,ar,tr,en',
+            'conversation_id' => 'nullable|string',
+        ]);
+
+        $audio = $request->file('audio');
+        $language = $request->input('language', 'fr');
+
+        $sttProvider = config('ai.voice.stt_provider', 'whisper');
+        $transcribedText = $this->speechToText($audio, $language, $sttProvider);
+
+        $orchestrator = app(AIOrchestrator::class);
+        $aiResponse = $orchestrator->handle(
+            $request->user(),
+            $transcribedText,
+            $request->input('conversation_id'),
+        );
+
+        $ttsProvider = config('ai.voice.tts_provider', 'edge_tts');
+        $audioUrl = $this->textToSpeech(
+            $aiResponse['response'] ?? $transcribedText,
+            $language,
+            null,
+            $ttsProvider,
+        );
+
+        return response()->json([
+            'data' => [
+                'transcribed_text' => $transcribedText,
+                'ai_response' => $aiResponse['response'] ?? '',
+                'conversation_id' => $aiResponse['conversation_id'] ?? null,
+                'audio_url' => $audioUrl,
+                'language' => $language,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  UploadedFile  $audio
+     */
+    private function speechToText($audio, string $language, string $provider): string
+    {
+        if ($provider === 'whisper') {
+            return $this->whisperTranscribe($audio, $language);
+        }
+
+        if ($provider === 'deepgram') {
+            return $this->deepgramTranscribe($audio, $language);
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  UploadedFile  $audio
+     */
+    private function whisperTranscribe($audio, string $language): string
+    {
+        $apiKey = config('ai.providers.openai.key');
+        if (! $apiKey) {
+            Log::warning('OpenAI API key not configured for Whisper STT');
+
+            return '';
+        }
+
+        $response = Http::withToken($apiKey)
+            ->timeout(30)
+            ->attach('file', file_get_contents($audio->getRealPath()), $audio->getClientOriginalName())
+            ->post('https://api.openai.com/v1/audio/transcriptions', [
+                'model' => 'whisper-1',
+                'language' => $language,
+                'response_format' => 'text',
+            ]);
+
+        if ($response->successful()) {
+            return trim($response->body());
+        }
+
+        Log::error('Whisper transcription failed', ['status' => $response->status()]);
+
+        return '';
+    }
+
+    /**
+     * @param  UploadedFile  $audio
+     */
+    private function deepgramTranscribe($audio, string $language): string
+    {
+        $apiKey = config('ai.voice.deepgram_key');
+        if (! $apiKey) {
+            Log::warning('Deepgram API key not configured');
+
+            return '';
+        }
+
+        $response = Http::withToken($apiKey)
+            ->withHeaders(['Content-Type' => $audio->getMimeType()])
+            ->timeout(30)
+            ->withBody(file_get_contents($audio->getRealPath()), $audio->getMimeType())
+            ->post('https://api.deepgram.com/v1/listen?language='.$language.'&model=nova-2');
+
+        if ($response->successful()) {
+            return $response->json('results.channels.0.alternatives.0.transcript') ?? '';
+        }
+
+        Log::error('Deepgram transcription failed', ['status' => $response->status()]);
+
+        return '';
+    }
+
+    private function textToSpeech(string $text, string $language, ?string $voice, string $provider): ?string
+    {
+        if ($provider === 'edge_tts') {
+            return $this->edgeTtsSynthesize($text, $language, $voice);
+        }
+
+        if ($provider === 'elevenlabs') {
+            return $this->elevenLabsSynthesize($text, $voice);
+        }
+
+        return null;
+    }
+
+    private function edgeTtsSynthesize(string $text, string $language, ?string $voice): ?string
+    {
+        $voiceMap = [
+            'fr' => 'fr-FR-DeniseNeural',
+            'ar' => 'ar-SA-ZariyahNeural',
+            'tr' => 'tr-TR-EmelNeural',
+            'en' => 'en-US-JennyNeural',
+        ];
+
+        $selectedVoice = $voice ?? ($voiceMap[$language] ?? 'fr-FR-DeniseNeural');
+        $filename = 'tts_'.uniqid().'.mp3';
+        $storagePath = storage_path('app/tts/'.$filename);
+
+        if (! is_dir(dirname($storagePath))) {
+            mkdir(dirname($storagePath), 0755, true);
+        }
+
+        $escapedText = escapeshellarg($text);
+        $escaped = escapeshellarg($selectedVoice);
+        $escapedPath = escapeshellarg($storagePath);
+
+        exec("edge-tts --voice={$escaped} --text={$escapedText} --write-media={$escapedPath} 2>&1", $output, $code);
+
+        if ($code !== 0) {
+            Log::warning('Edge TTS failed, returning null', ['code' => $code, 'output' => implode("\n", $output)]);
+
+            return null;
+        }
+
+        return url('storage/tts/'.$filename);
+    }
+
+    private function elevenLabsSynthesize(string $text, ?string $voiceId): ?string
+    {
+        $apiKey = config('ai.voice.elevenlabs_key');
+        if (! $apiKey) {
+            Log::warning('ElevenLabs API key not configured');
+
+            return null;
+        }
+
+        $selectedVoice = $voiceId ?? config('ai.voice.elevenlabs_default_voice', '21m00Tcm4TlvDq8ikWAM');
+
+        $response = Http::withHeaders(['xi-api-key' => $apiKey])
+            ->timeout(30)
+            ->post("https://api.elevenlabs.io/v1/text-to-speech/{$selectedVoice}", [
+                'text' => $text,
+                'model_id' => 'eleven_multilingual_v2',
+            ]);
+
+        if ($response->successful()) {
+            $filename = 'tts_'.uniqid().'.mp3';
+            $storagePath = storage_path('app/tts/'.$filename);
+            if (! is_dir(dirname($storagePath))) {
+                mkdir(dirname($storagePath), 0755, true);
+            }
+            file_put_contents($storagePath, $response->body());
+
+            return url('storage/tts/'.$filename);
+        }
+
+        Log::error('ElevenLabs TTS failed', ['status' => $response->status()]);
+
+        return null;
+    }
+}

--- a/api/config/ai.php
+++ b/api/config/ai.php
@@ -30,4 +30,16 @@ return [
 
     'max_conversation_messages' => 50,
     'context_window_tokens' => 4096,
+
+    'voice' => [
+        'stt_provider' => env('AI_STT_PROVIDER', 'whisper'),
+        'tts_provider' => env('AI_TTS_PROVIDER', 'edge_tts'),
+        'deepgram_key' => env('DEEPGRAM_API_KEY'),
+        'elevenlabs_key' => env('ELEVENLABS_API_KEY'),
+        'elevenlabs_default_voice' => env('ELEVENLABS_DEFAULT_VOICE', '21m00Tcm4TlvDq8ikWAM'),
+    ],
+
+    'agent' => [
+        'max_steps' => (int) env('AI_AGENT_MAX_STEPS', 10),
+    ],
 ];

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Http\Controllers\AI\AgentController;
+use App\Http\Controllers\AI\AIAnalyticsController;
 use App\Http\Controllers\AI\AIGatewayController;
+use App\Http\Controllers\AI\VoiceController;
 use App\Http\Middleware\AI\AIFeatureCheck;
 use App\Http\Middleware\AI\AIRateLimiter;
 use App\Http\Middleware\AI\AITenantInjector;
@@ -8,6 +11,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware(['throttle:api', 'auth:sanctum', AIFeatureCheck::class, AITenantInjector::class])->prefix('ai')->group(function () {
 
+    // Phase 1 — Chat IA
     Route::middleware([AIRateLimiter::class])->group(function () {
         Route::post('/chat', [AIGatewayController::class, 'chat']);
     });
@@ -15,4 +19,23 @@ Route::middleware(['throttle:api', 'auth:sanctum', AIFeatureCheck::class, AITena
     Route::get('/chat/history', [AIGatewayController::class, 'history']);
     Route::delete('/chat/{conversationId}', [AIGatewayController::class, 'deleteConversation'])->whereNumber('conversationId');
     Route::get('/tools', [AIGatewayController::class, 'tools']);
+
+    // Phase 3 — Voice IA (Sprint 17-18)
+    Route::middleware([AIRateLimiter::class])->group(function () {
+        Route::post('/voice/transcribe', [VoiceController::class, 'transcribe']);
+        Route::post('/voice/synthesize', [VoiceController::class, 'synthesize']);
+        Route::post('/voice/command', [VoiceController::class, 'command']);
+    });
+
+    // Phase 4 — Agents autonomes (Sprint 17-18)
+    Route::middleware([AIRateLimiter::class])->group(function () {
+        Route::post('/agent/run', [AgentController::class, 'run']);
+        Route::get('/agent/workflows', [AgentController::class, 'workflows']);
+    });
+
+    // Phase 2 — Analytics IA (super-admin, Sprint 17-18)
+    Route::get('/analytics/usage', [AIAnalyticsController::class, 'usage']);
+    Route::get('/analytics/costs', [AIAnalyticsController::class, 'costs']);
+    Route::get('/analytics/tools', [AIAnalyticsController::class, 'tools']);
+    Route::get('/analytics/errors', [AIAnalyticsController::class, 'errors']);
 });

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -482,3 +482,32 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - `GET /api/v1/feature-flags/matrix` matrice complete features x plans
 - `GET /api/v1/feature-flags/check/{featureKey}` verifier si feature active pour company
 - `PUT /api/v1/feature-flags/matrix` mettre a jour entree matrice (admin)
+
+### Rapports avances
+- `GET /api/v1/reports/recruitment-pipeline` candidats par statut
+- `GET /api/v1/reports/training-completion` inscriptions par statut
+- `GET /api/v1/reports/loan-summary` montants prets par statut
+- `GET /api/v1/reports/demographics` effectifs par departement et type contrat
+- `GET /api/v1/reports/cost-analysis` analyse couts (prets, formations) par annee
+
+---
+
+## IA Avancee — Voice, Agents, Analytics (Sprint 17-18)
+
+### Voice IA
+- `POST /api/ai/voice/transcribe` audio -> texte (Whisper ou Deepgram)
+- `POST /api/ai/voice/synthesize` texte -> audio (Edge TTS ou ElevenLabs)
+- `POST /api/ai/voice/command` pipeline complet audio -> IA -> audio
+- Support langues : fr, ar, tr, en
+- Rate limiting applique
+
+### Agents autonomes
+- `POST /api/ai/agent/run` executer une tache multi-step (max 10-20 etapes)
+- `GET /api/ai/agent/workflows` lister les workflows predefinis
+- Workflows : prepare_payroll, weekly_report, new_employee_onboarding
+
+### Analytics IA (super-admin)
+- `GET /api/ai/analytics/usage` utilisation par tenant (requests, tokens, couts)
+- `GET /api/ai/analytics/costs` couts par periode et provider (day/week/month)
+- `GET /api/ai/analytics/tools` outils les plus appeles
+- `GET /api/ai/analytics/errors` taux de succes + erreurs recentes


### PR DESCRIPTION
## Sprint 17-18 — IA Avancée

### Voice IA (3 endpoints)
- `POST /ai/voice/transcribe` — Audio → Texte (Whisper API / Deepgram)
- `POST /ai/voice/synthesize` — Texte → Audio (Edge TTS / ElevenLabs)
- `POST /ai/voice/command` — Pipeline complet: audio → STT → IA → TTS → audio
- Support 4 langues: FR, AR, TR, EN
- Voix par défaut par langue: DeniseNeural (FR), ZariyahNeural (AR), EmelNeural (TR), JennyNeural (EN)

### Agents Autonomes (2 endpoints)
- `POST /ai/agent/run` — Exécuter une tâche multi-step (max 10-20 étapes)
- `GET /ai/agent/workflows` — Lister les workflows prédéfinis
- AgentRunner: boucle tool-calling autonome
- 3 workflows: préparer paie, rapport hebdo, onboarding employé

### Analytics IA (4 endpoints)
- Usage par tenant (requests, tokens, coûts)
- Coûts par période/provider (day/week/month)
- Outils les plus appelés
- Taux de succès + erreurs récentes

### Configuration
- config/ai.php enrichi: voice providers, agent settings

**Gouvernance:**
- CHANGELOG.md v4.9.0
- SCENARIOS_TEST_API mise à jour