### PR TITLE
fix: controller stabilization — nullable fresh() chains, relation null checks (Partie 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.2] - 2026-05-12
+
+### Backend — Controller Stabilization (Partie 3 stabilisation)
+
+- Controllers : extraction des chaines `->fresh()->method()` nullables vers des variables typees (EvaluationController, ContractController, ApprovalController, LeavePolicyController, AuthController, UserAuthController)
+- Controllers : ajout de null checks sur les acces aux relations (employee, evaluator) dans les methodes serialize
+- Controllers : remplacement de `optional()` par operateur nullsafe dans KioskController
+
 ## [4.16.1] - 2026-05-12
 
 ### Backend — Controller Type Safety (Partie 2 stabilisation)

--- a/api/app/Http/Controllers/Api/V1/ApprovalController.php
+++ b/api/app/Http/Controllers/Api/V1/ApprovalController.php
@@ -146,7 +146,9 @@ class ApprovalController extends Controller
             $approvalRequest->update(['current_level' => $approvalRequest->current_level + 1]);
         }
 
-        return response()->json(['data' => $approvalRequest->fresh()->load('decisions')]);
+        /** @var ApprovalRequest $approvalRequestFresh */
+        $approvalRequestFresh = $approvalRequest->fresh();
+        return response()->json(['data' => $approvalRequestFresh->load('decisions')]);
     }
 
     public function reject(Request $request, ApprovalRequest $approvalRequest): JsonResponse
@@ -175,7 +177,9 @@ class ApprovalController extends Controller
 
         $approvalRequest->update(['status' => 'rejected']);
 
-        return response()->json(['data' => $approvalRequest->fresh()->load('decisions')]);
+        /** @var ApprovalRequest $approvalRequestFresh */
+        $approvalRequestFresh = $approvalRequest->fresh();
+        return response()->json(['data' => $approvalRequestFresh->load('decisions')]);
     }
 
     public function history(Request $request): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/AuthController.php
+++ b/api/app/Http/Controllers/Api/V1/AuthController.php
@@ -88,7 +88,10 @@ class AuthController extends Controller
 
         $employee = $this->employeeService->update($employee, $employee, $dto);
 
-        return (new EmployeeResource($employee->fresh()))->response();
+        /** @var Employee $fresh */
+        $fresh = $employee->fresh();
+
+        return (new EmployeeResource($fresh))->response();
     }
 
     public function updateLanguage(Request $request): JsonResponse
@@ -113,7 +116,10 @@ class AuthController extends Controller
 
         app()->setLocale($employee->preferred_language);
 
-        return (new EmployeeResource($employee->fresh()))->response();
+        /** @var Employee $fresh */
+        $fresh = $employee->fresh();
+
+        return (new EmployeeResource($fresh))->response();
     }
 
     public function changePassword(ChangePasswordRequest $request): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/ContractController.php
+++ b/api/app/Http/Controllers/Api/V1/ContractController.php
@@ -122,7 +122,9 @@ class ContractController extends Controller
 
         $contract->update($validated);
 
-        return response()->json(['data' => $contract->fresh()->load(['employee:id,first_name,last_name', 'department:id,name'])]);
+        /** @var Contract $contractFresh */
+        $contractFresh = $contract->fresh();
+        return response()->json(['data' => $contractFresh->load(['employee:id,first_name,last_name', 'department:id,name'])]);
     }
 
     public function amendments(Request $request, Contract $contract): JsonResponse
@@ -196,7 +198,9 @@ class ContractController extends Controller
 
         $contract->update(['status' => 'active', 'signed_at' => now()]);
 
-        return response()->json(['data' => $contract->fresh()->load('employee:id,first_name,last_name')]);
+        /** @var Contract $contractFresh */
+        $contractFresh = $contract->fresh();
+        return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
     }
 
     public function suspend(Request $request, Contract $contract): JsonResponse
@@ -215,7 +219,9 @@ class ContractController extends Controller
 
         $contract->update(['status' => 'suspended']);
 
-        return response()->json(['data' => $contract->fresh()->load('employee:id,first_name,last_name')]);
+        /** @var Contract $contractFresh */
+        $contractFresh = $contract->fresh();
+        return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
     }
 
     public function terminate(Request $request, Contract $contract): JsonResponse
@@ -242,7 +248,9 @@ class ContractController extends Controller
             'terminated_at' => now(),
         ]);
 
-        return response()->json(['data' => $contract->fresh()->load('employee:id,first_name,last_name')]);
+        /** @var Contract $contractFresh */
+        $contractFresh = $contract->fresh();
+        return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
     }
 
     public function renew(Request $request, Contract $contract): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/EvaluationController.php
+++ b/api/app/Http/Controllers/Api/V1/EvaluationController.php
@@ -122,7 +122,10 @@ class EvaluationController extends Controller
 
         $evaluation->update($data);
 
-        return response()->json(['data' => $this->serialize($evaluation->fresh()->load('employee', 'evaluator'))]);
+        /** @var Evaluation $fresh */
+        $fresh = $evaluation->fresh();
+
+        return response()->json(['data' => $this->serialize($fresh->load('employee', 'evaluator'))]);
     }
 
     public function submit(Request $request, Evaluation $evaluation): JsonResponse
@@ -135,7 +138,10 @@ class EvaluationController extends Controller
 
         $evaluation->update(['status' => 'submitted']);
 
-        return response()->json(['data' => $this->serialize($evaluation->fresh()->load('employee', 'evaluator'))]);
+        /** @var Evaluation $fresh */
+        $fresh = $evaluation->fresh();
+
+        return response()->json(['data' => $this->serialize($fresh->load('employee', 'evaluator'))]);
     }
 
     public function acknowledge(Request $request, Evaluation $evaluation): JsonResponse
@@ -148,7 +154,10 @@ class EvaluationController extends Controller
 
         $evaluation->update(['status' => 'acknowledged', 'acknowledged_at' => Carbon::now()]);
 
-        return response()->json(['data' => $this->serialize($evaluation->fresh()->load('employee', 'evaluator'))]);
+        /** @var Evaluation $fresh */
+        $fresh = $evaluation->fresh();
+
+        return response()->json(['data' => $this->serialize($fresh->load('employee', 'evaluator'))]);
     }
 
     public function destroy(Request $request, Evaluation $evaluation): JsonResponse
@@ -169,9 +178,9 @@ class EvaluationController extends Controller
         return [
             'id' => $e->id,
             'employee_id' => $e->employee_id,
-            'employee' => $e->relationLoaded('employee') ? ['id' => $e->employee->id, 'first_name' => $e->employee->first_name, 'last_name' => $e->employee->last_name, 'email' => $e->employee->email] : null,
+            'employee' => $e->relationLoaded('employee') && $e->employee ? ['id' => $e->employee->id, 'first_name' => $e->employee->first_name, 'last_name' => $e->employee->last_name, 'email' => $e->employee->email] : null,
             'evaluator_id' => $e->evaluator_id,
-            'evaluator' => $e->relationLoaded('evaluator') ? ['id' => $e->evaluator->id, 'first_name' => $e->evaluator->first_name, 'last_name' => $e->evaluator->last_name] : null,
+            'evaluator' => $e->relationLoaded('evaluator') && $e->evaluator ? ['id' => $e->evaluator->id, 'first_name' => $e->evaluator->first_name, 'last_name' => $e->evaluator->last_name] : null,
             'period' => $e->period,
             'score' => $e->score,
             'criteria' => $e->criteria,

--- a/api/app/Http/Controllers/Api/V1/KioskController.php
+++ b/api/app/Http/Controllers/Api/V1/KioskController.php
@@ -146,7 +146,7 @@ class KioskController extends Controller
             'data' => [
                 'processed_count' => count($processed),
                 'processed_log_ids' => $processed,
-                'last_sync_at' => optional($kiosk->fresh()->last_sync_at)->toIso8601String(),
+                'last_sync_at' => $kiosk->fresh()?->last_sync_at?->toIso8601String(),
             ],
         ]);
     }

--- a/api/app/Http/Controllers/Api/V1/LeavePolicyController.php
+++ b/api/app/Http/Controllers/Api/V1/LeavePolicyController.php
@@ -97,7 +97,9 @@ class LeavePolicyController extends Controller
 
         $leavePolicy->update($validated);
 
-        return response()->json(['data' => $leavePolicy->fresh()->load('absenceType:id,name,code')]);
+        /** @var LeavePolicy $leavePolicyFresh */
+        $leavePolicyFresh = $leavePolicy->fresh();
+        return response()->json(['data' => $leavePolicyFresh->load('absenceType:id,name,code')]);
     }
 
     public function balances(Request $request): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/UserAuthController.php
+++ b/api/app/Http/Controllers/Api/V1/UserAuthController.php
@@ -111,8 +111,11 @@ class UserAuthController extends Controller
         $user = $request->user('user_api');
         $user->update($validated);
 
+        /** @var User $fresh */
+        $fresh = $user->fresh();
+
         return new JsonResponse([
-            'data' => $this->formatUser($user->fresh()),
+            'data' => $this->formatUser($fresh),
         ]);
     }
 

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -94,6 +94,7 @@ Quand un domaine gagne une feature significative, ajouter:
 
 - v4.16.0 : Les annotations PHPDoc `@property`, `@return` et `@var Employee` ajoutees dans les modeles, services et controllers ne modifient aucun comportement runtime. Le helper `currentCompany()` est un remplacement fonctionnellement identique de `app('current_company')`. Le binding `LLMClient` dans AppServiceProvider preserve le meme comportement de selection provider. Aucun nouveau endpoint ni modification de contrat API.
 - v4.16.1 : Extraction des appels inline `$request->user()->` dans 8 controllers supplementaires. Aucun changement de comportement ni de contrat API.
+- v4.16.2 : Extraction des chaines `->fresh()->` nullables et ajout de null checks sur les relations. Aucun changement de comportement ni de contrat API.
 
 ## Notes 2026-05-08
 


### PR DESCRIPTION
## 📝 Description

**Partie 3 du plan de stabilisation backend** — Controller Stabilization.

Suite des PR #402 et #404, ce PR corrige les patterns de code restants qui causent des erreurs PHPStan dans les controllers :

### 1. Nullable `fresh()` chains
`Model::fresh()` retourne `static|null` — les appels chainés `->fresh()->load()` causent des `method.nonObject` car PHPStan sait que `fresh()` peut retourner `null`.

**Fix :** extraction vers une variable typée avant utilisation.

Fichiers corrigés :
- `EvaluationController` (3 chains)
- `ContractController` (4 chains)
- `ApprovalController` (2 chains)
- `LeavePolicyController` (1 chain)
- `AuthController` (2 chains)
- `UserAuthController` (1 chain)

### 2. Relation null checks
Les accès aux propriétés de relations (`$e->employee->id`) sans vérifier que la relation est non-null causent des `property.nonObject`.

**Fix :** ajout de `&& $e->employee` dans les conditions ternaires du serialize().

### 3. KioskController nullsafe
Remplacement de `optional($kiosk->fresh()->last_sync_at)->toIso8601String()` par `$kiosk->fresh()?->last_sync_at?->toIso8601String()` (PHP 8.0+ nullsafe operator).

### 4. AttendanceController syntax fix (from PR #404)
Correction d'une annotation `@var` incorrectement placée à l'intérieur d'un array literal `fill([...])`, causant une ParseError PHP et 21 tests en échec.

Dépend de : PR #404

## 🧪 How Has This Been Tested?

- [x] CI Backend (PHP 8.4 + PostgreSQL 16 + Redis 7)
- [x] CI Backend Quality (PHPStan/Larastan)
- [x] CI Governance Gates
- [x] Self-review : aucun changement de comportement

## 🚩 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (CHANGELOG.md, REGISTRE_SCENARIOS_TESTS.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


Link to Devin session: https://app.devin.ai/sessions/fa808c2c65654bb8b4e359f4688890f4