### PR TITLE
feat: enriched health checks, metrics endpoint, structured JSON logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# CHANGELOG - LEOPARDO RH
+﻿# CHANGELOG - LEOPARDO RH 
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.12.0] - 2026-05-11
+
+### DevOps — Health enrichi, Metrics, Structured Logging
+
+- Health : checks queue (driver + size) et memory (usage_mb, peak_mb, limit_mb)
+- Health : ajout environment et uptime_seconds dans la reponse
+- Metrics : GET /api/v1/metrics — companies, employees, system info
+- Logging : middleware StructuredLogging enregistre chaque requete API en JSON
+- Logging : channels `structured` (daily JSON, 14j) et `audit` (daily JSON, 90j)
+- Logging : exclusion automatique des endpoints /health du logging
+
 ## [4.10.0] - 2026-05-11
 
 ### Mise a jour PLAN_ACTION — Bilan post sprints 1-18

--- a/api/app/Http/Controllers/Api/V1/HealthController.php
+++ b/api/app/Http/Controllers/Api/V1/HealthController.php
@@ -34,17 +34,25 @@ class HealthController extends Controller
         $database = $this->checkDatabase();
         $redis = $this->checkRedis();
         $storage = $this->checkStorage();
+        $queue = $this->checkQueue();
+        $memory = $this->checkMemory();
 
         $globalOk = $database['ok'];
 
         $payload = [
             'status' => $globalOk ? 'ok' : 'fail',
             'version' => $version,
+            'environment' => app()->environment(),
             'checks' => [
                 'database' => $database,
                 'redis' => $redis,
                 'storage' => $storage,
+                'queue' => $queue,
+                'memory' => $memory,
             ],
+            'uptime_seconds' => defined('LARAVEL_START')
+                ? (int) round(microtime(true) - LARAVEL_START)
+                : null,
             'timestamp' => now()->toIso8601String(),
         ];
 
@@ -172,6 +180,65 @@ class HealthController extends Controller
             'checks' => ['database' => $database],
             'timestamp' => now()->toIso8601String(),
         ], $code);
+    }
+
+    /**
+     * @return array{ok: bool, driver?: string, size?: int}
+     */
+    private function checkQueue(): array
+    {
+        $driver = (string) config('queue.default', 'sync');
+
+        if ($driver === 'sync') {
+            return ['ok' => true, 'driver' => 'sync'];
+        }
+
+        try {
+            $size = app('queue')->connection()->size();
+
+            return [
+                'ok' => true,
+                'driver' => $driver,
+                'size' => $size,
+            ];
+        } catch (Throwable) {
+            return ['ok' => false, 'driver' => $driver];
+        }
+    }
+
+    /**
+     * @return array{ok: bool, usage_mb: int, peak_mb: int, limit_mb: int|null}
+     */
+    private function checkMemory(): array
+    {
+        $usage = memory_get_usage(true);
+        $peak = memory_get_peak_usage(true);
+        $limit = $this->parseMemoryLimit(ini_get('memory_limit') ?: '-1');
+
+        return [
+            'ok' => $limit < 0 || $usage < $limit * 0.9,
+            'usage_mb' => (int) round($usage / 1048576),
+            'peak_mb' => (int) round($peak / 1048576),
+            'limit_mb' => $limit > 0 ? (int) round($limit / 1048576) : null,
+        ];
+    }
+
+    private function parseMemoryLimit(string $limit): int
+    {
+        $limit = trim($limit);
+        if ($limit === '-1') {
+            return -1;
+        }
+
+        $value = (int) $limit;
+        $unit = strtolower(substr($limit, -1));
+
+        return match ($unit) {
+            'g' => $value * 1073741824,
+            'm' => $value * 1048576,
+            'k' => $value * 1024,
+            default => $value,
+        };
     }
 
     private function stringConfigValue(mixed $value): string

--- a/api/app/Http/Controllers/Api/V1/MetricsController.php
+++ b/api/app/Http/Controllers/Api/V1/MetricsController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class MetricsController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        return response()->json([
+            'companies' => $this->companyCounts(),
+            'employees' => $this->employeeCounts(),
+            'system' => $this->systemMetrics(),
+            'timestamp' => now()->toIso8601String(),
+        ]);
+    }
+
+    private function companyCounts(): array
+    {
+        try {
+            $total = DB::table('companies')->count();
+            $active = DB::table('companies')->where('status', 'active')->count();
+            $trial = DB::table('companies')->where('status', 'trial')->count();
+
+            return compact('total', 'active', 'trial');
+        } catch (\Throwable) {
+            return ['total' => 0, 'active' => 0, 'trial' => 0];
+        }
+    }
+
+    private function employeeCounts(): array
+    {
+        try {
+            $total = DB::table('employees')->count();
+            $active = DB::table('employees')->where('status', 'active')->count();
+
+            return compact('total', 'active');
+        } catch (\Throwable) {
+            return ['total' => 0, 'active' => 0];
+        }
+    }
+
+    private function systemMetrics(): array
+    {
+        return [
+            'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
+            'memory_usage_mb' => (int) round(memory_get_usage(true) / 1048576),
+            'cache_driver' => (string) config('cache.default'),
+            'queue_driver' => (string) config('queue.default'),
+            'db_driver' => (string) config('database.default'),
+        ];
+    }
+}

--- a/api/app/Http/Middleware/StructuredLogging.php
+++ b/api/app/Http/Middleware/StructuredLogging.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class StructuredLogging
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $start = microtime(true);
+
+        $response = $next($request);
+
+        $duration = (int) round((microtime(true) - $start) * 1000);
+
+        if ($this->shouldLog($request)) {
+            Log::channel('structured')->info('http_request', [
+                'method' => $request->method(),
+                'uri' => $request->getRequestUri(),
+                'status' => $response->getStatusCode(),
+                'duration_ms' => $duration,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+                'user_id' => $request->user()?->id,
+                'company_id' => $request->user()?->company_id ?? null,
+                'request_id' => $request->header('X-Request-Id'),
+            ]);
+        }
+
+        return $response;
+    }
+
+    private function shouldLog(Request $request): bool
+    {
+        $path = $request->path();
+
+        if (str_starts_with($path, 'api/v1/health')) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -5,6 +5,7 @@ use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\Cameras\EnsureCameraModuleMiddleware;
 use App\Http\Middleware\RequestIdMiddleware;
 use App\Http\Middleware\SetLocale;
+use App\Http\Middleware\StructuredLogging;
 use App\Http\Middleware\TenantMiddleware;
 use App\Http\Middleware\Web\EnsureEmployeeMiddleware;
 use App\Http\Middleware\Web\EnsureManagerMiddleware;
@@ -33,7 +34,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class]);
+        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class, StructuredLogging::class]);
 
         $middleware->alias([
             'tenant' => TenantMiddleware::class,

--- a/api/config/logging.php
+++ b/api/config/logging.php
@@ -127,6 +127,24 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'structured' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/structured.log'),
+            'level' => env('LOG_LEVEL', 'info'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+            'formatter' => Monolog\Formatter\JsonFormatter::class,
+        ],
+
+        'audit' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/audit.log'),
+            'level' => 'info',
+            'days' => 90,
+            'replace_placeholders' => true,
+            'formatter' => Monolog\Formatter\JsonFormatter::class,
+        ],
+
     ],
 
 ];

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -24,6 +24,7 @@ Route::prefix('v1')->group(function (): void {
     Route::get('/health', HealthController::class);
     Route::get('/health/live', [HealthController::class, 'live']);
     Route::get('/health/ready', [HealthController::class, 'ready']);
+    Route::get('/metrics', \App\Http\Controllers\Api\V1\MetricsController::class);
 
     // Auth (core, hors module)
     Route::middleware(['throttle:10,1'])->group(function (): void {

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -1,6 +1,6 @@
 # SCENARIOS DE TEST API POUR GITHUB ACTIONS
 
-## Objectif
+## Objectif 
 
 Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur les roles reels de l'application, les domaines metier critiques et les risques multitenant.
 

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -556,3 +556,20 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 - `GET /api/ai/analytics/costs` couts par periode et provider (day/week/month)
 - `GET /api/ai/analytics/tools` outils les plus appeles
 - `GET /api/ai/analytics/errors` taux de succes + erreurs recentes
+
+---
+
+## DevOps — Health enrichi, Metrics, Structured Logging (Post-Sprint)
+
+### Health enrichi
+- `GET /api/v1/health` — Inclut desormais : queue (driver + size), memory (usage_mb, peak_mb, limit_mb), environment, uptime_seconds
+- `GET /api/v1/health/live` — Sonde liveness inchangee
+- `GET /api/v1/health/ready` — Sonde readiness inchangee
+
+### Metrics platform
+- `GET /api/v1/metrics` — Retourne: companies (total, active, trial), employees (total, active), system (php_version, laravel_version, memory_usage_mb, cache_driver, queue_driver, db_driver)
+
+### Structured Logging
+- Middleware `StructuredLogging` enregistre chaque requete API en JSON : method, uri, status, duration_ms, ip, user_agent, user_id, company_id, request_id
+- Channel `structured` : daily JSON logs dans `storage/logs/structured.log`
+- Channel `audit` : daily JSON logs dans `storage/logs/audit.log` (90 jours retention)


### PR DESCRIPTION
## Summary

DevOps improvements for monitoring and observability:

- **Health enrichi** — `/api/v1/health` now includes queue check (driver + pending size), memory check (usage/peak/limit MB), environment name, and uptime_seconds
- **Metrics endpoint** — `GET /api/v1/metrics` returns company counts (total/active/trial), employee counts (total/active), and system info (PHP/Laravel versions, drivers)
- **StructuredLogging middleware** — Logs every API request as JSON: method, uri, status, duration_ms, ip, user_agent, user_id, company_id, request_id. Health endpoints excluded.
- **Logging channels** — `structured` (daily JSON, 14-day retention) and `audit` (daily JSON, 90-day retention) channels added to `config/logging.php`

## Review & Testing Checklist for Human

- [ ] Verify `/api/v1/health` response includes new queue/memory/uptime fields
- [ ] Verify `/api/v1/metrics` is accessible without auth (public monitoring endpoint)
- [ ] Check that structured logs appear in `storage/logs/structured-*.log` after requests
- [ ] Confirm health endpoints are NOT logged (noise reduction)

### Notes

- StructuredLogging uses `Log::channel('structured')` to write to a separate file, not the main application log
- The metrics endpoint is intentionally unauthenticated for monitoring tools (UptimeRobot, Datadog, etc.)
- Memory check warns at 90% of PHP memory_limit

Link to Devin session: https://app.devin.ai/sessions/b0f38569e0aa4cd5bef3eb00ff3232ea