### PR TITLE
feat(api): audit sensitive HR data access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,3 +305,4 @@ Procedure recommandee :
 - Les droits employes RGPD sont servis par `GET /api/v1/privacy/export`, `POST /api/v1/privacy/deletion-request` et `PATCH /api/v1/privacy/biometric-consent`, tous sous `auth:sanctum` + `tenant`.
 - Une demande de suppression doit rester non destructive par defaut : creer une `privacy_requests` pour revue RH/juridique, ne pas supprimer directement l'employe ni ses donnees paie/attendance.
 - Le retrait du consentement biometrique doit desactiver les flags visage/empreinte et effacer les chemins de references de templates. Ne pas reactiver des templates simplement parce que `consented=true`; l'enrolement reste le role du workflow biometrie.
+- Les acces RH sensibles doivent passer par `DataAccessAuditLogger` quand c'est possible. Le logger doit rester non bloquant et enregistrer `category=hr_data_access` dans `audit_logs` pour que le dashboard audit et la future couche IA puissent tracer les consultations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.28] - 2026-05-14
+
+### Security — HR data access audit trail
+
+- Securite : ajout de `DataAccessAuditLogger` pour journaliser les acces RH sensibles sans bloquer la requete metier en cas d'incident d'audit.
+- API : les endpoints employees list/detail et privacy export creent maintenant une entree `audit_logs` avec acteur, tenant, cible et metadata `category=hr_data_access`.
+- Tests : couverture Feature de la journalisation sur liste employees, fiche employee et export privacy.
+
 ## [4.16.27] - 2026-05-14
 
 ### Security — Privacy/RGPD employee data rights

--- a/api/app/Http/Controllers/Api/V1/EmployeeController.php
+++ b/api/app/Http/Controllers/Api/V1/EmployeeController.php
@@ -12,13 +12,17 @@ use App\Http\Requests\Api\V1\StoreEmployeeRequest;
 use App\Http\Requests\Api\V1\UpdateEmployeeRequest;
 use App\Http\Resources\Api\V1\EmployeeResource;
 use App\Models\Employee;
+use App\Services\DataAccessAuditLogger;
 use App\Services\EmployeeService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class EmployeeController extends Controller
 {
-    public function __construct(private readonly EmployeeService $employeeService) {}
+    public function __construct(
+        private readonly EmployeeService $employeeService,
+        private readonly DataAccessAuditLogger $dataAccessAuditLogger,
+    ) {}
 
     /**
      * Liste des employés avec pagination
@@ -40,8 +44,11 @@ class EmployeeController extends Controller
         mobile_compatible: true
     )]
     #[RequiresPermission('employees.view')]
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
         $this->authorize('viewAny', Employee::class);
 
         $perPage = max(1, min(100, (int) request()->integer('per_page', 20)));
@@ -64,6 +71,13 @@ class EmployeeController extends Controller
             ])
             ->orderBy('id')
             ->paginate($perPage);
+
+        $this->dataAccessAuditLogger->record($request, $actor, 'hr_data.employee_list_viewed', null, [
+            'resource' => 'employees',
+            'result_count' => $paginator->count(),
+            'per_page' => $paginator->perPage(),
+            'page' => $paginator->currentPage(),
+        ]);
 
         return EmployeeResource::collection($paginator)->response();
     }
@@ -129,6 +143,13 @@ class EmployeeController extends Controller
             ->findOrFail($employeeId);
 
         $this->authorize('view', $employee);
+
+        /** @var Employee $actor */
+        $actor = $request->user();
+        $this->dataAccessAuditLogger->record($request, $actor, 'hr_data.employee_profile_viewed', $employee, [
+            'resource' => 'employee_profile',
+            'target_employee_id' => $employee->id,
+        ]);
 
         return (new EmployeeResource($employee))->response();
     }

--- a/api/app/Http/Controllers/Api/V1/PrivacyController.php
+++ b/api/app/Http/Controllers/Api/V1/PrivacyController.php
@@ -11,16 +11,26 @@ use App\Models\Employee;
 use App\Models\ExpenseClaim;
 use App\Models\PaySlip;
 use App\Models\PrivacyRequest;
+use App\Services\DataAccessAuditLogger;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class PrivacyController extends Controller
 {
+    public function __construct(
+        private readonly DataAccessAuditLogger $dataAccessAuditLogger,
+    ) {}
+
     public function export(Request $request): JsonResponse
     {
         /** @var Employee $employee */
         $employee = $request->user();
+
+        $this->dataAccessAuditLogger->record($request, $employee, 'hr_data.privacy_exported', $employee, [
+            'resource' => 'privacy_export',
+            'format_version' => '2026-05-14',
+        ]);
 
         return new JsonResponse([
             'data' => [

--- a/api/app/Services/DataAccessAuditLogger.php
+++ b/api/app/Services/DataAccessAuditLogger.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\AuditLog;
+use App\Models\Employee;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Throwable;
+
+class DataAccessAuditLogger
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function record(Request $request, Employee $actor, string $action, ?Model $target = null, array $metadata = []): void
+    {
+        try {
+            AuditLog::query()->create([
+                'company_id' => $actor->company_id,
+                'user_id' => $actor->id,
+                'action' => $action,
+                'auditable_type' => $target?->getMorphClass(),
+                'auditable_id' => $target?->getKey(),
+                'old_values' => null,
+                'new_values' => null,
+                'ip_address' => $request->ip(),
+                'user_agent' => $this->truncateUserAgent($request->userAgent()),
+                'metadata' => [
+                    'category' => 'hr_data_access',
+                    'route' => optional($request->route())->getName() ?? $request->path(),
+                    ...$metadata,
+                ],
+            ]);
+        } catch (Throwable $exception) {
+            report($exception);
+        }
+    }
+
+    private function truncateUserAgent(?string $userAgent): ?string
+    {
+        if ($userAgent === null) {
+            return null;
+        }
+
+        return substr($userAgent, 0, 255);
+    }
+}

--- a/api/tests/Feature/EmployeesRbacTest.php
+++ b/api/tests/Feature/EmployeesRbacTest.php
@@ -86,6 +86,11 @@ class EmployeesRbacTest extends TestCase
         $this->assertContains('manager@a.test', $emails);
         $this->assertContains('employee@a.test', $emails);
         $this->assertNotContains('employee@b.test', $emails);
+        $this->assertDatabaseHas('audit_logs', [
+            'company_id' => $companyA->id,
+            'user_id' => $managerA->id,
+            'action' => 'hr_data.employee_list_viewed',
+        ]);
     }
 
     public function test_employee_cannot_list_employees(): void
@@ -154,6 +159,13 @@ class EmployeesRbacTest extends TestCase
         $self = $this->withHeader('Authorization', "Bearer {$token}")
             ->getJson("/api/v1/employees/{$employeeA->id}");
         $self->assertOk();
+        $this->assertDatabaseHas('audit_logs', [
+            'company_id' => $companyA->id,
+            'user_id' => $employeeA->id,
+            'action' => 'hr_data.employee_profile_viewed',
+            'auditable_type' => Employee::class,
+            'auditable_id' => $employeeA->id,
+        ]);
 
         $other = $this->withHeader('Authorization', "Bearer {$token}")
             ->getJson("/api/v1/employees/{$managerA->id}");

--- a/api/tests/Feature/PrivacyControllerTest.php
+++ b/api/tests/Feature/PrivacyControllerTest.php
@@ -111,6 +111,14 @@ class PrivacyControllerTest extends TestCase
             ->assertJsonPath('data.activity_summary.pay_slips_count', 1)
             ->assertJsonPath('data.activity_summary.expense_claims_count', 1)
             ->assertJsonMissing(['email' => 'colleague@example.test']);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'company_id' => $company->id,
+            'user_id' => $employee->id,
+            'action' => 'hr_data.privacy_exported',
+            'auditable_type' => Employee::class,
+            'auditable_id' => $employee->id,
+        ]);
     }
 
     public function test_employee_can_submit_deletion_request_without_destroying_account(): void

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -192,6 +192,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - `POST /api/v1/privacy/deletion-request` cree une demande tracee non destructive pour revue RH/juridique et ne supprime jamais le compte immediatement
 - `PATCH /api/v1/privacy/biometric-consent` enregistre le consentement ou retire le consentement en desactivant les flags biometriques et en effacant les references de templates
 - Les endpoints privacy restent sous `auth:sanctum` + `tenant` et ne prennent jamais d'`employee_id` client pour eviter l'export d'un collegue ou d'un autre tenant
+- Les acces aux fiches employees et exports privacy creent une entree `audit_logs` avec `category=hr_data_access`, acteur, tenant et cible quand elle existe
 
 ## Mapping attendu vers les suites GitHub Actions
 
@@ -221,6 +222,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - Contrat abonnement plateforme pour upgrade, suspension, expiration et notes client
 - Contrat metrics overview plateforme pour MRR/ARR, impayes, encaissements, companies, abonnements et facturation
 - Contrats privacy/RGPD pour export donnees personnelles, demande de suppression et consentement biometrique employe
+- Journalisation `audit_logs` des acces RH sensibles : liste employees, fiche employee, export privacy
 - Health endpoint
 
 ### Suites a ajouter ou durcir progressivement

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -102,7 +102,7 @@
 - [ ] Registre des traitements (document interne)
 - [x] Consentement employe pour le traitement biometrique via `PATCH /api/v1/privacy/biometric-consent`
 - [ ] Chiffrement des donnees sensibles au repos (AES-256 pour IBAN, salaire)
-- [ ] Journalisation des acces aux donnees RH (audit trail)
+- [x] Journalisation des acces aux donnees RH (audit trail) via `audit_logs` pour fiches employes et exports privacy
 ```
 
 ### 2.3 Sauvegarde & Reprise


### PR DESCRIPTION
## Summary
- add non-blocking DataAccessAuditLogger backed by audit_logs
- record sensitive HR accesses for employee list/detail and privacy export
- add feature assertions and update Plan 14, scenarios, changelog, AGENTS

## Validation
- php -l changed PHP files
- git diff --check
- governance check passed
- php artisan test --filter=PrivacyControllerTest could not run locally because this Windows PHP lacks mbstring (known local blocker); GitHub Actions will validate