### PR TITLE
docs(openapi): document platform metrics overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Procedure recommandee :
 - Le cockpit `admin-dashboard` doit consommer les contrats plateforme reels (`/platform/companies/health`, `/platform/companies/{id}/health`, `/subscription`, `/plans`) avant toute nouvelle statistique mockee.
 - `GET /api/v1/platform/metrics/overview` est le contrat d'agregats pour le cockpit super-admin : MRR/ARR, encaissements, impayes, companies, subscriptions, billing et systeme. Il doit rester sous `super_admin_api`, non nominatif, et tolerant aux tables billing absentes pendant les migrations progressives.
 - Le dashboard admin doit consommer `/platform/metrics/overview` pour les chiffres financiers globaux. Ne pas recalculer ARR, impayes ou encaissements cote frontend a partir de listes partielles.
+- Quand un contrat plateforme est consomme par le dashboard ou la future IA, l'ajouter aussi dans `api/openapi.yaml` avec schemas `data.*` explicites afin d'eviter les integrations a l'aveugle.
 - La page Support admin sert maintenant d'intake demandes clients via `/platform/company-requests`; ne pas y remettre de tickets mockes tant qu'un vrai module support n'a pas son API dediee.
 - Le dashboard d'accueil admin doit rester une synthese des contrats plateforme existants. Eviter les endpoints `/admin/dashboard/*` tant qu'ils n'existent pas cote API.
 - Approuver une `company_request` doit declencher le provisioning partage via `CompanyProvisioningService` et remplir `approved_company_id`; ne pas se limiter a changer le statut.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.10] - 2026-05-13
+
+### OpenAPI — Platform Metrics Contract (Lot 6)
+
+- OpenAPI : documentation de `GET /api/v1/platform/metrics/overview` avec securite `SuperAdminBearerAuth`.
+- OpenAPI : ajout des schemas d'agregats plateforme pour revenue, companies, subscriptions, billing, system et `generated_at`.
+
 ## [4.16.9] - 2026-05-13
 
 ### Documentation — Roadmap Execution Post Lots

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -315,6 +315,25 @@ paths:
         "422":
           $ref: "#/components/responses/Validation422"
 
+  /platform/metrics/overview:
+    get:
+      tags: ["Platform"]
+      summary: "Agregats business du cockpit super-admin"
+      description: "Retourne des metriques globales non nominatives pour piloter MRR, ARR, encaissements, impayes, companies, subscriptions, billing et systeme."
+      security:
+        - SuperAdminBearerAuth: []
+      responses:
+        "200":
+          description: "Metriques plateforme agregees"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformMetricsOverviewResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+
   /employees:
     get:
       tags: ["Employees"]
@@ -2440,6 +2459,125 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    PlatformMetricsOverviewResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            revenue:
+              $ref: "#/components/schemas/PlatformMetricsRevenue"
+            companies:
+              $ref: "#/components/schemas/PlatformMetricsCompanies"
+            subscriptions:
+              $ref: "#/components/schemas/PlatformMetricsSubscriptions"
+            billing:
+              $ref: "#/components/schemas/PlatformMetricsBilling"
+            system:
+              $ref: "#/components/schemas/PlatformMetricsSystem"
+            generated_at:
+              type: string
+              format: date-time
+
+    PlatformMetricsRevenue:
+      type: object
+      properties:
+        currency:
+          type: string
+          example: "DZD"
+        mrr:
+          type: number
+          format: float
+          example: 128
+        arr:
+          type: number
+          format: float
+          example: 1536
+        collected_30d:
+          type: number
+          format: float
+          example: 119
+        overdue_total:
+          type: number
+          format: float
+          example: 50
+
+    PlatformMetricsCompanies:
+      type: object
+      properties:
+        total:
+          type: integer
+          example: 12
+        active:
+          type: integer
+          example: 8
+        trial:
+          type: integer
+          example: 2
+        suspended:
+          type: integer
+          example: 1
+        expired:
+          type: integer
+          example: 1
+
+    PlatformMetricsSubscriptions:
+      type: object
+      properties:
+        total:
+          type: integer
+          example: 12
+        active:
+          type: integer
+          example: 8
+        trial:
+          type: integer
+          example: 2
+        past_due:
+          type: integer
+          example: 1
+        cancelled_30d:
+          type: integer
+          example: 1
+
+    PlatformMetricsBilling:
+      type: object
+      properties:
+        invoices_total:
+          type: integer
+          example: 24
+        invoices_paid:
+          type: integer
+          example: 18
+        invoices_overdue:
+          type: integer
+          example: 3
+        payments_completed_30d:
+          type: integer
+          example: 7
+
+    PlatformMetricsSystem:
+      type: object
+      properties:
+        php_version:
+          type: string
+          example: "8.4.20"
+        laravel_version:
+          type: string
+          example: "11.x"
+        memory_usage_mb:
+          type: integer
+          example: 32
+        cache_driver:
+          type: string
+          example: "redis"
+        queue_driver:
+          type: string
+          example: "redis"
+        db_driver:
+          type: string
+          example: "pgsql"
 
     PlatformCompanyCreateRequest:
       type: object


### PR DESCRIPTION
## Summary
- document GET /api/v1/platform/metrics/overview in OpenAPI
- add explicit schemas for revenue, companies, subscriptions, billing and system aggregates
- update changelog and AGENTS with the OpenAPI contract rule

## Validation
- OpenAPI YAML parsed with PyYAML
- git diff --check HEAD~1..HEAD
- powershell -ExecutionPolicy Bypass -File dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD