### PR TITLE
feat(api): add privacy data rights endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,3 +299,9 @@ Procedure recommandee :
 - `hr_extended.php` centralise toutes les routes des modules etendus (conges, contrats, recrutement, formation, loans, frais, webhooks, audit).
 - Le trait `Approvable` est un pattern reutilisable pour brancher le workflow d'approbation sur n'importe quel modele (Absence, ExpenseClaim, etc.).
 - Les contrats doivent rester explicitement scopes par `company_id` dans `index`, `expiring`, `myContracts` et les endpoints self-service. Ne pas compter uniquement sur les IDs de route : la creation doit refuser un `employee_id` hors tenant, et PDF/amendments doivent verifier proprietaire ou manager.
+
+### 2026-05-14 - Privacy / RGPD self-service
+
+- Les droits employes RGPD sont servis par `GET /api/v1/privacy/export`, `POST /api/v1/privacy/deletion-request` et `PATCH /api/v1/privacy/biometric-consent`, tous sous `auth:sanctum` + `tenant`.
+- Une demande de suppression doit rester non destructive par defaut : creer une `privacy_requests` pour revue RH/juridique, ne pas supprimer directement l'employe ni ses donnees paie/attendance.
+- Le retrait du consentement biometrique doit desactiver les flags visage/empreinte et effacer les chemins de references de templates. Ne pas reactiver des templates simplement parce que `consented=true`; l'enrolement reste le role du workflow biometrie.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.27] - 2026-05-14
+
+### Security — Privacy/RGPD employee data rights
+
+- API : ajout de `GET /api/v1/privacy/export` pour exporter le bundle personnel de l'employe authentifie avec compteurs scopes tenant.
+- API : ajout de `POST /api/v1/privacy/deletion-request` pour enregistrer une demande de suppression non destructive et auditable.
+- API : ajout de `PATCH /api/v1/privacy/biometric-consent` pour enregistrer ou retirer le consentement biometrique en nettoyant les references de templates.
+- Tests : couverture Feature des contrats privacy, non-divulgation des donnees collegue et persistance des demandes RGPD.
+
 ## [4.16.26] - 2026-05-13
 
 ### Security — HR extension tenant isolation

--- a/api/app/Http/Controllers/Api/V1/PrivacyController.php
+++ b/api/app/Http/Controllers/Api/V1/PrivacyController.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Absence;
+use App\Models\AttendanceLog;
+use App\Models\Employee;
+use App\Models\ExpenseClaim;
+use App\Models\PaySlip;
+use App\Models\PrivacyRequest;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PrivacyController extends Controller
+{
+    public function export(Request $request): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        return new JsonResponse([
+            'data' => [
+                'employee' => $this->employeePayload($employee),
+                'activity_summary' => [
+                    'attendance_logs_count' => $this->countEmployeeRows(AttendanceLog::class, $employee),
+                    'absence_requests_count' => $this->countEmployeeRows(Absence::class, $employee),
+                    'pay_slips_count' => $this->countEmployeeRows(PaySlip::class, $employee),
+                    'expense_claims_count' => $this->countEmployeeRows(ExpenseClaim::class, $employee),
+                ],
+                'privacy' => [
+                    'exported_at' => now()->toIso8601String(),
+                    'scope' => 'authenticated_employee_self_service',
+                    'format_version' => '2026-05-14',
+                ],
+            ],
+        ]);
+    }
+
+    public function storeDeletionRequest(Request $request): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        $validated = $request->validate([
+            'reason' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $privacyRequest = PrivacyRequest::query()->create([
+            'company_id' => $employee->company_id,
+            'employee_id' => $employee->id,
+            'type' => 'deletion',
+            'status' => 'received',
+            'requested_payload' => [
+                'reason' => $validated['reason'] ?? null,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+                'requested_at' => now()->toIso8601String(),
+                'destructive_action' => false,
+            ],
+        ]);
+
+        return new JsonResponse([
+            'data' => [
+                'id' => $privacyRequest->id,
+                'type' => $privacyRequest->type,
+                'status' => $privacyRequest->status,
+                'message' => 'Deletion request received for HR/legal review.',
+            ],
+        ], 202);
+    }
+
+    public function updateBiometricConsent(Request $request): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        $validated = $request->validate([
+            'consented' => ['required', 'boolean'],
+        ]);
+
+        $consented = (bool) $validated['consented'];
+        $employee->forceFill([
+            'biometric_face_enabled' => $consented ? $employee->biometric_face_enabled : false,
+            'biometric_fingerprint_enabled' => $consented ? $employee->biometric_fingerprint_enabled : false,
+            'biometric_face_reference_path' => $consented ? $employee->biometric_face_reference_path : null,
+            'biometric_fingerprint_reference_path' => $consented ? $employee->biometric_fingerprint_reference_path : null,
+            'biometric_consent_at' => $consented ? ($employee->biometric_consent_at ?? now()) : null,
+        ])->save();
+
+        PrivacyRequest::query()->create([
+            'company_id' => $employee->company_id,
+            'employee_id' => $employee->id,
+            'type' => 'biometric_consent',
+            'status' => 'completed',
+            'processed_at' => now(),
+            'requested_payload' => [
+                'consented' => $consented,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+                'processed_at' => now()->toIso8601String(),
+            ],
+        ]);
+
+        return new JsonResponse([
+            'data' => [
+                'biometric_face_enabled' => $employee->biometric_face_enabled,
+                'biometric_fingerprint_enabled' => $employee->biometric_fingerprint_enabled,
+                'biometric_consent_at' => optional($employee->biometric_consent_at)->toIso8601String(),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function employeePayload(Employee $employee): array
+    {
+        return [
+            'id' => $employee->id,
+            'company_id' => $employee->company_id,
+            'matricule' => $employee->matricule,
+            'first_name' => $employee->first_name,
+            'last_name' => $employee->last_name,
+            'preferred_name' => $employee->preferred_name,
+            'email' => $employee->email,
+            'personal_email' => $employee->personal_email,
+            'phone' => $employee->phone,
+            'role' => $employee->role,
+            'manager_role' => $employee->manager_role,
+            'status' => $employee->status,
+            'preferred_language' => $employee->preferred_language,
+            'biometric_face_enabled' => $employee->biometric_face_enabled,
+            'biometric_fingerprint_enabled' => $employee->biometric_fingerprint_enabled,
+            'biometric_consent_at' => optional($employee->biometric_consent_at)->toIso8601String(),
+            'created_at' => optional($employee->created_at)->toIso8601String(),
+            'updated_at' => optional($employee->updated_at)->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    private function countEmployeeRows(string $modelClass, Employee $employee): int
+    {
+        return $modelClass::query()
+            ->where('company_id', $employee->company_id)
+            ->where('employee_id', $employee->id)
+            ->count();
+    }
+}

--- a/api/app/Models/Employee.php
+++ b/api/app/Models/Employee.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Sanctum\HasApiTokens;
@@ -27,14 +28,14 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $address_line
  * @property string|null $postal_code
  * @property string|null $password_hash
- * @property \Illuminate\Support\Carbon $date_of_birth
+ * @property Carbon $date_of_birth
  * @property string|null $place_of_birth
  * @property string $gender
  * @property string|null $nationality
  * @property string|null $marital_status
  * @property string $contract_type
- * @property \Illuminate\Support\Carbon $contract_start
- * @property \Illuminate\Support\Carbon|null $contract_end
+ * @property Carbon $contract_start
+ * @property Carbon|null $contract_end
  * @property string $salary_type
  * @property float|null $salary_base
  * @property float|null $hourly_rate
@@ -47,8 +48,8 @@ use Laravel\Sanctum\HasApiTokens;
  * @property bool $biometric_fingerprint_enabled
  * @property string|null $biometric_face_reference_path
  * @property string|null $biometric_fingerprint_reference_path
- * @property \Illuminate\Support\Carbon|null $biometric_consent_at
- * @property \Illuminate\Support\Carbon|null $invitation_accepted_at
+ * @property Carbon|null $biometric_consent_at
+ * @property Carbon|null $invitation_accepted_at
  * @property string|null $emergency_contact_name
  * @property string|null $emergency_contact_phone
  * @property string|null $emergency_contact_relation
@@ -58,9 +59,9 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string $bank_account
  * @property string $national_id
  * @property int $failed_login_attempts
- * @property \Illuminate\Support\Carbon|null $locked_until
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $locked_until
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class Employee extends Authenticatable
 {
@@ -217,6 +218,12 @@ class Employee extends Authenticatable
     public function biometricEnrollmentRequests(): HasMany
     {
         return $this->hasMany(BiometricEnrollmentRequest::class, 'employee_id');
+    }
+
+    /** @return HasMany<PrivacyRequest, $this> */
+    public function privacyRequests(): HasMany
+    {
+        return $this->hasMany(PrivacyRequest::class, 'employee_id');
     }
 
     /**

--- a/api/app/Models/PrivacyRequest.php
+++ b/api/app/Models/PrivacyRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int|null $company_id
+ * @property int|null $employee_id
+ * @property string $type
+ * @property string $status
+ * @property array<string, mixed>|null $requested_payload
+ * @property Carbon|null $processed_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class PrivacyRequest extends Model
+{
+    use BelongsToCompany;
+
+    protected $table = 'privacy_requests';
+
+    protected $fillable = [
+        'company_id',
+        'employee_id',
+        'type',
+        'status',
+        'requested_payload',
+        'processed_at',
+    ];
+
+    protected $casts = [
+        'requested_payload' => 'array',
+        'processed_at' => 'datetime',
+    ];
+
+    /** @return BelongsTo<Employee, $this> */
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'employee_id');
+    }
+}

--- a/api/database/migrations/tenant/2026_05_14_000001_create_privacy_requests_table.php
+++ b/api/database/migrations/tenant/2026_05_14_000001_create_privacy_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('privacy_requests')) {
+            return;
+        }
+
+        Schema::create('privacy_requests', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+            $table->unsignedInteger('employee_id')->index();
+            $table->string('type', 40)->index();
+            $table->string('status', 30)->default('received')->index();
+            $table->json('requested_payload')->nullable();
+            $table->timestampTz('processed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['company_id', 'type', 'status']);
+            $table->index(['employee_id', 'type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('privacy_requests');
+    }
+};

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -44,6 +44,7 @@ tags:
   - name: "Me"
   - name: "Invitations"
   - name: "Biometrics"
+  - name: "Privacy"
   - name: "Kiosks"
   - name: "Cameras"
 
@@ -215,6 +216,73 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/BiometricEnrollmentRequest"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /privacy/export:
+    get:
+      tags: ["Privacy"]
+      summary: "Exporter les donnees personnelles de l'employe authentifie"
+      responses:
+        "200":
+          description: "Bundle personnel self-service"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PrivacyExportResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+
+  /privacy/deletion-request:
+    post:
+      tags: ["Privacy"]
+      summary: "Creer une demande de suppression non destructive"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  nullable: true
+                  maxLength: 1000
+      responses:
+        "202":
+          description: "Demande recue pour revue RH/juridique"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PrivacyRequestResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /privacy/biometric-consent:
+    patch:
+      tags: ["Privacy"]
+      summary: "Enregistrer ou retirer le consentement biometrique"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ["consented"]
+              properties:
+                consented:
+                  type: boolean
+      responses:
+        "200":
+          description: "Etat biometrique courant"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BiometricConsentResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
         "422":
           $ref: "#/components/responses/Validation422"
 
@@ -2339,6 +2407,120 @@ components:
           type: string
         company:
           $ref: "#/components/schemas/CompanyMini"
+
+    PrivacyExportResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            employee:
+              type: object
+              properties:
+                id:
+                  type: integer
+                company_id:
+                  type: string
+                  format: uuid
+                matricule:
+                  type: string
+                  nullable: true
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                preferred_name:
+                  type: string
+                  nullable: true
+                email:
+                  type: string
+                  format: email
+                personal_email:
+                  type: string
+                  format: email
+                  nullable: true
+                phone:
+                  type: string
+                  nullable: true
+                role:
+                  type: string
+                manager_role:
+                  type: string
+                  nullable: true
+                status:
+                  type: string
+                preferred_language:
+                  type: string
+                  nullable: true
+                biometric_face_enabled:
+                  type: boolean
+                biometric_fingerprint_enabled:
+                  type: boolean
+                biometric_consent_at:
+                  type: string
+                  format: date-time
+                  nullable: true
+                created_at:
+                  type: string
+                  format: date-time
+                  nullable: true
+                updated_at:
+                  type: string
+                  format: date-time
+                  nullable: true
+            activity_summary:
+              type: object
+              properties:
+                attendance_logs_count:
+                  type: integer
+                absence_requests_count:
+                  type: integer
+                pay_slips_count:
+                  type: integer
+                expense_claims_count:
+                  type: integer
+            privacy:
+              type: object
+              properties:
+                exported_at:
+                  type: string
+                  format: date-time
+                scope:
+                  type: string
+                format_version:
+                  type: string
+
+    PrivacyRequestResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: integer
+            type:
+              type: string
+              example: "deletion"
+            status:
+              type: string
+              example: "received"
+            message:
+              type: string
+
+    BiometricConsentResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            biometric_face_enabled:
+              type: boolean
+            biometric_fingerprint_enabled:
+              type: boolean
+            biometric_consent_at:
+              type: string
+              format: date-time
+              nullable: true
 
     LoginResponse:
       type: object

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\BiometricEnrollmentController;
 use App\Http\Controllers\Api\V1\CompanyRequestController;
 use App\Http\Controllers\Api\V1\HealthController;
+use App\Http\Controllers\Api\V1\MetricsController;
 use App\Http\Controllers\Api\V1\OnboardingChecklistController;
 use App\Http\Controllers\Api\V1\OnboardingController;
 use App\Http\Controllers\Api\V1\PlatformAuthController;
@@ -14,6 +15,7 @@ use App\Http\Controllers\Api\V1\PlatformCompanyRequestController;
 use App\Http\Controllers\Api\V1\PlatformCompanySubscriptionController;
 use App\Http\Controllers\Api\V1\PlatformMetricsOverviewController;
 use App\Http\Controllers\Api\V1\PlatformPlanController;
+use App\Http\Controllers\Api\V1\PrivacyController;
 use App\Http\Controllers\Api\V1\TranslationCatalogController;
 use App\Http\Controllers\Web\PlatformCompanyController;
 use Illuminate\Support\Facades\Route;
@@ -25,7 +27,7 @@ Route::prefix('v1')->group(function (): void {
     Route::get('/health', HealthController::class);
     Route::get('/health/live', [HealthController::class, 'live']);
     Route::get('/health/ready', [HealthController::class, 'ready']);
-    Route::get('/metrics', \App\Http\Controllers\Api\V1\MetricsController::class);
+    Route::get('/metrics', MetricsController::class);
 
     // Auth (core, hors module)
     Route::middleware(['throttle:10,1'])->group(function (): void {
@@ -53,6 +55,9 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/auth/logout', [AuthController::class, 'logout']);
         Route::get('/auth/biometric-enrollment', [BiometricEnrollmentController::class, 'myStatus']);
         Route::post('/auth/biometric-enrollment', [BiometricEnrollmentController::class, 'store']);
+        Route::get('/privacy/export', [PrivacyController::class, 'export']);
+        Route::post('/privacy/deletion-request', [PrivacyController::class, 'storeDeletionRequest']);
+        Route::patch('/privacy/biometric-consent', [PrivacyController::class, 'updateBiometricConsent']);
 
         // Feature Registry API - Mobile synchronization
         Route::prefix('features')->group(function (): void {

--- a/api/tests/Feature/PrivacyControllerTest.php
+++ b/api/tests/Feature/PrivacyControllerTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Absence;
+use App\Models\AbsenceType;
+use App\Models\AttendanceLog;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\ExpenseClaim;
+use App\Models\PayrollRun;
+use App\Models\PaySlip;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class PrivacyControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_employee_can_export_own_personal_data_bundle(): void
+    {
+        [$company, $employee] = $this->privacyActor([
+            'preferred_name' => 'Leo',
+            'biometric_face_enabled' => true,
+            'biometric_consent_at' => now()->subDay(),
+        ]);
+        $otherEmployee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'colleague@example.test',
+        ]);
+
+        AttendanceLog::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => now()->toDateString(),
+            'check_in' => now()->subHours(8),
+            'check_out' => now(),
+            'method' => 'mobile',
+            'status' => 'completed',
+            'hours_worked' => 8,
+        ]);
+        AttendanceLog::create([
+            'company_id' => $company->id,
+            'employee_id' => $otherEmployee->id,
+            'date' => now()->toDateString(),
+            'method' => 'mobile',
+            'status' => 'completed',
+        ]);
+
+        $absenceType = AbsenceType::factory()->create([
+            'company_id' => $company->id,
+        ]);
+        Absence::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'absence_type_id' => $absenceType->id,
+            'start_date' => now()->addDay()->toDateString(),
+            'end_date' => now()->addDay()->toDateString(),
+            'days_count' => 1,
+            'status' => 'pending',
+        ]);
+        ExpenseClaim::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Taxi',
+            'total_amount' => 1200,
+            'currency' => 'DZD',
+            'status' => 'submitted',
+        ]);
+        $run = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'validated',
+        ]);
+        PaySlip::create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'validated',
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson('/api/v1/privacy/export');
+
+        $response->assertOk()
+            ->assertJsonPath('data.employee.id', $employee->id)
+            ->assertJsonPath('data.employee.preferred_name', 'Leo')
+            ->assertJsonPath('data.employee.biometric_face_enabled', true)
+            ->assertJsonPath('data.activity_summary.attendance_logs_count', 1)
+            ->assertJsonPath('data.activity_summary.absence_requests_count', 1)
+            ->assertJsonPath('data.activity_summary.pay_slips_count', 1)
+            ->assertJsonPath('data.activity_summary.expense_claims_count', 1)
+            ->assertJsonMissing(['email' => 'colleague@example.test']);
+    }
+
+    public function test_employee_can_submit_deletion_request_without_destroying_account(): void
+    {
+        [$company, $employee] = $this->privacyActor();
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->postJson('/api/v1/privacy/deletion-request', [
+            'reason' => 'Je veux fermer mon compte.',
+        ]);
+
+        $response->assertAccepted()
+            ->assertJsonPath('data.type', 'deletion')
+            ->assertJsonPath('data.status', 'received');
+
+        $this->assertDatabaseHas('privacy_requests', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'type' => 'deletion',
+            'status' => 'received',
+        ]);
+        $this->assertDatabaseHas('employees', [
+            'id' => $employee->id,
+            'email' => $employee->email,
+        ]);
+    }
+
+    public function test_employee_can_withdraw_biometric_consent(): void
+    {
+        [, $employee] = $this->privacyActor([
+            'biometric_face_enabled' => true,
+            'biometric_fingerprint_enabled' => true,
+            'biometric_face_reference_path' => 'biometrics/faces/ref.jpg',
+            'biometric_fingerprint_reference_path' => 'device:finger-1',
+            'biometric_consent_at' => now()->subWeek(),
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->patchJson('/api/v1/privacy/biometric-consent', [
+            'consented' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.biometric_face_enabled', false)
+            ->assertJsonPath('data.biometric_fingerprint_enabled', false)
+            ->assertJsonPath('data.biometric_consent_at', null);
+
+        $employee->refresh();
+        $this->assertFalse($employee->biometric_face_enabled);
+        $this->assertFalse($employee->biometric_fingerprint_enabled);
+        $this->assertNull($employee->biometric_face_reference_path);
+        $this->assertNull($employee->biometric_fingerprint_reference_path);
+
+        $this->assertDatabaseHas('privacy_requests', [
+            'employee_id' => $employee->id,
+            'type' => 'biometric_consent',
+            'status' => 'completed',
+        ]);
+    }
+
+    public function test_employee_can_record_biometric_consent_without_enabling_templates(): void
+    {
+        [, $employee] = $this->privacyActor([
+            'biometric_face_enabled' => false,
+            'biometric_fingerprint_enabled' => false,
+            'biometric_consent_at' => null,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->patchJson('/api/v1/privacy/biometric-consent', [
+            'consented' => true,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.biometric_face_enabled', false)
+            ->assertJsonPath('data.biometric_fingerprint_enabled', false);
+
+        $employee->refresh();
+        $this->assertNotNull($employee->biometric_consent_at);
+        $this->assertFalse($employee->biometric_face_enabled);
+        $this->assertFalse($employee->biometric_fingerprint_enabled);
+    }
+
+    /**
+     * @param  array<string, mixed>  $employeeAttributes
+     * @return array{0: Company, 1: Employee}
+     */
+    private function privacyActor(array $employeeAttributes = []): array
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            ...$employeeAttributes,
+        ]);
+
+        return [$company, $employee];
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -783,6 +783,22 @@ trait CreatesMvpSchema
             });
         }
 
+        if (! Schema::hasTable($this->moduleTable('privacy_requests'))) {
+            Schema::create($this->moduleTable('privacy_requests'), function (Blueprint $table): void {
+                $table->id();
+                $table->uuid('company_id')->index();
+                $table->unsignedInteger('employee_id')->index();
+                $table->string('type', 40)->index();
+                $table->string('status', 30)->default('received')->index();
+                $table->json('requested_payload')->nullable();
+                $table->timestampTz('processed_at')->nullable();
+                $table->timestamps();
+
+                $table->index(['company_id', 'type', 'status']);
+                $table->index(['employee_id', 'type']);
+            });
+        }
+
         if (! Schema::hasTable($this->moduleTable('pay_slips'))) {
             Schema::create($this->moduleTable('pay_slips'), function (Blueprint $table): void {
                 $table->id();
@@ -1132,6 +1148,7 @@ trait CreatesMvpSchema
         DB::statement('DROP TABLE IF EXISTS "job_postings"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "pay_slip_lines"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "pay_slips"'.$cascade);
+        DB::statement('DROP TABLE IF EXISTS "privacy_requests"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "payroll_runs"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "ai_audit_logs"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "ai_conversations"'.$cascade);

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -186,6 +186,13 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - Le payload expose `go_live_ready` et `next_actions` pour guider l'installation client sans interpretation cote frontend
 - Les metriques de progression ne doivent pas compter une etape paie complete si aucun salaire ou taux horaire n'est renseigne
 
+### 16. Privacy / RGPD self-service
+
+- `GET /api/v1/privacy/export` retourne uniquement le bundle de donnees de l'employe authentifie et des compteurs d'activite scopes par `company_id`
+- `POST /api/v1/privacy/deletion-request` cree une demande tracee non destructive pour revue RH/juridique et ne supprime jamais le compte immediatement
+- `PATCH /api/v1/privacy/biometric-consent` enregistre le consentement ou retire le consentement en desactivant les flags biometriques et en effacant les references de templates
+- Les endpoints privacy restent sous `auth:sanctum` + `tenant` et ne prennent jamais d'`employee_id` client pour eviter l'export d'un collegue ou d'un autre tenant
+
 ## Mapping attendu vers les suites GitHub Actions
 
 ### Suite `Unit`
@@ -213,6 +220,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - Contrat catalogue plans plateforme pour eviter les `plan_id` hardcodes cote frontend
 - Contrat abonnement plateforme pour upgrade, suspension, expiration et notes client
 - Contrat metrics overview plateforme pour MRR/ARR, impayes, encaissements, companies, abonnements et facturation
+- Contrats privacy/RGPD pour export donnees personnelles, demande de suppression et consentement biometrique employe
 - Health endpoint
 
 ### Suites a ajouter ou durcir progressivement

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -97,10 +97,10 @@
 ### 2.2 Conformite RGPD / Loi 18-07 (DZ)
 ```
 - [ ] Page politique de confidentialite + CGU
-- [ ] Mecanisme d'export des donnees personnelles (droit d'acces)
-- [ ] Mecanisme de suppression des donnees (droit a l'oubli)
+- [x] Mecanisme d'export des donnees personnelles (droit d'acces) via `GET /api/v1/privacy/export`
+- [x] Mecanisme de suppression des donnees (droit a l'oubli) via demande tracee `POST /api/v1/privacy/deletion-request`
 - [ ] Registre des traitements (document interne)
-- [ ] Consentement employe pour le traitement biometrique
+- [x] Consentement employe pour le traitement biometrique via `PATCH /api/v1/privacy/biometric-consent`
 - [ ] Chiffrement des donnees sensibles au repos (AES-256 pour IBAN, salaire)
 - [ ] Journalisation des acces aux donnees RH (audit trail)
 ```


### PR DESCRIPTION
## Summary
- add employee self-service privacy export endpoint
- add non-destructive deletion request tracking
- add biometric consent update/withdraw endpoint and tenant migration
- document OpenAPI, scenarios, changelog, and Plan 14 progress

## Validation
- php -l new/changed PHP files
- vendor/bin/pint --dirty
- git diff --check
- governance check passed
- php artisan test --filter=PrivacyControllerTest could not run locally because this Windows PHP lacks mbstring (known local blocker)