### PR TITLE
feat(api): publish Swagger UI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le workflow `Database Backup & Restore Drill` porte le backup PostgreSQL quotidien et le drill restore mensuel. Il saute proprement si les secrets ne sont pas configures ; ne pas supprimer ce skip, il evite les faux rouges sur forks/PR.
 - Le code splitting par route est deja actif dans `front/admin-dashboard/src/router/index.js` via `component: () => import(...)`. Ne pas reouvrir cet item Plan 14 sauf si une route redevient importee en eager.
 - La vue recrutement admin consomme les endpoints backend reels `/v1/recruitment/jobs`, `/v1/recruitment/jobs/{id}/applicants` et `/v1/recruitment/applicants/{id}/status`; ne pas revenir aux anciens chemins inexistants `/v1/job-postings` ou `/v1/applicants`.
+- La documentation API publique est servie par le backend sur `/docs` et lit directement la spec canonique `/docs/openapi.yaml` depuis `api/openapi.yaml`; eviter toute copie divergente de la specification.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.42] - 2026-05-14
+
+### API Contracts — Swagger UI publication
+
+- Backend : publication publique de Swagger UI sur `/docs`, branchee sur la specification canonique `/docs/openapi.yaml`.
+- Tests : ajout d'une couverture Feature garantissant que la page docs et le YAML OpenAPI restent accessibles sans authentification.
+- Plan : coche du point Plan 14 "Documentation OpenAPI complete et validee en CI" apres ajout de l'interface Swagger UI publique.
+
 ## [4.16.41] - 2026-05-14
 
 ### Front admin — Recruitment workflow alignment

--- a/api/resources/views/docs/openapi.blade.php
+++ b/api/resources/views/docs/openapi.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Leopardo RH API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+    <style>
+        body {
+            margin: 0;
+            background: #f8fafc;
+        }
+
+        .topbar {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+        window.addEventListener('load', function () {
+            window.ui = SwaggerUIBundle({
+                url: '/docs/openapi.yaml',
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                displayRequestDuration: true,
+                persistAuthorization: true,
+            })
+        })
+    </script>
+</body>
+</html>

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -17,6 +17,21 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+Route::get('/docs', function () {
+    return view('docs.openapi');
+})->name('docs.openapi');
+
+Route::get('/docs/openapi.yaml', function () {
+    $path = base_path('openapi.yaml');
+
+    abort_unless(is_file($path), 404);
+
+    return response((string) file_get_contents($path), 200, [
+        'Cache-Control' => 'public, max-age=300',
+        'Content-Type' => 'application/yaml; charset=UTF-8',
+    ]);
+})->name('docs.openapi.spec');
+
 Route::middleware('guest:super_admin_web')->group(function (): void {
     Route::get('/platform/login', [PlatformAuthController::class, 'showLogin'])->name('platform.login');
     Route::post('/platform/login', [PlatformAuthController::class, 'login'])->name('platform.login.store');

--- a/api/tests/Feature/OpenApiDocsTest.php
+++ b/api/tests/Feature/OpenApiDocsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class OpenApiDocsTest extends TestCase
+{
+    public function test_swagger_ui_page_is_public(): void
+    {
+        $this->get('/docs')
+            ->assertOk()
+            ->assertSee('Leopardo RH API Docs')
+            ->assertSee('/docs/openapi.yaml');
+    }
+
+    public function test_openapi_yaml_is_served_from_the_canonical_spec(): void
+    {
+        $this->get('/docs/openapi.yaml')
+            ->assertOk()
+            ->assertSee('openapi: "3.0.3"', false)
+            ->assertSee('Leopardo RH API', false);
+    }
+}

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -49,6 +49,8 @@ Note 2026-05-14 : les endpoints sensibles utilisent des limiters nommes configur
 - Une erreur de bootstrap ne fuit pas d'informations sensibles
 - Le middleware `RequestIdMiddleware` ajoute un header `X-Request-Id` a chaque reponse API
 - Un `X-Request-Id` fourni dans la requete est reechoe dans la reponse
+- `GET /docs` publie Swagger UI sans authentification
+- `GET /docs/openapi.yaml` sert la specification canonique `api/openapi.yaml` sans copie divergente
 
 ### 2. Auth publique et onboarding
 

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -175,7 +175,7 @@
 
 ### 4.4 API Publique
 ```
-- [ ] Documentation OpenAPI complete et validee en CI (surface plateforme recente documentee, publication Swagger UI restante)
+- [x] Documentation OpenAPI complete et validee en CI (surface plateforme recente documentee, Swagger UI publiee sur `/docs`)
 - [ ] SDK client JavaScript/Python genere depuis OpenAPI
 - [ ] Rate limiting API avec plans (starter: 100 req/min, pro: 1000, enterprise: illimite)
 - [ ] Versioning API (v1 stable, v2 beta)


### PR DESCRIPTION
## Summary
- publish Swagger UI at /docs
- serve /docs/openapi.yaml from the canonical api/openapi.yaml file
- add Feature tests for public docs page and spec access
- update Plan 14, CHANGELOG and AGENTS notes

## Validation
- npx --yes @redocly/cli@1.34.5 lint api/openapi.yaml (valid, 131 existing warnings)
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1

## Local limitation
- php artisan test could not run directly because php is not on the Windows PATH
- Docker validation could not run because Docker Desktop Linux engine is not running