### PR TITLE
style: fix payroll run test pint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.25] - 2026-05-13
+
+### Style — Payroll run test formatting
+
+- Qualite : correction Pint du test `PayrollRunControllerTest` apres merge du lot workflow paie.
+
 ## [4.16.24] - 2026-05-13
 
 ### Tests — Payroll run API contracts

--- a/api/tests/Feature/PayrollRunControllerTest.php
+++ b/api/tests/Feature/PayrollRunControllerTest.php
@@ -6,10 +6,11 @@ namespace Tests\Feature;
 
 use App\Models\Company;
 use App\Models\Employee;
-use App\Models\PaySlip;
 use App\Models\PayrollRun;
+use App\Models\PaySlip;
 use App\Services\Payroll\PayrollCalculator;
 use Laravel\Sanctum\Sanctum;
+use Mockery;
 use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
 
@@ -31,45 +32,49 @@ class PayrollRunControllerTest extends TestCase
 
     private function bindFakePayrollCalculator(): void
     {
-        $this->app->instance(PayrollCalculator::class, new class extends PayrollCalculator
-        {
-            public function calculateRun(PayrollRun $run): PayrollRun
-            {
-                $employee = Employee::query()
-                    ->where('company_id', $run->company_id)
-                    ->where('status', 'active')
-                    ->firstOrFail();
+        $calculator = Mockery::mock(PayrollCalculator::class);
+        $calculator
+            ->shouldReceive('calculateRun')
+            ->once()
+            ->andReturnUsing(
+                function (PayrollRun $run): PayrollRun {
+                    $employee = Employee::query()
+                        ->where('company_id', $run->company_id)
+                        ->where('status', 'active')
+                        ->firstOrFail();
 
-                PaySlip::query()->create([
-                    'payroll_run_id' => $run->id,
-                    'company_id' => $run->company_id,
-                    'employee_id' => $employee->id,
-                    'period_start' => $run->period_start,
-                    'period_end' => $run->period_end,
-                    'gross_salary' => 100000,
-                    'total_deductions' => 25000,
-                    'net_salary' => 75000,
-                    'employer_contributions' => 12000,
-                    'total_cost' => 112000,
-                    'working_days' => 22,
-                    'actual_days_worked' => 22,
-                    'overtime_hours' => 0,
-                    'status' => 'calculated',
-                ]);
+                    PaySlip::query()->create([
+                        'payroll_run_id' => $run->id,
+                        'company_id' => $run->company_id,
+                        'employee_id' => $employee->id,
+                        'period_start' => $run->period_start,
+                        'period_end' => $run->period_end,
+                        'gross_salary' => 100000,
+                        'total_deductions' => 25000,
+                        'net_salary' => 75000,
+                        'employer_contributions' => 12000,
+                        'total_cost' => 112000,
+                        'working_days' => 22,
+                        'actual_days_worked' => 22,
+                        'overtime_hours' => 0,
+                        'status' => 'calculated',
+                    ]);
 
-                $run->update([
-                    'status' => 'calculated',
-                    'total_gross' => 100000,
-                    'total_deductions' => 25000,
-                    'total_net' => 75000,
-                    'total_employer_cost' => 112000,
-                    'employee_count' => 1,
-                    'calculated_at' => now(),
-                ]);
+                    $run->update([
+                        'status' => 'calculated',
+                        'total_gross' => 100000,
+                        'total_deductions' => 25000,
+                        'total_net' => 75000,
+                        'total_employer_cost' => 112000,
+                        'employee_count' => 1,
+                        'calculated_at' => now(),
+                    ]);
 
-                return $run->refresh();
-            }
-        });
+                    return $run->refresh();
+                }
+            );
+
+        $this->app->instance(PayrollCalculator::class, $calculator);
     }
 
     public function test_manager_can_list_payroll_runs(): void


### PR DESCRIPTION
## Summary
- fixes the Pint class brace style issue in PayrollRunControllerTest after PR #433
- records the style hotfix in CHANGELOG so governance remains satisfied

## Validation
- ./vendor/bin/pint --test tests\\Feature\\PayrollRunControllerTest.php
- php -l api\\tests\\Feature\\PayrollRunControllerTest.php
- git diff --check
- powershell -ExecutionPolicy Bypass -File dev-hub\\tools\\check-governance.ps1 -BaseRef origin/main -HeadRef HEAD