### PR TITLE
feat(api): add platform metrics overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,7 @@ Procedure recommandee :
 - Le contrat abonnement `GET/PATCH /api/v1/platform/companies/{company}/subscription` est volontairement fournisseur-agnostique : plan/statut/dates/notes seulement. Brancher Stripe/PayPal/local PSP plus tard derriere ce contrat, pas dans le premier lot.
 - `GET /api/v1/platform/plans` fournit le catalogue a utiliser par l'admin-dashboard pour les formulaires d'abonnement ; ne pas hardcoder les `plan_id` cote frontend.
 - Le cockpit `admin-dashboard` doit consommer les contrats plateforme reels (`/platform/companies/health`, `/platform/companies/{id}/health`, `/subscription`, `/plans`) avant toute nouvelle statistique mockee.
+- `GET /api/v1/platform/metrics/overview` est le contrat d'agregats pour le cockpit super-admin : MRR/ARR, encaissements, impayes, companies, subscriptions, billing et systeme. Il doit rester sous `super_admin_api`, non nominatif, et tolerant aux tables billing absentes pendant les migrations progressives.
 - La page Support admin sert maintenant d'intake demandes clients via `/platform/company-requests`; ne pas y remettre de tickets mockes tant qu'un vrai module support n'a pas son API dediee.
 - Le dashboard d'accueil admin doit rester une synthese des contrats plateforme existants. Eviter les endpoints `/admin/dashboard/*` tant qu'ils n'existent pas cote API.
 - Approuver une `company_request` doit declencher le provisioning partage via `CompanyProvisioningService` et remplir `approved_company_id`; ne pas se limiter a changer le statut.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.7] - 2026-05-13
+
+### Backend — Platform Metrics Overview (Lot 4)
+
+- API plateforme : ajout de `GET /api/v1/platform/metrics/overview` reserve au guard `super_admin_api`.
+- Super admin : exposition d'agregats business stables pour MRR/ARR, encaissements 30 jours, impayes, companies, abonnements, facturation et contexte systeme.
+- Billing : lecture resiliente des tables tenant `subscriptions`, `invoices` et `payments` afin de ne pas casser les environnements partiellement migres.
+- Tests : couverture Feature du contrat super-admin et du refus unauthenticated pour proteger le futur cockpit plateforme.
+
 ## [4.16.6] - 2026-05-13
 
 ### Backend — Feature Registry Console Typing (Lot 3)

--- a/api/app/Http/Controllers/Api/V1/PlatformMetricsOverviewController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformMetricsOverviewController.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class PlatformMetricsOverviewController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'revenue' => $this->revenueMetrics(),
+                'companies' => $this->companyMetrics(),
+                'subscriptions' => $this->subscriptionMetrics(),
+                'billing' => $this->billingMetrics(),
+                'system' => $this->systemMetrics(),
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, int|float|string>
+     */
+    private function revenueMetrics(): array
+    {
+        $mrr = $this->monthlyRecurringRevenue();
+        $collected30d = $this->sumPaymentsSince(now()->subDays(30));
+        $overdue = $this->sumInvoicesByStatus('overdue');
+
+        return [
+            'currency' => $this->primaryCurrency(),
+            'mrr' => $mrr,
+            'arr' => $mrr * 12,
+            'collected_30d' => $collected30d,
+            'overdue_total' => $overdue,
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function companyMetrics(): array
+    {
+        return $this->safeArray(fn (): array => [
+            'total' => (int) DB::table('companies')->count(),
+            'active' => (int) DB::table('companies')->where('status', 'active')->count(),
+            'trial' => (int) DB::table('companies')->where('status', 'trial')->count(),
+            'suspended' => (int) DB::table('companies')->where('status', 'suspended')->count(),
+            'expired' => (int) DB::table('companies')->where('status', 'expired')->count(),
+        ], [
+            'total' => 0,
+            'active' => 0,
+            'trial' => 0,
+            'suspended' => 0,
+            'expired' => 0,
+        ]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function subscriptionMetrics(): array
+    {
+        return $this->safeArray(fn (): array => [
+            'total' => (int) DB::table($this->tenantTable('subscriptions'))->count(),
+            'active' => (int) DB::table($this->tenantTable('subscriptions'))->where('status', 'active')->count(),
+            'trial' => (int) DB::table($this->tenantTable('subscriptions'))->where('status', 'trial')->count(),
+            'past_due' => (int) DB::table($this->tenantTable('subscriptions'))->where('status', 'past_due')->count(),
+            'cancelled_30d' => (int) DB::table($this->tenantTable('subscriptions'))
+                ->where('status', 'cancelled')
+                ->where('cancelled_at', '>=', now()->subDays(30))
+                ->count(),
+        ], [
+            'total' => 0,
+            'active' => 0,
+            'trial' => 0,
+            'past_due' => 0,
+            'cancelled_30d' => 0,
+        ]);
+    }
+
+    /**
+     * @return array<string, int|float>
+     */
+    private function billingMetrics(): array
+    {
+        return $this->safeArray(fn (): array => [
+            'invoices_total' => (int) DB::table($this->tenantTable('invoices'))->count(),
+            'invoices_paid' => (int) DB::table($this->tenantTable('invoices'))->where('status', 'paid')->count(),
+            'invoices_overdue' => (int) DB::table($this->tenantTable('invoices'))->where('status', 'overdue')->count(),
+            'payments_completed_30d' => (int) DB::table($this->tenantTable('payments'))
+                ->where('status', 'completed')
+                ->where('created_at', '>=', now()->subDays(30))
+                ->count(),
+        ], [
+            'invoices_total' => 0,
+            'invoices_paid' => 0,
+            'invoices_overdue' => 0,
+            'payments_completed_30d' => 0,
+        ]);
+    }
+
+    /**
+     * @return array<string, string|int>
+     */
+    private function systemMetrics(): array
+    {
+        return [
+            'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
+            'memory_usage_mb' => (int) round(memory_get_usage(true) / 1048576),
+            'cache_driver' => (string) config('cache.default'),
+            'queue_driver' => (string) config('queue.default'),
+            'db_driver' => (string) config('database.default'),
+        ];
+    }
+
+    private function monthlyRecurringRevenue(): float
+    {
+        return $this->safeFloat(function (): float {
+            $value = DB::table('companies')
+                ->join('plans', 'plans.id', '=', 'companies.plan_id')
+                ->whereIn('companies.status', ['active', 'trial'])
+                ->sum('plans.price_monthly');
+
+            return round((float) $value, 2);
+        });
+    }
+
+    private function sumPaymentsSince(\DateTimeInterface $since): float
+    {
+        return $this->safeFloat(function () use ($since): float {
+            $value = DB::table($this->tenantTable('payments'))
+                ->where('status', 'completed')
+                ->where('created_at', '>=', $since)
+                ->sum('amount');
+
+            return round((float) $value, 2);
+        });
+    }
+
+    private function sumInvoicesByStatus(string $status): float
+    {
+        return $this->safeFloat(function () use ($status): float {
+            $value = DB::table($this->tenantTable('invoices'))
+                ->where('status', $status)
+                ->sum('total');
+
+            return round((float) $value, 2);
+        });
+    }
+
+    private function primaryCurrency(): string
+    {
+        return $this->safeString(function (): string {
+            $currency = DB::table('companies')
+                ->select('currency', DB::raw('count(*) as count'))
+                ->groupBy('currency')
+                ->orderByDesc('count')
+                ->value('currency');
+
+            return is_string($currency) && $currency !== '' ? $currency : 'DZD';
+        }, 'DZD');
+    }
+
+    private function tenantTable(string $table): string
+    {
+        return DB::getDriverName() === 'pgsql' ? 'shared_tenants.'.$table : $table;
+    }
+
+    /**
+     * @template T of array<string, mixed>
+     *
+     * @param  callable(): T  $callback
+     * @param  T  $fallback
+     * @return T
+     */
+    private function safeArray(callable $callback, array $fallback): array
+    {
+        try {
+            return $callback();
+        } catch (Throwable) {
+            return $fallback;
+        }
+    }
+
+    /**
+     * @param  callable(): float  $callback
+     */
+    private function safeFloat(callable $callback): float
+    {
+        try {
+            return $callback();
+        } catch (Throwable) {
+            return 0.0;
+        }
+    }
+
+    /**
+     * @param  callable(): string  $callback
+     */
+    private function safeString(callable $callback, string $fallback): string
+    {
+        try {
+            return $callback();
+        } catch (Throwable) {
+            return $fallback;
+        }
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\V1\PlatformCompanyFeatureController;
 use App\Http\Controllers\Api\V1\PlatformCompanyHealthController;
 use App\Http\Controllers\Api\V1\PlatformCompanyRequestController;
 use App\Http\Controllers\Api\V1\PlatformCompanySubscriptionController;
+use App\Http\Controllers\Api\V1\PlatformMetricsOverviewController;
 use App\Http\Controllers\Api\V1\PlatformPlanController;
 use App\Http\Controllers\Api\V1\TranslationCatalogController;
 use App\Http\Controllers\Web\PlatformCompanyController;
@@ -109,6 +110,7 @@ Route::prefix('v1')->group(function (): void {
         Route::patch('/companies/{company}/subscription', [PlatformCompanySubscriptionController::class, 'update']);
         Route::get('/companies/{company}/features', [PlatformCompanyFeatureController::class, 'show']);
         Route::patch('/companies/{company}/features', [PlatformCompanyFeatureController::class, 'update']);
+        Route::get('/metrics/overview', PlatformMetricsOverviewController::class);
 
         Route::get('/company-requests', [PlatformCompanyRequestController::class, 'index']);
         Route::get('/company-requests/{id}', [PlatformCompanyRequestController::class, 'show'])->whereNumber('id');

--- a/api/tests/Feature/PlatformMetricsOverviewApiTest.php
+++ b/api/tests/Feature/PlatformMetricsOverviewApiTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\SuperAdmin;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class PlatformMetricsOverviewApiTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_super_admin_can_view_platform_metrics_overview(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-13 08:00:00', 'UTC'));
+
+        try {
+            DB::table('plans')->insert([
+                ['id' => 1, 'name' => 'Starter', 'price_monthly' => 29, 'price_yearly' => 290, 'trial_days' => 14, 'is_active' => true],
+                ['id' => 2, 'name' => 'Pro', 'price_monthly' => 99, 'price_yearly' => 990, 'trial_days' => 14, 'is_active' => true],
+            ]);
+
+            $active = Company::factory()->create(['plan_id' => 2, 'status' => 'active', 'currency' => 'DZD']);
+            $trial = Company::factory()->create(['plan_id' => 1, 'status' => 'trial', 'currency' => 'DZD']);
+            $suspended = Company::factory()->suspended()->create(['plan_id' => 1, 'currency' => 'EUR']);
+
+            DB::table('subscriptions')->insert([
+                ['company_id' => $active->id, 'plan' => 'pro', 'status' => 'active', 'payment_method' => 'manual', 'created_at' => now(), 'updated_at' => now()],
+                ['company_id' => $trial->id, 'plan' => 'starter', 'status' => 'trial', 'payment_method' => 'manual', 'created_at' => now(), 'updated_at' => now()],
+                ['company_id' => $suspended->id, 'plan' => 'starter', 'status' => 'past_due', 'payment_method' => 'manual', 'created_at' => now(), 'updated_at' => now()],
+            ]);
+
+            $invoiceId = DB::table('invoices')->insertGetId([
+                'company_id' => $active->id,
+                'number' => 'LEO-2026-0001',
+                'amount' => 100,
+                'currency' => 'DZD',
+                'tax_amount' => 19,
+                'total' => 119,
+                'status' => 'paid',
+                'due_date' => now()->addDays(5)->toDateString(),
+                'paid_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            DB::table('invoices')->insert([
+                'company_id' => $suspended->id,
+                'number' => 'LEO-2026-0002',
+                'amount' => 50,
+                'currency' => 'DZD',
+                'tax_amount' => 0,
+                'total' => 50,
+                'status' => 'overdue',
+                'due_date' => now()->subDays(3)->toDateString(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table('payments')->insert([
+                'invoice_id' => $invoiceId,
+                'company_id' => $active->id,
+                'amount' => 119,
+                'currency' => 'DZD',
+                'method' => 'manual',
+                'status' => 'completed',
+                'paid_at' => now(),
+                'created_at' => now(),
+            ]);
+
+            Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+            $response = $this->getJson('/api/v1/platform/metrics/overview');
+
+            $response->assertOk();
+            $response->assertJsonPath('data.revenue.currency', 'DZD');
+            $response->assertJsonPath('data.revenue.mrr', 128);
+            $response->assertJsonPath('data.revenue.arr', 1536);
+            $response->assertJsonPath('data.revenue.collected_30d', 119);
+            $response->assertJsonPath('data.revenue.overdue_total', 50);
+            $response->assertJsonPath('data.companies.total', 3);
+            $response->assertJsonPath('data.companies.active', 1);
+            $response->assertJsonPath('data.companies.trial', 1);
+            $response->assertJsonPath('data.companies.suspended', 1);
+            $response->assertJsonPath('data.subscriptions.active', 1);
+            $response->assertJsonPath('data.subscriptions.trial', 1);
+            $response->assertJsonPath('data.subscriptions.past_due', 1);
+            $response->assertJsonPath('data.billing.invoices_paid', 1);
+            $response->assertJsonPath('data.billing.invoices_overdue', 1);
+            $response->assertJsonPath('data.billing.payments_completed_30d', 1);
+            $response->assertJsonStructure([
+                'data' => [
+                    'system' => ['php_version', 'laravel_version', 'memory_usage_mb', 'cache_driver', 'queue_driver', 'db_driver'],
+                    'generated_at',
+                ],
+            ]);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_metrics_overview_requires_super_admin_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/platform/metrics/overview');
+
+        $response->assertUnauthorized();
+    }
+
+    private function superAdmin(): SuperAdmin
+    {
+        return SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => fake()->unique()->safeEmail(),
+            'password_hash' => Hash::make('password123'),
+        ]);
+    }
+}

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -92,6 +92,7 @@ Quand un domaine gagne une feature significative, ajouter:
 
 ## Notes 2026-05-12
 
+- v4.16.7 : Le contrat `GET /api/v1/platform/metrics/overview` devient une surface plateforme critique pour le cockpit super-admin. Il doit rester protege par `super_admin_api`, exposer uniquement des agregats non nominatifs et rester tolerant aux tables billing absentes pendant les migrations progressives.
 - v4.16.0 : Les annotations PHPDoc `@property`, `@return` et `@var Employee` ajoutees dans les modeles, services et controllers ne modifient aucun comportement runtime. Le helper `currentCompany()` est un remplacement fonctionnellement identique de `app('current_company')`. Le binding `LLMClient` dans AppServiceProvider preserve le meme comportement de selection provider. Aucun nouveau endpoint ni modification de contrat API.
 - v4.16.1 : Extraction des appels inline `$request->user()->` dans 8 controllers supplementaires. Aucun changement de comportement ni de contrat API.
 - v4.16.2 : Extraction des chaines `->fresh()->` nullables et ajout de null checks sur les relations. Aucun changement de comportement ni de contrat API.

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -164,9 +164,11 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - `GET /api/v1/platform/companies/health` retourne le portefeuille client avec MRR total, repartition des risques et prochaine action par company
 - `GET /api/v1/platform/plans` retourne le catalogue des plans pour alimenter les formulaires d'abonnement super-admin
 - `GET/PATCH /api/v1/platform/companies/{company}/subscription` lit et met a jour plan, statut, dates d'abonnement et notes client
+- `GET /api/v1/platform/metrics/overview` retourne les agregats plateforme MRR/ARR, encaissements 30 jours, impayes, companies, abonnements, facturation et systeme
 - Le health client classe clairement le risque (`low`, `medium`, `high`) et reste reserve au guard `super_admin_api`
 - Les metriques health ne doivent jamais lire les donnees d'un autre tenant ni dependre d'un `current_company` applicatif
 - Le contrat abonnement refuse les statuts inconnus, les plans inexistants et les dates incoherentes
+- Le contrat metrics overview reste reserve au guard `super_admin_api`, ne retourne aucune donnee nominative tenant et tolere les tables billing absentes pendant les migrations progressives
 
 ### 14. Catalogue de traductions distant et variantes de locale
 
@@ -208,6 +210,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - Contrat health plateforme pour adoption, retention et upsell client
 - Contrat catalogue plans plateforme pour eviter les `plan_id` hardcodes cote frontend
 - Contrat abonnement plateforme pour upgrade, suspension, expiration et notes client
+- Contrat metrics overview plateforme pour MRR/ARR, impayes, encaissements, companies, abonnements et facturation
 - Health endpoint
 
 ### Suites a ajouter ou durcir progressivement
@@ -574,6 +577,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 
 ### Metrics platform
 - `GET /api/v1/metrics` — Retourne: companies (total, active, trial), employees (total, active), system (php_version, laravel_version, memory_usage_mb, cache_driver, queue_driver, db_driver)
+- `GET /api/v1/platform/metrics/overview` — Retourne: revenue (currency, mrr, arr, collected_30d, overdue_total), companies, subscriptions, billing, system et generated_at pour le cockpit super-admin
 
 ### Structured Logging
 - Middleware `StructuredLogging` enregistre chaque requete API en JSON : method, uri, status, duration_ms, ip, user_agent, user_id, company_id, request_id


### PR DESCRIPTION
## Summary
- add protected GET /api/v1/platform/metrics/overview for super-admin cockpit aggregates
- expose revenue, company, subscription, billing and system metrics without tenant personal data
- add feature tests and governance documentation for the new API contract

## Validation
- php -l api/app/Http/Controllers/Api/V1/PlatformMetricsOverviewController.php
- php -l api/tests/Feature/PlatformMetricsOverviewApiTest.php
- git diff --check HEAD~1..HEAD
- powershell -ExecutionPolicy Bypass -File dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD

Note: local php artisan test is blocked on this Windows PHP by missing mbstring (Illuminate\\Support\\mb_split). GitHub Actions remain the source of truth.