### PR TITLE
ci: add OWASP ZAP baseline scan

### DIFF
--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -1,0 +1,102 @@
+name: OWASP ZAP Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "Base URL to scan"
+        required: false
+        default: ""
+  workflow_run:
+    workflows: ["Deploy - Leopardo RH"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_ZAP_TARGET_URL: https://gestionemployerbackend.onrender.com
+
+concurrency:
+  group: owasp-zap-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  should-run:
+    name: Check deployment status
+    runs-on: ubuntu-latest
+    outputs:
+      run_scan: ${{ steps.check.outputs.run_scan }}
+    steps:
+      - name: Determine if ZAP should run
+        id: check
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_scan=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
+            echo "run_scan=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  zap-baseline:
+    name: ZAP Baseline Scan
+    runs-on: ubuntu-latest
+    needs: should-run
+    if: needs.should-run.outputs.run_scan == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Resolve target URL
+        id: target
+        shell: bash
+        run: |
+          INPUT_URL="${{ github.event.inputs.target_url }}"
+          URL="${INPUT_URL:-${DEFAULT_ZAP_TARGET_URL}}"
+          URL="${URL%/}"
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "Scanning ${URL}"
+
+      - name: Wait for health endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="${{ steps.target.outputs.url }}/api/v1/health"
+          for attempt in {1..6}; do
+            if curl --fail --silent --show-error "${URL}" | grep -q '"status"'; then
+              echo "API health endpoint is ready."
+              exit 0
+            fi
+            echo "Health check attempt ${attempt}/6 failed; retrying in 10s."
+            sleep 10
+          done
+          echo "API health endpoint did not become ready: ${URL}"
+          exit 1
+
+      - name: Run OWASP ZAP baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p zap-reports
+          docker run --rm \
+            -v "${PWD}/zap-reports:/zap/wrk:rw" \
+            ghcr.io/zaproxy/zaproxy:stable \
+            zap-baseline.py \
+              -t "${{ steps.target.outputs.url }}" \
+              -J zap-baseline.json \
+              -r zap-baseline.html \
+              -w zap-baseline.md \
+              -I
+
+      - name: Upload ZAP reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: owasp-zap-baseline
+          path: zap-reports/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Pour `web/`, utiliser un workflow dedie vitrine (`web-marketing-ci.yml`) sur `web/**` au lieu de recycler les checks admin.
 - Dans `tests.yml`, ne pas faire porter la dette mobile historique a des PR backend/web en declenchant `mobile-tests` uniquement parce que le workflow lui-meme change. Le job mobile doit rester cale sur `mobile/**` tant que la base n'est pas completement assainie.
 - Pour `Backend Quality`, garder Pint et PHPStan en gates diff-aware sur les fichiers PHP backend modifies. Cela bloque les nouvelles regressions sans faire porter la dette historique hors perimetre au PR courant. Garder les artefacts et la visibilite du baseline.
+- Le workflow `OWASP ZAP Baseline` scanne la cible staging apres un deploy `main` reussi ou via `workflow_dispatch`. Il produit des artefacts HTML/Markdown/JSON et utilise `-I` pour ne pas bloquer sur les warnings informatifs ; traiter les alertes en lots dedies plutot que desactiver le scan.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.35] - 2026-05-14
+
+### Security — OWASP ZAP baseline CI
+
+- CI : ajout d'un workflow `OWASP ZAP Baseline` lance manuellement ou apres un deploiement `main` reussi.
+- Securite : le scan cible l'API staging Render, verifie `/api/v1/health` avant analyse et publie les rapports ZAP HTML/Markdown/JSON en artefacts.
+- Plan : coche du point Plan 14 "Activer OWASP ZAP scan automatise dans CI".
+
 ## [4.16.34] - 2026-05-14
 
 ### API Contracts — OpenAPI plateforme

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -86,7 +86,7 @@
 
 ### 2.1 Audit Securite
 ```
-- [ ] Activer OWASP ZAP scan automatise dans CI
+- [x] Activer OWASP ZAP scan automatise dans CI
 - [ ] Audit SQL injection sur tous les endpoints avec parametres
 - [ ] Verifier CSRF/XSS protection sur formulaires admin
 - [ ] Audit des permissions RBAC : matrice complete roles/routes


### PR DESCRIPTION
## Summary
- add an OWASP ZAP baseline workflow for manual runs and successful main deployments
- verify the staging health endpoint before scanning
- upload ZAP HTML, Markdown, and JSON reports as CI artifacts

## Validation
- git diff --cached --check
- Get-Content .github/workflows/owasp-zap.yml | npx --yes yaml@2.7.0 valid
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1

## Notes
- The workflow uses the documented Render staging URL by default and can be pointed at another base URL with workflow_dispatch.