### PR TITLE
docs(architecture): add ADR, C4 and operations runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le code splitting par route est deja actif dans `front/admin-dashboard/src/router/index.js` via `component: () => import(...)`. Ne pas reouvrir cet item Plan 14 sauf si une route redevient importee en eager.
 - La vue recrutement admin consomme les endpoints backend reels `/v1/recruitment/jobs`, `/v1/recruitment/jobs/{id}/applicants` et `/v1/recruitment/applicants/{id}/status`; ne pas revenir aux anciens chemins inexistants `/v1/job-postings` ou `/v1/applicants`.
 - La documentation API publique est servie par le backend sur `/docs` et lit directement la spec canonique `/docs/openapi.yaml` depuis `api/openapi.yaml`; eviter toute copie divergente de la specification.
+- Les decisions d'architecture structurantes vivent dans `docs/architecture/adr/`, le diagramme C4 dans `docs/architecture/C4_ARCHITECTURE.md`, et le point d'entree operations dans `docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md`.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.43] - 2026-05-14
+
+### Architecture — ADR, C4 and operations runbook
+
+- Architecture : ajout du registre ADR avec decisions multi-tenant PostgreSQL, OpenAPI canonique et GitHub Actions source de verite.
+- Architecture : ajout du diagramme C4 contexte/containers/composants backend dans `docs/architecture/C4_ARCHITECTURE.md`.
+- Operations : ajout d'un runbook operations central reliant deploy, rollback, incidents, observabilite et backup/restore.
+
 ## [4.16.42] - 2026-05-14
 
 ### API Contracts — Swagger UI publication

--- a/docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md
+++ b/docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md
@@ -1,0 +1,33 @@
+# RUNBOOK - OPERATIONS
+
+## Objectif
+
+Donner le point d'entree unique pour les procedures d'exploitation Leopardo RH. Ce document ne remplace pas les runbooks specialises ; il indique quel runbook utiliser selon l'incident ou l'action.
+
+## Runbooks sources de verite
+
+| Situation | Runbook |
+|---|---|
+| Deploiement staging/production | `docs/GESTION_PROJET/RUNBOOK_DEPLOY.md` |
+| Rollback applicatif | `docs/GESTION_PROJET/RUNBOOK_ROLLBACK.md` |
+| Incident P1 | `docs/GESTION_PROJET/RUNBOOK_INCIDENT_P1.md` |
+| Observabilite Sentry | `docs/GESTION_PROJET/RUNBOOK_OBSERVABILITY.md` |
+| Backup et restore PostgreSQL | `docs/GESTION_PROJET/RUNBOOK_BACKUP_RESTORE.md` |
+| Journal des drills | `docs/GESTION_PROJET/RUNBOOK_DRILLS_LOG.md` |
+| Tests locaux | `docs/GESTION_PROJET/RUNBOOK_LOCAL_TESTS.md` |
+
+## Sequence incident
+
+1. Qualifier impact : API indisponible, fuite potentielle, paie bloquee, pointage bloque, degradation mineure.
+2. Lire le dernier SHA deploye et les checks GitHub Actions associes.
+3. Si indisponibilite production : appliquer `RUNBOOK_INCIDENT_P1.md`.
+4. Si regression post-deploy : appliquer `RUNBOOK_ROLLBACK.md`.
+5. Si corruption ou perte de donnees suspectee : appliquer `RUNBOOK_BACKUP_RESTORE.md` et ouvrir un drill horodate.
+6. Documenter la cause, le correctif, les checks et les actions preventives dans le changelog ou le runbook concerne.
+
+## Invariants
+
+- `main` distant reste la source de verite.
+- Un deploy se raisonne par SHA, pas seulement par nom de branche.
+- Ne pas ignorer un rouge GitHub Actions requis.
+- Le statut externe Vercel peut etre non bloquant uniquement quand il echoue sans logs applicatifs et que les GitHub Actions requis sont verts.

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -220,9 +220,9 @@
 
 ### 6.1 Documentation Technique
 ```
-- [ ] Architecture Decision Records (ADR) pour les choix critiques
-- [ ] Diagramme d'architecture (C4 model) : contexte, containers, composants
-- [ ] Runbook operations : deploiement, rollback, monitoring, incidents
+- [x] Architecture Decision Records (ADR) pour les choix critiques
+- [x] Diagramme d'architecture (C4 model) : contexte, containers, composants
+- [x] Runbook operations : deploiement, rollback, monitoring, incidents
 - [ ] Guide integration partenaires (webhooks, API, SSO)
 ```
 

--- a/docs/architecture/C4_ARCHITECTURE.md
+++ b/docs/architecture/C4_ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Leopardo RH - C4 Architecture
+
+## Niveau 1 - Contexte
+
+```mermaid
+C4Context
+    title Leopardo RH - Contexte systeme
+    Person(employee, "Employe", "Pointe, consulte ses bulletins et demande des conges")
+    Person(manager, "Manager/RH", "Valide, pilote l'equipe et prepare la paie")
+    Person(superAdmin, "Super-admin plateforme", "Suit les clients, plans, health et support")
+    Person(integrator, "Integrateur partenaire", "Consomme API, webhooks et exports")
+    System(leopardo, "Leopardo RH", "SaaS RH multi-tenant pour PME")
+    System_Ext(openai, "LLM providers", "OpenAI / Claude via LLMClient")
+    System_Ext(storage, "Object Storage", "Backups, exports, documents")
+    System_Ext(sentry, "Sentry", "Observabilite optionnelle")
+    Rel(employee, leopardo, "Mobile / Web manager")
+    Rel(manager, leopardo, "Web manager / Admin tenant")
+    Rel(superAdmin, leopardo, "Admin-dashboard")
+    Rel(integrator, leopardo, "OpenAPI / Webhooks")
+    Rel(leopardo, openai, "Orchestration IA")
+    Rel(leopardo, storage, "Backups et fichiers")
+    Rel(leopardo, sentry, "Erreurs et traces")
+```
+
+## Niveau 2 - Containers
+
+```mermaid
+C4Container
+    title Leopardo RH - Containers
+    Person(user, "Utilisateurs")
+    Container(admin, "Admin Dashboard", "Vue 3 / Vite", "Pilotage plateforme et modules admin")
+    Container(web, "Web manager", "Laravel Blade / Next selon surface", "Portail manager et vitrine")
+    Container(mobile, "Mobile", "Flutter Riverpod", "Pointage, conges, paie, notifications")
+    Container(api, "Backend API", "Laravel 11 / PHP 8.4", "API REST, RBAC, tenant, workflows RH")
+    ContainerDb(pg, "PostgreSQL 16", "Schemas public/tenant", "Donnees transactionnelles")
+    Container(redis, "Redis 7", "Cache / queue / rate limit", "Performance et traitements async")
+    Container(ci, "GitHub Actions", "CI/CD", "Tests, quality, deploy gates")
+    Rel(user, admin, "HTTPS")
+    Rel(user, web, "HTTPS")
+    Rel(user, mobile, "HTTPS")
+    Rel(admin, api, "Bearer API")
+    Rel(web, api, "Session/API")
+    Rel(mobile, api, "Bearer API")
+    Rel(api, pg, "SQL + search_path tenant")
+    Rel(api, redis, "Cache, queue, throttle")
+    Rel(ci, api, "Tests, migrations, quality")
+```
+
+## Niveau 3 - Backend composants critiques
+
+```mermaid
+C4Component
+    title Leopardo RH - Backend Laravel
+    Container_Boundary(api, "Backend API") {
+        Component(routes, "Routes API/Web", "Laravel routes", "Surface v1, modules, docs")
+        Component(auth, "Auth + RBAC", "Sanctum / guards / middleware", "Auth employee, super-admin, manager roles")
+        Component(tenant, "TenantMiddleware + TenantManager", "Middleware/service", "Resolution company et search_path")
+        Component(hr, "Services RH", "PayrollService, AttendanceService, AbsenceService", "Logique metier coeur")
+        Component(ai, "AI Orchestrator", "App\\AI\\Orchestrator", "Boucle agentique plafonnee")
+        Component(audit, "Audit/Webhooks", "Listeners/services", "Traçabilite et integrations")
+        Component(openapi, "OpenAPI docs", "api/openapi.yaml + Swagger UI", "Contrat integrateurs")
+    }
+    ContainerDb(pg, "PostgreSQL")
+    Container(redis, "Redis")
+    Rel(routes, auth, "Controle acces")
+    Rel(auth, tenant, "Contexte tenant")
+    Rel(routes, hr, "Commandes metier")
+    Rel(hr, audit, "Events")
+    Rel(routes, ai, "Routes IA gardees")
+    Rel(openapi, routes, "Documente")
+    Rel(tenant, pg, "SET search_path")
+    Rel(hr, pg, "Eloquent/SQL")
+    Rel(hr, redis, "Cache/queue")
+```
+
+## Regles de maintien
+
+- Mettre a jour ce diagramme quand une surface deployable, un store ou un provider externe devient critique.
+- Garder `api/openapi.yaml` comme source contractuelle, pas ce document.
+- Les decisions structurantes doivent etre ajoutees dans `docs/architecture/adr/`.

--- a/docs/architecture/adr/0001-multi-tenant-postgresql.md
+++ b/docs/architecture/adr/0001-multi-tenant-postgresql.md
@@ -1,0 +1,31 @@
+# ADR 0001 - Multi-tenant PostgreSQL
+
+## Statut
+
+Acceptee.
+
+## Contexte
+
+Leopardo RH sert des PME differentes avec des donnees RH sensibles : paie, pointage, documents, biometrie et audit. La plateforme doit eviter les fuites inter-tenant tout en gardant un cout d'exploitation compatible avec des clients de 5 a 50 employes.
+
+## Decision
+
+Le backend Laravel conserve PostgreSQL comme base transactionnelle principale avec :
+
+- schemas separes pour les tenants dedies ;
+- schema `shared_tenants` pour les petits clients mutualises ;
+- tables publiques pour la plateforme, les plans, les super-admins et le provisioning ;
+- `TenantMiddleware` responsable du contexte tenant et du `search_path` ;
+- `company_id` obligatoire sur les modeles tenant directs ;
+- tests de securite pour les modeles isoles par chaine FK.
+
+## Consequences
+
+Cette decision donne une isolation forte sans multiplier les services. Elle impose de verifier le `search_path` avant toute requete tenant, de ne pas contourner les global scopes sans justification, et de garder les migrations separees entre `database/migrations/public` et `database/migrations/tenant`.
+
+## Regles operationnelles
+
+- Ne jamais lire une donnee tenant avant resolution du tenant courant.
+- Toute nouvelle table tenant directe doit porter `company_id`.
+- Toute table sans `company_id` direct doit avoir un test d'isolation via parent FK.
+- Les migrations publiques doivent rester idempotentes pour Render.

--- a/docs/architecture/adr/0002-api-contracts-openapi.md
+++ b/docs/architecture/adr/0002-api-contracts-openapi.md
@@ -1,0 +1,26 @@
+# ADR 0002 - Contrats API OpenAPI
+
+## Statut
+
+Acceptee.
+
+## Contexte
+
+Les surfaces backend sont consommees par le mobile Flutter, l'admin-dashboard, le web manager, les integrateurs futurs et les workflows de monitoring. Sans contrat canonique, les clients peuvent reintroduire des endpoints fictifs ou divergents.
+
+## Decision
+
+`api/openapi.yaml` est la specification canonique des endpoints exposes. Elle est validee par `OpenAPI CI` et publiee par le backend sur :
+
+- `/docs` pour Swagger UI ;
+- `/docs/openapi.yaml` pour la spec source.
+
+## Consequences
+
+Le backend ne doit pas dupliquer la specification dans un asset statique separe. Les changements d'endpoint doivent mettre a jour `api/openapi.yaml`, les scenarios de test API et, si necessaire, les tests Feature.
+
+## Regles operationnelles
+
+- Toute nouvelle route publique ou partenaire doit etre documentee dans OpenAPI.
+- Les clients frontend doivent consommer les contrats reels, pas des routes inventees.
+- La CI OpenAPI peut garder des warnings historiques, mais elle doit rester valide.

--- a/docs/architecture/adr/0003-ci-github-actions-source-of-truth.md
+++ b/docs/architecture/adr/0003-ci-github-actions-source-of-truth.md
@@ -1,0 +1,23 @@
+# ADR 0003 - GitHub Actions comme source de verite
+
+## Statut
+
+Acceptee.
+
+## Contexte
+
+Le poste local Windows peut manquer de runtimes, de navigateurs ou de services Docker actifs. Les tests complets doivent tout de meme rester reproductibles avant merge.
+
+## Decision
+
+GitHub Actions est la source de verite pour merger vers `main`. Le local sert aux validations rapides et aux corrections ciblees ; le merge attend les checks requis verts sur PR.
+
+## Consequences
+
+Les PR doivent rester petites, avec une intention claire. En cas de rouge CI, on lit `gh run view --log-failed`, on corrige l'erreur exacte, puis on repousse. Les statuts externes non applicatifs deja documentes, comme certains echecs Vercel sans logs de build applicatif, ne bloquent pas si les GitHub Actions requis sont verts.
+
+## Regles operationnelles
+
+- Ne jamais pousser directement sur `main`.
+- Une branche par sujet, avec changelog et scenarios si le comportement change.
+- Ne pas masquer un test rouge par `continue-on-error` sans repropagation explicite.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records
+
+Ce dossier capture les decisions structurantes qui doivent rester stables pour Leopardo RH. Une ADR est ajoutee quand un choix influence la securite, l'exploitation, le multi-tenant, les contrats API ou les couts de changement futurs.
+
+## Registre
+
+| ADR | Statut | Decision |
+|---|---|---|
+| [0001](0001-multi-tenant-postgresql.md) | Acceptee | Multi-tenant PostgreSQL avec schemas separes et mode shared controle |
+| [0002](0002-api-contracts-openapi.md) | Acceptee | OpenAPI canonique dans `api/openapi.yaml`, publie via Swagger UI |
+| [0003](0003-ci-github-actions-source-of-truth.md) | Acceptee | GitHub Actions est la source de verite de validation |
+
+## Format
+
+Chaque ADR contient :
+
+- Contexte
+- Decision
+- Consequences
+- Regles operationnelles


### PR DESCRIPTION
## Summary
- add ADR registry and first accepted decisions for multi-tenancy, OpenAPI contracts and GitHub Actions validation
- add C4 context/container/backend component architecture diagram
- add operations runbook index for deploy, rollback, incidents, observability and backup/restore
- update Plan 14, CHANGELOG and AGENTS notes

## Validation
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1