### PR TITLE
docs(api): document platform OpenAPI contracts

### DIFF
--- a/.github/workflows/openapi-ci.yml
+++ b/.github/workflows/openapi-ci.yml
@@ -1,0 +1,27 @@
+name: OpenAPI CI
+
+on:
+  pull_request:
+    paths:
+      - "api/openapi.yaml"
+      - ".github/workflows/openapi-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "api/openapi.yaml"
+      - ".github/workflows/openapi-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-openapi:
+    name: Lint OpenAPI contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Lint api/openapi.yaml
+        run: npx --yes @redocly/cli@1.34.5 lint api/openapi.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - La branche distante `devin/1778717175-plan14-phase1-tests` apportait les suites Plan 14 Phase 1 : E2E admin-dashboard, integration API et tests de modeles Flutter. Elle doit etre integree depuis un `origin/main` recent, pas mergee telle quelle si les checks GitHub Actions sont rouges.
 - Les vues admin-dashboard ne doivent pas contenir de `catch {}` vide : `Web Lint` bloque avec `no-empty`. Ajouter au minimum un `console.warn(...)` explicite ou un etat d'erreur utilisateur selon le contexte.
 - Les tests Feature qui declenchent `AbsenceRequested`, `AbsenceApproved`, `AbsenceRejected`, `PayrollValidated` ou d'autres evenements metier peuvent passer par `WebhookListener`. Le schema de test MVP doit donc creer `webhook_endpoints` et `webhook_deliveries`, sinon PostgreSQL echoue avec `relation "webhook_endpoints" does not exist` avant meme les assertions.
+- Les contrats plateforme recents doivent rester dans `api/openapi.yaml`. Le workflow `OpenAPI CI` lance Redocly uniquement quand la spec ou son workflow changent ; corriger la spec plutot que laisser les frontends deviner les shapes `data` / `meta`.
 
 ### Audit 2026-05-13 - IA, RBAC et tenant runtime
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.34] - 2026-05-14
+
+### API Contracts — OpenAPI plateforme
+
+- OpenAPI : documentation des contrats plateforme recents (`plans`, health portefeuille/detail, subscription, features, company requests).
+- CI : ajout d'un workflow dedie `OpenAPI CI` pour linter `api/openapi.yaml` sur PR et push `main`.
+- Plan : actualisation des plans d'action 13/14 apres integration des tests Devin Plan 14 et du socle k6/Sentry.
+
 ## [4.16.33] - 2026-05-14
 
 ### Tests — Integration branche Devin Plan 14

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -383,6 +383,246 @@ paths:
         "422":
           $ref: "#/components/responses/Validation422"
 
+  /platform/plans:
+    get:
+      tags: ["Platform"]
+      summary: "Lister le catalogue des plans SaaS"
+      security:
+        - SuperAdminBearerAuth: []
+      responses:
+        "200":
+          description: "Catalogue des plans actifs et inactifs"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformPlansResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+
+  /platform/companies/health:
+    get:
+      tags: ["Platform"]
+      summary: "Vue portefeuille health des societes"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+      responses:
+        "200":
+          description: "Resume compact adoption, risque et MRR par societe"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyHealthPortfolioResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+
+  /platform/companies/{company}/health:
+    get:
+      tags: ["Platform"]
+      summary: "Health detaille d'une societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CompanyUuid"
+      responses:
+        "200":
+          description: "Adoption, abonnement, anomalies et prochaine action"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyHealthResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+
+  /platform/companies/{company}/subscription:
+    get:
+      tags: ["Platform"]
+      summary: "Lire l'abonnement plateforme d'une societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CompanyUuid"
+      responses:
+        "200":
+          description: "Abonnement courant"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanySubscriptionResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+    patch:
+      tags: ["Platform"]
+      summary: "Mettre a jour l'abonnement plateforme d'une societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CompanyUuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlatformCompanySubscriptionUpdateRequest"
+      responses:
+        "200":
+          description: "Abonnement mis a jour"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanySubscriptionResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /platform/companies/{company}/features:
+    get:
+      tags: ["Platform"]
+      summary: "Lire les feature flags d'une societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CompanyUuid"
+      responses:
+        "200":
+          description: "Feature flags actifs et modules connus"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyFeaturesResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+    patch:
+      tags: ["Platform"]
+      summary: "Mettre a jour les feature flags d'une societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CompanyUuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlatformCompanyFeaturesUpdateRequest"
+      responses:
+        "200":
+          description: "Feature flags mis a jour"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyFeaturesResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /platform/company-requests:
+    get:
+      tags: ["Platform"]
+      summary: "Lister les demandes de creation de societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: ["pending", "approved", "rejected"]
+      responses:
+        "200":
+          description: "Demandes paginees"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyRequestsResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+
+  /platform/company-requests/{id}:
+    get:
+      tags: ["Platform"]
+      summary: "Lire une demande de creation de societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/NumericId"
+      responses:
+        "200":
+          description: "Detail de la demande"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyRequestResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+    patch:
+      tags: ["Platform"]
+      summary: "Approuver ou rejeter une demande de creation de societe"
+      security:
+        - SuperAdminBearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/NumericId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlatformCompanyRequestReviewRequest"
+      responses:
+        "200":
+          description: "Decision enregistree"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformCompanyRequestReviewResponse"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
   /platform/metrics/overview:
     get:
       tags: ["Platform"]
@@ -2175,6 +2415,19 @@ components:
       required: true
       schema:
         type: integer
+    NumericId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    CompanyUuid:
+      name: company
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     DeviceCode:
       name: deviceCode
       in: path
@@ -2761,6 +3014,365 @@ components:
           type: string
           example: "pgsql"
 
+    PlatformPlan:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        price_monthly:
+          type: number
+          format: float
+        price_yearly:
+          type: number
+          format: float
+        max_employees:
+          type: integer
+          nullable: true
+        features:
+          type: object
+          additionalProperties: true
+        trial_days:
+          type: integer
+        is_active:
+          type: boolean
+
+    PlatformPlansResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/PlatformPlan"
+
+    PlatformCompanySubscription:
+      type: object
+      properties:
+        company_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: ["active", "trial", "suspended", "expired"]
+        plan:
+          type: object
+          properties:
+            id:
+              type: integer
+              nullable: true
+            name:
+              type: string
+              nullable: true
+            price_monthly:
+              type: number
+              format: float
+              nullable: true
+            price_yearly:
+              type: number
+              format: float
+              nullable: true
+            max_employees:
+              type: integer
+              nullable: true
+        subscription_start:
+          type: string
+          format: date
+          nullable: true
+        subscription_end:
+          type: string
+          format: date
+          nullable: true
+        currency:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+
+    PlatformCompanySubscriptionResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PlatformCompanySubscription"
+
+    PlatformCompanySubscriptionUpdateRequest:
+      type: object
+      required: ["plan_id", "status"]
+      properties:
+        plan_id:
+          type: integer
+        status:
+          type: string
+          enum: ["active", "trial", "suspended", "expired"]
+        subscription_start:
+          type: string
+          format: date
+          nullable: true
+        subscription_end:
+          type: string
+          format: date
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+          maxLength: 1000
+
+    PlatformCompanyFeaturesResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            company_id:
+              type: string
+              format: uuid
+            features:
+              type: object
+              additionalProperties:
+                type: boolean
+            known_modules:
+              type: array
+              items:
+                type: string
+
+    PlatformCompanyFeaturesUpdateRequest:
+      type: object
+      required: ["features"]
+      properties:
+        features:
+          type: object
+          additionalProperties:
+            type: boolean
+
+    PlatformHealthCompany:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        status:
+          type: string
+        country:
+          type: string
+        currency:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+
+    PlatformCompanyHealthResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            company:
+              $ref: "#/components/schemas/PlatformHealthCompany"
+            plan:
+              type: object
+              additionalProperties: true
+            features:
+              type: object
+              additionalProperties: true
+            period:
+              type: object
+              additionalProperties: true
+            subscription:
+              type: object
+              additionalProperties: true
+            adoption:
+              type: object
+              properties:
+                health_score:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+                risk_level:
+                  type: string
+                  enum: ["low", "medium", "high"]
+                employees:
+                  type: object
+                  additionalProperties: true
+                attendance:
+                  type: object
+                  additionalProperties: true
+                onboarding:
+                  type: object
+                  additionalProperties: true
+                anomalies:
+                  type: object
+                  additionalProperties: true
+            next_actions:
+              type: array
+              items:
+                $ref: "#/components/schemas/PlatformNextAction"
+
+    PlatformCompanyHealthPortfolioResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            summary:
+              type: object
+              additionalProperties: true
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  company:
+                    $ref: "#/components/schemas/PlatformHealthCompany"
+                  plan:
+                    type: object
+                    additionalProperties: true
+                  subscription:
+                    type: object
+                    additionalProperties: true
+                  health_score:
+                    type: integer
+                  risk_level:
+                    type: string
+                  employees_active:
+                    type: integer
+                  attendance_logs_30d:
+                    type: integer
+                  last_punch_at:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  critical_anomalies_30d:
+                    type: integer
+                  next_action:
+                    type: object
+                    nullable: true
+                    allOf:
+                      - $ref: "#/components/schemas/PlatformNextAction"
+
+    PlatformNextAction:
+      type: object
+      properties:
+        key:
+          type: string
+        label:
+          type: string
+        priority:
+          type: string
+          enum: ["low", "medium", "high"]
+
+    PlatformCompanyRequest:
+      type: object
+      properties:
+        id:
+          type: integer
+        company_name:
+          type: string
+        sector:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        email:
+          type: string
+          format: email
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: ["pending", "approved", "rejected"]
+        admin_notes:
+          type: string
+          nullable: true
+        user:
+          nullable: true
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            email:
+              type: string
+              format: email
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        reviewed_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    PlatformCompanyRequestsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformCompanyRequest"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    PlatformCompanyRequestResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PlatformCompanyRequest"
+
+    PlatformCompanyRequestReviewRequest:
+      type: object
+      required: ["status"]
+      properties:
+        status:
+          type: string
+          enum: ["approved", "rejected"]
+        admin_notes:
+          type: string
+          nullable: true
+          maxLength: 2000
+        plan_id:
+          type: integer
+          nullable: true
+
+    PlatformCompanyRequestReviewResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: integer
+            status:
+              type: string
+              enum: ["approved", "rejected"]
+            approved_company_id:
+              type: string
+              format: uuid
+              nullable: true
+            admin_notes:
+              type: string
+              nullable: true
+            reviewed_at:
+              type: string
+              format: date-time
+              nullable: true
+
     PlatformCompanyCreateRequest:
       type: object
       required:
@@ -3030,6 +3642,7 @@ components:
         author_id:
           type: integer
         author:
+          type: object
           allOf:
             - $ref: "#/components/schemas/TaskCommentAuthorMini"
           nullable: true
@@ -3237,12 +3850,14 @@ components:
         employee_id:
           type: integer
         employee:
+          type: object
           allOf:
             - $ref: "#/components/schemas/EvaluationEmployeeMini"
           nullable: true
         evaluator_id:
           type: integer
         evaluator:
+          type: object
           allOf:
             - $ref: "#/components/schemas/EvaluationEvaluatorMini"
           nullable: true

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -18,11 +18,11 @@
 - IA integree (chat, voice, analytics)
 
 ### Faiblesses a corriger
-- Pas de tests E2E frontend (Playwright)
+- Tests E2E frontend Playwright amorces sur l'admin-dashboard (navigation, dashboard, paie, conges, exports)
 - Pas de monitoring production actif (Sentry configure mais pas deploye)
 - Pas d'integration tierce reelle (banques, CNAS/CNSS)
 - Documentation API incomplete pour les integrateurs
-- Performance non mesuree sous charge
+- Performance outillee par k6, benchmarks cibles encore a executer
 - Pas de conformite RGPD/loi 18-07 DZ documentee
 - Pas d'audit securite independant
 
@@ -50,22 +50,22 @@
 **Objectif :** 0 regression visible par le client
 
 ```
-- [ ] Setup Playwright dans front/admin-dashboard/ (config + fixtures)
-- [ ] Scenario login + dashboard chargement KPI
-- [ ] Scenario paie : creer un run → calculer → valider → telecharger bulletin
-- [ ] Scenario conges : soumettre → approuver → verifier solde
+- [x] Setup Playwright dans front/admin-dashboard/ (config + fixtures)
+- [x] Scenario login + dashboard chargement KPI
+- [x] Scenario paie : creer un run → calculer → valider → telecharger bulletin
+- [x] Scenario conges : soumettre → approuver → verifier solde
 - [ ] Scenario recrutement : creer poste → pipeline kanban → changer stage
-- [ ] Scenario exports : generer rapport PDF/CSV
-- [ ] Integrer dans CI web-ci.yml avec screenshots on failure
+- [x] Scenario exports : generer rapport PDF/CSV
+- [x] Integrer dans CI web-ci.yml avec screenshots on failure
 ```
 
 ### 1.2 Tests Integration API — Scenarios metier complets
 **Objectif :** Couvrir les parcours client de bout en bout
 
 ```
-- [ ] Scenario onboarding : creer entreprise → ajouter employes → configurer paie pays
-- [ ] Scenario cycle paie mensuel : pointage → calcul → validation → bulletins → export banque
-- [ ] Scenario conges avec regles : demande → validation manager → deduction solde → rapport
+- [x] Scenario onboarding : creer entreprise → ajouter employes → configurer paie pays
+- [x] Scenario cycle paie mensuel : pointage → calcul → validation → bulletins → export banque
+- [x] Scenario conges avec regles : demande → validation manager → deduction solde → rapport
 - [ ] Scenario multi-tenant : isolation complete entre 2 entreprises (donnees, fichiers, logs)
 - [ ] Coverage backend cible : 60% (actuel : ~40%)
 ```
@@ -175,7 +175,7 @@
 
 ### 4.4 API Publique
 ```
-- [ ] Documentation OpenAPI 3.1 complete et publiee (Swagger UI)
+- [ ] Documentation OpenAPI complete et validee en CI (surface plateforme recente documentee, publication Swagger UI restante)
 - [ ] SDK client JavaScript/Python genere depuis OpenAPI
 - [ ] Rate limiting API avec plans (starter: 100 req/min, pro: 1000, enterprise: illimite)
 - [ ] Versioning API (v1 stable, v2 beta)

--- a/docs/PLAN_ACTION/14_ROADMAP_EXECUTION_POST_LOTS.md
+++ b/docs/PLAN_ACTION/14_ROADMAP_EXECUTION_POST_LOTS.md
@@ -1,7 +1,7 @@
-# 14 - ROADMAP D'EXECUTION ACTUALISEE (Post lots 4-5)
+# 14 - ROADMAP D'EXECUTION ACTUALISEE (Post lots 4-6)
 
 **Date :** 2026-05-13
-**Contexte :** Ce document enrichit le plan d'action apres l'implementation des lots plateforme metrics backend et dashboard admin. Il ne remplace pas `13_RESTANT_POST_SPRINTS.md` : il transforme l'inventaire en sequence d'execution pragmatique, orientee API solide, ventes, scalabilite et dette technique.
+**Contexte :** Ce document enrichit le plan d'action apres l'implementation des lots plateforme metrics backend, dashboard admin, tests Devin Plan 14 et contrats OpenAPI plateforme. Il ne remplace pas `13_RESTANT_POST_SPRINTS.md` : il transforme l'inventaire en sequence d'execution pragmatique, orientee API solide, ventes, scalabilite et dette technique.
 
 ---
 
@@ -13,6 +13,7 @@
 |---|---|---|---|
 | Lot 4 | Backend API | `GET /api/v1/platform/metrics/overview` protege par `super_admin_api` | Backend, coverage, quality, security, CodeQL, governance verts |
 | Lot 5 | Admin dashboard | Cockpit et abonnements branches sur `/platform/metrics/overview` | Web lint, build, Playwright, governance verts |
+| Lot 6 | API Contracts & OpenAPI | Contrats plateforme recents documentes dans `api/openapi.yaml` + lint OpenAPI CI | OpenAPI CI a valider par PR dediee |
 
 ### Ce que ces lots confirment
 
@@ -81,8 +82,8 @@
 
 Livrables :
 
-- Completer `api/openapi.yaml` pour les contrats plateforme recents : auth, health, plans, subscription, company requests, metrics overview.
-- Ajouter une verification CI minimale de validite OpenAPI.
+- [x] Completer `api/openapi.yaml` pour les contrats plateforme recents : auth, health, plans, subscription, company requests, metrics overview.
+- [x] Ajouter une verification CI minimale de validite OpenAPI.
 - Documenter les shapes `data`, `meta`, erreurs `401/403/422`.
 - Aligner le dashboard admin sur ces contrats et noter les endpoints non documentes restants.
 


### PR DESCRIPTION
## Summary
- documents the missing platform contracts in api/openapi.yaml: plans, company health, subscription, feature flags, company requests
- adds an OpenAPI CI workflow that lints the spec only when the spec/workflow changes
- updates Plan 14 docs to reflect the tests and platform contract progress already merged

## Validation
- npx --yes @redocly/cli@1.34.5 lint api/openapi.yaml (valid, historical warnings only)
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1