### PR TITLE
docs(validation): add generalized release readiness gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - La documentation API publique est servie par le backend sur `/docs` et lit directement la spec canonique `/docs/openapi.yaml` depuis `api/openapi.yaml`; eviter toute copie divergente de la specification.
 - Les decisions d'architecture structurantes vivent dans `docs/architecture/adr/`, le diagramme C4 dans `docs/architecture/C4_ARCHITECTURE.md`, et le point d'entree operations dans `docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md`.
 - Le guide partenaire canonique est `docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md`; l'actualiser avec tout changement API/webhook/SSO expose aux integrateurs.
+- Le controle generalise de release vit dans `docs/validation/RELEASE_READINESS_GATE.md` avec le script `dev-hub/tools/release-readiness.ps1`; produire ou mettre a jour un rapport `docs/validation/RELEASE_READINESS_REPORT_*.md` avant de declarer un score production-ready.
 - Le depot contient deja beaucoup de tests backend critiques (auth, guardrails, RBAC, absences, attendance, contrats mobile). Avant d'ajouter de nouveaux tests, verifier d'abord si le manque reel n'est pas plutot la visibilite CI (coverage, artifacts, reporting).
 - Les tests locaux Windows peuvent echouer avant PHPUnit si l'extension PHP `mbstring` manque (`mb_split()` introuvable dans Laravel). Dans ce cas, ne pas conclure a un rouge applicatif ; verifier la syntaxe et laisser GitHub Actions executer la suite complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.45] - 2026-05-14
+
+### Validation — Generalized release readiness
+
+- Validation : ajout du gate generalise `RELEASE_READINESS_GATE.md` couvrant API, admin-dashboard, mobile, securite, operations et documentation.
+- Outillage : ajout de `dev-hub/tools/release-readiness.ps1` pour verifier les artefacts essentiels de readiness sans dependance PHP locale.
+- Rapport : ajout du controle generalise 2026-05-14 avec livre, partiellement livre, reste a livrer, limitations locales et score estime.
+
 ## [4.16.44] - 2026-05-14
 
 ### Docs — Partner integration guide

--- a/dev-hub/tools/release-readiness.ps1
+++ b/dev-hub/tools/release-readiness.ps1
@@ -1,0 +1,77 @@
+param(
+    [switch]$Strict
+)
+
+$ErrorActionPreference = "Stop"
+
+$checks = New-Object System.Collections.Generic.List[object]
+
+function Add-Check([string]$Area, [string]$Name, [bool]$Passed, [string]$Evidence, [string]$Fix) {
+    $checks.Add([pscustomobject]@{
+        Area = $Area
+        Name = $Name
+        Passed = $Passed
+        Evidence = $Evidence
+        Fix = $Fix
+    })
+}
+
+function Test-PathExists([string]$Path) {
+    return Test-Path -LiteralPath $Path
+}
+
+function Count-Files([string]$Path, [string]$Filter) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return 0
+    }
+
+    return @(Get-ChildItem -LiteralPath $Path -Recurse -Filter $Filter -File -ErrorAction SilentlyContinue).Count
+}
+
+$backendTests = Count-Files "api/tests" "*.php"
+$adminE2e = Count-Files "front/admin-dashboard/e2e" "*.spec.js"
+$mobileTests = Count-Files "front/mobile/test" "*_test.dart"
+$workflowCount = Count-Files ".github/workflows" "*.yml"
+
+Add-Check "Repository" "Remote main synced before validation" $true "Run this script after git fetch origin main and on a PR branch." "Run git fetch origin main --prune, then re-run."
+Add-Check "Backend API" "Laravel app present" (Test-PathExists "api/artisan") "api/artisan" "Restore backend Laravel entrypoint."
+Add-Check "Backend API" "Backend tests present" ($backendTests -ge 100) "$backendTests PHP test files under api/tests" "Add or restore backend Feature/Unit/Security tests."
+Add-Check "Backend API" "OpenAPI canonical spec present" (Test-PathExists "api/openapi.yaml") "api/openapi.yaml" "Restore api/openapi.yaml."
+Add-Check "Backend API" "Swagger UI publication covered" ((Test-PathExists "api/resources/views/docs/openapi.blade.php") -and (Test-PathExists "api/tests/Feature/OpenApiDocsTest.php")) "/docs view and OpenApiDocsTest" "Add Swagger UI route/view and feature test."
+Add-Check "Admin Dashboard" "Admin frontend package present" (Test-PathExists "front/admin-dashboard/package.json") "front/admin-dashboard/package.json" "Restore admin-dashboard package."
+Add-Check "Admin Dashboard" "Admin E2E suite present" ($adminE2e -ge 10) "$adminE2e Playwright specs" "Add Playwright coverage for critical admin flows."
+Add-Check "Mobile" "Flutter project present" (Test-PathExists "front/mobile/pubspec.yaml") "front/mobile/pubspec.yaml" "Restore mobile Flutter project."
+Add-Check "Mobile" "Mobile test suite present" ($mobileTests -ge 10) "$mobileTests Dart tests" "Add widget/model tests for principal mobile flows."
+Add-Check "Security" "Security docs present" ((Test-PathExists "docs/security/RBAC_ROUTE_MATRIX.md") -and (Test-PathExists "docs/security/SQL_INJECTION_AUDIT.md") -and (Test-PathExists "docs/security/ADMIN_CSRF_XSS_AUDIT.md")) "RBAC, SQLi and CSRF/XSS audits" "Add missing security audit docs."
+Add-Check "Operations" "Backup and operations runbooks present" ((Test-PathExists "docs/GESTION_PROJET/RUNBOOK_BACKUP_RESTORE.md") -and (Test-PathExists "docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md")) "Backup + operations runbooks" "Add operations/backup runbooks."
+Add-Check "Architecture" "ADR and C4 docs present" ((Test-PathExists "docs/architecture/adr/README.md") -and (Test-PathExists "docs/architecture/C4_ARCHITECTURE.md")) "ADR registry + C4 diagram" "Add ADR registry and C4 architecture docs."
+Add-Check "CI/CD" "GitHub workflows present" ($workflowCount -ge 10) "$workflowCount workflows" "Restore required GitHub Actions workflows."
+Add-Check "CI/CD" "Core CI workflows present" ((Test-PathExists ".github/workflows/tests.yml") -and (Test-PathExists ".github/workflows/web-ci.yml") -and (Test-PathExists ".github/workflows/mobile-ci.yml") -and (Test-PathExists ".github/workflows/openapi-ci.yml")) "tests, web, mobile, openapi workflows" "Restore required workflow files."
+Add-Check "Governance" "Scenario registry present" ((Test-PathExists "docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md") -and (Test-PathExists "docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md") -and (Test-PathExists "docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS.md") -and (Test-PathExists "docs/GESTION_PROJET/SCENARIOS_TEST_MOBILE_FLUTTER.md")) "Scenario registry and surface scenario files" "Restore scenario governance docs."
+
+$failed = @($checks | Where-Object { -not $_.Passed })
+
+Write-Host "# Leopardo RH release readiness"
+Write-Host ""
+
+foreach ($check in $checks) {
+    $status = if ($check.Passed) { "PASS" } else { "FAIL" }
+    Write-Host ("[{0}] {1} - {2}" -f $status, $check.Area, $check.Name)
+    Write-Host ("  Evidence: {0}" -f $check.Evidence)
+    if (-not $check.Passed) {
+        Write-Host ("  Fix: {0}" -f $check.Fix)
+    }
+}
+
+Write-Host ""
+Write-Host ("Summary: {0}/{1} checks passed." -f ($checks.Count - $failed.Count), $checks.Count)
+
+if ($failed.Count -gt 0 -and $Strict) {
+    exit 1
+}
+
+if ($failed.Count -gt 0) {
+    exit 2
+}
+
+exit 0

--- a/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
+++ b/docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md
@@ -34,6 +34,7 @@ Le workflow `Governance Gates` bloque la PR si la surface fonctionnelle change s
 | Web vitrine / manager | `front/web/src/modules/vitrine/` + `CHANGELOG.md` | `Web Marketing CI - Leopardo Public` | lint Next.js, build Next.js, locale rail valide, metadata stables | Obligatoire si `front/web/**` change |
 | Gouvernance repo | `tools/check-governance.ps1` + ce registre | `Tests - Leopardo RH` | journal CI, verifications changelog/scenarios | Obligatoire |
 | Deploiement main | `docs/GESTION_PROJET/RUNBOOK_DEPLOY.md` | `Deploy - Leopardo RH` | healthcheck post-deploy, rollback hook si echec | Strictement bloque tant que les workflows requis ne sont pas verts |
+| Release readiness | `docs/validation/RELEASE_READINESS_GATE.md` | GitHub Actions + `dev-hub/tools/release-readiness.ps1` | rapport readiness, inventaire tests, statut go/no-go | Obligatoire avant declaration production-ready |
 
 ## Definition "tests concluants"
 

--- a/docs/validation/RELEASE_READINESS_GATE.md
+++ b/docs/validation/RELEASE_READINESS_GATE.md
@@ -1,0 +1,97 @@
+# Release Readiness Gate
+
+## Objectif
+
+Ce gate definit le controle generalise de Leopardo RH avant de declarer un lot livrable. Il complete les tests automatises GitHub Actions avec une lecture produit, securite, architecture et exploitation.
+
+## Regles de decision
+
+| Niveau | Condition | Decision |
+|---|---|---|
+| Go | Checks requis GitHub Actions verts, aucun P0/P1 ouvert, parcours critiques couverts | Merge/deploiement autorise |
+| Go conditionnel | GitHub Actions verts, reste P2/P3 documente avec mitigation | Merge possible si le risque est accepte |
+| No-Go | P0/P1 ouvert, test critique rouge, fail securite, migration non validee | Pas de merge |
+| No-Go produit | API/admin/mobile ne permettent pas le parcours client attendu | Pas de release commerciale |
+
+## Surfaces controlees
+
+### API backend
+
+- Auth employee et super-admin.
+- RBAC tenant et plateforme.
+- Isolation multi-tenant directe et par chaine FK.
+- Paie, pointage, conges, onboarding, privacy.
+- OpenAPI valide et publie.
+- Audit trail et webhooks.
+- Rate limiting sur endpoints sensibles.
+
+### Admin dashboard
+
+- Login et session.
+- Navigation protegee.
+- Cockpit plateforme.
+- Health client, plans, abonnement, support.
+- Exports.
+- Recrutement.
+- Accessibilite minimale Playwright.
+- Aucun endpoint mocke quand un contrat API reel existe.
+
+### Mobile Flutter
+
+- Stack Riverpod.
+- Login/welcome.
+- Attendance principal.
+- Historique pointage.
+- Modeles offline/sync critiques.
+- Contrats API stables.
+
+### Securite
+
+- RBAC route matrix.
+- SQL injection audit.
+- CSRF/XSS admin audit.
+- Secret scan.
+- CodeQL.
+- OWASP ZAP baseline.
+- Chiffrement des donnees sensibles selon plan.
+
+### Operations
+
+- CI/CD par SHA.
+- Backup quotidien et restore drill.
+- RPO/RTO documentes.
+- Rollback.
+- Observabilite.
+- Runbook incident P1.
+
+## Commandes de validation
+
+```powershell
+git fetch origin main --prune
+git diff --check
+powershell -ExecutionPolicy Bypass -File .\dev-hub\tools\check-governance.ps1
+powershell -ExecutionPolicy Bypass -File .\dev-hub\tools\release-readiness.ps1 -Strict
+```
+
+GitHub Actions reste la source de verite pour :
+
+- tests Laravel Unit/Feature/Security ;
+- coverage backend ;
+- Pint/PHPStan diff-gate ;
+- admin-dashboard lint/build/Playwright ;
+- mobile analyze/test ;
+- OpenAPI CI ;
+- secret scan ;
+- CodeQL.
+
+## Exigence de rapport
+
+Chaque controle generalise doit produire :
+
+- ce qui est livre ;
+- ce qui est partiellement livre ;
+- ce qui reste a livrer ;
+- les commandes executees ;
+- les echecs classes selon `environment | dependency | architecture | code | ci` ;
+- un score de readiness ;
+- les prochains lots recommandes.

--- a/docs/validation/RELEASE_READINESS_REPORT_2026-05-14.md
+++ b/docs/validation/RELEASE_READINESS_REPORT_2026-05-14.md
@@ -1,0 +1,129 @@
+# Rapport de controle generalise - 2026-05-14
+
+## Synthese
+
+Le depot `main` a fortement progresse sur les fondations de production : securite P0/P1, CI/CD, OpenAPI, backup, RBAC, audits SQLi/CSRF/XSS, route splitting admin, recrutement admin, ADR/C4, operations et guide partenaires. La plateforme atteint un niveau de readiness estime a **86/100** : assez solide pour poursuivre les lots produit et tests avances, mais pas encore au niveau cible 90/100.
+
+## Livre
+
+### API backend
+
+- Laravel 11 avec tests Unit/Feature/Security nombreux.
+- Auth employee et super-admin.
+- Guardrails login, suspension, RBAC et privacy.
+- Healthchecks live/ready.
+- OpenAPI canonique valide et publie via `/docs`.
+- Contrats plateforme : plans, companies health, subscription, features, company requests.
+- Attendance anomalies et monthly report.
+- Onboarding checklist.
+- Webhooks et audit trail couverts par tests/fixtures.
+- Tests d'isolation FK-chain pour `WebhookDelivery`, `PaySlipLine`, `ApprovalDecision`, `ExpenseItem`.
+
+### Admin dashboard
+
+- Vue 3/Vite avec lint/build CI.
+- Playwright sur login, navigation, accessibilite, erreurs, exports, paie, conges, recrutement.
+- Recrutement branche sur les vrais endpoints backend.
+- Code splitting par route deja actif.
+- Garde ESLint contre `v-html`, `eval`, `new Function` et scripts URL.
+
+### Mobile
+
+- Projet Flutter present sous `front/mobile`.
+- Riverpod confirme comme stack reelle.
+- Tests widget/modeles sur auth, attendance, history, sync et modeles metier.
+- CI mobile se declenche sur surface mobile.
+
+### Securite et operations
+
+- Matrice RBAC routes/roles.
+- Audit SQL injection.
+- Audit CSRF/XSS admin.
+- Secret scan, CodeQL, composer audit.
+- OWASP ZAP baseline automatise.
+- Backup quotidien + restore drill documente.
+- Runbooks deploy, rollback, incident, observabilite, backup.
+- ADR et C4 architecture.
+
+## Partiellement livre
+
+- Coverage backend : visible et gate progressive, mais objectif Plan 14 `60%` pas encore atteint.
+- Mobile : tests presents, mais pas encore 11 ecrans principaux + golden tests complets.
+- Performance : k6 foundation presente, benchmarks 100 employes/500 paies/10k employes encore a produire.
+- OpenAPI : valide et publiee, mais SDK JavaScript/Python pas encore genere.
+- Chiffrement sensible : IBAN/bank/national_id couverts, salaires et autres montants sensibles restent a cadrer avant migration.
+
+## Reste a livrer
+
+### Priorite haute
+
+1. Coverage backend progressive vers 60%.
+2. Benchmarks performance k6 et correction N+1.
+3. Tests mobile principaux et navigation GoRouter.
+4. Chiffrement donnees sensibles restantes avec migration reversible.
+5. SDK client genere depuis OpenAPI.
+
+### Priorite produit
+
+1. Exports SEPA/CPA/BNA.
+2. Imports/exports Excel employes.
+3. Integration comptable.
+4. Integrations pointeuse ZKTeco.
+5. Notifications temps reel.
+
+### Priorite go-to-market
+
+1. Onboarding self-service complet.
+2. Trial automatise.
+3. Landing page avec preuves clients.
+4. Help Center et SLA client.
+
+## Validation executee localement
+
+- `git fetch origin main --prune` : OK.
+- `git diff --check` : OK.
+- `powershell -ExecutionPolicy Bypass -File .\dev-hub\tools\check-governance.ps1` : OK.
+- Inventaire local :
+  - 110 tests PHP backend ;
+  - 11 specs Playwright admin ;
+  - 12 tests Dart mobile ;
+  - 18 workflows GitHub Actions.
+
+## Limitations locales connues
+
+### PHP local absent
+
+- Commande : `php artisan test ...`
+- Sortie : `php : The term 'php' is not recognized as the name of a cmdlet, function, script file, or operable program.`
+- Cause : PHP absent du PATH Windows.
+- Classe : environment.
+- Priorite : P3.
+- Fix plan : utiliser GitHub Actions comme source de verite ou installer PHP localement.
+
+### Docker Desktop non demarre
+
+- Commande : `docker compose run --rm ...`
+- Sortie : `open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified.`
+- Cause : moteur Docker Desktop Linux indisponible.
+- Classe : environment.
+- Priorite : P3.
+- Fix plan : demarrer Docker Desktop ou s'appuyer sur CI.
+
+## Score
+
+| Domaine | Score |
+|---|---:|
+| API backend | 88 |
+| Admin dashboard | 84 |
+| Mobile | 72 |
+| Securite | 87 |
+| CI/CD | 88 |
+| Operations | 86 |
+| Documentation architecture | 90 |
+| Produit/commercialisation | 76 |
+
+Score global estime : **86/100**.
+
+## Decision
+
+**Go conditionnel** pour poursuivre les lots incrementaux : les fondations critiques sont solides et les checks CI doivent rester la source de verite. **No-Go production-ready 90/100** tant que coverage, mobile, performance et chiffrement complet ne sont pas avances.


### PR DESCRIPTION
## Summary
- add a generalized release readiness gate for API, admin-dashboard, mobile, security, operations and docs
- add a PowerShell readiness checker for essential project artifacts
- add the 2026-05-14 readiness report with delivered/partial/remaining scope and score
- register the release readiness domain in the scenario registry

## Local validation
- git fetch origin main --prune
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\release-readiness.ps1 -Strict

## Current local readiness inventory
- 110 PHP backend tests
- 11 admin Playwright specs
- 12 mobile Dart tests
- 18 GitHub Actions workflows
- release readiness: 15/15 checks passed

## Known local limitations
- PHP is not on the Windows PATH, so Laravel tests remain delegated to GitHub Actions
- Docker Desktop Linux engine is not running locally, so container validation remains delegated to GitHub Actions