### PR TITLE
test: harden HR extension tenant isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 
 - `routes/modules/rh.php` porte le socle RH transverse (employes, contrats, absences, rapports courants) alors que `routes/modules/hr_extended.php` porte les extensions post-MVP. Avant de deplacer une route, verifier le controller et le scenario de test associe.
 - Les routes IA experimentales voice/agent restent sous feature AI + rate limit ; toute exposition plus large doit passer par une feature flag explicite et une couverture RBAC.
+- Dans les extensions RH (`RecruitmentController`, `TrainingController`, `EmployeeLoanController`, `ExpenseClaimController`), les index doivent toujours demarrer par `where('company_id', $actor->company_id)` et les references employees/departments/positions/trainers/interviewers doivent etre validees dans le tenant courant.
 
 ### Paie multi-pays et exports bancaires
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.26] - 2026-05-13
+
+### Security — HR extension tenant isolation
+
+- Securite : les listes recrutement, formation, prets et notes de frais filtrent maintenant explicitement par `company_id`.
+- Securite : les champs `employee_id`, `trainer_id`, `department_id`, `position_id` et `interviewer_id` des modules etendus refusent les references hors tenant.
+- Tests : extension des suites Recruitment, Training, EmployeeLoan et ExpenseClaim avec scenarios d'isolation tenant et refus cross-tenant.
+
 ## [4.16.25] - 2026-05-13
 
 ### Style — Payroll run test formatting

--- a/api/app/Http/Controllers/Api/V1/EmployeeLoanController.php
+++ b/api/app/Http/Controllers/Api/V1/EmployeeLoanController.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Employee;
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\EmployeeLoan;
 use App\Models\LoanRepayment;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 
 class EmployeeLoanController extends Controller
 {
@@ -19,7 +20,9 @@ class EmployeeLoanController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        $query = EmployeeLoan::query()->with('employee:id,first_name,last_name');
+        $query = EmployeeLoan::query()
+            ->where('company_id', $actor->company_id)
+            ->with('employee:id,first_name,last_name');
 
         if (! $actor->isManager()) {
             $query->where('employee_id', $actor->id);
@@ -40,7 +43,13 @@ class EmployeeLoanController extends Controller
         $actor = $request->user();
 
         $validated = $request->validate([
-            'employee_id' => $actor->isManager() ? 'required|integer|exists:employees,id' : 'prohibited',
+            'employee_id' => $actor->isManager()
+                ? [
+                    'required',
+                    'integer',
+                    Rule::exists('employees', 'id')->where('company_id', $actor->company_id),
+                ]
+                : 'prohibited',
             'loan_type' => 'required|in:personal,housing,vehicle,education,emergency',
             'amount' => 'required|numeric|min:1',
             'interest_rate' => 'nullable|numeric|min:0|max:100',
@@ -114,7 +123,7 @@ class EmployeeLoanController extends Controller
         if (! $actor->hasManagerRole('principal', 'rh')) {
             abort(403);
         }
-        if (! in_array($employeeLoan->status, ['draft', 'pending_approval'])) {
+        if (in_array($employeeLoan->status, ['draft', 'pending_approval'], true) === false) {
             abort(422, 'Loan is not in approvable state.');
         }
 

--- a/api/app/Http/Controllers/Api/V1/ExpenseClaimController.php
+++ b/api/app/Http/Controllers/Api/V1/ExpenseClaimController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Employee;
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\ExpenseClaim;
 use App\Models\ExpenseItem;
 use Illuminate\Http\JsonResponse;
@@ -17,7 +17,9 @@ class ExpenseClaimController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
-        $query = ExpenseClaim::query()->with('employee:id,first_name,last_name');
+        $query = ExpenseClaim::query()
+            ->where('company_id', $actor->company_id)
+            ->with('employee:id,first_name,last_name');
 
         if (! $actor->isManager()) {
             $query->where('employee_id', $actor->id);

--- a/api/app/Http/Controllers/Api/V1/RecruitmentController.php
+++ b/api/app/Http/Controllers/Api/V1/RecruitmentController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Models\Applicant;
+use App\Models\Employee;
 use App\Models\Interview;
 use App\Models\JobPosting;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class RecruitmentController extends Controller
 {
@@ -24,7 +25,9 @@ class RecruitmentController extends Controller
             abort(403);
         }
 
-        $query = JobPosting::query()->with('department:id,name');
+        $query = JobPosting::query()
+            ->where('company_id', $actor->company_id)
+            ->with('department:id,name');
 
         if ($request->filled('status')) {
             $query->where('status', $request->input('status'));
@@ -44,8 +47,16 @@ class RecruitmentController extends Controller
         $validated = $request->validate([
             'title' => 'required|string|max:200',
             'description' => 'nullable|string',
-            'department_id' => 'nullable|integer|exists:departments,id',
-            'position_id' => 'nullable|integer|exists:positions,id',
+            'department_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('departments', 'id')->where('company_id', $actor->company_id),
+            ],
+            'position_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('positions', 'id')->where('company_id', $actor->company_id),
+            ],
             'location' => 'nullable|string|max:200',
             'remote_policy' => 'nullable|in:onsite,hybrid,remote',
             'contract_type' => 'nullable|in:cdi,cdd,stage,freelance',
@@ -91,8 +102,16 @@ class RecruitmentController extends Controller
         $validated = $request->validate([
             'title' => 'sometimes|string|max:200',
             'description' => 'nullable|string',
-            'department_id' => 'nullable|integer|exists:departments,id',
-            'position_id' => 'nullable|integer|exists:positions,id',
+            'department_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('departments', 'id')->where('company_id', $actor->company_id),
+            ],
+            'position_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('positions', 'id')->where('company_id', $actor->company_id),
+            ],
             'location' => 'nullable|string|max:200',
             'remote_policy' => 'nullable|in:onsite,hybrid,remote',
             'contract_type' => 'nullable|in:cdi,cdd,stage,freelance',
@@ -200,7 +219,11 @@ class RecruitmentController extends Controller
         }
 
         $validated = $request->validate([
-            'interviewer_id' => 'nullable|integer|exists:employees,id',
+            'interviewer_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $actor->company_id),
+            ],
             'type' => 'required|in:phone,video,onsite,technical',
             'scheduled_at' => 'required|date',
             'duration_minutes' => 'nullable|integer|min:15|max:480',

--- a/api/app/Http/Controllers/Api/V1/TrainingController.php
+++ b/api/app/Http/Controllers/Api/V1/TrainingController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Models\Employee;
 use App\Http\Controllers\Controller;
+use App\Models\Employee;
 use App\Models\TrainingCourse;
 use App\Models\TrainingEnrollment;
 use App\Models\TrainingSession;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class TrainingController extends Controller
 {
@@ -18,7 +19,9 @@ class TrainingController extends Controller
 
     public function indexCourses(Request $request): JsonResponse
     {
-        $query = TrainingCourse::query();
+        /** @var Employee $actor */
+        $actor = $request->user();
+        $query = TrainingCourse::query()->where('company_id', $actor->company_id);
 
         if ($request->filled('category')) {
             $query->where('category', $request->input('category'));
@@ -119,7 +122,11 @@ class TrainingController extends Controller
         }
 
         $validated = $request->validate([
-            'trainer_id' => 'nullable|integer|exists:employees,id',
+            'trainer_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $actor->company_id),
+            ],
             'external_trainer' => 'nullable|string|max:200',
             'start_date' => 'required|date',
             'end_date' => 'required|date|after_or_equal:start_date',
@@ -148,7 +155,11 @@ class TrainingController extends Controller
         }
 
         $validated = $request->validate([
-            'trainer_id' => 'nullable|integer|exists:employees,id',
+            'trainer_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $actor->company_id),
+            ],
             'external_trainer' => 'nullable|string|max:200',
             'start_date' => 'sometimes|date',
             'end_date' => 'sometimes|date',
@@ -176,7 +187,11 @@ class TrainingController extends Controller
         }
 
         $validated = $request->validate([
-            'employee_id' => 'required|integer|exists:employees,id',
+            'employee_id' => [
+                'required',
+                'integer',
+                Rule::exists('employees', 'id')->where('company_id', $actor->company_id),
+            ],
         ]);
 
         $enrollment = TrainingEnrollment::firstOrCreate([

--- a/api/tests/Feature/EmployeeLoanControllerTest.php
+++ b/api/tests/Feature/EmployeeLoanControllerTest.php
@@ -123,4 +123,47 @@ class EmployeeLoanControllerTest extends TestCase
 
         $this->putJson("/api/v1/loans/{$loan->id}/approve")->assertStatus(403);
     }
+
+    public function test_loans_are_scoped_to_tenant_and_foreign_employee_is_rejected(): void
+    {
+        $company = Company::factory()->create();
+        $otherCompany = Company::factory()->create();
+        $manager = Employee::factory()->managerRh()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $foreignEmployee = Employee::factory()->create(['company_id' => $otherCompany->id]);
+        EmployeeLoan::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'amount' => 12000,
+            'currency' => 'DZD',
+            'installments' => 3,
+            'installment_amount' => 4000,
+            'start_date' => now()->addMonth(),
+            'status' => 'pending_approval',
+        ]);
+        $foreignLoan = EmployeeLoan::create([
+            'company_id' => $otherCompany->id,
+            'employee_id' => $foreignEmployee->id,
+            'amount' => 9000,
+            'currency' => 'DZD',
+            'installments' => 3,
+            'installment_amount' => 3000,
+            'start_date' => now()->addMonth(),
+            'status' => 'pending_approval',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson('/api/v1/loans')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+        $this->getJson("/api/v1/loans/{$foreignLoan->id}")->assertNotFound();
+        $this->postJson('/api/v1/loans', [
+            'employee_id' => $foreignEmployee->id,
+            'amount' => 50000,
+            'loan_type' => 'housing',
+            'installments' => 12,
+            'start_date' => now()->addMonth()->toDateString(),
+        ])->assertUnprocessable();
+    }
 }

--- a/api/tests/Feature/ExpenseClaimControllerTest.php
+++ b/api/tests/Feature/ExpenseClaimControllerTest.php
@@ -118,4 +118,51 @@ class ExpenseClaimControllerTest extends TestCase
             ]],
         ])->assertStatus(422);
     }
+
+    public function test_expense_claims_are_scoped_by_tenant_and_owner(): void
+    {
+        $company = Company::factory()->create();
+        $otherCompany = Company::factory()->create();
+        $manager = Employee::factory()->managerRh()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $coworker = Employee::factory()->create(['company_id' => $company->id]);
+        $foreignEmployee = Employee::factory()->create(['company_id' => $otherCompany->id]);
+
+        ExpenseClaim::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Own claim',
+            'total_amount' => 2000,
+            'currency' => 'DZD',
+            'status' => 'submitted',
+        ]);
+        ExpenseClaim::create([
+            'company_id' => $company->id,
+            'employee_id' => $coworker->id,
+            'title' => 'Coworker claim',
+            'total_amount' => 3000,
+            'currency' => 'DZD',
+            'status' => 'submitted',
+        ]);
+        $foreignClaim = ExpenseClaim::create([
+            'company_id' => $otherCompany->id,
+            'employee_id' => $foreignEmployee->id,
+            'title' => 'Foreign claim',
+            'total_amount' => 4000,
+            'currency' => 'DZD',
+            'status' => 'submitted',
+        ]);
+
+        Sanctum::actingAs($employee);
+        $this->getJson('/api/v1/expense-claims')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+        $this->getJson("/api/v1/expense-claims/{$foreignClaim->id}")->assertNotFound();
+
+        Sanctum::actingAs($manager);
+        $this->getJson('/api/v1/expense-claims')
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+        $this->putJson("/api/v1/expense-claims/{$foreignClaim->id}/approve")->assertNotFound();
+    }
 }

--- a/api/tests/Feature/RecruitmentControllerTest.php
+++ b/api/tests/Feature/RecruitmentControllerTest.php
@@ -39,11 +39,18 @@ class RecruitmentControllerTest extends TestCase
             'title' => 'Developpeur Backend',
             'status' => 'published',
         ]);
+        JobPosting::create([
+            'company_id' => Company::factory()->create()->id,
+            'created_by' => $manager->id,
+            'title' => 'Foreign Job',
+            'status' => 'published',
+        ]);
 
         Sanctum::actingAs($manager);
 
         $response = $this->getJson('/api/v1/recruitment/jobs');
         $response->assertOk();
+        $response->assertJsonCount(1, 'data');
     }
 
     public function test_rh_manager_can_create_job_posting(): void
@@ -131,5 +138,33 @@ class RecruitmentControllerTest extends TestCase
         $response = $this->postJson("/api/v1/recruitment/jobs/{$job->id}/publish");
         $response->assertOk();
         $response->assertJsonPath('data.status', 'published');
+    }
+
+    public function test_recruitment_jobs_are_isolated_by_tenant(): void
+    {
+        $company = Company::factory()->create();
+        $otherCompany = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create([
+            'company_id' => $company->id,
+            'manager_role' => 'rh',
+        ]);
+        $foreignJob = JobPosting::create([
+            'company_id' => $otherCompany->id,
+            'created_by' => Employee::factory()->managerRh()->create(['company_id' => $otherCompany->id])->id,
+            'title' => 'Foreign Job',
+            'status' => 'draft',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson("/api/v1/recruitment/jobs/{$foreignJob->id}")->assertNotFound();
+        $this->putJson("/api/v1/recruitment/jobs/{$foreignJob->id}", [
+            'title' => 'Leaked update',
+        ])->assertNotFound();
+        $this->postJson("/api/v1/recruitment/jobs/{$foreignJob->id}/applicants", [
+            'first_name' => 'Nadia',
+            'last_name' => 'Candidate',
+            'email' => 'nadia@example.com',
+        ])->assertNotFound();
     }
 }

--- a/api/tests/Feature/TrainingControllerTest.php
+++ b/api/tests/Feature/TrainingControllerTest.php
@@ -39,11 +39,17 @@ class TrainingControllerTest extends TestCase
             'title' => 'Formation Securite',
             'type' => 'internal',
         ]);
+        TrainingCourse::create([
+            'company_id' => Company::factory()->create()->id,
+            'title' => 'Foreign Course',
+            'type' => 'internal',
+        ]);
 
         Sanctum::actingAs($employee);
 
         $response = $this->getJson('/api/v1/training/courses');
         $response->assertOk();
+        $response->assertJsonCount(1, 'data');
     }
 
     public function test_rh_can_create_course(): void
@@ -141,5 +147,37 @@ class TrainingControllerTest extends TestCase
             'employee_id' => $employee->id,
         ]);
         $response->assertStatus(201);
+    }
+
+    public function test_training_isolated_by_tenant_and_rejects_foreign_enrollment(): void
+    {
+        $company = Company::factory()->create();
+        $otherCompany = Company::factory()->create();
+        $manager = Employee::factory()->managerRh()->create(['company_id' => $company->id]);
+        $foreignEmployee = Employee::factory()->create(['company_id' => $otherCompany->id]);
+        $foreignCourse = TrainingCourse::create([
+            'company_id' => $otherCompany->id,
+            'title' => 'Foreign Course',
+            'type' => 'internal',
+        ]);
+        $course = TrainingCourse::create([
+            'company_id' => $company->id,
+            'title' => 'Internal Course',
+            'type' => 'internal',
+        ]);
+        $session = TrainingSession::create([
+            'training_course_id' => $course->id,
+            'company_id' => $company->id,
+            'start_date' => now()->addWeek(),
+            'end_date' => now()->addWeeks(2),
+            'status' => 'planned',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson("/api/v1/training/courses/{$foreignCourse->id}")->assertNotFound();
+        $this->postJson("/api/v1/training/sessions/{$session->id}/enroll", [
+            'employee_id' => $foreignEmployee->id,
+        ])->assertUnprocessable();
     }
 }

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -297,24 +297,28 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - `POST /api/v1/recruitment/jobs/{id}/applicants` ajoute un candidat
 - `POST /api/v1/recruitment/applicants/{id}/interviews` planifie un entretien
 - RBAC : employes non-managers recoivent 403 sur toutes les routes recrutement
+- Isolation : listes, details, mises a jour et creation de candidats restent scopees au `company_id` courant.
 
 ### Module D — Formation/LMS
 - `POST /api/v1/training/courses` cree un cours (manager RH)
 - `POST /api/v1/training/courses/{id}/sessions` planifie une session
 - `POST /api/v1/training/sessions/{id}/enroll` inscrit un employe
 - `PUT /api/v1/training/enrollments/{id}` complete une inscription (score, feedback)
+- Isolation : catalogue, details, sessions, trainers et enrollments refusent les ressources ou employees hors tenant.
 
 ### Module E — Prets employes
 - `POST /api/v1/loans` cree un pret avec echeancier auto-genere
 - `PUT /api/v1/loans/{id}/approve` approuve un pret (manager RH)
 - `PUT /api/v1/loans/{id}/disburse` debloque les fonds (apres approbation)
 - Validation : un pret non approuve ne peut pas etre debloque (422)
+- Isolation : manager ne voit que les prets de son tenant et ne peut pas creer/approuver un pret pour un employe externe.
 
 ### Module F — Notes de frais
 - `POST /api/v1/expense-claims` cree une note avec items
 - `PUT /api/v1/expense-claims/{id}/submit` soumet pour approbation
 - `PUT /api/v1/expense-claims/{id}/approve` approuve (manager RH)
 - Validation : seul le draft peut etre soumis, seul le submitted peut etre approuve
+- Isolation : employe ne voit que ses notes, manager seulement celles de son tenant, et les approvals cross-tenant retournent 404.
 
 ### Module G — Organigramme
 - `GET /api/v1/org-chart` retourne l'arbre hierarchique complet

--- a/docs/PLAN_ACTION/13_RESTANT_POST_SPRINTS.md
+++ b/docs/PLAN_ACTION/13_RESTANT_POST_SPRINTS.md
@@ -181,10 +181,10 @@ Fichiers a creer dans tests/Feature/ :
 - [x] PaySlipControllerTest.php (~4 tests : list, detail, PDF, self-service)
 - [x] LeavePolicyControllerTest.php (~6 tests : CRUD, accrual, balance, RBAC)
 - [x] ContractControllerTest.php (~6 tests : CRUD, amendment, expiring, RBAC, isolation tenant)
-- [ ] RecruitmentControllerTest.php (~8 tests : job CRUD, apply, pipeline, interview, RBAC)
-- [ ] TrainingControllerTest.php (~6 tests : course CRUD, session, enrollment, RBAC)
-- [ ] EmployeeLoanControllerTest.php (~6 tests : CRUD, repayment schedule, RBAC)
-- [ ] ExpenseClaimControllerTest.php (~6 tests : CRUD, approve, reject, RBAC)
+- [x] RecruitmentControllerTest.php (~8 tests : job CRUD, apply, pipeline, interview, RBAC, isolation tenant)
+- [x] TrainingControllerTest.php (~6 tests : course CRUD, session, enrollment, RBAC, isolation tenant)
+- [x] EmployeeLoanControllerTest.php (~6 tests : CRUD, repayment schedule, RBAC, isolation tenant)
+- [x] ExpenseClaimControllerTest.php (~6 tests : CRUD, approve, reject, RBAC, isolation tenant)
 
 Total estime : ~110 nouveaux tests -> coverage backend > 70%
 ```


### PR DESCRIPTION
## Summary
- scope recruitment, training, loans and expense claim indexes to the current tenant
- validate cross-tenant employee/department/position/trainer/interviewer references
- extend Feature tests for tenant isolation across HR extension modules
- update Plan 13, API scenarios, changelog and agent notes

## Validation
- php -l changed HR extension controllers and tests
- git diff --check
- powershell -ExecutionPolicy Bypass -File dev-hub\\tools\\check-governance.ps1 -BaseRef origin/main -HeadRef HEAD

## Local note
- targeted `php artisan test` is blocked by the local Windows PHP missing mbstring (`mb_split()`); GitHub Actions is the test source of truth.