### PR TITLE
test(api): harden contract tenant isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,3 +296,4 @@ Procedure recommandee :
 - Les modeles LeavePolicy, LeaveBalance, LeaveAccrual, Contract, ContractAmendment, ApprovalWorkflow/Request/Decision existaient deja en tant que modeles. Verifier les routes et controllers avant de creer du code duplique.
 - `hr_extended.php` centralise toutes les routes des modules etendus (conges, contrats, recrutement, formation, loans, frais, webhooks, audit).
 - Le trait `Approvable` est un pattern reutilisable pour brancher le workflow d'approbation sur n'importe quel modele (Absence, ExpenseClaim, etc.).
+- Les contrats doivent rester explicitement scopes par `company_id` dans `index`, `expiring`, `myContracts` et les endpoints self-service. Ne pas compter uniquement sur les IDs de route : la creation doit refuser un `employee_id` hors tenant, et PDF/amendments doivent verifier proprietaire ou manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.23] - 2026-05-13
+
+### Security — Contract tenant isolation
+
+- Securite : `ContractController` filtre maintenant les listes, alertes d'expiration et contrats self-service par `company_id`.
+- Securite : la creation de contrat refuse un employe hors tenant ; les endpoints PDF/amendments appliquent le meme controle proprietaire que le detail contrat.
+- Tests : `ContractWorkflowTest` couvre index tenant-scope, refus cross-tenant employee, expirations tenant-scope et interdiction self-service sur les contrats d'un collegue.
+
 ## [4.16.22] - 2026-05-13
 
 ### CI — Coverage gate bootstrap

--- a/api/app/Http/Controllers/Api/V1/ContractController.php
+++ b/api/app/Http/Controllers/Api/V1/ContractController.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Models\Contract;
 use App\Models\ContractAmendment;
+use App\Models\Employee;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 
 class ContractController extends Controller
 {
@@ -17,9 +18,11 @@ class ContractController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        $query = Contract::query()->with(['employee:id,first_name,last_name', 'department:id,name', 'position:id,name']);
+        $query = Contract::query()
+            ->with(['employee:id,first_name,last_name', 'department:id,name', 'position:id,name'])
+            ->where('company_id', $actor->company_id);
 
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             $query->where('employee_id', $actor->id);
         } elseif ($request->filled('employee_id')) {
             $query->where('employee_id', $request->integer('employee_id'));
@@ -38,7 +41,7 @@ class ContractController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
 
@@ -60,6 +63,17 @@ class ContractController extends Controller
             'clauses' => 'nullable|array',
         ]);
 
+        $employeeBelongsToCompany = Employee::query()
+            ->where('company_id', $actor->company_id)
+            ->whereKey($validated['employee_id'])
+            ->exists();
+
+        if ($employeeBelongsToCompany === false) {
+            throw ValidationException::withMessages([
+                'employee_id' => ['The selected employee is invalid.'],
+            ]);
+        }
+
         $contract = Contract::create([
             ...$validated,
             'company_id' => $actor->company_id,
@@ -77,7 +91,7 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->isManager() && $contract->employee_id !== $actor->id) {
+        if ($actor->isManager() === false && $contract->employee_id !== $actor->id) {
             abort(403);
         }
 
@@ -91,7 +105,7 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
 
@@ -124,6 +138,7 @@ class ContractController extends Controller
 
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
+
         return response()->json(['data' => $contractFresh->load(['employee:id,first_name,last_name', 'department:id,name'])]);
     }
 
@@ -133,6 +148,9 @@ class ContractController extends Controller
         $actor = $request->user();
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
+        }
+        if ($actor->isManager() === false && $contract->employee_id !== $actor->id) {
+            abort(403);
         }
 
         return response()->json(['data' => $contract->amendments()->orderByDesc('effective_date')->get()]);
@@ -145,7 +163,7 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
 
@@ -170,12 +188,13 @@ class ContractController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
         $days = $request->integer('days', 30);
         $contracts = Contract::expiringSoon($days)
+            ->where('company_id', $actor->company_id)
             ->with('employee:id,first_name,last_name')
             ->get();
 
@@ -189,7 +208,7 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
         if ($contract->status !== 'draft') {
@@ -200,6 +219,7 @@ class ContractController extends Controller
 
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
+
         return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
     }
 
@@ -210,7 +230,7 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
         if ($contract->status !== 'active') {
@@ -221,6 +241,7 @@ class ContractController extends Controller
 
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
+
         return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
     }
 
@@ -231,10 +252,10 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
-        if (! in_array($contract->status, ['active', 'suspended'], true)) {
+        if (in_array($contract->status, ['active', 'suspended'], true) === false) {
             return response()->json(['message' => 'Contract must be active or suspended to terminate.'], 422);
         }
 
@@ -250,6 +271,7 @@ class ContractController extends Controller
 
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
+
         return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
     }
 
@@ -260,7 +282,7 @@ class ContractController extends Controller
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->hasManagerRole('principal', 'rh')) {
+        if ($actor->hasManagerRole('principal', 'rh') === false) {
             abort(403);
         }
 
@@ -303,6 +325,7 @@ class ContractController extends Controller
         $actor = $request->user();
 
         $contracts = Contract::query()
+            ->where('company_id', $actor->company_id)
             ->where('employee_id', $actor->id)
             ->with(['department:id,name', 'position:id,name'])
             ->orderByDesc('start_date')
@@ -317,6 +340,9 @@ class ContractController extends Controller
         $actor = $request->user();
         if ($contract->company_id !== $actor->company_id) {
             abort(404);
+        }
+        if ($actor->isManager() === false && $contract->employee_id !== $actor->id) {
+            abort(403);
         }
 
         $data = $contract->load(['employee:id,first_name,last_name,email', 'department:id,name', 'position:id,name', 'amendments'])->toArray();

--- a/api/tests/Feature/Contracts/ContractWorkflowTest.php
+++ b/api/tests/Feature/Contracts/ContractWorkflowTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Contracts;
 
 use App\Models\Company;
 use App\Models\Contract;
+use App\Models\ContractAmendment;
 use App\Models\Employee;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
@@ -119,6 +120,46 @@ class ContractWorkflowTest extends TestCase
         return [$company, $manager, $employee];
     }
 
+    private function makeOtherTenant(string $suffix = '02'): array
+    {
+        $company = Company::query()->create([
+            'name' => "Other Contract Co {$suffix}",
+            'slug' => "other-contract-co-{$suffix}",
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => "other-contract-{$suffix}@test.com",
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => "MGR-C{$suffix}",
+            'first_name' => 'Other',
+            'last_name' => 'Manager',
+            'email' => "boss-{$suffix}@contract-co.test",
+            'password_hash' => Hash::make('password'),
+            'role' => 'manager',
+            'manager_role' => 'rh',
+            'status' => 'active',
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => "EMP-C{$suffix}",
+            'first_name' => 'Other',
+            'last_name' => 'Employee',
+            'email' => "employee-{$suffix}@contract-co.test",
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        return [$company, $manager, $employee];
+    }
+
     public function test_create_draft_contract(): void
     {
         [$company, $manager, $employee] = $this->makeManagerAndCompany();
@@ -134,6 +175,58 @@ class ContractWorkflowTest extends TestCase
         $response->assertCreated();
         $response->assertJsonPath('data.status', 'draft');
         $response->assertJsonPath('data.contract_type', 'cdi');
+    }
+
+    public function test_manager_cannot_create_contract_for_other_tenant_employee(): void
+    {
+        [, $manager] = $this->makeManagerAndCompany();
+        [, , $otherEmployee] = $this->makeOtherTenant();
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson('/api/v1/contracts', [
+            'employee_id' => $otherEmployee->id,
+            'contract_type' => 'cdi',
+            'start_date' => '2026-06-01',
+            'base_salary' => 85000,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors('employee_id');
+        $this->assertDatabaseMissing('contracts', [
+            'employee_id' => $otherEmployee->id,
+            'base_salary' => 85000,
+        ]);
+    }
+
+    public function test_contract_index_is_scoped_to_actor_company(): void
+    {
+        [$company, $manager, $employee] = $this->makeManagerAndCompany();
+        [$otherCompany, , $otherEmployee] = $this->makeOtherTenant();
+        Sanctum::actingAs($manager);
+
+        Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'contract_type' => 'cdi',
+            'start_date' => '2026-01-01',
+            'base_salary' => 55000,
+            'status' => 'active',
+            'created_by' => $manager->id,
+        ]);
+        Contract::query()->create([
+            'company_id' => $otherCompany->id,
+            'employee_id' => $otherEmployee->id,
+            'contract_type' => 'cdd',
+            'start_date' => '2026-01-01',
+            'base_salary' => 99000,
+            'status' => 'active',
+        ]);
+
+        $response = $this->getJson('/api/v1/contracts');
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.company_id', $company->id);
     }
 
     public function test_activate_draft_contract(): void
@@ -255,5 +348,75 @@ class ContractWorkflowTest extends TestCase
         $response->assertOk();
         $response->assertJsonStructure(['data' => [['id', 'contract_type', 'status']]]);
         $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_expiring_contracts_are_tenant_scoped(): void
+    {
+        [$company, $manager, $employee] = $this->makeManagerAndCompany();
+        [$otherCompany, , $otherEmployee] = $this->makeOtherTenant();
+        Sanctum::actingAs($manager);
+
+        Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'contract_type' => 'cdd',
+            'start_date' => now()->subMonths(6)->toDateString(),
+            'end_date' => now()->addDays(10)->toDateString(),
+            'base_salary' => 45000,
+            'status' => 'active',
+        ]);
+        Contract::query()->create([
+            'company_id' => $otherCompany->id,
+            'employee_id' => $otherEmployee->id,
+            'contract_type' => 'cdd',
+            'start_date' => now()->subMonths(6)->toDateString(),
+            'end_date' => now()->addDays(10)->toDateString(),
+            'base_salary' => 90000,
+            'status' => 'active',
+        ]);
+
+        $response = $this->getJson('/api/v1/contracts/expiring?days=30');
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.company_id', $company->id);
+    }
+
+    public function test_employee_cannot_view_coworker_contract_pdf_or_amendments(): void
+    {
+        [$company, $manager, $employee] = $this->makeManagerAndCompany();
+        $coworker = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'EMP-C03',
+            'first_name' => 'Coworker',
+            'last_name' => 'RH',
+            'email' => 'coworker@contract-co.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        $contract = Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $coworker->id,
+            'contract_type' => 'cdi',
+            'start_date' => '2026-01-01',
+            'base_salary' => 55000,
+            'status' => 'active',
+            'created_by' => $manager->id,
+        ]);
+        ContractAmendment::query()->create([
+            'company_id' => $company->id,
+            'contract_id' => $contract->id,
+            'amendment_type' => 'salary_change',
+            'changes' => ['base_salary' => 60000],
+            'effective_date' => '2026-07-01',
+            'approved_by' => $manager->id,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson("/api/v1/contracts/{$contract->id}")->assertForbidden();
+        $this->getJson("/api/v1/contracts/{$contract->id}/generate-pdf")->assertForbidden();
+        $this->getJson("/api/v1/contracts/{$contract->id}/amendments")->assertForbidden();
     }
 }

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -276,6 +276,9 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - `GET /api/v1/contracts/{id}/generate-pdf` genere les donnees PDF
 - `GET /api/v1/me/contracts` retourne les contrats de l'employe connecte
 - RBAC : employe voit uniquement ses propres contrats
+- Isolation : `GET /api/v1/contracts` et `GET /api/v1/contracts/expiring` ne retournent que le tenant courant
+- Isolation : `POST /api/v1/contracts` refuse un `employee_id` hors tenant
+- Self-service : un employe ne peut pas consulter, generer le PDF ou lire les avenants du contrat d'un collegue
 - Scheduler : `contracts:alert-expiring` alerte a 30/15/7 jours
 
 ### Module K — Workflows d'approbation

--- a/docs/PLAN_ACTION/13_RESTANT_POST_SPRINTS.md
+++ b/docs/PLAN_ACTION/13_RESTANT_POST_SPRINTS.md
@@ -180,7 +180,7 @@ Fichiers a creer dans tests/Feature/ :
 - [ ] PayrollRunControllerTest.php (~8 tests : create, calculate, validate, cancel, summary, RBAC)
 - [x] PaySlipControllerTest.php (~4 tests : list, detail, PDF, self-service)
 - [x] LeavePolicyControllerTest.php (~6 tests : CRUD, accrual, balance, RBAC)
-- [ ] ContractControllerTest.php (~6 tests : CRUD, amendment, expiring, RBAC)
+- [x] ContractControllerTest.php (~6 tests : CRUD, amendment, expiring, RBAC, isolation tenant)
 - [ ] RecruitmentControllerTest.php (~8 tests : job CRUD, apply, pipeline, interview, RBAC)
 - [ ] TrainingControllerTest.php (~6 tests : course CRUD, session, enrollment, RBAC)
 - [ ] EmployeeLoanControllerTest.php (~6 tests : CRUD, repayment schedule, RBAC)


### PR DESCRIPTION
## Summary
- scope contract index, expiring alerts and self-service contracts to the actor company
- reject contract creation for employees outside the tenant and protect PDF/amendments self-service access
- extend ContractWorkflowTest and update Plan 13, API scenarios, CHANGELOG and AGENTS

## Validation
- php -l api/app/Http/Controllers/Api/V1/ContractController.php
- php -l api/tests/Feature/Contracts/ContractWorkflowTest.php
- api/vendor/bin/pint --test app/Http/Controllers/Api/V1/ContractController.php tests/Feature/Contracts/ContractWorkflowTest.php
- powershell -ExecutionPolicy Bypass -File dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD
- php artisan test --filter=ContractWorkflowTest (blocked locally: missing mbstring / mb_split on Windows)