### PR TITLE
fix: type feature registry console commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Procedure recommandee :
 - Sur Windows local, PHPStan peut etre non representatif si `phpstan.ci.neon` genere par CI reference Larastan absent/incomplet dans `vendor`. Dans ce cas, verifier au minimum `php -l` et laisser GitHub Actions Linux servir de source de verite.
 - Les commandes Artisan qui lisent `$this->argument()` / `$this->option()` doivent normaliser les valeurs avant de les passer aux services (`string|null` attendu), sinon PHPStan voit `array|bool|string|null` et la dette revient vite.
 - Si le job backend principal echoue sur `composer validate` avec `github oauth token contains invalid characters`, verifier que le setup PHP force bien `tools: composer:v2`, comme les jobs backend-quality et coverage.
+- Pour les commandes console de detection/registre de features, preferer des helpers locaux `stringValue`, `stringList`, `optionString` et `optionBool` plutot que caster inline des tableaux `mixed`; cela garde PHPStan exploitable et les sorties Artisan previsibles.
 - Les notifications API ne sont pas les `DatabaseNotification` Laravel natives : le modele interne doit exposer `markAsRead()` et `Employee` doit declarer explicitement `notifications()` / `unreadNotifications()`.
 - Les analytics IA doivent rester alignees sur le schema reel `ai_audit_logs` : `input_tokens`, `output_tokens`, `cost_cents`, `duration_ms`, `error`, `tools_called`. Ne pas reintroduire les colonnes fantomes `total_tokens`, `cost`, `tool_called`, `response_time_ms`, `status`, `error_message`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ﻿# CHANGELOG - LEOPARDO RH 
 # Format : Keep a Changelog (keepachangelog.com)
-# Versioning : Semantic Versioning (semver.org)  
+# Versioning : Semantic Versioning (semver.org)
+
+## [4.16.6] - 2026-05-13
+
+### Backend — Feature Registry Console Typing (Lot 3)
+
+- Feature Registry : reecriture type-safe des commandes `features:demo`, `features:detect` et `features:test-detector`.
+- PHPStan : retrait des ignores baseline residuels lies aux commandes console du registre de fonctionnalites.
+- Console : normalisation des options, listes et tableaux de manifeste pour eviter les erreurs `mixed` dans les sorties Artisan.
 
 ## [4.16.5] - 2026-05-13
 

--- a/api/app/Console/Commands/DemoFeatureRegistryCommand.php
+++ b/api/app/Console/Commands/DemoFeatureRegistryCommand.php
@@ -8,98 +8,218 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Commande de démonstration du Feature Registry
- *
- * Cette commande illustre l'utilisation complète du système de registre
- * des fonctionnalités avec des exemples concrets.
+ * Demonstration du registre central des fonctionnalites API.
  */
 class DemoFeatureRegistryCommand extends Command
 {
-    /**
-     * Nom et signature de la commande
-     *
-     * @var string
-     */
     protected $signature = 'features:demo
-                            {--reset : Réinitialiser les données de démonstration}
+                            {--reset : Reinitialiser les donnees de demonstration}
                             {--mobile-version=1.0.0 : Version mobile pour les tests}';
 
-    /**
-     * Description de la commande
-     *
-     * @var string
-     */
-    protected $description = 'Démonstration complète du système Feature Registry';
+    protected $description = 'Demonstration complete du systeme Feature Registry';
 
-    /**
-     * Exécute la commande de démonstration
-     */
     public function handle(FeatureRegistryInterface $registry): int
     {
-        $this->info('🚀 Démonstration du Feature Registry');
+        $this->info('Demonstration du Feature Registry');
         $this->newLine();
 
-        if ($this->option('reset')) {
+        if ($this->optionBool('reset')) {
             $this->resetDemoData();
         }
 
-        // 1. Créer des fonctionnalités d'exemple
-        $this->info('📝 1. Création de fonctionnalités d\'exemple...');
+        $this->info('1. Creation de fonctionnalites d\'exemple...');
         $this->createDemoFeatures($registry);
 
-        // 2. Afficher les statistiques
-        $this->info('📊 2. Statistiques du registre:');
+        $this->info('2. Statistiques du registre:');
         $this->displayStatistics($registry);
 
-        // 3. Tester la récupération de fonctionnalités
-        $this->info('🔍 3. Test de récupération des fonctionnalités:');
+        $this->info('3. Test de recuperation des fonctionnalites:');
         $this->testFeatureRetrieval($registry);
 
-        // 4. Tester la compatibilité mobile
-        $this->info('📱 4. Test de compatibilité mobile:');
+        $this->info('4. Test de compatibilite mobile:');
         $this->testMobileCompatibility($registry);
 
-        // 5. Générer et afficher le manifeste
-        $this->info('📋 5. Génération du manifeste:');
+        $this->info('5. Generation du manifeste:');
         $this->generateAndDisplayManifest($registry);
 
-        // 6. Tester la synchronisation
-        $this->info('🔄 6. Test de synchronisation:');
+        $this->info('6. Test de synchronisation:');
         $this->testSynchronization($registry);
 
-        // 7. Tester le cache
-        $this->info('💾 7. Test du système de cache:');
+        $this->info('7. Test du systeme de cache:');
         $this->testCaching($registry);
 
         $this->newLine();
-        $this->info('✅ Démonstration terminée avec succès!');
+        $this->info('Demonstration terminee avec succes.');
 
         return Command::SUCCESS;
     }
 
-    /**
-     * Réinitialise les données de démonstration
-     */
     private function resetDemoData(): void
     {
-        $this->warn('🗑️  Suppression des données de démonstration...');
+        $this->warn('Suppression des donnees de demonstration...');
 
         DB::table('features')->where('key', 'like', 'demo_%')->delete();
 
-        $this->info('✅ Données supprimées.');
+        $this->info('Donnees supprimees.');
+        $this->newLine();
+    }
+
+    private function createDemoFeatures(FeatureRegistryInterface $registry): void
+    {
+        foreach ($this->demoFeatures() as $featureData) {
+            $feature = new Feature($featureData);
+            $registry->registerFeature($feature);
+
+            $this->line('  OK '.$feature->title.' enregistree');
+        }
+
+        $this->newLine();
+    }
+
+    private function displayStatistics(FeatureRegistryInterface $registry): void
+    {
+        $stats = $registry->getStatistics();
+
+        $this->table(
+            ['Metrique', 'Valeur'],
+            [
+                ['Total des fonctionnalites', $this->statInt($stats, 'total_features')],
+                ['Fonctionnalites actives', $this->statInt($stats, 'active_features')],
+                ['Fonctionnalites inactives', $this->statInt($stats, 'inactive_features')],
+                ['Mises a jour recentes', $this->statInt($stats, 'recently_updated')],
+            ]
+        );
+
+        $byStatus = $this->statArray($stats, 'by_status');
+        if ($byStatus !== []) {
+            $this->info('Par statut:');
+            foreach ($byStatus as $status => $count) {
+                $this->line('  - '.(string) $status.': '.(string) $count);
+            }
+        }
+
+        $this->newLine();
+    }
+
+    private function testFeatureRetrieval(FeatureRegistryInterface $registry): void
+    {
+        $allFeatures = $registry->getFeatures();
+        $this->line('  Total des fonctionnalites: '.$allFeatures->count());
+
+        $specificFeature = $registry->getFeature('demo_employee_management');
+        if ($specificFeature instanceof Feature) {
+            $this->line('  Fonctionnalite trouvee: '.$specificFeature->title);
+        }
+
+        $exists = $registry->hasFeature('demo_employee_management');
+        $this->line('  Fonctionnalite existe: '.$this->boolLabel($exists));
+
+        $this->newLine();
+    }
+
+    private function testMobileCompatibility(FeatureRegistryInterface $registry): void
+    {
+        $mobileVersion = $this->optionString('mobile-version', '1.0.0');
+
+        $compatibleFeatures = $registry->getCompatibleFeatures($mobileVersion);
+        $this->line('  Fonctionnalites compatibles avec v'.$mobileVersion.': '.$compatibleFeatures->count());
+
+        foreach ($compatibleFeatures as $feature) {
+            $maxVersion = $feature->mobile_version_max ? ' - '.$feature->mobile_version_max : '';
+            $this->line('    - '.$feature->title.' (v'.$feature->mobile_version_min.$maxVersion.')');
+        }
+
+        $oldCompatible = $registry->getCompatibleFeatures('1.0.0');
+        $this->line('  Fonctionnalites compatibles avec v1.0.0: '.$oldCompatible->count());
+
+        $this->newLine();
+    }
+
+    private function generateAndDisplayManifest(FeatureRegistryInterface $registry): void
+    {
+        $mobileVersion = $this->optionString('mobile-version', '1.0.0');
+        $manifest = $registry->getManifest($mobileVersion);
+
+        $this->line('  Manifeste genere pour la version mobile '.$mobileVersion.':');
+        $this->line('    - Version API: '.$this->stringValue($manifest, 'version'));
+        $this->line('    - Genere le: '.$this->stringValue($manifest, 'generated_at'));
+        $this->line('    - Nombre de fonctionnalites: '.$this->statInt($manifest, 'total_features'));
+
+        if ($this->output->isVerbose()) {
+            $this->newLine();
+            $this->info('Detail des fonctionnalites:');
+
+            $rows = [];
+            foreach ($this->statArray($manifest, 'features') as $feature) {
+                if (is_array($feature)) {
+                    $rows[] = $this->manifestFeatureRow($feature);
+                }
+            }
+
+            $this->table(['Cle', 'Titre', 'Endpoint', 'Methodes', 'Permissions'], $rows);
+        }
+
+        $this->newLine();
+    }
+
+    private function testSynchronization(FeatureRegistryInterface $registry): void
+    {
+        $this->line('  Lancement de la synchronisation...');
+
+        $result = $registry->synchronize();
+
+        $this->line('    - Nouvelles fonctionnalites: '.$result['new']);
+        $this->line('    - Fonctionnalites mises a jour: '.$result['updated']);
+        $this->line('    - Fonctionnalites supprimees: '.$result['removed']);
+
+        if ($result['errors'] !== []) {
+            $this->warn('    - Erreurs: '.count($result['errors']));
+            foreach ($result['errors'] as $error) {
+                $this->line('      - '.$error);
+            }
+        } else {
+            $this->line('    OK Aucune erreur');
+        }
+
+        $this->newLine();
+    }
+
+    private function testCaching(FeatureRegistryInterface $registry): void
+    {
+        $this->line('  Test du cache...');
+
+        $start = microtime(true);
+        $features1 = $registry->getFeatures();
+        $time1 = round((microtime(true) - $start) * 1000, 2);
+
+        $start = microtime(true);
+        $features2 = $registry->getFeatures();
+        $time2 = round((microtime(true) - $start) * 1000, 2);
+
+        $this->line('    - Premier appel: '.$time1.'ms ('.$features1->count().' fonctionnalites)');
+        $this->line('    - Deuxieme appel: '.$time2.'ms ('.$features2->count().' fonctionnalites)');
+
+        if ($time2 < $time1 && $time1 > 0.0) {
+            $improvement = round(($time1 - $time2) / $time1 * 100, 1);
+            $this->line('    OK Cache fonctionnel (amelioration: '.$improvement.'%)');
+        }
+
+        $registry->invalidateCache();
+        $this->line('    Cache invalide');
+
         $this->newLine();
     }
 
     /**
-     * Crée des fonctionnalités d'exemple
+     * @return array<int, array<string, mixed>>
      */
-    private function createDemoFeatures(FeatureRegistryInterface $registry): void
+    private function demoFeatures(): array
     {
-        $demoFeatures = [
+        return [
             [
                 'key' => 'demo_employee_management',
-                'title' => 'Gestion des Employés (Démo)',
-                'description' => 'Créer, modifier et gérer les employés de l\'entreprise',
+                'title' => 'Gestion des Employes (Demo)',
+                'description' => 'Creer, modifier et gerer les employes de l\'entreprise',
                 'endpoint' => '/api/v1/employees',
                 'http_methods' => ['GET', 'POST', 'PUT', 'DELETE'],
                 'parameters' => [
@@ -133,7 +253,7 @@ class DemoFeatureRegistryCommand extends Command
                     'ui_type' => 'list',
                     'form_schema' => [
                         'fields' => [
-                            ['name' => 'first_name', 'type' => 'text', 'label' => 'Prénom', 'required' => true],
+                            ['name' => 'first_name', 'type' => 'text', 'label' => 'Prenom', 'required' => true],
                             ['name' => 'last_name', 'type' => 'text', 'label' => 'Nom', 'required' => true],
                             ['name' => 'email', 'type' => 'email', 'label' => 'Email', 'required' => true],
                         ],
@@ -142,8 +262,8 @@ class DemoFeatureRegistryCommand extends Command
             ],
             [
                 'key' => 'demo_attendance_tracking',
-                'title' => 'Suivi des Présences (Démo)',
-                'description' => 'Enregistrer et consulter les heures de présence',
+                'title' => 'Suivi des Presences (Demo)',
+                'description' => 'Enregistrer et consulter les heures de presence',
                 'endpoint' => '/api/v1/attendance',
                 'http_methods' => ['GET', 'POST'],
                 'parameters' => [
@@ -173,8 +293,8 @@ class DemoFeatureRegistryCommand extends Command
             ],
             [
                 'key' => 'demo_advanced_reporting',
-                'title' => 'Rapports Avancés (Démo)',
-                'description' => 'Génération de rapports détaillés et analytics',
+                'title' => 'Rapports Avances (Demo)',
+                'description' => 'Generation de rapports detailles et analytics',
                 'endpoint' => '/api/v1/reports/advanced',
                 'http_methods' => ['GET'],
                 'parameters' => [
@@ -192,7 +312,7 @@ class DemoFeatureRegistryCommand extends Command
                     ],
                 ],
                 'permissions' => ['reports.advanced'],
-                'mobile_version_min' => '1.5.0', // Version plus récente requise
+                'mobile_version_min' => '1.5.0',
                 'mobile_version_max' => null,
                 'api_version' => 'v1',
                 'status' => 'active',
@@ -203,196 +323,103 @@ class DemoFeatureRegistryCommand extends Command
             ],
             [
                 'key' => 'demo_legacy_feature',
-                'title' => 'Fonctionnalité Héritée (Démo)',
-                'description' => 'Ancienne fonctionnalité en cours de dépréciation',
+                'title' => 'Fonctionnalite Heritee (Demo)',
+                'description' => 'Ancienne fonctionnalite en cours de depreciation',
                 'endpoint' => '/api/v1/legacy/old-feature',
                 'http_methods' => ['GET'],
                 'parameters' => [],
                 'response_schema' => ['data' => 'object'],
                 'permissions' => ['legacy.access'],
                 'mobile_version_min' => '1.0.0',
-                'mobile_version_max' => '1.2.0', // Limitée aux anciennes versions
+                'mobile_version_max' => '1.2.0',
                 'api_version' => 'v1',
                 'status' => 'deprecated',
                 'metadata' => [
                     'ui_type' => 'generic',
-                    'deprecation_notice' => 'Cette fonctionnalité sera supprimée dans la version 2.0',
+                    'deprecation_notice' => 'Cette fonctionnalite sera supprimee dans la version 2.0',
                 ],
             ],
         ];
-
-        foreach ($demoFeatures as $featureData) {
-            $feature = new Feature($featureData);
-            $registry->registerFeature($feature);
-
-            $this->line('  ✅ '.$feature->title.' enregistrée');
-        }
-
-        $this->newLine();
     }
 
     /**
-     * Affiche les statistiques du registre
+     * @param  array<string, mixed>  $feature
+     * @return array<int, string>
      */
-    private function displayStatistics(FeatureRegistryInterface $registry): void
+    private function manifestFeatureRow(array $feature): array
     {
-        $stats = $registry->getStatistics();
+        return [
+            $this->stringValue($feature, 'key'),
+            $this->stringValue($feature, 'title'),
+            $this->stringValue($feature, 'endpoint'),
+            implode(', ', $this->stringList($feature['methods'] ?? [])),
+            implode(', ', $this->stringList($feature['permissions'] ?? [])),
+        ];
+    }
 
-        $this->table(
-            ['Métrique', 'Valeur'],
-            [
-                ['Total des fonctionnalités', $stats['total_features']],
-                ['Fonctionnalités actives', $stats['active_features']],
-                ['Fonctionnalités inactives', $stats['inactive_features']],
-                ['Mises à jour récentes', $stats['recently_updated']],
-            ]
-        );
+    private function optionBool(string $key): bool
+    {
+        return filter_var($this->option($key), FILTER_VALIDATE_BOOL);
+    }
 
-        if (! empty($stats['by_status'])) {
-            $this->info('Par statut:');
-            foreach ($stats['by_status'] as $status => $count) {
-                $this->line('  - '.$status.': '.$count);
-            }
+    private function optionString(string $key, string $default): string
+    {
+        $value = $this->option($key);
+
+        if ($value === null || $value === false || is_array($value)) {
+            return $default;
         }
 
-        $this->newLine();
+        $value = trim((string) $value);
+
+        return $value === '' ? $default : $value;
     }
 
     /**
-     * Teste la récupération des fonctionnalités
+     * @param  array<string, mixed>  $stats
      */
-    private function testFeatureRetrieval(FeatureRegistryInterface $registry): void
+    private function statInt(array $stats, string $key): int
     {
-        // Test récupération de toutes les fonctionnalités
-        $allFeatures = $registry->getFeatures();
-        $this->line('  📋 Total des fonctionnalités: '.$allFeatures->count());
+        $value = $stats[$key] ?? 0;
 
-        // Test récupération d'une fonctionnalité spécifique
-        $specificFeature = $registry->getFeature('demo_employee_management');
-        if ($specificFeature) {
-            $this->line('  🎯 Fonctionnalité trouvée: '.$specificFeature->title);
-        }
-
-        // Test vérification d'existence
-        $exists = $registry->hasFeature('demo_employee_management');
-        $this->line('  ✅ Fonctionnalité existe: '.($exists ? 'Oui' : 'Non'));
-
-        $this->newLine();
+        return is_numeric($value) ? (int) $value : 0;
     }
 
     /**
-     * Teste la compatibilité mobile
+     * @param  array<string, mixed>  $stats
+     * @return array<array-key, mixed>
      */
-    private function testMobileCompatibility(FeatureRegistryInterface $registry): void
+    private function statArray(array $stats, string $key): array
     {
-        $mobileVersion = $this->option('mobile-version');
+        $value = $stats[$key] ?? [];
 
-        $compatibleFeatures = $registry->getCompatibleFeatures($mobileVersion);
-        $this->line('  📱 Fonctionnalités compatibles avec v'.$mobileVersion.': '.$compatibleFeatures->count());
-
-        foreach ($compatibleFeatures as $feature) {
-            $maxVersion = $feature->mobile_version_max ? ' - '.$feature->mobile_version_max : '';
-            $this->line('    - '.$feature->title.' (v'.$feature->mobile_version_min.$maxVersion.')');
-        }
-
-        // Test avec une version plus ancienne
-        $oldCompatible = $registry->getCompatibleFeatures('1.0.0');
-        $this->line('  📱 Fonctionnalités compatibles avec v1.0.0: '.$oldCompatible->count());
-
-        $this->newLine();
+        return is_array($value) ? $value : [];
     }
 
     /**
-     * Génère et affiche le manifeste
+     * @param  array<string, mixed>  $data
      */
-    private function generateAndDisplayManifest(FeatureRegistryInterface $registry): void
+    private function stringValue(array $data, string $key, string $default = ''): string
     {
-        $mobileVersion = $this->option('mobile-version');
-        $manifest = $registry->getManifest($mobileVersion);
+        $value = $data[$key] ?? $default;
 
-        $this->line('  📋 Manifeste généré pour la version mobile '.$mobileVersion.':');
-        $this->line('    - Version API: '.$manifest['version']);
-        $this->line('    - Généré le: '.$manifest['generated_at']);
-        $this->line('    - Nombre de fonctionnalités: '.$manifest['total_features']);
-
-        if ($this->option('verbose')) {
-            $this->newLine();
-            $this->info('Détail des fonctionnalités:');
-
-            $headers = ['Clé', 'Titre', 'Endpoint', 'Méthodes', 'Permissions'];
-            $rows = [];
-
-            foreach ($manifest['features'] as $feature) {
-                /** @var array<string, mixed> $feature */
-                $rows[] = [
-                    (string) $feature['key'],
-                    (string) $feature['title'],
-                    (string) $feature['endpoint'],
-                    implode(', ', (array) $feature['methods']),
-                    implode(', ', (array) $feature['permissions']),
-                ];
-            }
-
-            $this->table($headers, $rows);
-        }
-
-        $this->newLine();
+        return is_scalar($value) ? (string) $value : $default;
     }
 
     /**
-     * Teste la synchronisation
+     * @return list<string>
      */
-    private function testSynchronization(FeatureRegistryInterface $registry): void
+    private function stringList(mixed $value): array
     {
-        $this->line('  🔄 Lancement de la synchronisation...');
-
-        $result = $registry->synchronize();
-
-        /** @var array<string, mixed> $result */
-        $this->line('    - Nouvelles fonctionnalités: '.(string) $result['new']);
-        $this->line('    - Fonctionnalités mises à jour: '.(string) $result['updated']);
-        $this->line('    - Fonctionnalités supprimées: '.(string) $result['removed']);
-
-        if (! empty($result['errors'])) {
-            $this->warn('    - Erreurs: '.count((array) $result['errors']));
-            foreach ((array) $result['errors'] as $error) {
-                $this->line('      • '.$error);
-            }
-        } else {
-            $this->line('    ✅ Aucune erreur');
+        if (! is_array($value)) {
+            return [];
         }
 
-        $this->newLine();
+        return array_values(array_map('strval', $value));
     }
 
-    /**
-     * Teste le système de cache
-     */
-    private function testCaching(FeatureRegistryInterface $registry): void
+    private function boolLabel(bool $value): string
     {
-        $this->line('  💾 Test du cache...');
-
-        // Premier appel (devrait mettre en cache)
-        $start = microtime(true);
-        $features1 = $registry->getFeatures();
-        $time1 = round((microtime(true) - $start) * 1000, 2);
-
-        // Deuxième appel (devrait utiliser le cache)
-        $start = microtime(true);
-        $features2 = $registry->getFeatures();
-        $time2 = round((microtime(true) - $start) * 1000, 2);
-
-        $this->line('    - Premier appel: '.$time1.'ms ('.$features1->count().' fonctionnalités)');
-        $this->line('    - Deuxième appel: '.$time2.'ms ('.$features2->count().' fonctionnalités)');
-
-        if ($time2 < $time1) {
-            $this->line('    ✅ Cache fonctionnel (amélioration: '.round(($time1 - $time2) / $time1 * 100, 1).'%)');
-        }
-
-        // Test invalidation du cache
-        $registry->invalidateCache();
-        $this->line('    🗑️  Cache invalidé');
-
-        $this->newLine();
+        return $value ? 'Oui' : 'Non';
     }
 }

--- a/api/app/Console/Commands/DetectFeaturesCommand.php
+++ b/api/app/Console/Commands/DetectFeaturesCommand.php
@@ -6,106 +6,135 @@ use App\Contracts\FeatureDetectorInterface;
 use Illuminate\Console\Command;
 
 /**
- * Commande Artisan pour détecter les nouvelles fonctionnalités API
+ * Detecte les nouvelles fonctionnalites API exposees par les routes Laravel.
  */
 class DetectFeaturesCommand extends Command
 {
-    /**
-     * The name and signature of the console command.
-     */
     protected $signature = 'features:detect
-                            {--dry-run : Afficher les fonctionnalités détectées sans les enregistrer}
-                            {--details : Afficher des informations détaillées}';
+                            {--dry-run : Afficher les fonctionnalites detectees sans les enregistrer}
+                            {--details : Afficher des informations detaillees}';
 
-    /**
-     * The console command description.
-     */
-    protected $description = 'Détecte automatiquement les nouvelles fonctionnalités API';
+    protected $description = 'Detecte automatiquement les nouvelles fonctionnalites API';
 
-    /**
-     * Execute the console command.
-     */
     public function handle(FeatureDetectorInterface $detector): int
     {
-        $this->info('🔍 Détection des nouvelles fonctionnalités API...');
+        $this->info('Detection des nouvelles fonctionnalites API...');
 
         try {
-            // Scanner les routes
-            $this->info('📡 Scan des routes API...');
             $routes = $detector->scanRoutes();
-            $this->info("✅ {$routes->count()} routes API trouvées");
+            $this->info($routes->count().' routes API trouvees');
 
-            if ($this->option('details')) {
+            if ($this->optionBool('details')) {
                 $this->table(
-                    ['URI', 'Méthodes', 'Contrôleur', 'Action'],
-                    $routes->map(fn (array $route) => [
-                        (string) $route['uri'],
-                        implode(', ', (array) $route['methods']),
-                        class_basename((string) $route['controller_class']),
-                        (string) $route['method'],
-                    ])->toArray()
+                    ['URI', 'Methodes', 'Controleur', 'Action'],
+                    $routes->map(fn (array $route): array => $this->routeRow($route))->toArray()
                 );
             }
 
-            // Détecter les nouvelles fonctionnalités
-            $this->info('🆕 Détection des nouvelles fonctionnalités...');
             $newFeatures = $detector->detectNewFeatures();
-
             if ($newFeatures->isEmpty()) {
-                $this->info('✨ Aucune nouvelle fonctionnalité détectée');
+                $this->info('Aucune nouvelle fonctionnalite detectee');
 
                 return self::SUCCESS;
             }
 
-            $this->info("🎉 {$newFeatures->count()} nouvelles fonctionnalités détectées !");
-
-            // Afficher les fonctionnalités détectées
+            $this->info($newFeatures->count().' nouvelles fonctionnalites detectees');
             $this->table(
-                ['Clé', 'Titre', 'Endpoint', 'Méthodes', 'Type UI'],
-                $newFeatures->map(fn (array $feature) => [
-                    (string) $feature['key'],
-                    (string) $feature['title'],
-                    (string) $feature['endpoint'],
-                    implode(', ', (array) $feature['http_methods']),
-                    isset($feature['metadata']) && is_array($feature['metadata']) ? (string) ($feature['metadata']['ui_type'] ?? 'generic') : 'generic',
-                ])->toArray()
+                ['Cle', 'Titre', 'Endpoint', 'Methodes', 'Type UI'],
+                $newFeatures->map(fn (array $feature): array => $this->featureRow($feature))->toArray()
             );
 
-            if ($this->option('dry-run')) {
-                $this->warn('🔍 Mode dry-run : aucune fonctionnalité n\'a été enregistrée');
+            if ($this->optionBool('dry-run')) {
+                $this->warn('Mode dry-run : aucune fonctionnalite n\'a ete enregistree');
 
                 return self::SUCCESS;
             }
 
-            // Enregistrer les fonctionnalités (sera implémenté dans la phase suivante)
-            $this->warn('💾 Enregistrement des fonctionnalités (à implémenter dans le Feature Registry)');
-
-            // Détecter les changements
-            $this->info('🔄 Détection des changements...');
-            $changes = $detector->detectChanges();
-
-            if ($changes->isNotEmpty()) {
-                $this->info("⚠️  {$changes->count()} changements détectés dans les fonctionnalités existantes");
-
-                foreach ($changes as $change) {
-                    /** @var array<string, mixed> $change */
-                    $changeType = (string) $change['type'];
-                    $featureKey = (string) $change['feature_key'];
-                    $icon = $changeType === 'removed' ? '🗑️' : '📝';
-                    $this->line("{$icon} {$changeType}: {$featureKey}");
-                }
-            }
+            $this->warn('Enregistrement des fonctionnalites a brancher dans le Feature Registry.');
+            $this->displayChanges($detector);
 
             return self::SUCCESS;
-
         } catch (\Exception $e) {
-            $this->error("❌ Erreur lors de la détection : {$e->getMessage()}");
+            $this->error('Erreur lors de la detection : '.$e->getMessage());
 
-            if ($this->option('details')) {
+            if ($this->optionBool('details')) {
                 $this->error($e->getTraceAsString());
             }
 
             return self::FAILURE;
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $route
+     * @return array<int, string>
+     */
+    private function routeRow(array $route): array
+    {
+        return [
+            $this->stringValue($route, 'uri'),
+            implode(', ', $this->stringList($route['methods'] ?? [])),
+            class_basename($this->stringValue($route, 'controller_class')),
+            $this->stringValue($route, 'method'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $feature
+     * @return array<int, string>
+     */
+    private function featureRow(array $feature): array
+    {
+        $metadata = is_array($feature['metadata'] ?? null) ? $feature['metadata'] : [];
+
+        return [
+            $this->stringValue($feature, 'key'),
+            $this->stringValue($feature, 'title'),
+            $this->stringValue($feature, 'endpoint'),
+            implode(', ', $this->stringList($feature['http_methods'] ?? [])),
+            $this->stringValue($metadata, 'ui_type', 'generic'),
+        ];
+    }
+
+    private function displayChanges(FeatureDetectorInterface $detector): void
+    {
+        $changes = $detector->detectChanges();
+        if ($changes->isEmpty()) {
+            return;
+        }
+
+        $this->info($changes->count().' changements detectes dans les fonctionnalites existantes');
+        foreach ($changes as $change) {
+            $type = $this->stringValue($change, 'type');
+            $featureKey = $this->stringValue($change, 'feature_key');
+            $this->line("- {$type}: {$featureKey}");
+        }
+    }
+
+    private function optionBool(string $key): bool
+    {
+        return filter_var($this->option($key), FILTER_VALIDATE_BOOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function stringValue(array $data, string $key, string $default = ''): string
+    {
+        $value = $data[$key] ?? $default;
+
+        return is_scalar($value) ? (string) $value : $default;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map('strval', $value));
     }
 }

--- a/api/app/Console/Commands/TestFeatureDetectorCommand.php
+++ b/api/app/Console/Commands/TestFeatureDetectorCommand.php
@@ -7,96 +7,131 @@ use Illuminate\Console\Command;
 
 class TestFeatureDetectorCommand extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
     protected $signature = 'features:test-detector {--limit=10 : Limit the number of features to display}';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Test the FeatureDetector service and display detected features';
 
-    /**
-     * Execute the console command.
-     */
     public function handle(FeatureDetector $detector): int
     {
         $this->info('Testing FeatureDetector service...');
 
         try {
-            // Test scanRoutes
-            $this->info('Scanning API routes...');
             $routes = $detector->scanRoutes();
-            $this->info("Found {$routes->count()} API routes");
+            $this->info('Found '.$routes->count().' API routes');
 
-            // Test detectNewFeatures
-            $this->info('Detecting new features...');
             $features = $detector->detectNewFeatures();
-            $this->info("Detected {$features->count()} new features");
+            $this->info('Detected '.$features->count().' new features');
+            $this->displayFeatures($features->take($this->limit()));
 
-            // Display limited features
-            $limit = (int) $this->option('limit');
-            $displayFeatures = $features->take($limit);
+            $this->displayEmployeeMetadata($detector);
+            $this->displayChanges($detector);
 
-            if ($displayFeatures->count() > 0) {
-                $this->info("\nFirst {$displayFeatures->count()} features:");
-
-                $headers = ['Key', 'Title', 'Endpoint', 'Methods', 'UI Type', 'Permissions'];
-                $rows = [];
-
-                foreach ($displayFeatures as $feature) {
-                    $rows[] = [
-                        $feature['key'],
-                        $feature['title'],
-                        $feature['endpoint'],
-                        implode(', ', $feature['http_methods']),
-                        $feature['metadata']['ui_type'],
-                        implode(', ', $feature['permissions']),
-                    ];
-                }
-
-                $this->table($headers, $rows);
-            }
-
-            // Test extractMetadata on a specific controller
-            $this->info("\nTesting metadata extraction on EmployeeController::index...");
-            $metadata = $detector->extractMetadata(
-                'App\Http\Controllers\Api\V1\EmployeeController',
-                'index'
-            );
-
-            $this->info("Title: {$metadata['title']}");
-            $this->info("Description: {$metadata['description']}");
-            $this->info("UI Type: {$metadata['ui_type']}");
-            $this->info('Mobile Compatible: '.($metadata['mobile_compatible'] ? 'Yes' : 'No'));
-            $this->info('Permissions: '.implode(', ', $metadata['permissions']));
-
-            // Test detectChanges
-            $this->info("\nDetecting changes in existing features...");
-            $changes = $detector->detectChanges();
-            $this->info("Found {$changes->count()} changes");
-
-            if ($changes->count() > 0) {
-                $this->warn('Changes detected:');
-                foreach ($changes->take(5) as $change) {
-                    $this->line("- {$change['type']}: {$change['feature_key']}");
-                }
-            }
-
-            $this->info("\n✅ FeatureDetector test completed successfully!");
+            $this->info('FeatureDetector test completed successfully.');
 
             return Command::SUCCESS;
-
         } catch (\Exception $e) {
-            $this->error("❌ Error testing FeatureDetector: {$e->getMessage()}");
-            $this->error("Trace: {$e->getTraceAsString()}");
+            $this->error('Error testing FeatureDetector: '.$e->getMessage());
+            $this->error('Trace: '.$e->getTraceAsString());
 
             return Command::FAILURE;
         }
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<int, array<string, mixed>>  $features
+     */
+    private function displayFeatures(\Illuminate\Support\Collection $features): void
+    {
+        if ($features->isEmpty()) {
+            return;
+        }
+
+        $this->info("\nFirst ".$features->count().' features:');
+        $this->table(
+            ['Key', 'Title', 'Endpoint', 'Methods', 'UI Type', 'Permissions'],
+            $features->map(fn (array $feature): array => $this->featureRow($feature))->toArray()
+        );
+    }
+
+    private function displayEmployeeMetadata(FeatureDetector $detector): void
+    {
+        $this->info("\nTesting metadata extraction on EmployeeController::index...");
+        $metadata = $detector->extractMetadata(
+            'App\Http\Controllers\Api\V1\EmployeeController',
+            'index'
+        );
+
+        $this->info('Title: '.$this->stringValue($metadata, 'title'));
+        $this->info('Description: '.$this->stringValue($metadata, 'description'));
+        $this->info('UI Type: '.$this->stringValue($metadata, 'ui_type'));
+        $this->info('Mobile Compatible: '.$this->boolLabel($metadata['mobile_compatible'] ?? false));
+        $this->info('Permissions: '.implode(', ', $this->stringList($metadata['permissions'] ?? [])));
+    }
+
+    private function displayChanges(FeatureDetector $detector): void
+    {
+        $changes = $detector->detectChanges();
+        $this->info("\nFound ".$changes->count().' changes');
+
+        if ($changes->isEmpty()) {
+            return;
+        }
+
+        $this->warn('Changes detected:');
+        foreach ($changes->take(5) as $change) {
+            $this->line('- '.$this->stringValue($change, 'type').': '.$this->stringValue($change, 'feature_key'));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $feature
+     * @return array<int, string>
+     */
+    private function featureRow(array $feature): array
+    {
+        $metadata = is_array($feature['metadata'] ?? null) ? $feature['metadata'] : [];
+
+        return [
+            $this->stringValue($feature, 'key'),
+            $this->stringValue($feature, 'title'),
+            $this->stringValue($feature, 'endpoint'),
+            implode(', ', $this->stringList($feature['http_methods'] ?? [])),
+            $this->stringValue($metadata, 'ui_type'),
+            implode(', ', $this->stringList($feature['permissions'] ?? [])),
+        ];
+    }
+
+    private function limit(): int
+    {
+        $value = $this->option('limit');
+
+        return is_numeric($value) ? max(1, (int) $value) : 10;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function stringValue(array $data, string $key, string $default = ''): string
+    {
+        $value = $data[$key] ?? $default;
+
+        return is_scalar($value) ? (string) $value : $default;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map('strval', $value));
+    }
+
+    private function boolLabel(mixed $value): string
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOL) ? 'Yes' : 'No';
     }
 }

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -1,342 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 2
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''      • '' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''    \- Généré le\: '' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''    \- Nombre de…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''    \- Version API\: '' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''  \- '' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''  📋 Manifeste…'' and array\|bool\|string\|null results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between ''  📱 Fonctionnalités…'' and array\|bool\|string\|null results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''\: '' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''\:'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 6
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#1 \$mobileVersion of method App\\Contracts\\FeatureRegistryInterface\:\:getCompatibleFeatures\(\) expects string, array\|bool\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#1 \$mobileVersion of method App\\Contracts\\FeatureRegistryInterface\:\:getManifest\(\) expects string\|null, array\|bool\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/Console/Commands/DemoFeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 9
-			path: app/Console/Commands/DetectFeaturesCommand.php
-
-		-
-			message: '#^Parameter \#1 \$callback of method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:map\(\) expects callable\(mixed, int\|string\)\: array\{string, string, string, string, string\}, Closure\(array\)\: array\{string, string, string, string, string\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/DetectFeaturesCommand.php
-
-		-
-			message: '#^Parameter \#1 \$callback of method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:map\(\) expects callable\(mixed, int\|string\)\: array\{string, string, string, string\}, Closure\(array\)\: array\{string, string, string, string\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/DetectFeaturesCommand.php
-
-		-
-			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/Console/Commands/DetectFeaturesCommand.php
-
-		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 3
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access offset ''cache_driver'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access offset ''features_cached'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access offset ''manifest_cached'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access property \$api_version on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access property \$endpoint on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access property \$http_methods on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access property \$key on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access property \$status on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access property \$title on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#1 \$mobileVersion of method App\\Contracts\\FeatureRegistryInterface\:\:getCompatibleFeatures\(\) expects string, array\|string\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#1 \$string of method Illuminate\\Console\\Command\:\:line\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#1 \$version of method App\\Contracts\\FeatureRegistryInterface\:\:getFeatures\(\) expects string\|null, array\|bool\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Parameter \#2 \$array of function implode expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$action \(array\|bool\|string\|null\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$cacheStatus\[''cache_driver''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$count \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 2
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$error \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$mobileVersion \(non\-empty\-array\|non\-falsy\-string\|true\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$result\[''new''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$result\[''removed''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$result\[''updated''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$stats\[''active_features''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$stats\[''inactive_features''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$stats\[''last_synchronization''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$stats\[''recently_updated''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$stats\[''total_features''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$status \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$version \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Part \$version \(non\-empty\-array\|non\-falsy\-string\|true\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/FeatureRegistryCommand.php
-
-		-
-			message: '#^Cannot access offset ''ui_type'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
-			message: '#^Parameter \#2 \$array of function implode expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
-			message: '#^Part \$change\[''feature_key''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
-			message: '#^Part \$change\[''type''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
-			message: '#^Part \$metadata\[''description''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
-			message: '#^Part \$metadata\[''title''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
-			message: '#^Part \$metadata\[''ui_type''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/Console/Commands/TestFeatureDetectorCommand.php
-
-		-
 			message: '#^Cannot access offset ''gps_lat'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -6487,7 +6151,7 @@ parameters:
 			path: app/Http/Controllers/Web/InvitationManagementController.php
 
 		-
-			message: '#^Binary operation "\." between ''Invitation renvoyee…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''Invitation renvoyeeâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Http/Controllers/Web/InvitationManagementController.php
@@ -7207,7 +6871,7 @@ parameters:
 			path: app/Http/Requests/Api/V1/Estimation/ReceiptRequest.php
 
 		-
-			message: '#^Binary operation "\." between ''exists\:employees,id…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''exists\:employees,idâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 2
 			path: app/Http/Requests/Api/V1/Evaluation/EvaluationIndexRequest.php
@@ -12619,13 +12283,13 @@ parameters:
 			path: app/Services/AttendanceMonthlyReportService.php
 
 		-
-			message: '#^Binary operation "\." between ''attachment;…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''attachment;â€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Services/AttendanceMonthlyReportService.php
 
 		-
-			message: '#^Binary operation "\." between ''attendance\-monthly…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''attendance\-monthlyâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Services/AttendanceMonthlyReportService.php
@@ -15427,7 +15091,7 @@ parameters:
 			path: app/Services/SuperAdminService.php
 
 		-
-			message: '#^Binary operation "\." between ''Leopardo RH…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''Leopardo RHâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: app/Services/SuperAdminService.php
@@ -15475,7 +15139,7 @@ parameters:
 			path: app/Services/SuperAdminService.php
 
 		-
-			message: '#^Offset float\|int might not exist on ''ABCDEFGHIJKLMNOPQRS…''\.$#'
+			message: '#^Offset float\|int might not exist on ''ABCDEFGHIJKLMNOPQRSâ€¦''\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: app/Services/SuperAdminService.php
@@ -15937,7 +15601,7 @@ parameters:
 			path: tests/Feature/Absences/AbsenceIndexTest.php
 
 		-
-			message: '#^Binary operation "\." between ''/api/v1/absences…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''/api/v1/absencesâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: tests/Feature/Absences/AbsenceIndexTest.php
@@ -16687,7 +16351,7 @@ parameters:
 			path: tests/Feature/Cameras/CameraStreamTokenVerifyTest.php
 
 		-
-			message: '#^Binary operation "\." between ''/api/v1/internal…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''/api/v1/internalâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 7
 			path: tests/Feature/Cameras/CameraStreamTokenVerifyTest.php
@@ -17941,19 +17605,19 @@ parameters:
 			path: tests/Feature/Security/IndexCrossTenantValidationTest.php
 
 		-
-			message: '#^Binary operation "\." between ''/api/v1/absences…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''/api/v1/absencesâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: tests/Feature/Security/IndexCrossTenantValidationTest.php
 
 		-
-			message: '#^Binary operation "\." between ''/api/v1/evaluations…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''/api/v1/evaluationsâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 2
 			path: tests/Feature/Security/IndexCrossTenantValidationTest.php
 
 		-
-			message: '#^Binary operation "\." between ''/api/v1/salary…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''/api/v1/salaryâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: tests/Feature/Security/IndexCrossTenantValidationTest.php
@@ -17977,7 +17641,7 @@ parameters:
 			path: tests/Feature/Security/SalaryAdvanceSecurityTest.php
 
 		-
-			message: '#^Binary operation "\." between ''/api/v1/salary…'' and mixed results in an error\.$#'
+			message: '#^Binary operation "\." between ''/api/v1/salaryâ€¦'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: tests/Feature/Security/SalaryAdvanceSecurityTest.php


### PR DESCRIPTION
## Summary
- rewrite feature registry console demo/detect/test commands with typed helpers
- normalize option, manifest and list handling before rendering Artisan output
- remove resolved PHPStan baseline ignores for feature registry console commands

## Validation
- php -l on changed PHP command files
- powershell -ExecutionPolicy Bypass -File dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD

Note: local Pint/PHPStan remain blocked by the Windows PHP mbstring/Larastan setup documented in AGENTS.md; GitHub Actions is the source of truth.