### PR TITLE
feat: Iteration 5 — Monitoring (Sentry context, Slack alerts, slow query monitor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.55] - 2026-05-14
+
+### Feat — Iteration 5 monitoring et observabilite
+
+- Nouveau : `SentryContextMiddleware` — enrichissement tenant/user/role sur chaque requete API pour Sentry.
+- Nouveau : `SlackAlertNotification` — notification Slack webhook pour les evenements critiques (queue backup, erreurs).
+- Nouveau : `MonitorSlowQueries` artisan command — detection requetes lentes via pg_stat_statements (schedule 15 min).
+- Config : `services.slack.monitoring_webhook` ajoute pour recevoir les alertes monitoring.
+- Scheduler : `monitor:slow-queries` ajoute au schedule Laravel (toutes les 15 minutes).
+
 ## [4.16.50] - 2026-05-14
 
 ### CI — Mobile coverage ratchet

--- a/api/app/Console/Commands/MonitorSlowQueries.php
+++ b/api/app/Console/Commands/MonitorSlowQueries.php
@@ -37,11 +37,11 @@ class MonitorSlowQueries extends Command
 
         try {
             $slowQueries = DB::select(
-                "SELECT query, calls, mean_exec_time, total_exec_time, rows
+                'SELECT query, calls, mean_exec_time, total_exec_time, rows
                  FROM pg_stat_statements
                  WHERE mean_exec_time > ?
                  ORDER BY mean_exec_time DESC
-                 LIMIT ?",
+                 LIMIT ?',
                 [$threshold, $limit]
             );
         } catch (\Throwable $e) {
@@ -54,12 +54,12 @@ class MonitorSlowQueries extends Command
         }
 
         if (empty($slowQueries)) {
-            $this->info("Aucune requete lente (seuil: {$threshold}ms).");
+            $this->info('Aucune requete lente (seuil: '.$threshold.'ms).');
 
             return self::SUCCESS;
         }
 
-        $this->info(count($slowQueries)." requete(s) lente(s) detectee(s) (seuil: {$threshold}ms):");
+        $this->info(count($slowQueries).' requete(s) lente(s) detectee(s) (seuil: '.$threshold.'ms):');
 
         $rows = [];
         foreach ($slowQueries as $query) {

--- a/api/app/Console/Commands/MonitorSlowQueries.php
+++ b/api/app/Console/Commands/MonitorSlowQueries.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Monitor slow queries from PostgreSQL pg_stat_statements.
+ *
+ * This command queries the pg_stat_statements extension (if available)
+ * and logs any query whose mean_exec_time exceeds the configured threshold.
+ *
+ * Schedule: every 15 minutes in production.
+ */
+class MonitorSlowQueries extends Command
+{
+    protected $signature = 'monitor:slow-queries
+        {--threshold=500 : Seuil en millisecondes (par defaut 500ms)}
+        {--limit=20 : Nombre max de queries a afficher}';
+
+    protected $description = 'Liste les requetes SQL lentes depuis pg_stat_statements';
+
+    public function handle(): int
+    {
+        $threshold = (float) $this->option('threshold');
+        $limit = (int) $this->option('limit');
+
+        if (DB::getDriverName() !== 'pgsql') {
+            $this->warn('Cette commande ne fonctionne qu\'avec PostgreSQL.');
+
+            return self::SUCCESS;
+        }
+
+        try {
+            $slowQueries = DB::select(
+                "SELECT query, calls, mean_exec_time, total_exec_time, rows
+                 FROM pg_stat_statements
+                 WHERE mean_exec_time > ?
+                 ORDER BY mean_exec_time DESC
+                 LIMIT ?",
+                [$threshold, $limit]
+            );
+        } catch (\Throwable $e) {
+            $this->warn('pg_stat_statements non disponible : '.$e->getMessage());
+            Log::channel('structured')->warning('monitor:slow-queries pg_stat_statements unavailable', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        if (empty($slowQueries)) {
+            $this->info("Aucune requete lente (seuil: {$threshold}ms).");
+
+            return self::SUCCESS;
+        }
+
+        $this->info(count($slowQueries)." requete(s) lente(s) detectee(s) (seuil: {$threshold}ms):");
+
+        $rows = [];
+        foreach ($slowQueries as $query) {
+            $truncatedQuery = mb_substr($query->query, 0, 80);
+            $rows[] = [
+                $truncatedQuery,
+                $query->calls,
+                round($query->mean_exec_time, 2).'ms',
+                round($query->total_exec_time / 1000, 2).'s',
+                $query->rows,
+            ];
+
+            Log::channel('structured')->warning('Slow query detected', [
+                'query' => mb_substr($query->query, 0, 200),
+                'calls' => $query->calls,
+                'mean_exec_time_ms' => round($query->mean_exec_time, 2),
+                'total_exec_time_s' => round($query->total_exec_time / 1000, 2),
+                'rows' => $query->rows,
+            ]);
+        }
+
+        $this->table(
+            ['Query (tronquee)', 'Appels', 'Moy', 'Total', 'Lignes'],
+            $rows
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/api/app/Http/Middleware/SentryContextMiddleware.php
+++ b/api/app/Http/Middleware/SentryContextMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Employee;
+use Closure;
+use Illuminate\Http\Request;
+use Sentry\State\Scope;
+use Symfony\Component\HttpFoundation\Response;
+
+use function Sentry\configureScope;
+
+/**
+ * Enrich Sentry scope with tenant + user context on every API request.
+ *
+ * This middleware adds company_id, user role, and plan information to
+ * Sentry events so that errors can be triaged per-tenant in the dashboard.
+ */
+class SentryContextMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! function_exists('Sentry\\configureScope')) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+
+        if ($user instanceof Employee) {
+            configureScope(function (Scope $scope) use ($user, $request): void {
+                $scope->setUser([
+                    'id' => (string) $user->id,
+                    'email' => $user->email ?? '',
+                    'segment' => $user->role,
+                ]);
+
+                $scope->setTag('tenant.company_id', (string) $user->company_id);
+                $scope->setTag('user.role', $user->role);
+
+                if ($user->manager_role) {
+                    $scope->setTag('user.manager_role', $user->manager_role);
+                }
+
+                $scope->setContext('tenant', [
+                    'company_id' => $user->company_id,
+                    'role' => $user->role,
+                    'manager_role' => $user->manager_role,
+                    'request_id' => $request->header('X-Request-Id', ''),
+                ]);
+            });
+        }
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/SentryContextMiddleware.php
+++ b/api/app/Http/Middleware/SentryContextMiddleware.php
@@ -23,6 +23,7 @@ class SentryContextMiddleware
     public function handle(Request $request, Closure $next): Response
     {
         if (! function_exists('Sentry\\configureScope')) {
+            /** @var Response */
             return $next($request);
         }
 
@@ -52,6 +53,7 @@ class SentryContextMiddleware
             });
         }
 
+        /** @var Response */
         return $next($request);
     }
 }

--- a/api/app/Notifications/SlackAlertNotification.php
+++ b/api/app/Notifications/SlackAlertNotification.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Envoie une alerte Slack via webhook pour les evenements critiques.
+ *
+ * Usage:
+ *   Notification::route('slack', config('services.slack.monitoring_webhook'))
+ *       ->notify(new SlackAlertNotification('Queue backup > 100 jobs', 'warning', ['queue' => 'payroll', 'count' => 150]));
+ */
+class SlackAlertNotification extends Notification
+{
+    use Queueable;
+
+    private const SEVERITY_EMOJI = [
+        'critical' => ':rotating_light:',
+        'warning' => ':warning:',
+        'info' => ':information_source:',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function __construct(
+        private readonly string $message,
+        private readonly string $severity = 'warning',
+        private readonly array $context = [],
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['slack'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSlack(object $notifiable): array
+    {
+        $emoji = self::SEVERITY_EMOJI[$this->severity] ?? ':bell:';
+        $env = config('app.env', 'unknown');
+        $text = "{$emoji} *[Leopardo RH — {$env}]* {$this->message}";
+
+        if ($this->context !== []) {
+            $text .= "\n```\n".json_encode($this->context, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n```";
+        }
+
+        return [
+            'text' => $text,
+        ];
+    }
+}

--- a/api/app/Notifications/SlackAlertNotification.php
+++ b/api/app/Notifications/SlackAlertNotification.php
@@ -47,7 +47,7 @@ class SlackAlertNotification extends Notification
     public function toSlack(object $notifiable): array
     {
         $emoji = self::SEVERITY_EMOJI[$this->severity] ?? ':bell:';
-        $env = config('app.env', 'unknown');
+        $env = (string) config('app.env', 'unknown');
         $text = "{$emoji} *[Leopardo RH — {$env}]* {$this->message}";
 
         if ($this->context !== []) {

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Exceptions\DomainException;
 use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\Cameras\EnsureCameraModuleMiddleware;
+use App\Http\Middleware\SentryContextMiddleware;
 use App\Http\Middleware\RequestIdMiddleware;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\StructuredLogging;
@@ -31,6 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('billing:check-trials')->daily();
         $schedule->command('billing:check-overdue')->daily();
         $schedule->command('billing:generate-invoices')->monthlyOn(1, '03:00');
+        $schedule->command('monitor:slow-queries --threshold=500')->everyFifteenMinutes();
     })
     ->withRouting(
         api: __DIR__.'/../routes/api.php',
@@ -39,7 +41,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class, StructuredLogging::class]);
+        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class, StructuredLogging::class, SentryContextMiddleware::class]);
 
         $middleware->alias([
             'tenant' => TenantMiddleware::class,

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -3,8 +3,8 @@
 use App\Exceptions\DomainException;
 use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\Cameras\EnsureCameraModuleMiddleware;
-use App\Http\Middleware\SentryContextMiddleware;
 use App\Http\Middleware\RequestIdMiddleware;
+use App\Http\Middleware\SentryContextMiddleware;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\StructuredLogging;
 use App\Http\Middleware\TenantMiddleware;

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -21,6 +21,7 @@ return [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
         ],
+        'monitoring_webhook' => env('SLACK_MONITORING_WEBHOOK_URL'),
     ],
 
     'google' => [


### PR DESCRIPTION
## Summary

**Iteration 5 du plan d'execution** : monitoring et observabilite — enrichissement Sentry, alertes Slack, detection requetes lentes.

### Nouveaux composants

1. **`SentryContextMiddleware`** — Enrichissement Sentry par requete :
   - Injecte tenant `company_id`, user `role`, `manager_role` dans le scope Sentry
   - Ajoute le `X-Request-Id` au contexte tenant
   - Permet le triage d'erreurs par tenant dans le dashboard Sentry
   - Prepended au pipeline API global

2. **`SlackAlertNotification`** — Alertes Slack pour evenements critiques :
   - Support 3 niveaux de severite (critical, warning, info) avec emojis
   - Inclut le contexte JSON structure dans le message
   - Prefixe avec l'environnement (production/staging)
   - Usage: `Notification::route('slack', config('services.slack.monitoring_webhook'))->notify(new SlackAlertNotification(...))`

3. **`MonitorSlowQueries`** artisan command :
   - Interroge `pg_stat_statements` pour detecter les requetes > 500ms
   - Affiche tableau formatee avec query, appels, temps moyen, total, lignes
   - Log structure sur channel `structured` pour chaque requete lente
   - Skip proprement si pg_stat_statements non disponible
   - Schedule: toutes les 15 minutes en production

4. **Configuration** :
   - `services.slack.monitoring_webhook` pour l'URL du webhook Slack monitoring
   - Variable env: `SLACK_MONITORING_WEBHOOK_URL`

### Taches du plan d'execution couvertes

- B1 : Sentry DSN + context enrichment
- B2 : Slack alerts webhook
- B4 : Slow query logger/monitor

## Review & Testing Checklist for Human

- [ ] Verifier que le `SentryContextMiddleware` n'impacte pas les performances (guard `function_exists` present)
- [ ] Configurer `SLACK_MONITORING_WEBHOOK_URL` dans le dashboard de deploiement si vous voulez recevoir les alertes
- [ ] Tester `php artisan monitor:slow-queries --threshold=100` en staging (necessite pg_stat_statements)

### Notes

- Le `SentryContextMiddleware` est no-op si Sentry n'est pas configure (guard `function_exists`)
- Le `MonitorSlowQueries` est no-op si pg_stat_statements n'est pas actif (catch + warning)
- L'iteration suivante ciblera : frontend admin dashboard screens (paie, conges, contrats)

Link to Devin session: https://app.devin.ai/sessions/29a5f6c617a44e649457a1b33499345b
Requested by: @kitokoh