### PR TITLE
test: cover payroll run workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Les tables `tax_slabs` et `social_contributions` sont creees par les migrations tenant. Le seeder `PayrollCountryConfigSeeder` doit etre lance dans le schema tenant courant, pas depuis un contexte public qui n'a pas ces tables.
 - Les exports bancaires doivent utiliser les colonnes reelles de `employees` : `iban` et `bank_account`. Ne pas reintroduire `rib` ou `bank_name` sans migration correspondante.
 - Pour les barèmes fiscaux de paie, les tranches documentees sont inclusives (`0-5000`, `5001-20000`). Utiliser le helper progressif de `AbstractCountryRules` pour eviter les erreurs d'unite aux bornes.
+- Pour tester `PayrollRunController` sans rendre la suite fragile face aux baremes/salary structures, binder un faux `PayrollCalculator` dans le container et verifier le contrat controller : run calcule, pay slip cree, validation/cancel et isolation tenant.
 
 ### Render et migrations PostgreSQL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.24] - 2026-05-13
+
+### Tests — Payroll run API contracts
+
+- Tests : extension de `PayrollRunControllerTest` pour couvrir calcul, validation, annulation et isolation tenant des runs de paie.
+- Qualite : `PayrollRunController` utilise maintenant des checks stricts sur les statuts et roles dans les actions sensibles.
+- Documentation : plan post-sprints et scenarios API synchronises avec la couverture workflow paie.
+
 ## [4.20.0] - 2026-05-13
 
 ### Finitions — Sentry APM, alerting, DEVELOPMENT.md, GTM (Plan 13 Sections 7-9) + Plan 14

--- a/api/app/Http/Controllers/Api/V1/PayrollRunController.php
+++ b/api/app/Http/Controllers/Api/V1/PayrollRunController.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Employee;
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\PayrollRun;
 use App\Services\Payroll\PayrollCalculator;
 use Illuminate\Http\JsonResponse;
@@ -18,7 +20,7 @@ class PayrollRunController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
@@ -47,7 +49,7 @@ class PayrollRunController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
@@ -77,7 +79,7 @@ class PayrollRunController extends Controller
         if ($payrollRun->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
@@ -93,11 +95,11 @@ class PayrollRunController extends Controller
         if ($payrollRun->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
-        if (! in_array($payrollRun->status, ['draft', 'calculated'])) {
+        if (in_array($payrollRun->status, ['draft', 'calculated'], true) === false) {
             return response()->json(['message' => 'Payroll run cannot be recalculated in current status.'], 422);
         }
 
@@ -114,7 +116,7 @@ class PayrollRunController extends Controller
         if ($payrollRun->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
@@ -142,11 +144,11 @@ class PayrollRunController extends Controller
         if ($payrollRun->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 
-        if (in_array($payrollRun->status, ['paid', 'cancelled'])) {
+        if (in_array($payrollRun->status, ['paid', 'cancelled'], true)) {
             return response()->json(['message' => 'Payroll run cannot be cancelled.'], 422);
         }
 
@@ -162,7 +164,7 @@ class PayrollRunController extends Controller
         if ($payrollRun->company_id !== $actor->company_id) {
             abort(404);
         }
-        if (! $actor->isManager()) {
+        if ($actor->isManager() === false) {
             abort(403);
         }
 

--- a/api/tests/Feature/PayrollRunControllerTest.php
+++ b/api/tests/Feature/PayrollRunControllerTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Feature;
 
 use App\Models\Company;
 use App\Models\Employee;
+use App\Models\PaySlip;
 use App\Models\PayrollRun;
+use App\Services\Payroll\PayrollCalculator;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
@@ -25,6 +29,49 @@ class PayrollRunControllerTest extends TestCase
         parent::tearDown();
     }
 
+    private function bindFakePayrollCalculator(): void
+    {
+        $this->app->instance(PayrollCalculator::class, new class extends PayrollCalculator
+        {
+            public function calculateRun(PayrollRun $run): PayrollRun
+            {
+                $employee = Employee::query()
+                    ->where('company_id', $run->company_id)
+                    ->where('status', 'active')
+                    ->firstOrFail();
+
+                PaySlip::query()->create([
+                    'payroll_run_id' => $run->id,
+                    'company_id' => $run->company_id,
+                    'employee_id' => $employee->id,
+                    'period_start' => $run->period_start,
+                    'period_end' => $run->period_end,
+                    'gross_salary' => 100000,
+                    'total_deductions' => 25000,
+                    'net_salary' => 75000,
+                    'employer_contributions' => 12000,
+                    'total_cost' => 112000,
+                    'working_days' => 22,
+                    'actual_days_worked' => 22,
+                    'overtime_hours' => 0,
+                    'status' => 'calculated',
+                ]);
+
+                $run->update([
+                    'status' => 'calculated',
+                    'total_gross' => 100000,
+                    'total_deductions' => 25000,
+                    'total_net' => 75000,
+                    'total_employer_cost' => 112000,
+                    'employee_count' => 1,
+                    'calculated_at' => now(),
+                ]);
+
+                return $run->refresh();
+            }
+        });
+    }
+
     public function test_manager_can_list_payroll_runs(): void
     {
         $company = Company::factory()->create();
@@ -42,6 +89,7 @@ class PayrollRunControllerTest extends TestCase
 
         $response = $this->getJson('/api/v1/payroll-runs');
         $response->assertOk();
+        $response->assertJsonCount(1, 'data');
     }
 
     public function test_manager_can_create_payroll_run(): void
@@ -120,5 +168,135 @@ class PayrollRunControllerTest extends TestCase
 
         $response = $this->getJson("/api/v1/payroll-runs/{$run->id}/summary");
         $response->assertOk();
+    }
+
+    public function test_manager_can_calculate_payroll_run_with_calculator_contract(): void
+    {
+        $this->bindFakePayrollCalculator();
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        Employee::factory()->create(['company_id' => $company->id, 'status' => 'active']);
+        $run = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'draft',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/calculate");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.status', 'calculated');
+        $response->assertJsonPath('data.pay_slips_count', 1);
+        $this->assertDatabaseHas('pay_slips', [
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'status' => 'calculated',
+        ]);
+    }
+
+    public function test_manager_can_validate_calculated_run_and_slips(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $run = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'calculated',
+        ]);
+        PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 100000,
+            'total_deductions' => 25000,
+            'net_salary' => 75000,
+            'employer_contributions' => 12000,
+            'total_cost' => 112000,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'calculated',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/validate");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.status', 'validated');
+        $this->assertDatabaseHas('pay_slips', [
+            'payroll_run_id' => $run->id,
+            'status' => 'validated',
+        ]);
+        $this->assertSame($manager->id, $run->fresh()->validated_by);
+    }
+
+    public function test_manager_can_cancel_draft_run_but_not_paid_run(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $draft = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'draft',
+        ]);
+        $paid = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->subMonth()->startOfMonth(),
+            'period_end' => now()->subMonth()->endOfMonth(),
+            'status' => 'paid',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson("/api/v1/payroll-runs/{$draft->id}/cancel")
+            ->assertOk()
+            ->assertJsonPath('data.status', 'cancelled');
+
+        $this->postJson("/api/v1/payroll-runs/{$paid->id}/cancel")
+            ->assertUnprocessable();
+    }
+
+    public function test_payroll_runs_are_isolated_by_tenant(): void
+    {
+        $company = Company::factory()->create();
+        $otherCompany = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $ownRun = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'draft',
+        ]);
+        $otherRun = PayrollRun::create([
+            'company_id' => $otherCompany->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'draft',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson('/api/v1/payroll-runs')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $ownRun->id);
+
+        $this->getJson("/api/v1/payroll-runs/{$otherRun->id}")->assertNotFound();
+        $this->postJson("/api/v1/payroll-runs/{$otherRun->id}/cancel")->assertNotFound();
     }
 }

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -374,6 +374,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - `GET /api/v1/payroll-runs/{id}/summary` retourne le resume avec totaux et liste employes
 - Validation : seul un run calculated peut etre valide, seul un run draft/calculated peut etre recalcule
 - RBAC : managers uniquement
+- Couverture Feature : liste scopee tenant, creation manager, calcul via contrat `PayrollCalculator`, validation run + bulletins, annulation draft, refus paid et refus d'acces cross-tenant.
 
 ### Pay Slips
 - `GET /api/v1/payroll-runs/{id}/pay-slips` liste les bulletins d'un run (manager)

--- a/docs/PLAN_ACTION/13_RESTANT_POST_SPRINTS.md
+++ b/docs/PLAN_ACTION/13_RESTANT_POST_SPRINTS.md
@@ -177,7 +177,7 @@ Fichiers a creer dans tests/Feature/ :
 - [x] EmployeeLoanControllerTest.php (~6 tests : CRUD, repayment schedule, RBAC)
 - [x] ExpenseClaimControllerTest.php (~6 tests : CRUD, approve, reject, RBAC)
 
-- [ ] PayrollRunControllerTest.php (~8 tests : create, calculate, validate, cancel, summary, RBAC)
+- [x] PayrollRunControllerTest.php (~8 tests : create, calculate, validate, cancel, summary, RBAC, isolation tenant)
 - [x] PaySlipControllerTest.php (~4 tests : list, detail, PDF, self-service)
 - [x] LeavePolicyControllerTest.php (~6 tests : CRUD, accrual, balance, RBAC)
 - [x] ContractControllerTest.php (~6 tests : CRUD, amendment, expiring, RBAC, isolation tenant)


### PR DESCRIPTION
## Summary
- extend PayrollRunControllerTest for calculate, validate, cancel and tenant-isolation contracts
- tighten strict role/status checks in PayrollRunController
- update Plan 13, API scenarios, changelog and agent notes

## Validation
- php -l api\\app\\Http\\Controllers\\Api\\V1\\PayrollRunController.php
- php -l api\\tests\\Feature\\PayrollRunControllerTest.php
- ./vendor/bin/pint --test app\\Http\\Controllers\\Api\\V1\\PayrollRunController.php tests\\Feature\\PayrollRunControllerTest.php
- git diff --check origin/main..HEAD
- powershell -ExecutionPolicy Bypass -File dev-hub\\tools\\check-governance.ps1 -BaseRef origin/main -HeadRef HEAD

## Local note
- php artisan test --filter=PayrollRunControllerTest is blocked on this Windows PHP install by missing mbstring (`mb_split()`); GitHub Actions remains the source of truth.