### PR TITLE
feat: Iteration 3 — Tests Feature rapports RH, org chart, export CSV audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Config : `services.slack.monitoring_webhook` ajoute pour recevoir les alertes monitoring.
 - Scheduler : `monitor:slow-queries` ajoute au schedule Laravel (toutes les 15 minutes).
 - Fix : tests Iteration 3 (`HrReportControllerTest`, `OrgChartControllerTest`, `AuditLogExportTest`) — creation explicite de `Company` + `company_id` pour eviter les violations NOT NULL PostgreSQL en CI.
+- Fix : `HrReportController::headcount` — qualification `employees.status` pour eviter l'ambiguite SQL PostgreSQL sur le join `contracts`.
 - Nouveau : `HrReportControllerTest` — 11 tests Feature (headcount, turnover, absenteeism, payroll-summary, overtime, recruitment-pipeline, training-completion, loan-summary, demographic-breakdown, cost-analysis + RBAC).
 - Nouveau : `OrgChartControllerTest` — 5 tests Feature (arbre, subordonnes, chaine hierarchique, 404, isolation tenant).
 - Nouveau : `AuditLogExportTest` — 5 tests Feature (export CSV, RBAC, filtre dates, index pagine, filtre action).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
 - Nouveau : `MonitorSlowQueries` artisan command — detection requetes lentes via pg_stat_statements (schedule 15 min).
 - Config : `services.slack.monitoring_webhook` ajoute pour recevoir les alertes monitoring.
 - Scheduler : `monitor:slow-queries` ajoute au schedule Laravel (toutes les 15 minutes).
+- Fix : tests Iteration 3 (`HrReportControllerTest`, `OrgChartControllerTest`, `AuditLogExportTest`) — creation explicite de `Company` + `company_id` pour eviter les violations NOT NULL PostgreSQL en CI.
+- Nouveau : `HrReportControllerTest` — 11 tests Feature (headcount, turnover, absenteeism, payroll-summary, overtime, recruitment-pipeline, training-completion, loan-summary, demographic-breakdown, cost-analysis + RBAC).
+- Nouveau : `OrgChartControllerTest` — 5 tests Feature (arbre, subordonnes, chaine hierarchique, 404, isolation tenant).
+- Nouveau : `AuditLogExportTest` — 5 tests Feature (export CSV, RBAC, filtre dates, index pagine, filtre action).
+- Nouveau : endpoint `GET /api/v1/audit-logs/export-csv` — export CSV des logs d'audit avec filtres dates.
+- Route ajoutee dans `routes/modules/hr_extended.php`.
 ## [4.16.52] - 2026-05-14
 
 ### Docs & Config — Iteration 2 documentation technique

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@
 - Plans 01, 02, 04, 05, 07, 08, 10 : mise a jour partielle, taches restantes identifiees.
 - Nouveau : creation de `15_PLAN_EXECUTION_CONSOLIDE.md` — inventaire complet des 193 taches restantes organisees en 12 categories et 7+ iterations.
 - Nouveau : mise a jour de `00_SOMMAIRE.md` avec references aux nouveaux documents.
+## [4.16.53] - 2026-05-14
+
+### Tests & Features — Iteration 3 tests manquants + export CSV audit
+
+- Nouveau : `HrReportControllerTest` — 11 tests Feature (headcount, turnover, absenteeism, payroll-summary, overtime, recruitment-pipeline, training-completion, loan-summary, demographic-breakdown, cost-analysis + RBAC).
+- Nouveau : `OrgChartControllerTest` — 5 tests Feature (arbre, subordonnes, chaine hierarchique, 404, isolation tenant).
+- Nouveau : `AuditLogExportTest` — 5 tests Feature (export CSV, RBAC, filtre dates, index pagine, filtre action).
+- Nouveau : endpoint `GET /api/v1/audit-logs/export-csv` — export CSV des logs d'audit avec filtres dates.
+- Route ajoutee dans `routes/modules/hr_extended.php`.
 
 ## [4.16.50] - 2026-05-14
 

--- a/api/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/api/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -89,7 +89,7 @@ class AuditLogController extends Controller
             $query->where('created_at', '<=', $request->input('to'));
         }
 
-        $filename = 'audit_logs_' . now()->format('Y-m-d_His') . '.csv';
+        $filename = 'audit_logs_'.now()->format('Y-m-d_His').'.csv';
 
         return response()->streamDownload(function () use ($query): void {
             $handle = fopen('php://output', 'w');
@@ -102,7 +102,7 @@ class AuditLogController extends Controller
             $query->chunk(500, function ($logs) use ($handle): void {
                 foreach ($logs as $log) {
                     $userName = $log->user
-                        ? $log->user->first_name . ' ' . $log->user->last_name
+                        ? $log->user->first_name.' '.$log->user->last_name
                         : '';
 
                     fputcsv($handle, [

--- a/api/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/api/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -9,6 +9,7 @@ use App\Models\AuditLog;
 use App\Models\Employee;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AuditLogController extends Controller
 {
@@ -65,5 +66,61 @@ class AuditLogController extends Controller
         }
 
         return response()->json(['data' => $auditLog->load('user:id,first_name,last_name')]);
+    }
+
+    public function exportCsv(Request $request): StreamedResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        if (! $actor->hasManagerRole('principal')) {
+            abort(403);
+        }
+
+        $query = AuditLog::query()
+            ->forCompany($actor->company_id)
+            ->with('user:id,first_name,last_name')
+            ->orderByDesc('created_at');
+
+        if ($request->filled('from')) {
+            $query->where('created_at', '>=', $request->input('from'));
+        }
+
+        if ($request->filled('to')) {
+            $query->where('created_at', '<=', $request->input('to'));
+        }
+
+        $filename = 'audit_logs_' . now()->format('Y-m-d_His') . '.csv';
+
+        return response()->streamDownload(function () use ($query): void {
+            $handle = fopen('php://output', 'w');
+            if ($handle === false) {
+                return;
+            }
+
+            fputcsv($handle, ['id', 'user', 'action', 'auditable_type', 'auditable_id', 'old_values', 'new_values', 'created_at']);
+
+            $query->chunk(500, function ($logs) use ($handle): void {
+                foreach ($logs as $log) {
+                    $userName = $log->user
+                        ? $log->user->first_name . ' ' . $log->user->last_name
+                        : '';
+
+                    fputcsv($handle, [
+                        $log->id,
+                        $userName,
+                        $log->action,
+                        $log->auditable_type,
+                        $log->auditable_id,
+                        is_array($log->old_values) ? json_encode($log->old_values) : ($log->old_values ?? ''),
+                        is_array($log->new_values) ? json_encode($log->new_values) : ($log->new_values ?? ''),
+                        $log->created_at?->toIso8601String() ?? '',
+                    ]);
+                }
+            });
+
+            fclose($handle);
+        }, $filename, [
+            'Content-Type' => 'text/csv',
+        ]);
     }
 }

--- a/api/app/Http/Controllers/Api/V1/HrReportController.php
+++ b/api/app/Http/Controllers/Api/V1/HrReportController.php
@@ -21,14 +21,14 @@ class HrReportController extends Controller
     {
         $this->authorizeManager($request);
 
-        $total = Employee::where('status', 'active')->count();
-        $byDepartment = Employee::where('status', 'active')
-            ->select('employees.*')
-            ->join('contracts', function ($join) {
+        $total = Employee::where('employees.status', 'active')->count();
+        $byDepartment = Employee::query()
+            ->where('employees.status', 'active')
+            ->join('contracts', function ($join): void {
                 $join->on('contracts.employee_id', '=', 'employees.id')
                     ->where('contracts.status', '=', 'active');
             })
-            ->select(DB::raw('contracts.department_id, count(*) as count'))
+            ->selectRaw('contracts.department_id, count(*) as count')
             ->groupBy('contracts.department_id')
             ->get();
 

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -110,6 +110,7 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
 
     // ── Module J — Audit Trail ──────────────────────────────────────────────
     Route::get('/audit-logs', [AuditLogController::class, 'index']);
+    Route::get('/audit-logs/export-csv', [AuditLogController::class, 'exportCsv']);
     Route::get('/audit-logs/{auditLog}', [AuditLogController::class, 'show']);
 
     // ── Module K — Approval Workflows ────────────────────────────────────────

--- a/api/tests/Feature/AuditLogExportTest.php
+++ b/api/tests/Feature/AuditLogExportTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Models\AuditLog;
+use App\Models\Company;
 use App\Models\Employee;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
@@ -28,7 +29,7 @@ class AuditLogExportTest extends TestCase
 
     public function test_export_csv_returns_csv_for_principal_manager(): void
     {
-        $manager = Employee::factory()->create([
+        $manager = $this->employee([
             'role' => 'manager',
             'manager_role' => 'principal',
             'status' => 'active',
@@ -52,7 +53,7 @@ class AuditLogExportTest extends TestCase
 
     public function test_export_csv_forbidden_for_non_principal(): void
     {
-        $employee = Employee::factory()->create([
+        $employee = $this->employee([
             'role' => 'employee',
             'status' => 'active',
         ]);
@@ -65,7 +66,7 @@ class AuditLogExportTest extends TestCase
 
     public function test_export_csv_with_date_filter(): void
     {
-        $manager = Employee::factory()->create([
+        $manager = $this->employee([
             'role' => 'manager',
             'manager_role' => 'principal',
             'status' => 'active',
@@ -79,7 +80,7 @@ class AuditLogExportTest extends TestCase
 
     public function test_audit_log_index_returns_paginated_list(): void
     {
-        $manager = Employee::factory()->create([
+        $manager = $this->employee([
             'role' => 'manager',
             'manager_role' => 'principal',
             'status' => 'active',
@@ -102,7 +103,7 @@ class AuditLogExportTest extends TestCase
 
     public function test_audit_log_index_filtered_by_action(): void
     {
-        $manager = Employee::factory()->create([
+        $manager = $this->employee([
             'role' => 'manager',
             'manager_role' => 'principal',
             'status' => 'active',
@@ -120,5 +121,17 @@ class AuditLogExportTest extends TestCase
         $response = $this->getJson('/api/v1/audit-logs?action=deleted');
 
         $response->assertOk();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function employee(array $attributes = []): Employee
+    {
+        $company = Company::factory()->create();
+
+        return Employee::factory()->create(array_merge([
+            'company_id' => $company->id,
+        ], $attributes));
     }
 }

--- a/api/tests/Feature/AuditLogExportTest.php
+++ b/api/tests/Feature/AuditLogExportTest.php
@@ -48,7 +48,7 @@ class AuditLogExportTest extends TestCase
         $response = $this->get('/api/v1/audit-logs/export-csv');
 
         $response->assertOk();
-        $response->assertHeader('content-type', 'text/csv; charset=UTF-8');
+        $response->assertHeader('content-type', 'text/csv; charset=utf-8');
     }
 
     public function test_export_csv_forbidden_for_non_principal(): void

--- a/api/tests/Feature/AuditLogExportTest.php
+++ b/api/tests/Feature/AuditLogExportTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\Employee;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class AuditLogExportTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_export_csv_returns_csv_for_principal_manager(): void
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        AuditLog::create([
+            'company_id' => $manager->company_id,
+            'user_id' => $manager->id,
+            'action' => 'created',
+            'auditable_type' => 'Employee',
+            'auditable_id' => $manager->id,
+            'new_values' => ['first_name' => 'Test'],
+        ]);
+
+        $response = $this->get('/api/v1/audit-logs/export-csv');
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'text/csv; charset=UTF-8');
+    }
+
+    public function test_export_csv_forbidden_for_non_principal(): void
+    {
+        $employee = Employee::factory()->create([
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($employee);
+
+        $response = $this->get('/api/v1/audit-logs/export-csv');
+
+        $response->assertForbidden();
+    }
+
+    public function test_export_csv_with_date_filter(): void
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        $response = $this->get('/api/v1/audit-logs/export-csv?from=2026-01-01&to=2026-12-31');
+
+        $response->assertOk();
+    }
+
+    public function test_audit_log_index_returns_paginated_list(): void
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        AuditLog::create([
+            'company_id' => $manager->company_id,
+            'user_id' => $manager->id,
+            'action' => 'updated',
+            'auditable_type' => 'Employee',
+            'auditable_id' => $manager->id,
+        ]);
+
+        $response = $this->getJson('/api/v1/audit-logs');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_audit_log_index_filtered_by_action(): void
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        AuditLog::create([
+            'company_id' => $manager->company_id,
+            'user_id' => $manager->id,
+            'action' => 'deleted',
+            'auditable_type' => 'Employee',
+            'auditable_id' => 1,
+        ]);
+
+        $response = $this->getJson('/api/v1/audit-logs?action=deleted');
+
+        $response->assertOk();
+    }
+}

--- a/api/tests/Feature/HrReportControllerTest.php
+++ b/api/tests/Feature/HrReportControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Models\Company;
 use App\Models\Employee;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
@@ -27,7 +28,9 @@ class HrReportControllerTest extends TestCase
 
     private function actingAsManager(): Employee
     {
+        $company = Company::factory()->create();
         $manager = Employee::factory()->create([
+            'company_id' => $company->id,
             'role' => 'manager',
             'status' => 'active',
         ]);
@@ -38,7 +41,9 @@ class HrReportControllerTest extends TestCase
 
     private function actingAsEmployee(): Employee
     {
+        $company = Company::factory()->create();
         $employee = Employee::factory()->create([
+            'company_id' => $company->id,
             'role' => 'employee',
             'status' => 'active',
         ]);

--- a/api/tests/Feature/HrReportControllerTest.php
+++ b/api/tests/Feature/HrReportControllerTest.php
@@ -149,7 +149,7 @@ class HrReportControllerTest extends TestCase
     {
         $this->actingAsManager();
 
-        $response = $this->getJson('/api/v1/reports/demographic-breakdown');
+        $response = $this->getJson('/api/v1/reports/demographics');
 
         $response->assertOk()
             ->assertJsonStructure(['data']);

--- a/api/tests/Feature/HrReportControllerTest.php
+++ b/api/tests/Feature/HrReportControllerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class HrReportControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    private function actingAsManager(): Employee
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        return $manager;
+    }
+
+    private function actingAsEmployee(): Employee
+    {
+        $employee = Employee::factory()->create([
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($employee);
+
+        return $employee;
+    }
+
+    public function test_headcount_returns_data_for_manager(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/headcount');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => ['total', 'by_department', 'by_contract_type', 'by_gender'],
+            ]);
+    }
+
+    public function test_headcount_forbidden_for_employee(): void
+    {
+        $this->actingAsEmployee();
+
+        $response = $this->getJson('/api/v1/reports/headcount');
+
+        $response->assertForbidden();
+    }
+
+    public function test_turnover_returns_hired_and_terminated(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/turnover?months=6');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => ['period_months', 'hired', 'terminated'],
+            ]);
+    }
+
+    public function test_absenteeism_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/absenteeism');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_payroll_summary_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/payroll-summary');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_overtime_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/overtime');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_recruitment_pipeline_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/recruitment-pipeline');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_training_completion_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/training-completion');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_loan_summary_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/loan-summary');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_demographic_breakdown_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/demographic-breakdown');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_cost_analysis_returns_data(): void
+    {
+        $this->actingAsManager();
+
+        $response = $this->getJson('/api/v1/reports/cost-analysis');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+}

--- a/api/tests/Feature/OrgChartControllerTest.php
+++ b/api/tests/Feature/OrgChartControllerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class OrgChartControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_index_returns_tree_structure(): void
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'status' => 'active',
+            'manager_id' => null,
+        ]);
+        Sanctum::actingAs($manager);
+
+        Employee::factory()->create([
+            'company_id' => $manager->company_id,
+            'role' => 'employee',
+            'status' => 'active',
+            'manager_id' => $manager->id,
+        ]);
+
+        $response = $this->getJson('/api/v1/org-chart');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_subordinates_returns_direct_reports(): void
+    {
+        $manager = Employee::factory()->create([
+            'role' => 'manager',
+            'status' => 'active',
+            'manager_id' => null,
+        ]);
+
+        $subordinate = Employee::factory()->create([
+            'company_id' => $manager->company_id,
+            'role' => 'employee',
+            'status' => 'active',
+            'manager_id' => $manager->id,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson("/api/v1/org-chart/{$manager->id}/subordinates");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_manager_chain_returns_hierarchy(): void
+    {
+        $director = Employee::factory()->create([
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+            'manager_id' => null,
+        ]);
+
+        $midManager = Employee::factory()->create([
+            'company_id' => $director->company_id,
+            'role' => 'manager',
+            'status' => 'active',
+            'manager_id' => $director->id,
+        ]);
+
+        $employee = Employee::factory()->create([
+            'company_id' => $director->company_id,
+            'role' => 'employee',
+            'status' => 'active',
+            'manager_id' => $midManager->id,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson("/api/v1/org-chart/{$employee->id}/manager-chain");
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_manager_chain_returns_404_for_nonexistent_employee(): void
+    {
+        $actor = Employee::factory()->create([
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($actor);
+
+        $response = $this->getJson('/api/v1/org-chart/999999/manager-chain');
+
+        $response->assertNotFound();
+    }
+
+    public function test_tenant_isolation_org_chart(): void
+    {
+        $managerA = Employee::factory()->create([
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        $managerB = Employee::factory()->create([
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($managerA);
+
+        $response = $this->getJson('/api/v1/org-chart');
+
+        $response->assertOk();
+
+        $ids = collect($response->json('data'))->pluck('id')->toArray();
+        $this->assertNotContains($managerB->id, $ids);
+    }
+}

--- a/api/tests/Feature/OrgChartControllerTest.php
+++ b/api/tests/Feature/OrgChartControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Models\Company;
 use App\Models\Employee;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
@@ -27,7 +28,9 @@ class OrgChartControllerTest extends TestCase
 
     public function test_index_returns_tree_structure(): void
     {
+        $company = Company::factory()->create();
         $manager = Employee::factory()->create([
+            'company_id' => $company->id,
             'role' => 'manager',
             'status' => 'active',
             'manager_id' => null,
@@ -49,7 +52,9 @@ class OrgChartControllerTest extends TestCase
 
     public function test_subordinates_returns_direct_reports(): void
     {
+        $company = Company::factory()->create();
         $manager = Employee::factory()->create([
+            'company_id' => $company->id,
             'role' => 'manager',
             'status' => 'active',
             'manager_id' => null,
@@ -72,7 +77,9 @@ class OrgChartControllerTest extends TestCase
 
     public function test_manager_chain_returns_hierarchy(): void
     {
+        $company = Company::factory()->create();
         $director = Employee::factory()->create([
+            'company_id' => $company->id,
             'role' => 'manager',
             'manager_role' => 'principal',
             'status' => 'active',
@@ -103,7 +110,9 @@ class OrgChartControllerTest extends TestCase
 
     public function test_manager_chain_returns_404_for_nonexistent_employee(): void
     {
+        $company = Company::factory()->create();
         $actor = Employee::factory()->create([
+            'company_id' => $company->id,
             'role' => 'employee',
             'status' => 'active',
         ]);
@@ -117,11 +126,13 @@ class OrgChartControllerTest extends TestCase
     public function test_tenant_isolation_org_chart(): void
     {
         $managerA = Employee::factory()->create([
+            'company_id' => Company::factory()->create()->id,
             'role' => 'manager',
             'status' => 'active',
         ]);
 
         $managerB = Employee::factory()->create([
+            'company_id' => Company::factory()->create()->id,
             'role' => 'manager',
             'status' => 'active',
         ]);

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -366,6 +366,7 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 ### Module J — Audit Trail
 - `GET /api/v1/audit-logs` retourne les logs filtres par action, type, user, date
 - `GET /api/v1/audit-logs/{id}` retourne le detail avec old/new values
+- `GET /api/v1/audit-logs/export-csv` exporte les logs en CSV avec filtres `from`/`to` (stream chunked)
 - RBAC : uniquement principal
 
 ## Paie Complete Multi-Pays (v4.3.0)


### PR DESCRIPTION
## Summary

**Iteration 3 du plan d'execution** : implementation des tests Feature manquants identifies dans l'audit (PR #461) + nouvel endpoint export CSV audit logs.

### Nouveaux tests (21 tests au total)

1. **`HrReportControllerTest`** — 11 tests Feature couvrant :
   - `GET /api/v1/reports/headcount` (data + RBAC employee=403)
   - `GET /api/v1/reports/turnover` (avec parametre months)
   - `GET /api/v1/reports/absenteeism`
   - `GET /api/v1/reports/payroll-summary`
   - `GET /api/v1/reports/overtime`
   - `GET /api/v1/reports/recruitment-pipeline`
   - `GET /api/v1/reports/training-completion`
   - `GET /api/v1/reports/loan-summary`
   - `GET /api/v1/reports/demographic-breakdown`
   - `GET /api/v1/reports/cost-analysis`

2. **`OrgChartControllerTest`** — 5 tests Feature couvrant :
   - `GET /api/v1/org-chart` (arbre hierarchique)
   - `GET /api/v1/org-chart/{id}/subordinates` (subordonnes directs)
   - `GET /api/v1/org-chart/{id}/manager-chain` (chaine hierarchique complete)
   - 404 pour employe inexistant
   - Isolation tenant (employes d'un autre company_id invisibles)

3. **`AuditLogExportTest`** — 5 tests Feature couvrant :
   - `GET /api/v1/audit-logs/export-csv` (format CSV, headers)
   - RBAC (principal manager=OK, employee=403)
   - Filtrage par dates (from/to)
   - Index pagine audit logs
   - Filtre par action

### Nouvel endpoint

- **`GET /api/v1/audit-logs/export-csv`** — Export CSV streame des logs d'audit
  - Parametres optionnels : `from`, `to` (dates)
  - RBAC : reserve aux managers `principal` uniquement
  - Colonnes : id, user, action, auditable_type, auditable_id, old_values, new_values, created_at
  - Streaming par chunks de 500 pour les grands volumes

### Taches du plan d'execution couvertes

- T-MOD-H4 : Tests Feature rapports RH dedies
- Plan 02 : Test Feature chaine hierarchique org chart
- Plan 02 : Export CSV audit logs

## Review & Testing Checklist for Human

- [ ] Verifier que les 21 nouveaux tests passent dans CI (`Backend Coverage` job)
- [ ] Spot-check l'endpoint export CSV en local avec un manager principal
- [ ] Verifier l'isolation tenant dans OrgChartControllerTest

### Notes

- Les tests utilisent `CreatesMvpSchema` trait comme les tests existants
- L'endpoint export CSV utilise `streamDownload` pour supporter les grands volumes sans OOM
- Les prochaines iterations cibleront securite + performance (Redis cache, JWT rotation, rate limiting)

Link to Devin session: https://app.devin.ai/sessions/29a5f6c617a44e649457a1b33499345b
Requested by: @kitokoh