### PR TITLE
chore(perf): add k6 API load smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,11 @@ Procedure recommandee :
 - Les surfaces sensibles utilisent des limiters nommes dans `AppServiceProvider` et configures via `api/config/security.php` : `auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`.
 - Pour les prochains endpoints auth, paie, privacy, IA ou super-admin, reutiliser ces limiters au lieu d'ajouter des `throttle:10,1` isoles.
 
+### 2026-05-14 - Load testing k6
+
+- Le socle de charge vit dans `dev-hub/load/k6/api-core-smoke.js` et reste read-only par defaut. Ne pas ajouter de mutations de pointage, paie ou exports dans ce script sans flag explicite.
+- Les benchmarks Plan 14 doivent etre consignes avec p50/p95, taux d'erreur et endpoints lents avant d'annoncer un SLA.
+
 ### 2026-05-08 - Render et transaction PostgreSQL abort
 
 - Sur PostgreSQL, une migration Laravel executee dans la transaction du migrateur ne doit pas lancer de requete de verification apres une erreur SQL, sinon on tombe sur `SQLSTATE[25P02] current transaction is aborted`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.32] - 2026-05-14
+
+### Performance — k6 load testing foundation
+
+- DevOps : ajout d'un script k6 read-only pour mesurer health, dashboard, employees, attendance, payroll et self-service.
+- Documentation : ajout du runbook `dev-hub/load/README.md` avec variables, seuils et procedure de benchmark Plan 14.
+- Plan : coche du setup k6 / Artillery pour tests de charge.
+
 ## [4.16.31] - 2026-05-14
 
 ### Security — Sensitive API rate limits

--- a/dev-hub/load/README.md
+++ b/dev-hub/load/README.md
@@ -1,0 +1,64 @@
+# Load testing Leopardo RH
+
+Ce dossier contient les scripts de charge k6 utilises pour mesurer les parcours API critiques sans modifier les donnees par defaut.
+
+## Script disponible
+
+| Script | Objectif | Mutations |
+|---|---|---|
+| `k6/api-core-smoke.js` | Health, dashboard manager, employees, attendance, payroll et self-service employe | Non |
+
+## Prerequis
+
+- Installer k6 : https://grafana.com/docs/k6/latest/set-up/install-k6/
+- Utiliser une base de staging ou de preproduction, jamais la production client sans fenetre de test.
+- Generer deux tokens Sanctum de test :
+  - `MANAGER_TOKEN` pour un manager/RH du tenant cible ;
+  - `EMPLOYEE_TOKEN` pour un employe du meme tenant.
+
+## Execution locale
+
+```bash
+BASE_URL="https://api-staging.leopardo-rh.com" \
+MANAGER_TOKEN="..." \
+EMPLOYEE_TOKEN="..." \
+k6 run dev-hub/load/k6/api-core-smoke.js
+```
+
+## Profil par defaut
+
+- `HEALTH_VUS=5` pendant `1m`
+- `MANAGER_VUS=5` pendant `1m`
+- `EMPLOYEE_VUS=5` pendant `1m`
+- seuil global : moins de 2% d'erreurs HTTP ;
+- p95 global sous 1200 ms ;
+- p95 paie sous 1500 ms.
+
+## Variables utiles
+
+| Variable | Defaut | Usage |
+|---|---|---|
+| `BASE_URL` | `http://localhost:8000` | API cible |
+| `MANAGER_TOKEN` | vide | Active les parcours manager/RH |
+| `EMPLOYEE_TOKEN` | `MANAGER_TOKEN` | Active les parcours self-service |
+| `HEALTH_VUS` | `5` | Utilisateurs virtuels health |
+| `MANAGER_VUS` | `5` | Utilisateurs virtuels manager |
+| `EMPLOYEE_VUS` | `5` | Utilisateurs virtuels employe |
+| `HEALTH_DURATION` | `1m` | Duree health |
+| `MANAGER_DURATION` | `1m` | Duree manager |
+| `EMPLOYEE_DURATION` | `1m` | Duree employe |
+
+## Procedure de benchmark Plan 14
+
+1. Creer un tenant staging avec au moins 100 employes.
+2. Generer un token manager et un token employe.
+3. Lancer le smoke de base pour valider les seuils.
+4. Augmenter progressivement `MANAGER_VUS` et `EMPLOYEE_VUS`.
+5. Consigner les resultats dans un rapport date : p50, p95, taux d'erreur, endpoints les plus lents.
+6. Ouvrir un ticket par goulot : N+1, index absent, payload trop lourd, cache manquant.
+
+## Garde-fous
+
+- Le script ne cree pas de pointage, run de paie, export bancaire ou document.
+- Les tests destructifs ou batch doivent vivre dans un script separe avec un flag explicite.
+- Ne jamais commiter de token dans ce dossier.

--- a/dev-hub/load/k6/api-core-smoke.js
+++ b/dev-hub/load/k6/api-core-smoke.js
@@ -1,0 +1,130 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const baseUrl = (__ENV.BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
+const managerToken = __ENV.MANAGER_TOKEN || '';
+const employeeToken = __ENV.EMPLOYEE_TOKEN || managerToken;
+
+const dashboardLatency = new Trend('dashboard_latency_ms');
+const attendanceLatency = new Trend('attendance_latency_ms');
+const payrollLatency = new Trend('payroll_latency_ms');
+
+export const options = {
+  scenarios: {
+    health: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.HEALTH_VUS || 5),
+      duration: __ENV.HEALTH_DURATION || '1m',
+      exec: 'healthScenario',
+    },
+    manager_read_paths: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.MANAGER_VUS || 5),
+      duration: __ENV.MANAGER_DURATION || '1m',
+      exec: 'managerReadScenario',
+      startTime: '5s',
+    },
+    employee_read_paths: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.EMPLOYEE_VUS || 5),
+      duration: __ENV.EMPLOYEE_DURATION || '1m',
+      exec: 'employeeReadScenario',
+      startTime: '10s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.02'],
+    http_req_duration: ['p(95)<1200'],
+    dashboard_latency_ms: ['p(95)<1000'],
+    attendance_latency_ms: ['p(95)<1200'],
+    payroll_latency_ms: ['p(95)<1500'],
+  },
+};
+
+function authHeaders(token) {
+  return token
+    ? {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    : {
+        headers: {
+          Accept: 'application/json',
+        },
+      };
+}
+
+function expectOk(response, label) {
+  check(response, {
+    [`${label} status is 2xx`]: (res) => res.status >= 200 && res.status < 300,
+    [`${label} json response`]: (res) => String(res.headers['Content-Type'] || '').includes('application/json'),
+  });
+}
+
+export function healthScenario() {
+  group('health probes', () => {
+    const live = http.get(`${baseUrl}/api/v1/health/live`, authHeaders(''));
+    expectOk(live, 'health live');
+
+    const ready = http.get(`${baseUrl}/api/v1/health/ready`, authHeaders(''));
+    check(ready, {
+      'health ready is not server error': (res) => res.status < 500,
+    });
+  });
+
+  sleep(1);
+}
+
+export function managerReadScenario() {
+  if (!managerToken) {
+    healthScenario();
+    return;
+  }
+
+  group('manager dashboard and HR reads', () => {
+    const dashboard = http.get(`${baseUrl}/api/v1/dashboard/kpi`, authHeaders(managerToken));
+    dashboardLatency.add(dashboard.timings.duration);
+    expectOk(dashboard, 'dashboard kpi');
+
+    const employees = http.get(`${baseUrl}/api/v1/employees?per_page=20`, authHeaders(managerToken));
+    expectOk(employees, 'employees list');
+
+    const anomalies = http.get(`${baseUrl}/api/v1/attendance/anomalies`, authHeaders(managerToken));
+    attendanceLatency.add(anomalies.timings.duration);
+    expectOk(anomalies, 'attendance anomalies');
+
+    const payrollRuns = http.get(`${baseUrl}/api/v1/payroll-runs?per_page=10`, authHeaders(managerToken));
+    payrollLatency.add(payrollRuns.timings.duration);
+    expectOk(payrollRuns, 'payroll runs');
+  });
+
+  sleep(1);
+}
+
+export function employeeReadScenario() {
+  if (!employeeToken) {
+    healthScenario();
+    return;
+  }
+
+  group('employee self-service reads', () => {
+    const me = http.get(`${baseUrl}/api/v1/auth/me`, authHeaders(employeeToken));
+    expectOk(me, 'auth me');
+
+    const today = http.get(`${baseUrl}/api/v1/attendance/today`, authHeaders(employeeToken));
+    attendanceLatency.add(today.timings.duration);
+    expectOk(today, 'attendance today');
+
+    const payslips = http.get(`${baseUrl}/api/v1/me/pay-slips`, authHeaders(employeeToken));
+    payrollLatency.add(payslips.timings.duration);
+    expectOk(payslips, 'my pay slips');
+
+    const monthly = http.get(`${baseUrl}/api/v1/me/monthly-summary`, authHeaders(employeeToken));
+    expectOk(monthly, 'monthly summary');
+  });
+
+  sleep(1);
+}

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -119,7 +119,7 @@
 
 ### 3.1 Load Testing
 ```
-- [ ] Setup k6 ou Artillery pour tests de charge
+- [x] Setup k6 pour tests de charge via `dev-hub/load/k6/api-core-smoke.js`
 - [ ] Benchmark : 100 employes simultanes (pointage, consultation paie)
 - [ ] Benchmark : calcul paie 500 employes en < 30 secondes
 - [ ] Benchmark : dashboard admin avec 10k employes (pagination, search)


### PR DESCRIPTION
## Summary
- add read-only k6 smoke script for API health, dashboard, employees, attendance, payroll and self-service paths
- document execution, thresholds, tokens and benchmark procedure under dev-hub/load
- update Plan 14, CHANGELOG and AGENTS for the load testing foundation

## Verification
- node --check dev-hub/load/k6/api-core-smoke.js
- git diff --check