### PR TITLE
docs: mark admin route code splitting complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - L'audit SQL injection courant vit dans `docs/security/SQL_INJECTION_AUDIT.md`. Toute introduction de tri/groupe/selection dynamique ou de raw SQL doit passer par allowlist, test de regression securite, et mise a jour de cet audit.
 - L'audit CSRF/XSS admin vit dans `docs/security/ADMIN_CSRF_XSS_AUDIT.md`. Garder ESLint bloquant sur `vue/no-v-html`, `no-eval`, `no-implied-eval`, `no-new-func` et `no-script-url`; toute exception doit documenter le sanitizer et le test associe.
 - Le workflow `Database Backup & Restore Drill` porte le backup PostgreSQL quotidien et le drill restore mensuel. Il saute proprement si les secrets ne sont pas configures ; ne pas supprimer ce skip, il evite les faux rouges sur forks/PR.
+- Le code splitting par route est deja actif dans `front/admin-dashboard/src/router/index.js` via `component: () => import(...)`. Ne pas reouvrir cet item Plan 14 sauf si une route redevient importee en eager.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.40] - 2026-05-14
+
+### Docs — Admin route code splitting status
+
+- Plan : coche du point Plan 14 "Code splitting par route" apres verification de `front/admin-dashboard/src/router/index.js`.
+- Front admin : confirmation que les routes utilisent deja le lazy loading Vue via `component: () => import(...)`.
+
 ## [4.16.39] - 2026-05-14
 
 ### Ops — Database backup automation

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -137,7 +137,7 @@
 
 ### 3.3 Optimisation Frontend
 ```
-- [ ] Code splitting par route (Vue.js lazy loading)
+- [x] Code splitting par route (Vue.js lazy loading via `component: () => import(...)` dans `front/admin-dashboard/src/router/index.js`)
 - [ ] Service Worker pour mode offline mobile (cache API + assets)
 - [ ] Optimisation bundle size (tree-shaking, analyse webpack)
 - [ ] Skeleton loading sur tous les ecrans (pas de blank screen)


### PR DESCRIPTION
## Summary
- mark the Plan 14 route code splitting item complete after verifying Vue lazy route imports
- document the proof in AGENTS.md so future agents do not repeat the work

## Validation
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1