### PR TITLE
docs(api): add partner integration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - La vue recrutement admin consomme les endpoints backend reels `/v1/recruitment/jobs`, `/v1/recruitment/jobs/{id}/applicants` et `/v1/recruitment/applicants/{id}/status`; ne pas revenir aux anciens chemins inexistants `/v1/job-postings` ou `/v1/applicants`.
 - La documentation API publique est servie par le backend sur `/docs` et lit directement la spec canonique `/docs/openapi.yaml` depuis `api/openapi.yaml`; eviter toute copie divergente de la specification.
 - Les decisions d'architecture structurantes vivent dans `docs/architecture/adr/`, le diagramme C4 dans `docs/architecture/C4_ARCHITECTURE.md`, et le point d'entree operations dans `docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md`.
+- Le guide partenaire canonique est `docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md`; l'actualiser avec tout changement API/webhook/SSO expose aux integrateurs.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.44] - 2026-05-14
+
+### Docs — Partner integration guide
+
+- Documentation : ajout du guide integration partenaires couvrant API REST, regles multi-tenant, webhooks, exports et cadrage SSO.
+- Plan : coche du point Plan 14 "Guide integration partenaires (webhooks, API, SSO)".
+
 ## [4.16.43] - 2026-05-14
 
 ### Architecture — ADR, C4 and operations runbook

--- a/docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md
+++ b/docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md
@@ -1,0 +1,110 @@
+# Guide Integration Partenaires
+
+## Objectif
+
+Ce guide donne le contrat d'integration minimal pour les partenaires Leopardo RH : API REST, webhooks, exports et futur SSO. Il sert aux integrateurs paie, comptabilite, pointeuses, support client et revendeurs terrain.
+
+## Prerequis
+
+- Obtenir un compte super-admin ou un compte tenant autorise.
+- Lire la documentation interactive : `/docs`.
+- Utiliser la specification canonique : `/docs/openapi.yaml`.
+- Tester d'abord sur un environnement sandbox ou staging.
+- Ne jamais partager un token entre deux clients.
+
+## API REST
+
+Les endpoints stables sont exposes sous `/api/v1`.
+
+### Authentification
+
+- Employes/managers : token Sanctum obtenu via `/api/v1/auth/login`.
+- Plateforme : token super-admin obtenu via `/api/v1/platform/auth/login`.
+- Les integrations serveur a serveur doivent utiliser un compte dedie, avec rotation controlee.
+
+### Regles multi-tenant
+
+- Une requete authentifiee est toujours rattachee a une company.
+- Les identifiants d'un autre tenant doivent retourner `403` ou `404`.
+- Les exports doivent etre demandes depuis le tenant source uniquement.
+- Les champs RH sensibles ne doivent pas etre caches hors du systeme partenaire sans base legale et duree de retention.
+
+## Webhooks
+
+Les webhooks diffusent les evenements metier vers un endpoint partenaire HTTPS.
+
+### Evenements supportes
+
+- `employee.created`
+- `employee.archived`
+- `attendance.checked_in`
+- `attendance.checked_out`
+- `absence.requested`
+- `absence.approved`
+- `absence.rejected`
+- `payroll.validated`
+
+### Contrat de livraison
+
+```json
+{
+  "event": "employee.created",
+  "company_id": "uuid",
+  "occurred_at": "2026-05-14T09:00:00Z",
+  "data": {
+    "id": 123
+  }
+}
+```
+
+### Exigences partenaire
+
+- Endpoint HTTPS public.
+- Repondre `2xx` en moins de 5 secondes.
+- Verifier la signature ou le secret partage quand il est fourni.
+- Traiter les evenements de facon idempotente.
+- Journaliser `event`, `company_id`, horodatage et statut de traitement.
+
+## Exports
+
+Les exports a privilegier pour les integrations sont :
+
+- paie : bulletins, rapports mensuels, virements quand disponibles ;
+- attendance : anomalies, rapport mensuel JSON/CSV/PDF ;
+- privacy : exports RGPD a usage strictement encadre ;
+- comptabilite : ecritures de paie quand le module sera active.
+
+## SSO SAML/OIDC
+
+Le SSO enterprise est planifie mais ne doit pas etre considere comme disponible tant qu'une ADR et un contrat OpenAPI dedie ne sont pas merges.
+
+Principes retenus pour la future integration :
+
+- OIDC prioritaire pour Google Workspace et Azure AD ;
+- SAML reserve aux clients enterprise qui l'exigent ;
+- mapping explicite `email -> employee/user lookup` ;
+- refus par defaut si l'utilisateur n'est pas lie a une company active ;
+- journalisation de chaque login SSO avec tenant, provider et resultat.
+
+## Checklist de recette partenaire
+
+- Healthcheck `/api/v1/health` OK.
+- Authentification OK avec un compte de test dedie.
+- Lecture d'une ressource autorisee OK.
+- Lecture d'une ressource hors tenant refusee.
+- Webhook nominal recu et traite.
+- Webhook rejoue sans doublon fonctionnel.
+- Erreur partenaire visible dans les logs de livraison.
+- Documentation de donnees personnelles et retention validee.
+
+## Support
+
+En cas d'incident d'integration, fournir :
+
+- environnement ;
+- company concernee ;
+- endpoint appele ou event webhook ;
+- `X-Request-Id` si present ;
+- horodatage UTC ;
+- payload minimal masque ;
+- resultat attendu et resultat observe.

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -223,7 +223,7 @@
 - [x] Architecture Decision Records (ADR) pour les choix critiques
 - [x] Diagramme d'architecture (C4 model) : contexte, containers, composants
 - [x] Runbook operations : deploiement, rollback, monitoring, incidents
-- [ ] Guide integration partenaires (webhooks, API, SSO)
+- [x] Guide integration partenaires (webhooks, API, SSO)
 ```
 
 ### 6.2 Documentation Commerciale


### PR DESCRIPTION
## Summary
- add canonical partner integration guide for REST API, multi-tenant rules, webhooks, exports and SSO framing
- update Plan 14, CHANGELOG and AGENTS notes

## Validation
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1