### PR TITLE
feat(web): add multilingual legal pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ Procedure recommandee :
 - Si un compte super-admin a le 2FA active, l'API renvoie `202 TWO_FA_REQUIRED`; le frontend doit traiter ce cas comme une etape de login et non comme un succes silencieux.
 - Le login admin supporte maintenant un toggle afficher / masquer le mot de passe. Si cette zone evolue encore, garder les labels ARIA synchronises avec l'etat visible/cache et couvrir la regression dans Playwright.
 - La vitrine publique `web/` a maintenant un vrai rail de locale client (`FR/EN/TR/AR`) sur la landing page. Pour les prochaines evolutions, reutiliser ce socle au lieu de rehardcoder des textes dans chaque composant.
+- Les pages legales de la vitrine vivent dans `front/web/src/app/privacy` et `front/web/src/app/terms`. Garder les liens footer reels vers ces routes et reutiliser `useVitrineLocale()` pour FR/EN/TR/AR + RTL au lieu de creer une logique locale separee.
 - Desormais, quand `web/**` change, les checks de lint/build doivent partir via `web-marketing-ci.yml`; ne pas se reposer uniquement sur le workflow admin.
 
 ### 2026-05-08 - Render et transaction PostgreSQL abort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.29] - 2026-05-14
+
+### Web — Legal pages vitrine multilingues
+
+- Web vitrine : ajout des pages publiques `/privacy` et `/terms` avec contenu FR/EN/TR/AR, support RTL arabe et selection de langue partagee.
+- SEO : ajout des routes legales au sitemap public.
+- Tests : extension Playwright pour verifier les liens footer vers les pages legales et le changement de langue.
+
 ## [4.16.28] - 2026-05-14
 
 ### CI/CD — E2E Playwright smoke tests & hardening (Partie 6 stabilisation)

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -92,6 +92,7 @@ Quand un domaine gagne une feature significative, ajouter:
 
 ## Notes 2026-05-12
 
+- v4.16.29 : La vitrine `front/web` expose maintenant les pages legales `/privacy` et `/terms` en FR/EN/TR/AR avec RTL arabe. Les scenarios Web Marketing doivent verifier les liens footer, le rendu des routes et le changement de langue sur ces pages.
 - v4.16.8 : Le cockpit `front/admin-dashboard` consomme maintenant `/platform/metrics/overview` pour les chiffres financiers globaux. Les scenarios web admin doivent verifier MRR, ARR, encaissements 30 jours, impayes et subscriptions sans recalculer ces agregats depuis des listes partielles.
 - v4.16.7 : Le contrat `GET /api/v1/platform/metrics/overview` devient une surface plateforme critique pour le cockpit super-admin. Il doit rester protege par `super_admin_api`, exposer uniquement des agregats non nominatifs et rester tolerant aux tables billing absentes pendant les migrations progressives.
 - v4.16.0 : Les annotations PHPDoc `@property`, `@return` et `@var Employee` ajoutees dans les modeles, services et controllers ne modifient aucun comportement runtime. Le helper `currentCompany()` est un remplacement fonctionnellement identique de `app('current_company')`. Le binding `LLMClient` dans AppServiceProvider preserve le meme comportement de selection provider. Aucun nouveau endpoint ni modification de contrat API.

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -96,7 +96,7 @@
 
 ### 2.2 Conformite RGPD / Loi 18-07 (DZ)
 ```
-- [ ] Page politique de confidentialite + CGU
+- [x] Page politique de confidentialite + CGU via la vitrine `/privacy` et `/terms` en FR/EN/TR/AR
 - [x] Mecanisme d'export des donnees personnelles (droit d'acces) via `GET /api/v1/privacy/export`
 - [x] Mecanisme de suppression des donnees (droit a l'oubli) via demande tracee `POST /api/v1/privacy/deletion-request`
 - [ ] Registre des traitements (document interne)

--- a/front/web/e2e/navigation-and-links.spec.ts
+++ b/front/web/e2e/navigation-and-links.spec.ts
@@ -107,6 +107,20 @@ test.describe('Navigation and Links E2E Tests', () => {
       expect(count).toBeGreaterThan(0);
     });
 
+    test('should navigate to legal pages from footer', async ({ page }) => {
+      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+      await page.locator('footer a[href="/privacy"]').first().click();
+      await page.waitForURL('**/privacy');
+      await expect(page.getByRole('heading', { name: /Politique de confidentialite|Privacy policy|Gizlilik politikasi|سياسة الخصوصية/i })).toBeVisible();
+
+      await page.goto('/');
+      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+      await page.locator('footer a[href="/terms"]').first().click();
+      await page.waitForURL('**/terms');
+      await expect(page.getByRole('heading', { name: /Conditions generales|Terms of use|Kullanim kosullari|شروط الاستخدام/i })).toBeVisible();
+    });
+
     test('should open social media links in new tab', async ({ page }) => {
       // Scroll to footer
       await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
@@ -237,6 +251,17 @@ test.describe('Navigation and Links E2E Tests', () => {
     test('should route to blog page at /blog', async ({ page }) => {
       await page.goto('/blog');
       expect(page.url()).toContain('blog');
+    });
+
+    test('should route to multilingual legal pages', async ({ page }) => {
+      await page.goto('/privacy');
+      await expect(page.getByRole('heading', { name: /Politique de confidentialite|Privacy policy|Gizlilik politikasi|سياسة الخصوصية/i })).toBeVisible();
+
+      await page.getByLabel(/Langue du document|Document language|Belge dili|لغة الوثيقة/i).selectOption('en');
+      await expect(page.getByRole('heading', { name: /Privacy policy/i })).toBeVisible();
+
+      await page.goto('/terms');
+      await expect(page.getByRole('heading', { name: /Terms of use/i })).toBeVisible();
     });
 
     test('should handle 404 for invalid routes', async ({ page }) => {

--- a/front/web/public/sitemap.xml
+++ b/front/web/public/sitemap.xml
@@ -52,6 +52,20 @@
     <priority>0.7</priority>
   </url>
 
+  <url>
+    <loc>https://leopardo.com/privacy</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://leopardo.com/terms</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
   <!-- Blog Pages -->
   <url>
     <loc>https://leopardo.com/blog</loc>

--- a/front/web/src/app/privacy/page.tsx
+++ b/front/web/src/app/privacy/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import { LegalPageShell } from '@/modules/vitrine/components/LegalPageShell'
+
+export const metadata: Metadata = {
+  title: 'Politique de confidentialite | Leopardo RH',
+  description:
+    'Politique de confidentialite multilingue de Leopardo RH pour les donnees RH, la conformite, les droits utilisateurs et la securite.',
+  alternates: {
+    canonical: '/privacy',
+  },
+}
+
+export default function PrivacyPage() {
+  return <LegalPageShell page="privacy" />
+}

--- a/front/web/src/app/terms/page.tsx
+++ b/front/web/src/app/terms/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import { LegalPageShell } from '@/modules/vitrine/components/LegalPageShell'
+
+export const metadata: Metadata = {
+  title: 'Conditions generales d utilisation | Leopardo RH',
+  description:
+    'Conditions generales d utilisation multilingues de Leopardo RH pour les clients, administrateurs, managers, employes et integrateurs.',
+  alternates: {
+    canonical: '/terms',
+  },
+}
+
+export default function TermsPage() {
+  return <LegalPageShell page="terms" />
+}

--- a/front/web/src/modules/vitrine/components/Footer.tsx
+++ b/front/web/src/modules/vitrine/components/Footer.tsx
@@ -4,6 +4,18 @@ import Link from 'next/link'
 import { Globe } from 'lucide-react'
 import { useVitrineLocale } from '../lib/vitrine-locale'
 
+function getFooterHref(sectionIndex: number, linkIndex: number): string {
+  if (sectionIndex === 2 && linkIndex === 0) {
+    return '/privacy'
+  }
+
+  if (sectionIndex === 2 && linkIndex === 1) {
+    return '/terms'
+  }
+
+  return '#'
+}
+
 export function Footer() {
   const { copy, locale, options } = useVitrineLocale()
   const activeLocale = options.find((option) => option.value === locale)
@@ -42,13 +54,17 @@ export function Footer() {
             <div key={`${section.title}-${index}`}>
               <h4 className="text-sm font-bold text-slate-900 dark:text-white mb-4 uppercase tracking-wider">{section.title}</h4>
               <ul className="space-y-2.5">
-                {section.links.map((link, linkIndex) => (
-                  <li key={`${section.title}-link-${linkIndex}`}>
-                    <Link href="#" className="text-sm text-slate-500 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
-                      {link}
-                    </Link>
-                  </li>
-                ))}
+                {section.links.map((link, linkIndex) => {
+                  const href = getFooterHref(index, linkIndex)
+
+                  return (
+                    <li key={`${section.title}-link-${linkIndex}`}>
+                      <Link href={href} className="text-sm text-slate-500 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
+                        {link}
+                      </Link>
+                    </li>
+                  )
+                })}
               </ul>
             </div>
           ))}

--- a/front/web/src/modules/vitrine/components/LegalPageShell.tsx
+++ b/front/web/src/modules/vitrine/components/LegalPageShell.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft, Globe2, ShieldCheck } from 'lucide-react'
+import type { AppLocale } from '@/lib/i18n'
+import { getLegalPageCopy, type LegalPageKind } from '../lib/legal-content'
+import { useVitrineLocale } from '../lib/vitrine-locale'
+
+type LegalPageShellProps = {
+  page: LegalPageKind
+}
+
+export function LegalPageShell({ page }: LegalPageShellProps) {
+  const { locale, direction, options, setLocale } = useVitrineLocale()
+  const copy = getLegalPageCopy(locale, page)
+
+  return (
+    <main dir={direction} className="min-h-screen bg-white text-slate-950 dark:bg-slate-950 dark:text-white">
+      <header className="border-b border-slate-200/80 bg-white/95 dark:border-slate-800/80 dark:bg-slate-950/95">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6 sm:px-6 md:flex-row md:items-center md:justify-between">
+          <Link
+            href="/"
+            className="inline-flex w-fit items-center gap-2 text-sm font-semibold text-slate-600 transition-colors hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            {copy.backLabel}
+          </Link>
+
+          <label className="flex w-full max-w-xs items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+            <Globe2 className="h-4 w-4 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+            <span className="sr-only">{copy.languageLabel}</span>
+            <select
+              aria-label={copy.languageLabel}
+              value={locale}
+              onChange={(event) => setLocale(event.target.value as AppLocale)}
+              className="w-full bg-transparent font-semibold text-slate-900 outline-none dark:text-white"
+            >
+              {options.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.nativeLabel}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </header>
+
+      <article className="mx-auto max-w-5xl px-4 py-14 sm:px-6 sm:py-16">
+        <div className="max-w-3xl">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-bold uppercase tracking-wide text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            {copy.eyebrow}
+          </div>
+          <h1 className="text-4xl font-black tracking-normal text-slate-950 dark:text-white sm:text-5xl">{copy.title}</h1>
+          <p className="mt-5 text-lg leading-8 text-slate-600 dark:text-slate-300">{copy.intro}</p>
+          <p className="mt-4 text-sm font-semibold text-slate-500 dark:text-slate-400">{copy.updatedAt}</p>
+        </div>
+
+        <div className="mt-12 divide-y divide-slate-200 border-y border-slate-200 dark:divide-slate-800 dark:border-slate-800">
+          {copy.sections.map((section) => (
+            <section key={section.title} className="grid gap-4 py-8 md:grid-cols-[220px_1fr] md:gap-10">
+              <h2 className="text-xl font-black text-slate-950 dark:text-white">{section.title}</h2>
+              <div className="space-y-4 text-base leading-8 text-slate-600 dark:text-slate-300">
+                {section.body.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <section className="mt-10 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-black text-slate-950 dark:text-white">{copy.contact.title}</h2>
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600 dark:text-slate-300">{copy.contact.body}</p>
+          <a
+            href={`mailto:${copy.contact.email}`}
+            className="mt-4 inline-flex font-semibold text-emerald-700 transition-colors hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+          >
+            {copy.contact.email}
+          </a>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/front/web/src/modules/vitrine/components/index.ts
+++ b/front/web/src/modules/vitrine/components/index.ts
@@ -15,6 +15,7 @@ export { FaqSection as LegacyFaqSection } from './FaqSection';
 export { CTASection as LegacyCTASection } from './CTASection';
 export { DemoSection } from './DemoSection';
 export { ParticleField } from './ParticleField';
+export { LegalPageShell } from './LegalPageShell';
 
 // Common Components
 export * from './common';

--- a/front/web/src/modules/vitrine/lib/index.ts
+++ b/front/web/src/modules/vitrine/lib/index.ts
@@ -21,3 +21,6 @@ export * from "./utils";
 
 // Locale
 export * from "./vitrine-locale";
+
+// Legal content
+export * from "./legal-content";

--- a/front/web/src/modules/vitrine/lib/legal-content.ts
+++ b/front/web/src/modules/vitrine/lib/legal-content.ts
@@ -1,0 +1,390 @@
+import type { AppLocale } from '@/lib/i18n'
+
+export type LegalPageKind = 'privacy' | 'terms'
+
+type LegalSection = {
+  title: string
+  body: string[]
+}
+
+export type LegalPageCopy = {
+  eyebrow: string
+  title: string
+  intro: string
+  updatedAt: string
+  backLabel: string
+  languageLabel: string
+  sections: LegalSection[]
+  contact: {
+    title: string
+    body: string
+    email: string
+  }
+}
+
+const legalPages: Record<AppLocale, Record<LegalPageKind, LegalPageCopy>> = {
+  fr: {
+    privacy: {
+      eyebrow: 'Conformite et donnees RH',
+      title: 'Politique de confidentialite',
+      intro:
+        'Leopardo RH traite des donnees RH sensibles pour aider les entreprises a piloter le pointage, la paie, les absences et les workflows terrain. Cette page explique notre approche de protection, de transparence et de controle.',
+      updatedAt: 'Derniere mise a jour : 14 mai 2026',
+      backLabel: 'Retour a l accueil',
+      languageLabel: 'Langue du document',
+      sections: [
+        {
+          title: 'Donnees traitees',
+          body: [
+            'Nous pouvons traiter des donnees d identification, de contact, de poste, de pointage, d absence, de paie, de documents RH, de roles, de permissions et de journaux techniques.',
+            'Les donnees biometriques ou assimilees ne doivent etre activees que lorsque le client dispose d une base legale claire et d un consentement ou cadre interne documente.',
+          ],
+        },
+        {
+          title: 'Finalites',
+          body: [
+            'Les traitements servent a securiser l acces, executer les processus RH, produire les rapports, notifier les utilisateurs, auditer les actions et maintenir la plateforme.',
+            'Les donnees ne sont pas revendues. Les acces internes sont limites aux besoins de support, securite, exploitation et conformite.',
+          ],
+        },
+        {
+          title: 'Droits des utilisateurs',
+          body: [
+            'Les utilisateurs peuvent demander l export de leurs donnees, une correction, une limitation ou une suppression selon les lois applicables et les obligations de conservation de l employeur.',
+            'La plateforme expose aussi des controles produit pour tracer les demandes de suppression et le consentement biometrique.',
+          ],
+        },
+        {
+          title: 'Securite',
+          body: [
+            'Leopardo RH applique l isolation multi-tenant, le controle d acces par roles, la journalisation des acces sensibles et une logique de moindre privilege.',
+            'Les clients restent responsables de la configuration de leurs utilisateurs, de leurs politiques internes et de la verification des obligations locales.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'Contact confidentialite',
+        body: 'Pour une demande de confidentialite ou de conformite, contactez notre equipe avec le nom de votre entreprise et le contexte de la demande.',
+        email: 'privacy@leopardo-rh.com',
+      },
+    },
+    terms: {
+      eyebrow: 'Conditions de service',
+      title: 'Conditions generales d utilisation',
+      intro:
+        'Ces conditions encadrent l utilisation de Leopardo RH par les entreprises, administrateurs, managers, employes, kiosques et integrateurs autorises.',
+      updatedAt: 'Derniere mise a jour : 14 mai 2026',
+      backLabel: 'Retour a l accueil',
+      languageLabel: 'Langue du document',
+      sections: [
+        {
+          title: 'Acces a la plateforme',
+          body: [
+            'L acces est reserve aux utilisateurs autorises par une entreprise cliente ou par Leopardo RH pour l administration de la plateforme.',
+            'Chaque utilisateur doit proteger ses identifiants, respecter les permissions accordees et signaler toute activite suspecte.',
+          ],
+        },
+        {
+          title: 'Usage acceptable',
+          body: [
+            'La plateforme doit etre utilisee pour des processus RH legitimes : pointage, paie, absences, documents, notifications, reporting, support et operations associees.',
+            'Il est interdit de contourner la securite, d extraire massivement des donnees sans autorisation ou d utiliser le service pour surveiller des personnes hors cadre legal.',
+          ],
+        },
+        {
+          title: 'Responsabilites client',
+          body: [
+            'Le client configure ses roles, ses workflows, ses regles RH, ses contenus et ses obligations de conformite locales.',
+            'Les integrations, exports et imports doivent etre verifies avant usage en production, surtout lorsqu ils alimentent la paie ou des documents officiels.',
+          ],
+        },
+        {
+          title: 'Disponibilite et evolution',
+          body: [
+            'Leopardo RH peut faire evoluer les modules, APIs et interfaces pour ameliorer la securite, la performance et la valeur produit.',
+            'Les operations critiques de maintenance, migration ou incident sont traitees selon les procedures d exploitation et de support en vigueur.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'Contact service',
+        body: 'Pour une question contractuelle ou une demande liee au service, contactez notre equipe avec votre identifiant entreprise.',
+        email: 'support@leopardo-rh.com',
+      },
+    },
+  },
+  en: {
+    privacy: {
+      eyebrow: 'HR data compliance',
+      title: 'Privacy policy',
+      intro:
+        'Leopardo RH processes sensitive HR data to help companies run attendance, payroll, leave and field workflows. This page explains our approach to protection, transparency and control.',
+      updatedAt: 'Last updated: May 14, 2026',
+      backLabel: 'Back to home',
+      languageLabel: 'Document language',
+      sections: [
+        {
+          title: 'Data we process',
+          body: [
+            'We may process identity, contact, job, attendance, leave, payroll, HR document, role, permission and technical audit data.',
+            'Biometric or biometric-like data should only be enabled when the customer has a clear legal basis and documented consent or internal policy.',
+          ],
+        },
+        {
+          title: 'Purposes',
+          body: [
+            'Processing supports secure access, HR workflows, reports, notifications, audit trails and platform operations.',
+            'We do not sell HR data. Internal access is limited to support, security, operations and compliance needs.',
+          ],
+        },
+        {
+          title: 'User rights',
+          body: [
+            'Users may request export, correction, limitation or deletion according to applicable laws and employer retention obligations.',
+            'The platform also exposes product controls to track deletion requests and biometric consent.',
+          ],
+        },
+        {
+          title: 'Security',
+          body: [
+            'Leopardo RH applies tenant isolation, role-based access control, sensitive data access logging and least-privilege principles.',
+            'Customers remain responsible for user configuration, internal policies and local legal obligations.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'Privacy contact',
+        body: 'For privacy or compliance requests, contact our team with your company name and request context.',
+        email: 'privacy@leopardo-rh.com',
+      },
+    },
+    terms: {
+      eyebrow: 'Service terms',
+      title: 'Terms of use',
+      intro:
+        'These terms govern the use of Leopardo RH by companies, administrators, managers, employees, kiosks and authorized integrators.',
+      updatedAt: 'Last updated: May 14, 2026',
+      backLabel: 'Back to home',
+      languageLabel: 'Document language',
+      sections: [
+        {
+          title: 'Platform access',
+          body: [
+            'Access is limited to users authorized by a customer company or by Leopardo RH for platform administration.',
+            'Each user must protect credentials, respect granted permissions and report suspicious activity.',
+          ],
+        },
+        {
+          title: 'Acceptable use',
+          body: [
+            'The platform must be used for legitimate HR processes: attendance, payroll, leave, documents, notifications, reporting, support and related operations.',
+            'Bypassing security, extracting data without authorization or monitoring people outside a legal framework is prohibited.',
+          ],
+        },
+        {
+          title: 'Customer responsibilities',
+          body: [
+            'The customer configures roles, workflows, HR rules, content and local compliance obligations.',
+            'Integrations, exports and imports must be verified before production use, especially when they feed payroll or official documents.',
+          ],
+        },
+        {
+          title: 'Availability and evolution',
+          body: [
+            'Leopardo RH may evolve modules, APIs and interfaces to improve security, performance and product value.',
+            'Critical maintenance, migration or incident operations are handled through the current operations and support procedures.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'Service contact',
+        body: 'For contractual or service questions, contact our team with your company identifier.',
+        email: 'support@leopardo-rh.com',
+      },
+    },
+  },
+  tr: {
+    privacy: {
+      eyebrow: 'IK veri uyumu',
+      title: 'Gizlilik politikasi',
+      intro:
+        'Leopardo RH, sirketlerin devam, bordro, izin ve saha is akışlarini yonetmesine yardim etmek icin hassas IK verilerini isler. Bu sayfa koruma, seffaflik ve kontrol yaklasimimizi aciklar.',
+      updatedAt: 'Son guncelleme: 14 Mayis 2026',
+      backLabel: 'Ana sayfaya don',
+      languageLabel: 'Belge dili',
+      sections: [
+        {
+          title: 'Islenen veriler',
+          body: [
+            'Kimlik, iletisim, gorev, devam, izin, bordro, IK belgeleri, roller, izinler ve teknik denetim kayitlari islenebilir.',
+            'Biyometrik veya benzeri veriler yalnizca musteri acik bir hukuki dayanak ve belgelenmis onay ya da ic politika sagladiginda etkinlestirilmelidir.',
+          ],
+        },
+        {
+          title: 'Amaclar',
+          body: [
+            'Isleme; guvenli erisim, IK is akislari, raporlar, bildirimler, denetim kayitlari ve platform operasyonlarini destekler.',
+            'IK verileri satilmaz. Ic erisim destek, guvenlik, operasyon ve uyum ihtiyaclariyla sinirlidir.',
+          ],
+        },
+        {
+          title: 'Kullanici haklari',
+          body: [
+            'Kullanicilar, geçerli yasalara ve isveren saklama yukumluluklerine gore ihrac, duzeltme, sinirlama veya silme talebinde bulunabilir.',
+            'Platform ayrica silme taleplerini ve biyometrik onayi izlemek icin urun kontrolleri sunar.',
+          ],
+        },
+        {
+          title: 'Guvenlik',
+          body: [
+            'Leopardo RH tenant izolasyonu, rol tabanli erisim kontrolu, hassas veri erisim gunlugu ve en az ayricalik ilkelerini uygular.',
+            'Musteriler kullanici yapilandirmasi, ic politikalar ve yerel hukuki yukumluluklerden sorumludur.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'Gizlilik iletisimi',
+        body: 'Gizlilik veya uyum talepleri icin sirket adiniz ve talep baglaminizla ekibimize ulasin.',
+        email: 'privacy@leopardo-rh.com',
+      },
+    },
+    terms: {
+      eyebrow: 'Hizmet sartlari',
+      title: 'Kullanim kosullari',
+      intro:
+        'Bu kosullar Leopardo RH nin sirketler, yoneticiler, mudurler, calisanlar, kiosklar ve yetkili entegratorler tarafindan kullanimini duzenler.',
+      updatedAt: 'Son guncelleme: 14 Mayis 2026',
+      backLabel: 'Ana sayfaya don',
+      languageLabel: 'Belge dili',
+      sections: [
+        {
+          title: 'Platform erisimi',
+          body: [
+            'Erisim, musteri sirket tarafindan veya platform yonetimi icin Leopardo RH tarafindan yetkilendirilen kullanicilarla sinirlidir.',
+            'Her kullanici kimlik bilgilerini korumali, verilen izinlere uymali ve supheli etkinlikleri bildirmelidir.',
+          ],
+        },
+        {
+          title: 'Kabul edilebilir kullanim',
+          body: [
+            'Platform mesru IK surecleri icin kullanilmalidir: devam, bordro, izin, belgeler, bildirimler, raporlama, destek ve ilgili operasyonlar.',
+            'Guvenligi asmak, yetkisiz veri cikarmak veya kisileri hukuki cerceve disinda izlemek yasaktir.',
+          ],
+        },
+        {
+          title: 'Musteri sorumluluklari',
+          body: [
+            'Musteri rollerini, is akislari, IK kurallari, icerikler ve yerel uyum yukumluluklerini yapilandirir.',
+            'Entegrasyonlar, ihraclar ve ithalatlar uretimden once dogrulanmalidir; ozellikle bordro veya resmi belgeleri besliyorsa.',
+          ],
+        },
+        {
+          title: 'Erisilebilirlik ve gelisim',
+          body: [
+            'Leopardo RH guvenlik, performans ve urun degerini artirmak icin modulleri, API leri ve arayuzleri gelistirebilir.',
+            'Kritik bakim, migrasyon veya olay operasyonlari guncel isletim ve destek prosedurleriyle yonetilir.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'Hizmet iletisimi',
+        body: 'Sozlesme veya hizmet sorulari icin sirket kimliginizle ekibimize ulasin.',
+        email: 'support@leopardo-rh.com',
+      },
+    },
+  },
+  ar: {
+    privacy: {
+      eyebrow: 'الامتثال وبيانات الموارد البشرية',
+      title: 'سياسة الخصوصية',
+      intro:
+        'تعالج Leopardo RH بيانات موارد بشرية حساسة لمساعدة الشركات على إدارة الحضور والرواتب والإجازات وسير العمل الميداني. توضح هذه الصفحة نهجنا في الحماية والشفافية والتحكم.',
+      updatedAt: 'آخر تحديث: 14 مايو 2026',
+      backLabel: 'العودة إلى الصفحة الرئيسية',
+      languageLabel: 'لغة الوثيقة',
+      sections: [
+        {
+          title: 'البيانات التي نعالجها',
+          body: [
+            'قد نعالج بيانات الهوية والاتصال والوظيفة والحضور والإجازات والرواتب ووثائق الموارد البشرية والأدوار والصلاحيات وسجلات التدقيق التقنية.',
+            'لا ينبغي تفعيل البيانات البيومترية أو المشابهة لها إلا عندما يملك العميل أساسا قانونيا واضحا وموافقة أو سياسة داخلية موثقة.',
+          ],
+        },
+        {
+          title: 'الأغراض',
+          body: [
+            'تدعم المعالجة الوصول الآمن وسير عمل الموارد البشرية والتقارير والإشعارات وسجلات التدقيق وتشغيل المنصة.',
+            'لا نبيع بيانات الموارد البشرية. يقتصر الوصول الداخلي على احتياجات الدعم والأمن والتشغيل والامتثال.',
+          ],
+        },
+        {
+          title: 'حقوق المستخدمين',
+          body: [
+            'يمكن للمستخدمين طلب تصدير البيانات أو تصحيحها أو تقييدها أو حذفها وفق القوانين المطبقة والتزامات صاحب العمل بالاحتفاظ.',
+            'توفر المنصة أيضا ضوابط لتتبع طلبات الحذف وموافقة البيانات البيومترية.',
+          ],
+        },
+        {
+          title: 'الأمان',
+          body: [
+            'تطبق Leopardo RH عزل المستأجرين والتحكم في الوصول حسب الأدوار وتسجيل الوصول إلى البيانات الحساسة ومبدأ أقل صلاحية.',
+            'يبقى العملاء مسؤولين عن إعداد المستخدمين والسياسات الداخلية والتحقق من الالتزامات القانونية المحلية.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'التواصل بخصوص الخصوصية',
+        body: 'لطلبات الخصوصية أو الامتثال، تواصل مع فريقنا مع اسم شركتك وسياق الطلب.',
+        email: 'privacy@leopardo-rh.com',
+      },
+    },
+    terms: {
+      eyebrow: 'شروط الخدمة',
+      title: 'شروط الاستخدام',
+      intro:
+        'تنظم هذه الشروط استخدام Leopardo RH من قبل الشركات والمسؤولين والمديرين والموظفين وأجهزة الكشك والمكاملين المعتمدين.',
+      updatedAt: 'آخر تحديث: 14 مايو 2026',
+      backLabel: 'العودة إلى الصفحة الرئيسية',
+      languageLabel: 'لغة الوثيقة',
+      sections: [
+        {
+          title: 'الوصول إلى المنصة',
+          body: [
+            'يقتصر الوصول على المستخدمين المصرح لهم من شركة عميلة أو من Leopardo RH لإدارة المنصة.',
+            'يجب على كل مستخدم حماية بيانات الدخول واحترام الصلاحيات الممنوحة والإبلاغ عن أي نشاط مشبوه.',
+          ],
+        },
+        {
+          title: 'الاستخدام المقبول',
+          body: [
+            'يجب استخدام المنصة لعمليات موارد بشرية مشروعة مثل الحضور والرواتب والإجازات والوثائق والإشعارات والتقارير والدعم والعمليات المرتبطة.',
+            'يحظر تجاوز الأمان أو استخراج البيانات دون تصريح أو مراقبة الأشخاص خارج إطار قانوني.',
+          ],
+        },
+        {
+          title: 'مسؤوليات العميل',
+          body: [
+            'يقوم العميل بإعداد الأدوار وسير العمل وقواعد الموارد البشرية والمحتوى والتزامات الامتثال المحلية.',
+            'يجب التحقق من التكاملات وعمليات التصدير والاستيراد قبل استخدامها في الإنتاج، خاصة عندما تغذي الرواتب أو الوثائق الرسمية.',
+          ],
+        },
+        {
+          title: 'التوفر والتطور',
+          body: [
+            'قد تطور Leopardo RH الوحدات وواجهات API والواجهات لتحسين الأمان والأداء وقيمة المنتج.',
+            'تدار عمليات الصيانة أو الترحيل أو الحوادث الحرجة وفق إجراءات التشغيل والدعم المعمول بها.',
+          ],
+        },
+      ],
+      contact: {
+        title: 'التواصل بخصوص الخدمة',
+        body: 'لأسئلة العقود أو الخدمة، تواصل مع فريقنا مع معرف شركتك.',
+        email: 'support@leopardo-rh.com',
+      },
+    },
+  },
+}
+
+export function getLegalPageCopy(locale: AppLocale, page: LegalPageKind): LegalPageCopy {
+  return legalPages[locale][page] ?? legalPages.fr[page]
+}

--- a/front/web/tsconfig.json
+++ b/front/web/tsconfig.json
@@ -26,7 +26,9 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
## Summary
- add public /privacy and /terms pages for the web vitrine in FR/EN/TR/AR with RTL-aware layout
- wire footer legal links to the real routes and add sitemap entries
- extend web navigation scenarios for legal routes and locale switching

## Verification
- npm run lint in front/web
- npm run build in front/web
- Playwright targeted smoke blocked locally because browser install failed with ENOSPC; CI should provision browsers