### PR TITLE
feat(api): add version headers and plan rate limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,12 @@ Procedure recommandee :
 - Les surfaces sensibles utilisent des limiters nommes dans `AppServiceProvider` et configures via `api/config/security.php` : `auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`.
 - Pour les prochains endpoints auth, paie, privacy, IA ou super-admin, reutiliser ces limiters au lieu d'ajouter des `throttle:10,1` isoles.
 
+### 2026-05-15 - Versioning API et quotas par plan
+
+- Le middleware `ApiVersionMiddleware` est dans le groupe API global et ajoute `X-API-Version` / `X-API-Supported-Versions`; si un frontend ou integrateur force `X-API-Version: v2` avant ouverture officielle de v2, l'API doit continuer a retourner `400 UNSUPPORTED_API_VERSION`.
+- Le limiter `api-plan` doit rester applique apres `auth:sanctum` + `tenant` sur les routes tenant authentifiees. Avant cet ordre, le plan commercial et le contexte tenant ne sont pas fiables.
+- Les quotas par plan vivent dans `api/config/security.php` sous `plan_rate_limits`; garder `enterprise_per_minute=0` pour illimite et abaisser les seuils uniquement via config dans les tests.
+
 ### 2026-05-14 - Load testing k6
 
 - Le socle de charge vit dans `dev-hub/load/k6/api-core-smoke.js` et reste read-only par defaut. Ne pas ajouter de mutations de pointage, paie ou exports dans ce script sans flag explicite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.56] - 2026-05-15
+
+### API — Versioning et quotas par plan
+
+- Nouveau : `ApiVersionMiddleware` expose `X-API-Version` et `X-API-Supported-Versions` sur les reponses API.
+- Securite contrat : une requete qui force une version API non supportee via `X-API-Version` retourne `400 UNSUPPORTED_API_VERSION`.
+- Nouveau : limiter `api-plan` configurable dans `config/security.php` avec quotas trial/starter/business/pro/enterprise.
+- Routes : application du limiter `api-plan` apres `auth:sanctum` + `tenant` sur les surfaces API authentifiees pour utiliser le plan reel de l'entreprise.
+- Tests : ajout d'une couverture Feature pour les headers de version, le rejet v2 et le `429` par plan Starter.
+
 ## [4.16.55] - 2026-05-14
 
 ### Feat — Iteration 5 monitoring et observabilite

--- a/api/app/Http/Middleware/ApiVersionMiddleware.php
+++ b/api/app/Http/Middleware/ApiVersionMiddleware.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiVersionMiddleware
+{
+    private const CURRENT_VERSION = 'v1';
+
+    /** @var list<string> */
+    private const SUPPORTED_VERSIONS = ['v1'];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $routeVersion = $this->routeVersion($request);
+        $requestedVersion = $this->requestedVersion($request);
+
+        if ($requestedVersion !== null && $requestedVersion !== $routeVersion) {
+            return $this->unsupportedVersion($requestedVersion);
+        }
+
+        if (! in_array($routeVersion, self::SUPPORTED_VERSIONS, true)) {
+            return $this->unsupportedVersion($routeVersion);
+        }
+
+        $request->attributes->set('api_version', $routeVersion);
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        $response->headers->set('X-API-Version', $routeVersion);
+        $response->headers->set('X-API-Supported-Versions', implode(',', self::SUPPORTED_VERSIONS));
+
+        return $response;
+    }
+
+    private function routeVersion(Request $request): string
+    {
+        $segment = $request->segment(2);
+
+        return is_string($segment) && preg_match('/^v[0-9]+$/', $segment) === 1
+            ? $segment
+            : self::CURRENT_VERSION;
+    }
+
+    private function requestedVersion(Request $request): ?string
+    {
+        $header = $request->header('X-API-Version');
+
+        return is_string($header) && $header !== '' ? strtolower($header) : null;
+    }
+
+    private function unsupportedVersion(string $version): JsonResponse
+    {
+        return response()->json([
+            'error' => 'UNSUPPORTED_API_VERSION',
+            'message' => 'UNSUPPORTED_API_VERSION',
+            'localized_message' => __('errors.UNSUPPORTED_API_VERSION'),
+            'supported_versions' => self::SUPPORTED_VERSIONS,
+            'requested_version' => $version,
+        ], 400)->withHeaders([
+            'X-API-Supported-Versions' => implode(',', self::SUPPORTED_VERSIONS),
+        ]);
+    }
+}

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -34,6 +34,7 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
@@ -94,6 +95,24 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by($request->ip());
         });
 
+        RateLimiter::for('api-plan', function (Request $request) {
+            $user = $request->user();
+            if (! $user instanceof Employee || ! $user->company_id) {
+                return Limit::perMinute((int) config('security.plan_rate_limits.default_per_minute', 100))
+                    ->by('plan:ip:'.$request->ip());
+            }
+
+            $plan = $this->resolveCompanyPlan((string) $user->company_id);
+            $limit = $this->resolvePlanLimit($plan);
+            $normalizedPlan = $this->normalizePlan($plan);
+
+            if ($limit <= 0) {
+                return Limit::none();
+            }
+
+            return Limit::perMinute($limit)->by('plan:'.$normalizedPlan.':company:'.$user->company_id);
+        });
+
         RateLimiter::for('auth-sensitive', function (Request $request) {
             $email = strtolower((string) $request->input('email', 'anonymous'));
 
@@ -139,5 +158,39 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute((int) config('security.rate_limits.ai_per_minute', 20))
                 ->by('ai:'.$key);
         });
+    }
+
+    private function resolvePlanLimit(string $plan): int
+    {
+        $normalized = $this->normalizePlan($plan);
+
+        return match ($normalized) {
+            'enterprise' => (int) config('security.plan_rate_limits.enterprise_per_minute', 0),
+            'business' => (int) config('security.plan_rate_limits.business_per_minute', 1000),
+            'professional' => (int) config('security.plan_rate_limits.professional_per_minute', 1000),
+            'pro' => (int) config('security.plan_rate_limits.pro_per_minute', 1000),
+            'starter' => (int) config('security.plan_rate_limits.starter_per_minute', 100),
+            'trial' => (int) config('security.plan_rate_limits.trial_per_minute', 60),
+            default => (int) config('security.plan_rate_limits.default_per_minute', 100),
+        };
+    }
+
+    private function resolveCompanyPlan(string $companyId): string
+    {
+        $planName = DB::table('companies')
+            ->leftJoin('plans', 'plans.id', '=', 'companies.plan_id')
+            ->where('companies.id', $companyId)
+            ->value('plans.name');
+
+        if (is_string($planName) && $planName !== '') {
+            return $planName;
+        }
+
+        return 'trial';
+    }
+
+    private function normalizePlan(string $plan): string
+    {
+        return strtolower(trim($plan));
     }
 }

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Exceptions\DomainException;
 use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\ApiVersionMiddleware;
 use App\Http\Middleware\Cameras\EnsureCameraModuleMiddleware;
 use App\Http\Middleware\RequestIdMiddleware;
 use App\Http\Middleware\SentryContextMiddleware;
@@ -41,7 +42,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->api(prepend: [RequestIdMiddleware::class, SetLocale::class, StructuredLogging::class, SentryContextMiddleware::class]);
+        $middleware->api(prepend: [RequestIdMiddleware::class, ApiVersionMiddleware::class, SetLocale::class, StructuredLogging::class, SentryContextMiddleware::class]);
 
         $middleware->alias([
             'tenant' => TenantMiddleware::class,

--- a/api/config/security.php
+++ b/api/config/security.php
@@ -8,4 +8,14 @@ return [
         'platform_per_minute' => (int) env('RATE_LIMIT_PLATFORM_PER_MINUTE', 60),
         'ai_per_minute' => (int) env('RATE_LIMIT_AI_PER_MINUTE', 20),
     ],
+
+    'plan_rate_limits' => [
+        'trial_per_minute' => (int) env('RATE_LIMIT_PLAN_TRIAL_PER_MINUTE', 60),
+        'starter_per_minute' => (int) env('RATE_LIMIT_PLAN_STARTER_PER_MINUTE', 100),
+        'business_per_minute' => (int) env('RATE_LIMIT_PLAN_BUSINESS_PER_MINUTE', 1000),
+        'professional_per_minute' => (int) env('RATE_LIMIT_PLAN_PROFESSIONAL_PER_MINUTE', 1000),
+        'pro_per_minute' => (int) env('RATE_LIMIT_PLAN_PRO_PER_MINUTE', 1000),
+        'enterprise_per_minute' => (int) env('RATE_LIMIT_PLAN_ENTERPRISE_PER_MINUTE', 0),
+        'default_per_minute' => (int) env('RATE_LIMIT_PLAN_DEFAULT_PER_MINUTE', 100),
+    ],
 ];

--- a/api/lang/ar/errors.php
+++ b/api/lang/ar/errors.php
@@ -38,4 +38,5 @@ return [
     'FORBIDDEN' => 'ليس لديك صلاحية لهذا الإجراء.',
     'SERVER_ERROR' => 'حدث خطأ. يرجى المحاولة مجدداً.',
     'VALIDATION_ERROR' => 'بعض الحقول غير صحيحة.',
+    'UNSUPPORTED_API_VERSION' => 'إصدار API غير مدعوم.',
 ];

--- a/api/lang/en/errors.php
+++ b/api/lang/en/errors.php
@@ -38,4 +38,5 @@ return [
     'FORBIDDEN' => 'You do not have permission for this action.',
     'SERVER_ERROR' => 'An error occurred. Please try again.',
     'VALIDATION_ERROR' => 'Some fields are incorrect.',
+    'UNSUPPORTED_API_VERSION' => 'Unsupported API version.',
 ];

--- a/api/lang/en/shared.php
+++ b/api/lang/en/shared.php
@@ -19,7 +19,7 @@ return [
             ],
             'field' => [
                 'title' => 'Mobile-first for field teams',
-                'body' => "The phone is the employee's main surface. Clock-ins, absences, and documents live here.",
+                'body' => 'The phone is the employee\'s main surface. Clock-ins, absences, and documents live here.',
             ],
             'modules' => [
                 'title' => 'Active modules, visible roadmap',

--- a/api/lang/fr/errors.php
+++ b/api/lang/fr/errors.php
@@ -38,4 +38,5 @@ return [
     'FORBIDDEN' => 'Vous n\'avez pas les droits pour cette action.',
     'SERVER_ERROR' => 'Une erreur est survenue. Veuillez réessayer.',
     'VALIDATION_ERROR' => 'Certains champs sont incorrects.',
+    'UNSUPPORTED_API_VERSION' => 'Version API non supportee.',
 ];

--- a/api/lang/tr/errors.php
+++ b/api/lang/tr/errors.php
@@ -38,4 +38,5 @@ return [
     'FORBIDDEN' => 'Bu işlem için yetkiniz yok.',
     'SERVER_ERROR' => 'Bir hata oluştu. Lütfen tekrar deneyin.',
     'VALIDATION_ERROR' => 'Bazı alanlar hatalı.',
+    'UNSUPPORTED_API_VERSION' => 'Desteklenmeyen API surumu.',
 ];

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -10,7 +10,7 @@ use App\Http\Middleware\AI\AITenantInjector;
 use App\Http\Middleware\AI\EnsureAIAnalyticsAccess;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'throttle:ai-sensitive', AIFeatureCheck::class, AITenantInjector::class])->prefix('ai')->group(function () {
+Route::middleware(['throttle:api', 'auth:sanctum', 'throttle:ai-sensitive', AIFeatureCheck::class, AITenantInjector::class, 'throttle:api-plan'])->prefix('ai')->group(function () {
 
     // Phase 1 — Chat IA
     Route::middleware([AIRateLimiter::class])->group(function () {

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -47,7 +47,7 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/invitation/{token}/activate', [OnboardingController::class, 'activate']);
     });
 
-    Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+    Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
         Route::get('/auth/me', [AuthController::class, 'me']);
         Route::patch('/auth/profile', [AuthController::class, 'updateProfile']);
         Route::patch('/auth/language', [AuthController::class, 'updateLanguage']);

--- a/api/routes/modules/billing.php
+++ b/api/routes/modules/billing.php
@@ -11,7 +11,7 @@ use App\Http\Controllers\Api\V1\PaymentWebhookController;
 use Illuminate\Support\Facades\Route;
 
 // ── Authenticated routes ──────────────────────────────────────────────────────
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // Billing
     Route::get('/billing/subscription', [BillingController::class, 'subscription']);

--- a/api/routes/modules/cabinet.php
+++ b/api/routes/modules/cabinet.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/cabinet/shared/{token}', [CabinetShareController::class, 'accessByToken'])
     ->middleware('throttle:60,1');
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->prefix('cabinet')->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->prefix('cabinet')->group(function (): void {
 
     // ── Stats ────────────────────────────────────────────────────────────────
     Route::get('/stats', [CabinetShareController::class, 'stats']);

--- a/api/routes/modules/cameras.php
+++ b/api/routes/modules/cameras.php
@@ -21,7 +21,7 @@ use App\Modules\Cameras\Interfaces\Api\V1\Controllers\InternalCameraTokenControl
 use App\Modules\Cameras\Interfaces\Api\V1\Controllers\PublicCameraViewerController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'module.cameras'])
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'module.cameras'])
     ->prefix('cameras')
     ->group(function (): void {
         Route::get('/', [CameraController::class, 'index']);

--- a/api/routes/modules/dashboard.php
+++ b/api/routes/modules/dashboard.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\Api\V1\ExportController;
 use App\Http\Controllers\Api\V1\NotificationController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // Dashboard
     Route::get('/dashboard/summary', [DashboardController::class, 'summary']);

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -21,7 +21,7 @@ use App\Http\Controllers\Api\V1\TrainingController;
 use App\Http\Controllers\Api\V1\WebhookController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // ── Module A — Leave Policies & Balances ────────────────────────────────
     Route::get('/leave-policies', [LeavePolicyController::class, 'index']);

--- a/api/routes/modules/payroll_engine.php
+++ b/api/routes/modules/payroll_engine.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\Api\V1\SocialContributionController;
 use App\Http\Controllers\Api\V1\TaxSlabController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:payroll-sensitive'])->group(function () {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'throttle:payroll-sensitive'])->group(function () {
 
     // Salary Structures
     Route::get('/salary-structures', [SalaryStructureController::class, 'index']);

--- a/api/routes/modules/rh.php
+++ b/api/routes/modules/rh.php
@@ -25,7 +25,7 @@ use App\Http\Controllers\Api\V1\SiteController;
 use App\Http\Controllers\Api\V1\TaskController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // ── Employees ─────────────────────────────────────────────────────────────
     Route::get('/employees', [EmployeeController::class, 'index']);

--- a/api/routes/modules/tracking.php
+++ b/api/routes/modules/tracking.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Api\V1\VehicleMaintenanceController;
 use App\Http\Controllers\Api\V1\VehicleTripController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
     // Vehicles CRUD
     Route::get('/vehicles', [VehicleController::class, 'index']);
     Route::post('/vehicles', [VehicleController::class, 'store']);

--- a/api/routes/modules/user.php
+++ b/api/routes/modules/user.php
@@ -36,6 +36,6 @@ Route::middleware(['throttle:api', 'auth:user_api'])->prefix('user')->group(func
 });
 
 // Manager: lier un utilisateur ordinaire a un employe
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
     Route::post('/employees/link-user', [UserEmployeeLinkController::class, 'linkByEmail']);
 });

--- a/api/tests/Feature/Security/ApiVersionAndPlanRateLimitTest.php
+++ b/api/tests/Feature/Security/ApiVersionAndPlanRateLimitTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class ApiVersionAndPlanRateLimitTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_api_responses_include_version_headers(): void
+    {
+        $response = $this->getJson('/api/v1/health/live');
+
+        $response->assertOk();
+        $response->assertHeader('X-API-Version', 'v1');
+        $response->assertHeader('X-API-Supported-Versions', 'v1');
+    }
+
+    public function test_unsupported_requested_api_version_is_rejected(): void
+    {
+        $response = $this->withHeader('X-API-Version', 'v2')->getJson('/api/v1/health/live');
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'error' => 'UNSUPPORTED_API_VERSION',
+                'requested_version' => 'v2',
+                'supported_versions' => ['v1'],
+            ]);
+    }
+
+    public function test_authenticated_api_is_rate_limited_by_current_plan(): void
+    {
+        config(['security.plan_rate_limits.starter_per_minute' => 2]);
+
+        DB::table('plans')->updateOrInsert(['name' => 'Starter'], [
+            'price_monthly' => 29,
+            'price_yearly' => 290,
+            'max_employees' => 20,
+            'features' => '{}',
+            'trial_days' => 14,
+            'is_active' => true,
+        ]);
+
+        $planId = DB::table('plans')->where('name', 'Starter')->value('id');
+
+        $company = Company::factory()->create(['plan_id' => $planId]);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'plan-rate-limit@example.test',
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/v1/auth/me')->assertOk();
+        $this->getJson('/api/v1/auth/me')->assertOk();
+        $this->getJson('/api/v1/auth/me')->assertStatus(429);
+    }
+}

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -37,6 +37,8 @@ Note 2026-05-12 : les tests Feature des modules post-sprints doivent verifier le
 
 Note 2026-05-14 : les endpoints sensibles utilisent des limiters nommes configurables (`auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`). Les scenarios API doivent conserver au moins un test `429` sur auth publique et un test `429` sur privacy authentifie.
 
+Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version`, `X-API-Supported-Versions`) et refuse un `X-API-Version` non supporte. Les routes authentifiees tenant portent aussi un limiter `api-plan` configurable par plan commercial ; garder un test `429` dedie sur un plan Starter avec seuil abaisse en test.
+
 ## Matrice complete des scenarios backend
 
 ### 1. Sante technique et bootstrap
@@ -48,6 +50,8 @@ Note 2026-05-14 : les endpoints sensibles utilisent des limiters nommes configur
 - Redis / cache / queue sync ne cassent pas les endpoints critiques
 - Une erreur de bootstrap ne fuit pas d'informations sensibles
 - Le middleware `RequestIdMiddleware` ajoute un header `X-Request-Id` a chaque reponse API
+- Le middleware `ApiVersionMiddleware` ajoute `X-API-Version: v1` et `X-API-Supported-Versions`
+- Une requete avec `X-API-Version: v2` sur `/api/v1/*` retourne `400 UNSUPPORTED_API_VERSION`
 - Un `X-Request-Id` fourni dans la requete est reechoe dans la reponse
 - `GET /docs` publie Swagger UI sans authentification
 - `GET /docs/openapi.yaml` sert la specification canonique `api/openapi.yaml` sans copie divergente
@@ -60,6 +64,7 @@ Note 2026-05-14 : les endpoints sensibles utilisent des limiters nommes configur
 - Login succes pour chaque role autorise
 - Login refuse pour mot de passe invalide
 - Login public retourne `429` apres depassement du limiter `auth-sensitive`
+- Une route authentifiee retourne `429` apres depassement du limiter `api-plan` du plan client
 - Login refuse pour compte inactif ou bloque
 - `me` retourne le bon role, tenant, permissions et contexte
 - Logout invalide le token en cours

--- a/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
+++ b/docs/PLAN_ACTION/14_PLAN_SOLIDIFICATION_MARCHE.md
@@ -177,8 +177,8 @@
 ```
 - [x] Documentation OpenAPI complete et validee en CI (surface plateforme recente documentee, Swagger UI publiee sur `/docs`)
 - [x] SDK client JavaScript/Python genere depuis OpenAPI via `dev-hub/tools/generate-openapi-sdk.mjs`
-- [ ] Rate limiting API avec plans (starter: 100 req/min, pro: 1000, enterprise: illimite)
-- [ ] Versioning API (v1 stable, v2 beta)
+- [x] Rate limiting API avec plans (starter: 100 req/min, business/pro: 1000, enterprise: illimite) — **FAIT** (`api-plan` limiter configurable, applique apres auth/tenant sur les routes API authentifiees)
+- [x] Versioning API (v1 stable, v2 beta) — **FAIT socle v1** (`ApiVersionMiddleware`, headers `X-API-Version` / `X-API-Supported-Versions`, rejet explicite des versions demandees non supportees)
 - [ ] Sandbox environnement pour les integrateurs
 ```
 

--- a/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
+++ b/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
@@ -38,7 +38,7 @@
 |---|-------|--------|--------|----------|
 | A1 | Creer `CONVENTIONS.md` | T-ARCH-13 | 0.5j | HIGH |
 | A2 | Creer `docs/api/VERSIONING.md` | T-ARCH-10 | 0.5j | HIGH |
-| A3 | Creer middleware `ApiVersion` | T-ARCH-09 | 1j | MEDIUM |
+| A3 | Creer middleware `ApiVersion` | T-ARCH-09 | 1j | DONE |
 | A4 | Creer `docs/architecture/PARTITIONING.md` | T-ARCH-15 | 0.5j | MEDIUM |
 | A5 | DDD migration progressive controllers existants | T-ARCH-02 | 5j+ | LOW |
 | A6 | Tests Feature rapport RH dedies | T-MOD-H4 | 1j | MEDIUM |
@@ -169,7 +169,7 @@
 
 | # | Tache | Source | Effort | Priorite |
 |---|-------|--------|--------|----------|
-| K1 | Rate limiting API par plan | Plan 14 | 1j | HIGH |
+| K1 | Rate limiting API par plan | Plan 14 | 1j | DONE |
 | K2 | SSO SAML/OIDC | Plan 14 | 3j | MEDIUM |
 | K3 | Multi-tenant isolation test complet | Plan 14 | 1j | HIGH |
 | K4 | Audit WCAG 2.1 AA | Plan 14 | 2j | LOW |
@@ -224,6 +224,11 @@
 - AES-256 chiffrement sensible
 - Rate limiting API par plan
 - Test isolation multi-tenant complet
+
+**Avancement 2026-05-15** :
+- A3/K1 livres : `ApiVersionMiddleware` expose le contrat de version `v1` sur toutes les reponses API et refuse les versions demandees non supportees.
+- Le limiter `api-plan` applique des quotas configurables par plan apres `auth:sanctum` + `tenant`, sans remplacer les limiters sensibles (`auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`).
+- Reste Iteration 4 : D1/D2/D4/D5/K3 a traiter par lots separes pour eviter un gros PR risque.
 
 ### Iteration 5 — Monitoring production
 **Cible** : B1, B2, B3, B4

--- a/docs/api/VERSIONING.md
+++ b/docs/api/VERSIONING.md
@@ -1,6 +1,6 @@
 # Politique de versioning API — Leopardo RH
 
-> Derniere mise a jour : 2026-05-14
+> Derniere mise a jour : 2026-05-15
 
 ---
 
@@ -66,8 +66,20 @@ Chaque reponse API inclut :
 
 ```
 X-API-Version: v1
+X-API-Supported-Versions: v1
 X-RateLimit-Limit: 1000
 X-RateLimit-Remaining: 999
+```
+
+Si un client envoie `X-API-Version` avec une version non supportee pour la route appelee, l'API retourne :
+
+```json
+{
+  "error": "UNSUPPORTED_API_VERSION",
+  "message": "UNSUPPORTED_API_VERSION",
+  "supported_versions": ["v1"],
+  "requested_version": "v2"
+}
 ```
 
 En cas de deprecation :
@@ -99,18 +111,19 @@ MAJOR.MINOR.PATCH (ex: 4.16.51)
 
 Le numero de version produit est independant de la version API (`v1`, `v2`).
 
-## 7. Middleware ApiVersion (a implementer)
+## 7. Middleware ApiVersion (implemente)
 
-Un middleware `ApiVersion` est prevu pour :
+Le middleware `ApiVersionMiddleware` :
 
-- Detecter la version demandee (prefixe URL ou header `Accept-Version`)
-- Injecter la version dans le contexte de la requete
-- Logger la version utilisee pour les metriques d'usage
-- Appliquer les transformations de compatibilite si necessaire
+- Detecte la version depuis le prefixe URL `/api/v1/*`
+- Compare la version demandee via `X-API-Version` si le client l'envoie
+- Injecte `api_version` dans les attributs de la requete
+- Ajoute les headers `X-API-Version` et `X-API-Supported-Versions`
+- Retourne `400 UNSUPPORTED_API_VERSION` avant controller si la version demandee n'est pas supportee
 
 ```php
-// Futur : app/Http/Middleware/ApiVersionMiddleware.php
-// Route::prefix('api/v1')->middleware(['api', 'api.version:v1'])->group(...)
+// app/Http/Middleware/ApiVersionMiddleware.php
+// Enregistre dans le groupe API global via bootstrap/app.php
 ```
 
 ## 8. References

--- a/shared/i18n/sync/utils.js
+++ b/shared/i18n/sync/utils.js
@@ -62,11 +62,15 @@ function toPhpArray(node, depth = 0) {
   const childIndent = '    '.repeat(depth + 1);
   const entries = Object.entries(node).map(([key, value]) => {
     if (typeof value === 'string') {
-      return `${childIndent}${JSON.stringify(key)} => ${JSON.stringify(value)},`;
+      return `${childIndent}${phpString(key)} => ${phpString(value)},`;
     }
-    return `${childIndent}${JSON.stringify(key)} => [\n${toPhpArray(value, depth + 1)}\n${childIndent}],`;
+    return `${childIndent}${phpString(key)} => [\n${toPhpArray(value, depth + 1)}\n${childIndent}],`;
   });
   return entries.join('\n');
+}
+
+function phpString(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
 function writePhpArray(filePath, payload) {


### PR DESCRIPTION
## Summary
- Add global API version middleware with v1 headers and unsupported-version rejection
- Add configurable plan-based rate limiter for authenticated tenant API routes
- Cover API version headers, unsupported version rejection, and Starter plan 429 behavior
- Update Plan 14, Plan 15, versioning docs, scenarios, changelog, and agent notes

## Local verification
- php -l api/app/Http/Middleware/ApiVersionMiddleware.php
- php -l api/app/Providers/AppServiceProvider.php
- php -l api/tests/Feature/Security/ApiVersionAndPlanRateLimitTest.php
- php -l API route/config/lang files touched
- git diff --check
- vendor/bin/pint --dirty

## Note
- Targeted local PHPUnit is blocked on this Windows PHP by missing mbstring (Illuminate\\Support\\mb_split), a known local environment limitation documented in AGENTS.md. GitHub Actions remains the source of truth.