### PR TITLE
feat(front): align recruitment workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - L'audit CSRF/XSS admin vit dans `docs/security/ADMIN_CSRF_XSS_AUDIT.md`. Garder ESLint bloquant sur `vue/no-v-html`, `no-eval`, `no-implied-eval`, `no-new-func` et `no-script-url`; toute exception doit documenter le sanitizer et le test associe.
 - Le workflow `Database Backup & Restore Drill` porte le backup PostgreSQL quotidien et le drill restore mensuel. Il saute proprement si les secrets ne sont pas configures ; ne pas supprimer ce skip, il evite les faux rouges sur forks/PR.
 - Le code splitting par route est deja actif dans `front/admin-dashboard/src/router/index.js` via `component: () => import(...)`. Ne pas reouvrir cet item Plan 14 sauf si une route redevient importee en eager.
+- La vue recrutement admin consomme les endpoints backend reels `/v1/recruitment/jobs`, `/v1/recruitment/jobs/{id}/applicants` et `/v1/recruitment/applicants/{id}/status`; ne pas revenir aux anciens chemins inexistants `/v1/job-postings` ou `/v1/applicants`.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.41] - 2026-05-14
+
+### Front admin — Recruitment workflow alignment
+
+- Front admin : alignement de la vue recrutement sur les endpoints backend reels `/v1/recruitment/jobs` et `/v1/recruitment/jobs/{id}/applicants`.
+- Front admin : ajout d'un formulaire minimal de creation de poste et d'actions d'avancement/retour candidat dans le pipeline Kanban.
+- Tests : ajout d'un scenario Playwright recrutement avec API mockee couvrant connexion, creation de poste, pipeline Kanban et avancement candidat.
+
 ## [4.16.40] - 2026-05-14
 
 ### Docs — Admin route code splitting status

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -54,7 +54,7 @@
 - [x] Scenario login + dashboard chargement KPI
 - [x] Scenario paie : creer un run → calculer → valider → telecharger bulletin
 - [x] Scenario conges : soumettre → approuver → verifier solde
-- [ ] Scenario recrutement : creer poste → pipeline kanban → changer stage
+- [x] Scenario recrutement : creer poste → pipeline kanban → changer stage
 - [x] Scenario exports : generer rapport PDF/CSV
 - [x] Integrer dans CI web-ci.yml avec screenshots on failure
 ```

--- a/front/admin-dashboard/.eslintrc.cjs
+++ b/front/admin-dashboard/.eslintrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
     es2022: true,
     node: true,
   },
+  ignorePatterns: ['dist/', 'node_modules/', 'playwright-report/', 'test-results/'],
   extends: ['eslint:recommended', 'plugin:vue/vue3-essential'],
   parser: 'vue-eslint-parser',
   parserOptions: {

--- a/front/admin-dashboard/e2e/exports-flow.spec.js
+++ b/front/admin-dashboard/e2e/exports-flow.spec.js
@@ -27,6 +27,28 @@ test.describe('Exports and reports (unauthenticated guard)', () => {
   })
 })
 
+test.describe('Recruitment page structure', () => {
+  test.skip(
+    !process.env.PLAYWRIGHT_AUTH_TOKEN,
+    'Skipped: requires PLAYWRIGHT_AUTH_TOKEN for authenticated tests',
+  )
+
+  test('recruitment view exposes jobs and pipeline controls', async ({ page }) => {
+    await page.addInitScript((token) => {
+      localStorage.setItem('admin_token', token)
+    }, process.env.PLAYWRIGHT_AUTH_TOKEN)
+
+    await page.goto('/recruitment')
+
+    await expect(page.getByRole('button', { name: /Pipeline Kanban/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Postes/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /Postes/i }).click()
+    await expect(page.getByPlaceholder(/Intitule du poste/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /Creer le poste/i })).toBeVisible()
+  })
+})
+
 test.describe('Exports page structure', () => {
   test.skip(
     !process.env.PLAYWRIGHT_AUTH_TOKEN,

--- a/front/admin-dashboard/e2e/navigation.spec.js
+++ b/front/admin-dashboard/e2e/navigation.spec.js
@@ -11,6 +11,7 @@ test.describe('Navigation and routing', () => {
       '/leaves',
       '/contracts',
       '/exports',
+      '/recruitment',
     ]
 
     for (const route of protectedRoutes) {

--- a/front/admin-dashboard/e2e/recruitment-flow.spec.js
+++ b/front/admin-dashboard/e2e/recruitment-flow.spec.js
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Recruitment flow', () => {
+  test('creates a job, opens the pipeline, and advances an applicant with mocked API', async ({ page }) => {
+    const corsHeaders = {
+      'Access-Control-Allow-Origin': 'http://127.0.0.1:4173',
+      'Access-Control-Allow-Headers': 'authorization, content-type, accept',
+      'Access-Control-Allow-Methods': 'GET, POST, PATCH, OPTIONS',
+    }
+    const fulfillJson = (route, body, status = 200) => route.fulfill({
+      status,
+      contentType: 'application/json',
+      headers: corsHeaders,
+      body: JSON.stringify(body),
+    })
+    const handleOptions = (route) => {
+      if (route.request().method() === 'OPTIONS') {
+        route.fulfill({ status: 204, headers: corsHeaders })
+        return true
+      }
+      return false
+    }
+    const jobs = [
+      {
+        id: 1,
+        title: 'Serveur senior',
+        location: 'Alger',
+        status: 'published',
+        created_at: '2026-05-14',
+      },
+    ]
+    const applicants = [
+      {
+        id: 10,
+        first_name: 'Nadia',
+        last_name: 'Belaid',
+        email: 'nadia@example.test',
+        status: 'new',
+        applied_at: '2026-05-14',
+      },
+    ]
+
+    await page.route(/\/platform\/auth\/login(?:\?.*)?$/, async (route) => {
+      if (handleOptions(route)) return
+      await fulfillJson(route, {
+          token: 'playwright-admin-token',
+          data: {
+            id: 1,
+            name: 'Admin',
+            email: 'admin@example.test',
+            role: 'super_admin',
+          },
+      })
+    })
+
+    await page.route(/\/platform\/auth\/me(?:\?.*)?$/, async (route) => {
+      if (handleOptions(route)) return
+      await fulfillJson(route, {
+          data: {
+            id: 1,
+            name: 'Admin',
+            email: 'admin@example.test',
+            role: 'super_admin',
+          },
+      })
+    })
+
+    await page.route(/\/api\/v1\/recruitment\/jobs(?:\?.*)?$/, async (route) => {
+      if (handleOptions(route)) return
+      if (route.request().method() === 'POST') {
+        const payload = route.request().postDataJSON()
+        jobs.push({
+          id: 2,
+          title: payload.title,
+          location: payload.location,
+          status: 'draft',
+          created_at: '2026-05-14',
+        })
+        await fulfillJson(route, { data: jobs.at(-1) }, 201)
+        return
+      }
+
+      await fulfillJson(route, { data: jobs })
+    })
+
+    await page.route(/\/api\/v1\/recruitment\/jobs\/\d+\/applicants(?:\?.*)?$/, async (route) => {
+      if (handleOptions(route)) return
+      const jobId = Number(route.request().url().match(/\/jobs\/(\d+)\/applicants/)?.[1])
+      await fulfillJson(route, { data: jobId === 1 ? applicants : [] })
+    })
+
+    await page.route(/\/api\/v1\/recruitment\/applicants\/\d+\/status(?:\?.*)?$/, async (route) => {
+      if (handleOptions(route)) return
+      const payload = route.request().postDataJSON()
+      applicants[0].status = payload.status
+      await fulfillJson(route, { data: applicants[0] })
+    })
+
+    await page.addInitScript(() => {
+      localStorage.setItem('admin_token', 'playwright-admin-token')
+    })
+
+    await page.goto('/recruitment')
+    await page.getByRole('button', { name: /Postes/i }).click()
+    await page.getByPlaceholder(/Intitule du poste/i).fill('Chef de rang')
+    await page.getByPlaceholder(/Lieu/i).fill('Oran')
+    await page.getByRole('button', { name: /Creer le poste/i }).click()
+
+    await expect(page.getByText('Chef de rang')).toBeVisible()
+
+    await page.getByRole('button', { name: /Pipeline Kanban/i }).click()
+    await expect(page.getByText('Nadia Belaid').first()).toBeVisible()
+    await page.getByRole('button', { name: /Avancer/i }).click()
+
+    await expect(page.getByText('Nadia Belaid').first()).toBeVisible()
+    expect(applicants[0].status).toBe('screening')
+  })
+})

--- a/front/admin-dashboard/src/router/index.js
+++ b/front/admin-dashboard/src/router/index.js
@@ -235,8 +235,15 @@ router.beforeEach(async (to, from, next) => {
 
   const authStore = useAuthStore()
 
-  // Vérifier l'authentification
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    if (authStore.token) {
+      const isValid = await authStore.checkAuth()
+      if (isValid) {
+        next()
+        return
+      }
+    }
+
     next('/login')
     return
   }

--- a/front/admin-dashboard/src/views/recruitment/RecruitmentView.vue
+++ b/front/admin-dashboard/src/views/recruitment/RecruitmentView.vue
@@ -21,6 +21,35 @@
       </button>
     </div>
 
+    <form v-if="activeTab === 'jobs'" class="grid gap-3 rounded-lg bg-white p-4 shadow md:grid-cols-4" @submit.prevent="createJob">
+      <input
+        v-model="jobForm.title"
+        type="text"
+        required
+        class="rounded-md border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500"
+        placeholder="Intitule du poste"
+      />
+      <input
+        v-model="jobForm.location"
+        type="text"
+        class="rounded-md border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500"
+        placeholder="Lieu"
+      />
+      <select v-model="jobForm.contract_type" class="rounded-md border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+        <option value="cdi">CDI</option>
+        <option value="cdd">CDD</option>
+        <option value="stage">Stage</option>
+        <option value="freelance">Freelance</option>
+      </select>
+      <button
+        type="submit"
+        :disabled="savingJob"
+        class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {{ savingJob ? 'Creation...' : 'Creer le poste' }}
+      </button>
+    </form>
+
     <DataTable
       v-if="activeTab === 'jobs'"
       :columns="jobColumns"
@@ -55,13 +84,31 @@
       <KanbanBoard
         :columns="pipelineStages"
         :items="filteredApplicants"
-        status-field="stage"
+        status-field="status"
         @item-click="viewApplicant"
       >
         <template #card="{ item }">
           <p class="text-sm font-medium text-gray-900">{{ item.first_name }} {{ item.last_name }}</p>
           <p class="mt-0.5 text-xs text-gray-500">{{ item.email }}</p>
           <p class="mt-1 text-xs text-gray-400">{{ item.job_title || 'Non assigne' }}</p>
+          <div class="mt-3 flex gap-2">
+            <button
+              v-if="previousStage(item.status)"
+              class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
+              type="button"
+              @click.stop="updateApplicantStatus(item, previousStage(item.status))"
+            >
+              Retour
+            </button>
+            <button
+              v-if="nextStage(item.status)"
+              class="rounded bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
+              type="button"
+              @click.stop="updateApplicantStatus(item, nextStage(item.status))"
+            >
+              Avancer
+            </button>
+          </div>
         </template>
       </KanbanBoard>
     </div>
@@ -77,7 +124,7 @@
       default-sort="applied_at"
       default-sort-dir="desc"
     >
-      <template #cell-stage="{ value }">
+      <template #cell-status="{ value }">
         <StatusBadge :status="value" :map="stageStatusMap" />
       </template>
     </DataTable>
@@ -94,10 +141,16 @@ import KanbanBoard from '@/components/common/KanbanBoard.vue'
 
 const loading = ref(false)
 const error = ref('')
+const savingJob = ref(false)
 const jobs = ref([])
 const applicants = ref([])
 const activeTab = ref('pipeline')
 const selectedJobId = ref('')
+const jobForm = ref({
+  title: '',
+  location: '',
+  contract_type: 'cdi',
+})
 
 const stats = ref({ open_jobs: 0, total_applicants: 0, interviews: 0, hired: 0 })
 
@@ -108,13 +161,15 @@ const tabs = [
 ]
 
 const pipelineStages = [
-  { key: 'applied', label: 'Candidature' },
+  { key: 'new', label: 'Candidature' },
   { key: 'screening', label: 'Pre-selection' },
   { key: 'interview', label: 'Entretien' },
   { key: 'offer', label: 'Offre' },
   { key: 'hired', label: 'Embauche' },
   { key: 'rejected', label: 'Refuse' },
 ]
+
+const stageKeys = pipelineStages.map(stage => stage.key)
 
 const jobColumns = [
   { key: 'title', label: 'Poste', sortable: true },
@@ -130,19 +185,21 @@ const applicantColumns = [
   { key: 'last_name', label: 'Nom', sortable: true },
   { key: 'email', label: 'Email', sortable: true },
   { key: 'job_title', label: 'Poste', sortable: true },
-  { key: 'stage', label: 'Etape', sortable: true },
+  { key: 'status', label: 'Etape', sortable: true },
   { key: 'applied_at', label: 'Date', sortable: true },
 ]
 
 const jobStatusMap = {
   open: { label: 'Ouvert', color: 'green' },
+  published: { label: 'Publie', color: 'green' },
   closed: { label: 'Ferme', color: 'gray' },
+  archived: { label: 'Archive', color: 'gray' },
   draft: { label: 'Brouillon', color: 'yellow' },
   filled: { label: 'Pourvu', color: 'blue' },
 }
 
 const stageStatusMap = {
-  applied: { label: 'Candidature', color: 'blue' },
+  new: { label: 'Candidature', color: 'blue' },
   screening: { label: 'Pre-selection', color: 'yellow' },
   interview: { label: 'Entretien', color: 'purple' },
   offer: { label: 'Offre', color: 'indigo' },
@@ -150,11 +207,11 @@ const stageStatusMap = {
   rejected: { label: 'Refuse', color: 'red' },
 }
 
-const selectedJob = computed(() => jobs.value.find(j => j.id === selectedJobId.value))
+const selectedJob = computed(() => jobs.value.find(j => String(j.id) === String(selectedJobId.value)))
 
 const filteredApplicants = computed(() => {
   if (!selectedJobId.value) return applicants.value
-  return applicants.value.filter(a => a.job_posting_id === selectedJobId.value)
+  return applicants.value.filter(a => String(a.job_posting_id) === String(selectedJobId.value))
 })
 
 function viewJobPipeline(job) {
@@ -162,23 +219,83 @@ function viewJobPipeline(job) {
   activeTab.value = 'pipeline'
 }
 
-function viewApplicant(item) { /* TODO: detail modal */ }
+function viewApplicant() {}
+
+function normalizePaginated(payload) {
+  if (Array.isArray(payload)) return payload
+  if (Array.isArray(payload?.data)) return payload.data
+  if (Array.isArray(payload?.data?.data)) return payload.data.data
+  return []
+}
+
+function previousStage(status) {
+  const index = stageKeys.indexOf(status)
+  if (index <= 0 || status === 'rejected') return null
+  return stageKeys[index - 1]
+}
+
+function nextStage(status) {
+  const index = stageKeys.indexOf(status)
+  if (index < 0 || index >= stageKeys.length - 2) return null
+  return stageKeys[index + 1]
+}
+
+async function createJob() {
+  savingJob.value = true
+  try {
+    await api.post('/v1/recruitment/jobs', {
+      ...jobForm.value,
+      description: jobForm.value.title,
+      remote_policy: 'onsite',
+    })
+    jobForm.value = { title: '', location: '', contract_type: 'cdi' }
+    await fetchData()
+  } catch {
+    error.value = 'Impossible de creer le poste.'
+  } finally {
+    savingJob.value = false
+  }
+}
+
+async function updateApplicantStatus(applicant, status) {
+  const previousStatus = applicant.status
+  applicant.status = status
+  try {
+    await api.patch(`/v1/recruitment/applicants/${applicant.id}/status`, { status })
+  } catch {
+    applicant.status = previousStatus
+    error.value = 'Impossible de mettre a jour le candidat.'
+  }
+}
 
 async function fetchData() {
   loading.value = true
   error.value = ''
   try {
-    const [jobsRes, applicantsRes] = await Promise.all([
-      api.get('/v1/job-postings'),
-      api.get('/v1/applicants'),
-    ])
-    jobs.value = jobsRes.data.data || jobsRes.data || []
-    applicants.value = applicantsRes.data.data || applicantsRes.data || []
+    const jobsRes = await api.get('/v1/recruitment/jobs')
+    jobs.value = normalizePaginated(jobsRes.data).map(job => ({
+      ...job,
+      department: job.department?.name || job.department || '',
+      applicants_count: job.applicants_count || 0,
+    }))
+
+    const applicantResponses = await Promise.all(
+      jobs.value.map(job => api.get(`/v1/recruitment/jobs/${job.id}/applicants`).catch(() => null)),
+    )
+    applicants.value = applicantResponses.flatMap((response, index) => {
+      const job = jobs.value[index]
+      return normalizePaginated(response?.data).map(applicant => ({
+        ...applicant,
+        job_title: job.title,
+        job_posting_id: job.id,
+      }))
+    })
+
     stats.value = {
-      open_jobs: jobs.value.filter(j => j.status === 'open').length,
+      open_jobs: jobs.value.filter(j => ['open', 'published'].includes(j.status)).length,
       total_applicants: applicants.value.length,
-      interviews: applicants.value.filter(a => a.stage === 'interview').length,
-      hired: applicants.value.filter(a => a.stage === 'hired').length,
+      interviews: applicants.value.filter(a => a.status === 'interview').length,
+      hired: applicants.value.filter(a => a.status === 'hired').length,
     }
   } catch {
     error.value = 'Impossible de charger les donnees de recrutement.'


### PR DESCRIPTION
## Summary
- align the admin recruitment view with the real /api/v1/recruitment contracts
- add job creation plus candidate status advancement through the kanban pipeline
- cover the create-job to pipeline/status-change flow with Playwright and register the route in navigation coverage
- ignore generated admin-dashboard build/test artifacts from ESLint

## Validation
- npm --prefix front/admin-dashboard run lint
- npm --prefix front/admin-dashboard run build
- CI=true npm --prefix front/admin-dashboard run test:e2e -- recruitment-flow.spec.js
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1