### PR TITLE
feat: Iteration 4 — PlanBasedRateLimiter, ApiVersionMiddleware, RUNBOOK workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.54] - 2026-05-14
+
+### Feat & Docs — Iteration 4 securite et performance
+
+- Nouveau : `PlanBasedRateLimiter` middleware — rate limiting par plan d'abonnement (free=60, starter=120, professional=300, enterprise=1000 req/min).
+- Nouveau : `ApiVersionMiddleware` — injection X-API-Version header, logging version, validation versions supportees.
+- Enregistrement des deux middleware dans `bootstrap/app.php` (aliases `plan.rate_limit` et `api.version`).
+- ApiVersionMiddleware ajoute au pipeline API global (prepend).
+- Documentation : RUNBOOK_DEPLOY.md enrichi (workers queue, scheduler cron, variables d'environnement, monitoring workers).
+
 ## [4.16.50] - 2026-05-14
 
 ### CI — Mobile coverage ratchet

--- a/api/app/Http/Middleware/ApiVersionMiddleware.php
+++ b/api/app/Http/Middleware/ApiVersionMiddleware.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiVersionMiddleware
+{
+    private const CURRENT_VERSION = 'v1';
+
+    private const SUPPORTED_VERSIONS = ['v1'];
+
+    public function handle(Request $request, Closure $next, string $version = self::CURRENT_VERSION): Response
+    {
+        if (! in_array($version, self::SUPPORTED_VERSIONS, true)) {
+            return response()->json([
+                'error' => 'UNSUPPORTED_API_VERSION',
+                'message' => __('API version :version is not supported. Supported versions: :supported', [
+                    'version' => $version,
+                    'supported' => implode(', ', self::SUPPORTED_VERSIONS),
+                ]),
+            ], 400);
+        }
+
+        $request->attributes->set('api_version', $version);
+
+        Log::channel('structured')->debug('API request', [
+            'api_version' => $version,
+            'path' => $request->path(),
+            'method' => $request->method(),
+        ]);
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        $response->headers->set('X-API-Version', $version);
+
+        return $response;
+    }
+}

--- a/api/app/Http/Middleware/PlanBasedRateLimiter.php
+++ b/api/app/Http/Middleware/PlanBasedRateLimiter.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+class PlanBasedRateLimiter
+{
+    /**
+     * Rate limits per plan tier (requests per minute).
+     *
+     * @var array<string, int>
+     */
+    private const PLAN_LIMITS = [
+        'free' => 60,
+        'starter' => 120,
+        'professional' => 300,
+        'enterprise' => 1000,
+    ];
+
+    private const DEFAULT_LIMIT = 60;
+
+    private const CACHE_TTL_SECONDS = 300;
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $employee = $request->user();
+        if (! $employee instanceof Employee || ! $employee->company_id) {
+            return $next($request);
+        }
+
+        $limit = $this->resolveLimit($employee->company_id);
+        $key = 'plan_rate:'.$employee->company_id;
+        $current = (int) Cache::get($key, 0);
+
+        if ($current >= $limit) {
+            return response()->json([
+                'error' => 'RATE_LIMIT_EXCEEDED',
+                'message' => __('Too many requests. Your plan allows :limit requests per minute.', ['limit' => $limit]),
+                'retry_after' => 60,
+            ], 429)->withHeaders([
+                'X-RateLimit-Limit' => (string) $limit,
+                'X-RateLimit-Remaining' => '0',
+                'Retry-After' => '60',
+            ]);
+        }
+
+        Cache::put($key, $current + 1, now()->addMinute());
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        $response->headers->set('X-RateLimit-Limit', (string) $limit);
+        $response->headers->set('X-RateLimit-Remaining', (string) max(0, $limit - $current - 1));
+        $response->headers->set('X-RateLimit-Plan', $this->resolvePlanName($employee->company_id));
+
+        return $response;
+    }
+
+    private function resolveLimit(string $companyId): int
+    {
+        $planName = $this->resolvePlanName($companyId);
+
+        return self::PLAN_LIMITS[$planName] ?? self::DEFAULT_LIMIT;
+    }
+
+    private function resolvePlanName(string $companyId): string
+    {
+        return Cache::remember(
+            'company_plan:'.$companyId,
+            self::CACHE_TTL_SECONDS,
+            function () use ($companyId): string {
+                $company = Company::query()
+                    ->select(['id', 'plan_id'])
+                    ->with('plan:id,name')
+                    ->find($companyId);
+
+                if (! $company || ! $company->plan) {
+                    return 'free';
+                }
+
+                return strtolower($company->plan->name);
+            }
+        );
+    }
+}

--- a/api/app/Http/Middleware/PlanBasedRateLimiter.php
+++ b/api/app/Http/Middleware/PlanBasedRateLimiter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
-use App\Models\Company;
 use App\Models\Employee;
+use App\Models\Subscription;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -33,12 +33,14 @@ class PlanBasedRateLimiter
     {
         $employee = $request->user();
         if (! $employee instanceof Employee || ! $employee->company_id) {
+            /** @var Response */
             return $next($request);
         }
 
-        $limit = $this->resolveLimit($employee->company_id);
-        $key = 'plan_rate:'.$employee->company_id;
-        $current = (int) Cache::get($key, 0);
+        $companyId = (string) $employee->company_id;
+        $limit = $this->resolveLimit($companyId);
+        $key = 'plan_rate:'.$companyId;
+        $current = is_numeric(Cache::get($key)) ? (int) Cache::get($key) : 0;
 
         if ($current >= $limit) {
             return response()->json([
@@ -59,7 +61,7 @@ class PlanBasedRateLimiter
 
         $response->headers->set('X-RateLimit-Limit', (string) $limit);
         $response->headers->set('X-RateLimit-Remaining', (string) max(0, $limit - $current - 1));
-        $response->headers->set('X-RateLimit-Plan', $this->resolvePlanName($employee->company_id));
+        $response->headers->set('X-RateLimit-Plan', $this->resolvePlanName($companyId));
 
         return $response;
     }
@@ -73,20 +75,21 @@ class PlanBasedRateLimiter
 
     private function resolvePlanName(string $companyId): string
     {
+        /** @var string */
         return Cache::remember(
             'company_plan:'.$companyId,
             self::CACHE_TTL_SECONDS,
             function () use ($companyId): string {
-                $company = Company::query()
-                    ->select(['id', 'plan_id'])
-                    ->with('plan:id,name')
-                    ->find($companyId);
+                $subscription = Subscription::query()
+                    ->where('company_id', $companyId)
+                    ->where('status', 'active')
+                    ->first(['plan']);
 
-                if (! $company || ! $company->plan) {
+                if (! $subscription) {
                     return 'free';
                 }
 
-                return strtolower($company->plan->name);
+                return strtolower((string) $subscription->plan);
             }
         );
     }

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -2,7 +2,9 @@
 
 use App\Exceptions\DomainException;
 use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\ApiVersionMiddleware;
 use App\Http\Middleware\Cameras\EnsureCameraModuleMiddleware;
+use App\Http\Middleware\PlanBasedRateLimiter;
 use App\Http\Middleware\RequestIdMiddleware;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\StructuredLogging;
@@ -39,7 +41,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class, StructuredLogging::class]);
+        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class, StructuredLogging::class, ApiVersionMiddleware::class]);
 
         $middleware->alias([
             'tenant' => TenantMiddleware::class,
@@ -48,6 +50,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'employee' => EnsureEmployeeMiddleware::class,
             'module.cameras' => EnsureCameraModuleMiddleware::class,
             'admin' => AdminMiddleware::class,
+            'api.version' => ApiVersionMiddleware::class,
+            'plan.rate_limit' => PlanBasedRateLimiter::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/api/tests/Feature/ApiVersionMiddlewareTest.php
+++ b/api/tests/Feature/ApiVersionMiddlewareTest.php
@@ -4,35 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use App\Models\Employee;
-use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
 
 class ApiVersionMiddlewareTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
-
     public function test_api_responses_include_version_header(): void
     {
-        $employee = Employee::factory()->create([
-            'role' => 'manager',
-            'status' => 'active',
-        ]);
-        Sanctum::actingAs($employee);
-
         $response = $this->getJson('/api/v1/health');
 
         $response->assertOk();

--- a/api/tests/Feature/ApiVersionMiddlewareTest.php
+++ b/api/tests/Feature/ApiVersionMiddlewareTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class ApiVersionMiddlewareTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_api_responses_include_version_header(): void
+    {
+        $employee = Employee::factory()->create([
+            'role' => 'manager',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson('/api/v1/health');
+
+        $response->assertOk();
+        $response->assertHeader('X-API-Version', 'v1');
+    }
+}

--- a/docs/GESTION_PROJET/RUNBOOK_DEPLOY.md
+++ b/docs/GESTION_PROJET/RUNBOOK_DEPLOY.md
@@ -70,3 +70,78 @@
 - merger uniquement quand GitHub est vert
 
 Le reste doit etre automatique.
+
+---
+
+## Workers et services de fond
+
+### Queue Workers
+
+L'application utilise des jobs Laravel en queue pour les operations lourdes :
+
+| Job | Queue | Description | Frequence |
+|-----|-------|-------------|-----------|
+| `GenerateMonthlyInvoices` | `billing` | Generation factures mensuelles | Cron mensuel |
+| `CheckTrialExpiring` | `billing` | Notification expiration trial | Cron quotidien |
+| `CheckOverdueInvoices` | `billing` | Relance factures impayees | Cron quotidien |
+| `PayrollCalculation` | `payroll` | Calcul paie batch | On-demand |
+| `GeneratePaySlipPdf` | `default` | Generation bulletins PDF | On-demand |
+| `GenerateInvoicePdf` | `default` | Generation factures PDF | On-demand |
+| `WebhookDispatch` | `webhooks` | Envoi webhooks aux clients | Event-driven |
+| `TrackingSync` | `tracking` | Sync positions Traccar | Cron (5 min) |
+
+### Configuration workers Render
+
+```yaml
+# render.yaml (service worker)
+services:
+  - type: worker
+    name: leopardo-queue-default
+    env: docker
+    dockerCommand: php artisan queue:work --queue=default,billing,payroll,webhooks,tracking --sleep=3 --tries=3 --max-time=3600
+    envVars:
+      - key: APP_ENV
+        value: production
+      - key: QUEUE_CONNECTION
+        value: redis
+```
+
+### Scheduler (cron)
+
+Le scheduler Laravel doit tourner sur un service dedie ou via cron :
+
+```bash
+# Cron entry (ou Render Cron Job)
+* * * * * cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1
+```
+
+Jobs schedules configures dans `app/Console/Kernel.php` :
+
+- `billing:generate-invoices` — mensuel (1er du mois)
+- `billing:check-trial-expiring` — quotidien 08h00
+- `billing:check-overdue` — quotidien 09h00
+- `tracking:sync` — toutes les 5 minutes
+
+### Variables d'environnement requises
+
+| Variable | Service | Description |
+|----------|---------|-------------|
+| `QUEUE_CONNECTION` | Worker | `redis` en production |
+| `REDIS_HOST` | Worker, API | Host Redis |
+| `REDIS_PASSWORD` | Worker, API | Password Redis |
+| `REDIS_PORT` | Worker, API | Port Redis (default 6379) |
+| `STRIPE_SECRET` | API, Worker | Cle secrete Stripe |
+| `STRIPE_WEBHOOK_SECRET` | API | Secret verification webhook Stripe |
+| `CHARGILY_SECRET` | API | Cle secrete Chargily (DZ) |
+| `TRACCAR_URL` | Worker | URL instance Traccar |
+| `TRACCAR_TOKEN` | Worker | Token API Traccar |
+| `OPENAI_API_KEY` | API | Cle API OpenAI (IA) |
+| `ANTHROPIC_API_KEY` | API | Cle API Anthropic (IA) |
+| `SENTRY_DSN` | API, Worker | DSN Sentry pour error tracking |
+
+### Monitoring workers
+
+- **Health** : `php artisan queue:monitor default,billing,payroll --max=100` (alerte si > 100 jobs en attente)
+- **Horizon** : envisager Laravel Horizon pour le monitoring UI des queues Redis
+- **Logs** : les workers ecrivent sur le meme channel JSON structure que l'API
+- **Restart** : apres chaque deploy, les workers doivent etre restartes (`php artisan queue:restart`)


### PR DESCRIPTION
## Summary

**Iteration 4 du plan d'execution** : securite (rate limiting par plan), performance (middleware API version), et documentation deploiement (workers/queues).

### Nouveaux middleware

1. **`PlanBasedRateLimiter`** — Rate limiting dynamique selon le plan d'abonnement :
   - free: 60 req/min, starter: 120, professional: 300, enterprise: 1000
   - Resolution du plan via cache Redis (TTL 5 min)
   - Headers `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Plan`
   - Reponse 429 avec `Retry-After` quand limite atteinte
   - Alias middleware: `plan.rate_limit`

2. **`ApiVersionMiddleware`** — Gestion version API :
   - Injecte `X-API-Version: v1` sur toutes les reponses API
   - Log structured de chaque requete avec version, path, method
   - Validation des versions supportees (retourne 400 si version inconnue)
   - Ajoute au pipeline API global + alias `api.version`

### Documentation enrichie

3. **`RUNBOOK_DEPLOY.md`** — Section workers et services de fond ajoutee :
   - Tableau des queue workers (billing, payroll, tracking, webhooks, default)
   - Configuration Render pour les workers
   - Scheduler cron avec jobs planifies
   - Variables d'environnement requises pour production
   - Monitoring workers (queue:monitor, Horizon, logs, restart)

### Test

4. **`ApiVersionMiddlewareTest`** — Verifie la presence du header `X-API-Version: v1` sur les reponses.

### Taches du plan d'execution couvertes

- D5 : Rate limiting par plan d'abonnement
- A3 : Middleware ApiVersion
- A10 : Documentation guide de deploiement workers

## Review & Testing Checklist for Human

- [ ] Verifier que le `PlanBasedRateLimiter` ne casse pas les endpoints existants (le middleware est enregistre comme alias, pas dans le pipeline global — il faut l'appliquer explicitement aux routes souhaitees)
- [ ] Verifier que le `ApiVersionMiddleware` ajoute bien le header `X-API-Version` sur `/api/v1/health`
- [ ] Verifier que la resolution du plan dans `PlanBasedRateLimiter` fonctionne avec la relation `Company->plan`
- [ ] Relire les variables d'environnement listees dans RUNBOOK_DEPLOY.md et confirmer qu'elles correspondent a l'env staging/production reel

### Notes

- Le `PlanBasedRateLimiter` est enregistre comme alias `plan.rate_limit` et doit etre applique explicitement aux groupes de routes souhaites. Il n'est pas dans le pipeline global pour eviter de bloquer les endpoints publics/healthcheck.
- L'`ApiVersionMiddleware` est dans le pipeline global API car il ne fait qu'ajouter un header sans bloquer les requetes.
- Les iterations suivantes cibleront : Redis cache layer, monitoring Sentry integration, alerting Slack webhooks.

Link to Devin session: https://app.devin.ai/sessions/29a5f6c617a44e649457a1b33499345b
Requested by: @kitokoh