### PR TITLE
feat(api): add sensitive endpoint rate limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,11 @@ Procedure recommandee :
 - Le registre interne des traitements vit dans `docs/security/REGISTRE_TRAITEMENTS_DONNEES_RH.md`. Le maintenir a jour a chaque nouveau module collectant une nouvelle categorie de donnees, integration externe, traitement IA ou usage biometrique.
 - Les points privacy publics (`/privacy`, `/terms`) et API (`/api/v1/privacy/export`, `/deletion-request`, `/biometric-consent`) doivent rester coherents avec ce registre.
 
+### 2026-05-14 - Rate limiting endpoints sensibles
+
+- Les surfaces sensibles utilisent des limiters nommes dans `AppServiceProvider` et configures via `api/config/security.php` : `auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`.
+- Pour les prochains endpoints auth, paie, privacy, IA ou super-admin, reutiliser ces limiters au lieu d'ajouter des `throttle:10,1` isoles.
+
 ### 2026-05-08 - Render et transaction PostgreSQL abort
 
 - Sur PostgreSQL, une migration Laravel executee dans la transaction du migrateur ne doit pas lancer de requete de verification apres une erreur SQL, sinon on tombe sur `SQLSTATE[25P02] current transaction is aborted`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.31] - 2026-05-14
+
+### Security — Sensitive API rate limits
+
+- API : ajout de limiters nommes configurables pour auth publique, privacy, paie, plateforme super-admin et IA.
+- Routes : application de `auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive` et `ai-sensitive` aux surfaces sensibles.
+- Tests : couverture Feature des reponses 429 sur login public et export privacy authentifie.
+
 ## [4.16.30] - 2026-05-14
 
 ### Compliance — Registre interne des traitements RH

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -31,6 +31,7 @@ use App\Policies\TrainingPolicy;
 use App\Policies\VehiclePolicy;
 use App\Services\TenantManager;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -91,6 +92,52 @@ class AppServiceProvider extends ServiceProvider
 
             // 60 requêtes par minute par IP pour les non-authentifiés
             return Limit::perMinute(60)->by($request->ip());
+        });
+
+        RateLimiter::for('auth-sensitive', function (Request $request) {
+            $email = strtolower((string) $request->input('email', 'anonymous'));
+
+            return Limit::perMinute((int) config('security.rate_limits.auth_per_minute', 10))
+                ->by('auth:'.$email.'|'.$request->ip());
+        });
+
+        RateLimiter::for('privacy-sensitive', function (Request $request) {
+            $user = $request->user();
+            $key = $user instanceof Employee
+                ? 'employee:'.$user->company_id.':'.$user->id
+                : 'ip:'.$request->ip();
+
+            return Limit::perMinute((int) config('security.rate_limits.privacy_per_minute', 20))
+                ->by('privacy:'.$key);
+        });
+
+        RateLimiter::for('payroll-sensitive', function (Request $request) {
+            $user = $request->user();
+            $key = $user instanceof Employee && $user->company_id
+                ? 'company:'.$user->company_id
+                : 'ip:'.$request->ip();
+
+            return Limit::perMinute((int) config('security.rate_limits.payroll_per_minute', 60))
+                ->by('payroll:'.$key);
+        });
+
+        RateLimiter::for('platform-sensitive', function (Request $request) {
+            $user = $request->user('super_admin_api');
+            $userId = $user instanceof AuthenticatableContract ? $user->getAuthIdentifier() : null;
+            $key = $userId !== null ? 'super-admin:'.$userId : 'ip:'.$request->ip();
+
+            return Limit::perMinute((int) config('security.rate_limits.platform_per_minute', 60))
+                ->by('platform:'.$key);
+        });
+
+        RateLimiter::for('ai-sensitive', function (Request $request) {
+            $user = $request->user();
+            $key = $user instanceof Employee && $user->company_id
+                ? 'company:'.$user->company_id
+                : 'ip:'.$request->ip();
+
+            return Limit::perMinute((int) config('security.rate_limits.ai_per_minute', 20))
+                ->by('ai:'.$key);
         });
     }
 }

--- a/api/config/security.php
+++ b/api/config/security.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'rate_limits' => [
+        'auth_per_minute' => (int) env('RATE_LIMIT_AUTH_PER_MINUTE', 10),
+        'privacy_per_minute' => (int) env('RATE_LIMIT_PRIVACY_PER_MINUTE', 20),
+        'payroll_per_minute' => (int) env('RATE_LIMIT_PAYROLL_PER_MINUTE', 60),
+        'platform_per_minute' => (int) env('RATE_LIMIT_PLATFORM_PER_MINUTE', 60),
+        'ai_per_minute' => (int) env('RATE_LIMIT_AI_PER_MINUTE', 20),
+    ],
+];

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -10,7 +10,7 @@ use App\Http\Middleware\AI\AITenantInjector;
 use App\Http\Middleware\AI\EnsureAIAnalyticsAccess;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', AIFeatureCheck::class, AITenantInjector::class])->prefix('ai')->group(function () {
+Route::middleware(['throttle:api', 'auth:sanctum', 'throttle:ai-sensitive', AIFeatureCheck::class, AITenantInjector::class])->prefix('ai')->group(function () {
 
     // Phase 1 — Chat IA
     Route::middleware([AIRateLimiter::class])->group(function () {

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -30,7 +30,7 @@ Route::prefix('v1')->group(function (): void {
     Route::get('/metrics', MetricsController::class);
 
     // Auth (core, hors module)
-    Route::middleware(['throttle:10,1'])->group(function (): void {
+    Route::middleware(['throttle:auth-sensitive'])->group(function (): void {
         Route::post('/auth/login', [AuthController::class, 'login']);
         Route::post('/auth/register', [AuthController::class, 'register']);
         Route::get('/auth/google', [AuthController::class, 'redirectToGoogle']);
@@ -55,9 +55,11 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/auth/logout', [AuthController::class, 'logout']);
         Route::get('/auth/biometric-enrollment', [BiometricEnrollmentController::class, 'myStatus']);
         Route::post('/auth/biometric-enrollment', [BiometricEnrollmentController::class, 'store']);
-        Route::get('/privacy/export', [PrivacyController::class, 'export']);
-        Route::post('/privacy/deletion-request', [PrivacyController::class, 'storeDeletionRequest']);
-        Route::patch('/privacy/biometric-consent', [PrivacyController::class, 'updateBiometricConsent']);
+        Route::middleware(['throttle:privacy-sensitive'])->group(function (): void {
+            Route::get('/privacy/export', [PrivacyController::class, 'export']);
+            Route::post('/privacy/deletion-request', [PrivacyController::class, 'storeDeletionRequest']);
+            Route::patch('/privacy/biometric-consent', [PrivacyController::class, 'updateBiometricConsent']);
+        });
 
         // Feature Registry API - Mobile synchronization
         Route::prefix('features')->group(function (): void {
@@ -98,7 +100,7 @@ Route::prefix('v1')->group(function (): void {
     require __DIR__.'/ai.php';
 
     // Platform (super-admin, hors module)
-    Route::middleware(['auth:super_admin_api'])->prefix('platform')->group(function (): void {
+    Route::middleware(['auth:super_admin_api', 'throttle:platform-sensitive'])->prefix('platform')->group(function (): void {
         Route::get('/auth/me', [PlatformAuthController::class, 'me']);
         Route::post('/auth/logout', [PlatformAuthController::class, 'logout']);
 

--- a/api/routes/modules/payroll_engine.php
+++ b/api/routes/modules/payroll_engine.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\Api\V1\SocialContributionController;
 use App\Http\Controllers\Api\V1\TaxSlabController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function () {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:payroll-sensitive'])->group(function () {
 
     // Salary Structures
     Route::get('/salary-structures', [SalaryStructureController::class, 'index']);

--- a/api/routes/modules/user.php
+++ b/api/routes/modules/user.php
@@ -13,7 +13,7 @@ use App\Http\Controllers\Api\V1\UserEmployeeLinkController;
 use Illuminate\Support\Facades\Route;
 
 // Public (sans auth, throttle strict)
-Route::middleware(['throttle:10,1'])->prefix('user')->group(function (): void {
+Route::middleware(['throttle:auth-sensitive'])->prefix('user')->group(function (): void {
     Route::post('/register', [UserAuthController::class, 'register']);
     Route::post('/login', [UserAuthController::class, 'login']);
     Route::post('/google-signin', [UserAuthController::class, 'googleSignIn']);

--- a/api/tests/Feature/Security/SensitiveRateLimitTest.php
+++ b/api/tests/Feature/Security/SensitiveRateLimitTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class SensitiveRateLimitTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_public_auth_login_is_rate_limited_by_email_and_ip(): void
+    {
+        config(['security.rate_limits.auth_per_minute' => 2]);
+
+        $payload = [
+            'email' => 'limited@example.test',
+            'password' => 'wrong-password',
+            'device_name' => 'test-suite',
+        ];
+
+        $this->postJson('/api/v1/auth/login', $payload)->assertStatus(401);
+        $this->postJson('/api/v1/auth/login', $payload)->assertStatus(401);
+        $this->postJson('/api/v1/auth/login', $payload)->assertStatus(429);
+    }
+
+    public function test_privacy_export_is_rate_limited_per_authenticated_employee(): void
+    {
+        config(['security.rate_limits.privacy_per_minute' => 2]);
+
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'privacy-rate-limit@example.test',
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/v1/privacy/export')->assertOk();
+        $this->getJson('/api/v1/privacy/export')->assertOk();
+        $this->getJson('/api/v1/privacy/export')->assertStatus(429);
+    }
+}

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -35,6 +35,8 @@ Definir une couverture backend exhaustive pour la CI GitHub Actions, alignee sur
 
 Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier les routes reelles (`/billing/subscription/*`, `/training/courses/{id}/sessions`, actions `PUT` pour prets/frais) et rester alignes avec le schema `CreatesMvpSchema`.
 
+Note 2026-05-14 : les endpoints sensibles utilisent des limiters nommes configurables (`auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`). Les scenarios API doivent conserver au moins un test `429` sur auth publique et un test `429` sur privacy authentifie.
+
 ## Matrice complete des scenarios backend
 
 ### 1. Sante technique et bootstrap
@@ -55,6 +57,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - Register refuse si payload invalide
 - Login succes pour chaque role autorise
 - Login refuse pour mot de passe invalide
+- Login public retourne `429` apres depassement du limiter `auth-sensitive`
 - Login refuse pour compte inactif ou bloque
 - `me` retourne le bon role, tenant, permissions et contexte
 - Logout invalide le token en cours
@@ -193,6 +196,7 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 - `PATCH /api/v1/privacy/biometric-consent` enregistre le consentement ou retire le consentement en desactivant les flags biometriques et en effacant les references de templates
 - Les endpoints privacy restent sous `auth:sanctum` + `tenant` et ne prennent jamais d'`employee_id` client pour eviter l'export d'un collegue ou d'un autre tenant
 - Les acces aux fiches employees et exports privacy creent une entree `audit_logs` avec `category=hr_data_access`, acteur, tenant et cible quand elle existe
+- Les endpoints privacy retournent `429` apres depassement du limiter `privacy-sensitive`
 
 ## Mapping attendu vers les suites GitHub Actions
 

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -90,7 +90,7 @@
 - [ ] Audit SQL injection sur tous les endpoints avec parametres
 - [ ] Verifier CSRF/XSS protection sur formulaires admin
 - [ ] Audit des permissions RBAC : matrice complete roles/routes
-- [ ] Rate limiting sur tous les endpoints sensibles (auth, paie, IA)
+- [x] Rate limiting sur endpoints sensibles auth, privacy, paie, plateforme et IA via limiters nommes configurables
 - [ ] Rotation automatique des tokens JWT (refresh token flow)
 ```
 


### PR DESCRIPTION
## Summary
- add configurable named rate limiters for auth, privacy, payroll, platform and AI surfaces
- apply the limiters to sensitive route groups while preserving existing auth/tenant middleware
- add Feature coverage for 429 responses on public auth login and authenticated privacy export

## Verification
- php -l on changed PHP files
- git diff --check
- php artisan test --filter=SensitiveRateLimitTest blocked locally by missing mbstring and ENOSPC log write; GitHub Actions is source of truth