### PR TITLE
fix: controller type safety — extract inline $request->user()-> calls (Partie 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.1] - 2026-05-12
+
+### Backend — Controller Type Safety (Partie 2 stabilisation)
+
+- Controllers : extraction des appels inline `$request->user()->` vers des variables typees dans 8 controllers (DepartmentController, PositionController, SiteController, ScheduleController, HrReportController, AttendanceController, LeavePolicyController, TrainingController)
+- Elimination des erreurs `method.nonObject` restantes sur les appels `isManager()` et `company_id` non types
+
 ## [4.16.0] - 2026-05-12
 
 ### Backend — Type Safety & Architecture (Partie 1 stabilisation)

--- a/api/app/Http/Controllers/Api/V1/AttendanceController.php
+++ b/api/app/Http/Controllers/Api/V1/AttendanceController.php
@@ -261,7 +261,9 @@ class AttendanceController extends Controller
             'check_in' => $effectiveCheckIn,
             'check_out' => $effectiveCheckOut,
             'method' => 'manual',
-            'corrected_by' => $request->user()->id,
+            /** @var Employee $user */
+            $user = $request->user();
+            'corrected_by' => $user->id,
             'correction_note' => $validated['notes'] ?? $attendanceLog->correction_note,
         ]);
 

--- a/api/app/Http/Controllers/Api/V1/AttendanceController.php
+++ b/api/app/Http/Controllers/Api/V1/AttendanceController.php
@@ -257,12 +257,13 @@ class AttendanceController extends Controller
             ]);
         }
 
+        /** @var Employee $user */
+        $user = $request->user();
+
         $attendanceLog->fill([
             'check_in' => $effectiveCheckIn,
             'check_out' => $effectiveCheckOut,
             'method' => 'manual',
-            /** @var Employee $user */
-            $user = $request->user();
             'corrected_by' => $user->id,
             'correction_note' => $validated['notes'] ?? $attendanceLog->correction_note,
         ]);

--- a/api/app/Http/Controllers/Api/V1/DepartmentController.php
+++ b/api/app/Http/Controllers/Api/V1/DepartmentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\Department;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -11,7 +12,9 @@ class DepartmentController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -27,19 +30,23 @@ class DepartmentController extends Controller
 
     public function store(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
         $data = $request->validate(['name' => ['required', 'string', 'max:100'], 'manager_id' => ['nullable', 'integer', 'min:1']]);
-        $dept = Department::create(['company_id' => $request->user()->company_id, ...$data]);
+        $dept = Department::create(['company_id' => $user->company_id, ...$data]);
 
         return response()->json(['data' => $this->serialize($dept)], 201);
     }
 
     public function show(Request $request, Department $department): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -48,7 +55,9 @@ class DepartmentController extends Controller
 
     public function update(Request $request, Department $department): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -60,7 +69,9 @@ class DepartmentController extends Controller
 
     public function destroy(Request $request, Department $department): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 

--- a/api/app/Http/Controllers/Api/V1/HrReportController.php
+++ b/api/app/Http/Controllers/Api/V1/HrReportController.php
@@ -167,7 +167,9 @@ class HrReportController extends Controller
 
     private function authorizeManager(Request $request): void
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
     }

--- a/api/app/Http/Controllers/Api/V1/LeavePolicyController.php
+++ b/api/app/Http/Controllers/Api/V1/LeavePolicyController.php
@@ -59,7 +59,9 @@ class LeavePolicyController extends Controller
 
     public function show(Request $request, LeavePolicy $leavePolicy): JsonResponse
     {
-        if ($leavePolicy->company_id !== $request->user()->company_id) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if ($leavePolicy->company_id !== $user->company_id) {
             abort(404);
         }
 

--- a/api/app/Http/Controllers/Api/V1/PositionController.php
+++ b/api/app/Http/Controllers/Api/V1/PositionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\Position;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -11,7 +12,9 @@ class PositionController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -32,19 +35,23 @@ class PositionController extends Controller
 
     public function store(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
         $data = $request->validate(['name' => ['required', 'string', 'max:100'], 'department_id' => ['nullable', 'integer', 'min:1']]);
-        $pos = Position::create(['company_id' => $request->user()->company_id, ...$data]);
+        $pos = Position::create(['company_id' => $user->company_id, ...$data]);
 
         return response()->json(['data' => $this->serialize($pos)], 201);
     }
 
     public function show(Request $request, Position $position): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -53,7 +60,9 @@ class PositionController extends Controller
 
     public function update(Request $request, Position $position): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -65,7 +74,9 @@ class PositionController extends Controller
 
     public function destroy(Request $request, Position $position): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 

--- a/api/app/Http/Controllers/Api/V1/ScheduleController.php
+++ b/api/app/Http/Controllers/Api/V1/ScheduleController.php
@@ -12,7 +12,9 @@ class ScheduleController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -40,7 +42,9 @@ class ScheduleController extends Controller
 
     public function show(Request $request, Schedule $schedule): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -68,7 +72,9 @@ class ScheduleController extends Controller
 
     public function destroy(Request $request, Schedule $schedule): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
         if ($schedule->is_default) {

--- a/api/app/Http/Controllers/Api/V1/SiteController.php
+++ b/api/app/Http/Controllers/Api/V1/SiteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\Site;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -11,7 +12,9 @@ class SiteController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -20,19 +23,23 @@ class SiteController extends Controller
 
     public function store(Request $request): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
         $data = $request->validate(['name' => ['required', 'string', 'max:100'], 'address' => ['nullable', 'string', 'max:500'], 'gps_lat' => ['nullable', 'numeric', 'between:-90,90'], 'gps_lng' => ['nullable', 'numeric', 'between:-180,180'], 'gps_radius_m' => ['nullable', 'integer', 'min:10', 'max:5000']]);
-        $site = Site::create(['company_id' => $request->user()->company_id, ...$data]);
+        $site = Site::create(['company_id' => $user->company_id, ...$data]);
 
         return response()->json(['data' => $this->serialize($site)], 201);
     }
 
     public function show(Request $request, Site $site): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -41,7 +48,9 @@ class SiteController extends Controller
 
     public function update(Request $request, Site $site): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 
@@ -53,7 +62,9 @@ class SiteController extends Controller
 
     public function destroy(Request $request, Site $site): JsonResponse
     {
-        if (! $request->user()->isManager()) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if (! $user->isManager()) {
             abort(403);
         }
 

--- a/api/app/Http/Controllers/Api/V1/TrainingController.php
+++ b/api/app/Http/Controllers/Api/V1/TrainingController.php
@@ -57,7 +57,9 @@ class TrainingController extends Controller
 
     public function showCourse(Request $request, TrainingCourse $trainingCourse): JsonResponse
     {
-        if ($trainingCourse->company_id !== $request->user()->company_id) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if ($trainingCourse->company_id !== $user->company_id) {
             abort(404);
         }
 
@@ -96,7 +98,9 @@ class TrainingController extends Controller
 
     public function indexSessions(Request $request, TrainingCourse $trainingCourse): JsonResponse
     {
-        if ($trainingCourse->company_id !== $request->user()->company_id) {
+        /** @var Employee $user */
+        $user = $request->user();
+        if ($trainingCourse->company_id !== $user->company_id) {
             abort(404);
         }
 

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -93,6 +93,7 @@ Quand un domaine gagne une feature significative, ajouter:
 ## Notes 2026-05-12
 
 - v4.16.0 : Les annotations PHPDoc `@property`, `@return` et `@var Employee` ajoutees dans les modeles, services et controllers ne modifient aucun comportement runtime. Le helper `currentCompany()` est un remplacement fonctionnellement identique de `app('current_company')`. Le binding `LLMClient` dans AppServiceProvider preserve le meme comportement de selection provider. Aucun nouveau endpoint ni modification de contrat API.
+- v4.16.1 : Extraction des appels inline `$request->user()->` dans 8 controllers supplementaires. Aucun changement de comportement ni de contrat API.
 
 ## Notes 2026-05-08
 


### PR DESCRIPTION
## 📝 Description

**Partie 2 du plan de stabilisation backend** — Controller Type Safety.

Suite de la PR #402, ce PR corrige les appels inline `$request->user()->` restants dans 8 controllers qui n'étaient pas couverts par le script d'annotation initial.

### Changements

Extraction des appels `$request->user()->isManager()` et `$request->user()->company_id` vers des variables typées `/** @var Employee $user */` dans :
- `DepartmentController` (6 corrections)
- `PositionController` (6 corrections)
- `SiteController` (6 corrections)
- `ScheduleController` (3 corrections)
- `HrReportController` (1 correction — méthode privée `authorizeManager`)
- `AttendanceController` (1 correction)
- `LeavePolicyController` (1 correction)
- `TrainingController` (2 corrections)

### Impact PHPStan
Élimine ~25 erreurs `method.nonObject` du baseline (appels `isManager()` et accès `company_id` sur `mixed`).

## 🧪 How Has This Been Tested?

- [x] CI Backend (PHP 8.4 + PostgreSQL 16 + Redis 7)
- [x] CI Backend Quality (PHPStan/Larastan)
- [x] CI Governance Gates
- [x] Self-review : aucun changement de comportement, uniquement PHPDoc + extraction de variables

## 🚩 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


Link to Devin session: https://app.devin.ai/sessions/fa808c2c65654bb8b4e359f4688890f4