### PR TITLE
ci: automate database backups

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -1,0 +1,159 @@
+name: Database Backup & Restore Drill
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "backup or drill"
+        required: true
+        default: "backup"
+        type: choice
+        options:
+          - backup
+          - drill
+  schedule:
+    - cron: "15 2 * * *"
+    - cron: "15 3 1 * *"
+
+permissions:
+  contents: read
+
+env:
+  BACKUP_DIR: /tmp/leopardo-backups
+  AWS_REGION: ${{ secrets.AWS_REGION || 'eu-west-3' }}
+
+concurrency:
+  group: database-backup-${{ github.event_name }}-${{ github.event.schedule || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  daily-backup:
+    name: Daily PostgreSQL backup
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'backup' || github.event_name == 'schedule' && github.event.schedule == '15 2 * * *'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install backup tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client age awscli
+
+      - name: Validate backup secrets
+        id: secrets
+        shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in DATABASE_URL BACKUP_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::notice::Database backup skipped; missing secrets: ${missing[*]}"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run pg_dump and upload to S3
+        if: steps.secrets.outputs.configured == 'true'
+        shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
+          BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${BACKUP_DIR}"
+          timestamp="$(date -u +%Y%m%d-%H%M%S)"
+          dump_file="${BACKUP_DIR}/leopardo-${timestamp}.dump"
+
+          pg_dump --format=custom --no-owner --no-privileges --file="${dump_file}" "${DATABASE_URL}"
+
+          if [[ -n "${BACKUP_AGE_RECIPIENT:-}" ]]; then
+            age --recipient "${BACKUP_AGE_RECIPIENT}" --output "${dump_file}.age" "${dump_file}"
+            rm -f "${dump_file}"
+            dump_file="${dump_file}.age"
+          fi
+
+          object_key="postgres/daily/$(date -u +%Y/%m/%d)/$(basename "${dump_file}")"
+          aws s3 cp "${dump_file}" "s3://${BACKUP_S3_BUCKET}/${object_key}" \
+            --region "${AWS_REGION}" \
+            --storage-class STANDARD_IA \
+            --sse AES256
+
+          echo "Backup uploaded to s3://${BACKUP_S3_BUCKET}/${object_key}"
+
+  monthly-restore-drill:
+    name: Monthly restore drill
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'drill' || github.event_name == 'schedule' && github.event.schedule == '15 3 1 * *'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install drill tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client age awscli
+
+      - name: Validate drill secrets
+        id: secrets
+        shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RESTORE_DB_URL: ${{ secrets.RESTORE_DB_URL }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in DATABASE_URL RESTORE_DB_URL; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::notice::Restore drill skipped; missing secrets: ${missing[*]}"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run backup restore drill
+        if: steps.secrets.outputs.configured == 'true'
+        shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RESTORE_DB_URL: ${{ secrets.RESTORE_DB_URL }}
+          BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
+          BACKUP_AGE_IDENTITY_FILE: ${{ secrets.BACKUP_AGE_IDENTITY_FILE }}
+        run: |
+          set -euo pipefail
+          chmod +x dev-hub/scripts/backup_drill.sh
+          dev-hub/scripts/backup_drill.sh
+
+      - name: Upload drill log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: database-restore-drill-log
+          path: /tmp/leopardo-backups/last-drill.log
+          if-no-files-found: ignore
+          retention-days: 90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - La matrice operationnelle routes/roles vit dans `docs/security/RBAC_ROUTE_MATRIX.md`. Toute PR qui ajoute/deplace une route protegee ou change un guard doit mettre cette matrice a jour avec le scenario/test associe.
 - L'audit SQL injection courant vit dans `docs/security/SQL_INJECTION_AUDIT.md`. Toute introduction de tri/groupe/selection dynamique ou de raw SQL doit passer par allowlist, test de regression securite, et mise a jour de cet audit.
 - L'audit CSRF/XSS admin vit dans `docs/security/ADMIN_CSRF_XSS_AUDIT.md`. Garder ESLint bloquant sur `vue/no-v-html`, `no-eval`, `no-implied-eval`, `no-new-func` et `no-script-url`; toute exception doit documenter le sanitizer et le test associe.
+- Le workflow `Database Backup & Restore Drill` porte le backup PostgreSQL quotidien et le drill restore mensuel. Il saute proprement si les secrets ne sont pas configures ; ne pas supprimer ce skip, il evite les faux rouges sur forks/PR.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.39] - 2026-05-14
+
+### Ops — Database backup automation
+
+- CI/Ops : ajout du workflow `Database Backup & Restore Drill` avec backup PostgreSQL quotidien vers S3/R2 et drill restore mensuel/manual.
+- Runbook : mise a jour du backup/restore avec secrets S3, RPO < 24h, RTO < 4h, fallback manuel et trace de drill.
+- Plan : coche des items Plan 14 backup quotidien, restore mensuel documente, RPO/RTO et runbook incident documente.
+
 ## [4.16.38] - 2026-05-14
 
 ### Security — Admin CSRF/XSS audit

--- a/docs/GESTION_PROJET/RUNBOOK_BACKUP_RESTORE.md
+++ b/docs/GESTION_PROJET/RUNBOOK_BACKUP_RESTORE.md
@@ -1,13 +1,14 @@
 # RUNBOOK - BACKUP / RESTORE
 
-Version 4.1.95 | 2026-05-07
+Version 4.16.39 | 2026-05-14
 
 ## 0. Procedure minimale a appliquer
 
-Pour Leopardo RH, la procedure minimale obligatoire reste volontairement simple :
+Pour Leopardo RH, la procedure minimale obligatoire combine automatisation et fallback manuel :
 
-- **Backup manuel hebdomadaire** de la base PostgreSQL de production
+- **Backup automatise quotidien** de la base PostgreSQL de production vers S3/R2
 - **Verification de restore mensuelle** sur une base scratch isolee
+- **Fallback manuel hebdomadaire** si le workflow quotidien est desactive ou sans secrets
 - **Trace obligatoire** dans `RUNBOOK_DRILLS_LOG.md`
 
 Si l'equipe n'active pas ou ne maintient pas le drill automatise, cette procedure minimale reste la reference d'exploitation.
@@ -21,9 +22,11 @@ Le "drill" (exercice de reprise) se fait sur une base **scratch isolee**,
 jamais contre la production.
 
 Cible :
-- **Production** : backup manuel hebdomadaire + restore mensuel verifie
+- **Production** : backup quotidien automatise + restore mensuel verifie
 - **Pre-prod** : drill automatise possible si l'infrastructure reste maintenue
 - **Reference de trace** : `RUNBOOK_DRILLS_LOG.md`
+- **RPO** : < 24h quand le workflow quotidien est configure
+- **RTO** : < 4h via restore scratch puis bascule applicative selon `RUNBOOK_ROLLBACK.md`
 
 ## 2. Secrets requis
 
@@ -34,10 +37,24 @@ Cible :
 | `BACKUP_AGE_RECIPIENT` | cle publique `age` pour chiffrer le dump (optionnel) | generee via `age-keygen` |
 | `BACKUP_AGE_IDENTITY_FILE` | cle privee `age` (pour restaurer un dump chiffre) | secret GitHub / 1Password |
 | `BACKUP_DIR` | dossier local ou on ecrit le dump | `/var/lib/leopardo/backups` en prod |
+| `BACKUP_S3_BUCKET` | bucket S3/R2 cible pour les dumps quotidiens | secret GitHub Actions |
+| `AWS_ACCESS_KEY_ID` | acces ecriture bucket backup | IAM limite au bucket |
+| `AWS_SECRET_ACCESS_KEY` | secret ecriture bucket backup | IAM limite au bucket |
+| `AWS_REGION` | region du bucket | `eu-west-3` par defaut |
 
 ## 3. Checklist operationnelle courte
 
-### Backup hebdomadaire
+### Backup quotidien automatise
+
+Le workflow `.github/workflows/database-backup.yml` execute :
+
+- `Daily PostgreSQL backup` tous les jours a 02:15 UTC
+- `Monthly restore drill` le 1er jour du mois a 03:15 UTC
+- `workflow_dispatch` manuel avec `mode=backup` ou `mode=drill`
+
+Si les secrets requis manquent, le workflow sort en notice et ne produit pas de faux backup.
+
+### Fallback manuel hebdomadaire
 
 1. Exporter un dump custom PostgreSQL avec `pg_dump`
 2. Chiffrer le dump si la cle `age` est disponible

--- a/docs/GESTION_PROJET/RUNBOOK_DRILLS_LOG.md
+++ b/docs/GESTION_PROJET/RUNBOOK_DRILLS_LOG.md
@@ -17,6 +17,6 @@ Use this file to record real drill executions (staging recommended).
 
 | ID | Drill | Deadline | Owner | Status |
 |---|---|---|---|---|
-| DR-01 | Backup restore test on staging | Before P1-06 merge | Project lead | TODO |
+| DR-01 | Backup restore test on staging | Monthly via `Database Backup & Restore Drill` or manual fallback | Project lead | SCHEDULED |
 | DR-02 | Rollback deployment test on staging | Before first beta | Project lead | TODO |
 | DR-03 | Incident P1 tabletop exercise | Before first beta | Project lead | TODO |

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -107,10 +107,10 @@
 
 ### 2.3 Sauvegarde & Reprise
 ```
-- [ ] Backup PostgreSQL automatise quotidien (pg_dump + S3)
-- [ ] Test de restauration mensuel documente
-- [ ] RPO < 24h, RTO < 4h documentes
-- [ ] Runbook incident documente (qui contacter, quoi faire)
+- [x] Backup PostgreSQL automatise quotidien (pg_dump + S3)
+- [x] Test de restauration mensuel documente
+- [x] RPO < 24h, RTO < 4h documentes
+- [x] Runbook incident documente (qui contacter, quoi faire)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add a scheduled/manual Database Backup & Restore Drill workflow
- run daily pg_dump uploads to S3/R2 when backup secrets are configured
- run monthly/manual restore drills through the existing backup_drill.sh script
- update backup/restore runbook with secrets, RPO/RTO, fallback, and drill tracking

## Validation
- Get-Content .github/workflows/database-backup.yml | npx --yes yaml@2.7.0 valid
- git diff --cached --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1

## Notes
- The workflow skips with a notice when secrets are missing so forks/PR contexts do not create false reds.