### PR TITLE
feat: Iteration 3 complete — pre-commit (A9) + AI write confirmation tests (C3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,24 @@ repos:
       - id: no-commit-to-branch
         args: ['--branch', 'main']
 
-  # PHP (Laravel backend)
+  # PHP (Laravel backend) — Pint on staged files
+  - repo: local
+    hooks:
+      - id: laravel-pint
+        name: Laravel Pint (api staged PHP)
+        language: system
+        entry: bash -c 'cd api && files=$(git diff --cached --name-only --diff-filter=ACM | grep "^api/" | sed "s#^api/##" | grep "\.php$" || true); if [ -n "$files" ]; then echo "$files" | xargs -r ./vendor/bin/pint; fi'
+        pass_filenames: false
+        stages: [pre-commit]
+
+  # PHP static analysis (diff-gate friendly; non-blocking locally on Windows)
   - repo: local
     hooks:
       - id: phpstan
-        name: PHPStan (diff-gate)
+        name: PHPStan (api)
         language: system
         entry: bash -c 'cd api && php vendor/bin/phpstan analyse --no-progress --error-format=table 2>/dev/null || true'
-        files: '\.php$'
+        files: '^api/.*\.php$'
         pass_filenames: false
         stages: [pre-commit]
 
@@ -34,21 +44,20 @@ repos:
   - repo: local
     hooks:
       - id: eslint-admin
-        name: ESLint (admin-dashboard)
+        name: ESLint (admin-dashboard staged)
         language: system
-        entry: bash -c 'cd front/admin-dashboard && npx eslint --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx 2>/dev/null || true'
-        files: 'front/admin-dashboard/.*\.(vue|js|jsx|ts|tsx)$'
+        entry: bash -c 'cd front/admin-dashboard && npx eslint --max-warnings=0 $(git diff --cached --name-only --diff-filter=ACM | grep "^front/admin-dashboard/" | sed "s#^front/admin-dashboard/##" | grep -E "\.(vue|js|jsx|ts|tsx)$" || true) 2>/dev/null || true'
         pass_filenames: false
         stages: [pre-commit]
 
-  # OpenAPI validation
+  # OpenAPI validation when spec changes
   - repo: local
     hooks:
       - id: openapi-lint
         name: OpenAPI lint
         language: system
         entry: bash -c 'npx @redocly/cli lint api/openapi.yaml --skip-rule no-unused-components 2>/dev/null || true'
-        files: 'openapi\.yaml$'
+        files: '(^api/openapi\.yaml$|openapi\.yaml$)'
         pass_filenames: false
         stages: [pre-commit]
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,79 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordClientIDDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist",
+      "filename": ".secrets.baseline"
+    }
+  ],
+  "results": [],
+  "generated_at": "2026-05-15T00:00:00Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@
 - Plans 01, 02, 04, 05, 07, 08, 10 : mise a jour partielle, taches restantes identifiees.
 - Nouveau : creation de `15_PLAN_EXECUTION_CONSOLIDE.md` — inventaire complet des 193 taches restantes organisees en 12 categories et 7+ iterations.
 - Nouveau : mise a jour de `00_SOMMAIRE.md` avec references aux nouveaux documents.
+## [4.16.54] - 2026-05-15
+
+### IA & CI — Iteration 3 complete (pre-commit + write confirmation)
+
+- Nouveau : confirmation obligatoire pour les outils IA write (`WriteToolPolicy`, `PendingActionStore`, `WriteActionRunner`) avec endpoints `POST /api/v1/ai/actions/{id}/confirm` et `/reject`.
+- Nouveau : `AIWriteActionConfirmationTest` — couverture confirmation/rejet/execution `create_absence` et `approve_absence`.
+- Orchestrator : expose `pending_confirmations` quand un outil write attend validation humaine.
+- CI local : `.pre-commit-config.yaml` enrichi (Pint sur PHP stage, baseline `.secrets.baseline` pour detect-secrets).
+
 ## [4.16.53] - 2026-05-14
 
 ### Tests & Features — Iteration 3 tests manquants + export CSV audit

--- a/api/app/AI/IntentEngine.php
+++ b/api/app/AI/IntentEngine.php
@@ -112,18 +112,50 @@ class IntentEngine
      */
     private function confirmationSummary(string $toolName, array $arguments): string
     {
+        $startDate = $this->stringArgument($arguments, 'start_date', '?');
+        $endDate = $this->stringArgument($arguments, 'end_date', $startDate);
+        $absenceId = $this->stringArgument($arguments, 'absence_id', '?');
+
         return match ($toolName) {
             'create_absence' => sprintf(
                 'Creer une demande d\'absence du %s au %s',
-                $arguments['start_date'] ?? '?',
-                $arguments['end_date'] ?? ($arguments['start_date'] ?? '?'),
+                $startDate,
+                $endDate,
             ),
             'approve_absence' => sprintf(
                 'Approuver l\'absence #%s',
-                $arguments['absence_id'] ?? '?',
+                $absenceId,
             ),
             default => "Confirmer l'action {$toolName}",
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    private function stringArgument(array $arguments, string $key, string $default): string
+    {
+        if (! array_key_exists($key, $arguments)) {
+            return $default;
+        }
+
+        $value = $arguments[$key];
+
+        return is_scalar($value) ? (string) $value : $default;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    private function intArgument(array $arguments, string $key, int $default): int
+    {
+        if (! array_key_exists($key, $arguments)) {
+            return $default;
+        }
+
+        $value = $arguments[$key];
+
+        return is_numeric($value) ? (int) $value : $default;
     }
 
     /**
@@ -158,7 +190,7 @@ class IntentEngine
             $query->where('department_id', $args['department_id']);
         }
 
-        $limit = min((int) ($args['limit'] ?? 20), 50);
+        $limit = min($this->intArgument($args, 'limit', 20), 50);
         $employees = $query->select(['id', 'first_name', 'last_name', 'email', 'post', 'department_id', 'status'])
             ->limit($limit)
             ->get();
@@ -214,7 +246,7 @@ class IntentEngine
     private function searchEmployees(string $companyId, array $args): array
     {
         $query = Employee::where('company_id', $companyId);
-        $search = $args['query'] ?? '';
+        $search = $this->stringArgument($args, 'query', '');
 
         if ($search !== '') {
             $query->where(function ($q) use ($search) {

--- a/api/app/AI/IntentEngine.php
+++ b/api/app/AI/IntentEngine.php
@@ -33,6 +33,10 @@ class IntentEngine
 
     private function executeSingleTool(ToolCall $toolCall, string $companyId, int $userId): ToolResult
     {
+        if ($this->writeToolPolicy->requiresConfirmation($toolCall->name)) {
+            return $this->pendingConfirmationResult($toolCall, $companyId, $userId);
+        }
+
         $tool = $this->toolRegistry->findTool($toolCall->name);
 
         if ($tool === null) {
@@ -45,10 +49,6 @@ class IntentEngine
         }
 
         try {
-            if ($this->writeToolPolicy->requiresConfirmation($toolCall->name)) {
-                return $this->pendingConfirmationResult($toolCall, $companyId, $userId);
-            }
-
             $result = $this->dispatchToolAction($toolCall->name, $toolCall->arguments, $companyId, $userId);
 
             return new ToolResult(

--- a/api/app/AI/IntentEngine.php
+++ b/api/app/AI/IntentEngine.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\AI;
 
 use App\AI\DTOs\AIResponse;

--- a/api/app/AI/IntentEngine.php
+++ b/api/app/AI/IntentEngine.php
@@ -12,6 +12,9 @@ class IntentEngine
 {
     public function __construct(
         private readonly ToolRegistry $toolRegistry,
+        private readonly WriteToolPolicy $writeToolPolicy,
+        private readonly PendingActionStore $pendingActionStore,
+        private readonly WriteActionRunner $writeActionRunner,
     ) {}
 
     /**
@@ -42,6 +45,10 @@ class IntentEngine
         }
 
         try {
+            if ($this->writeToolPolicy->requiresConfirmation($toolCall->name)) {
+                return $this->pendingConfirmationResult($toolCall, $companyId, $userId);
+            }
+
             $result = $this->dispatchToolAction($toolCall->name, $toolCall->arguments, $companyId, $userId);
 
             return new ToolResult(
@@ -58,6 +65,63 @@ class IntentEngine
                 success: false,
             );
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    public function executeConfirmedWrite(string $toolName, array $arguments, string $companyId, int $userId): array
+    {
+        if (! $this->writeToolPolicy->requiresConfirmation($toolName)) {
+            return ['error' => "Tool '{$toolName}' does not require confirmation."];
+        }
+
+        return $this->writeActionRunner->run($toolName, $arguments, $companyId, $userId);
+    }
+
+    private function pendingConfirmationResult(ToolCall $toolCall, string $companyId, int $userId): ToolResult
+    {
+        $pendingId = $this->pendingActionStore->store(
+            $companyId,
+            $userId,
+            $toolCall->name,
+            $toolCall->arguments,
+        );
+
+        $payload = [
+            'status' => 'confirmation_required',
+            'pending_action_id' => $pendingId,
+            'tool' => $toolCall->name,
+            'summary' => $this->confirmationSummary($toolCall->name, $toolCall->arguments),
+            'arguments' => $toolCall->arguments,
+        ];
+
+        return new ToolResult(
+            toolCallId: $toolCall->id,
+            name: $toolCall->name,
+            content: json_encode($payload) ?: '{}',
+            success: true,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    private function confirmationSummary(string $toolName, array $arguments): string
+    {
+        return match ($toolName) {
+            'create_absence' => sprintf(
+                'Creer une demande d\'absence du %s au %s',
+                $arguments['start_date'] ?? '?',
+                $arguments['end_date'] ?? ($arguments['start_date'] ?? '?'),
+            ),
+            'approve_absence' => sprintf(
+                'Approuver l\'absence #%s',
+                $arguments['absence_id'] ?? '?',
+            ),
+            default => "Confirmer l'action {$toolName}",
+        };
     }
 
     /**

--- a/api/app/AI/Orchestrator.php
+++ b/api/app/AI/Orchestrator.php
@@ -47,6 +47,7 @@ class Orchestrator
         $response = $this->client->chat($llmMessages, $tools);
 
         $toolsUsed = [];
+        $pendingConfirmations = [];
         $maxIterations = 3;
         $iteration = 0;
 
@@ -55,6 +56,14 @@ class Orchestrator
 
             foreach ($results as $result) {
                 $toolsUsed[] = $result->name;
+                $decoded = json_decode($result->content, true);
+                if (is_array($decoded) && ($decoded['status'] ?? null) === 'confirmation_required') {
+                    $pendingConfirmations[] = $decoded;
+                }
+            }
+
+            if ($pendingConfirmations !== []) {
+                break;
             }
 
             if ($this->client->provider() === 'claude') {
@@ -120,6 +129,7 @@ class Orchestrator
             'conversation_id' => $conversationId,
             'response' => $response->content,
             'tools_used' => $toolsUsed,
+            'pending_confirmations' => $pendingConfirmations,
             'tokens' => ['input' => $response->inputTokens, 'output' => $response->outputTokens],
         ];
     }

--- a/api/app/AI/Orchestrator.php
+++ b/api/app/AI/Orchestrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\AI;
 
 use App\AI\DTOs\AIRequest;

--- a/api/app/AI/PendingActionStore.php
+++ b/api/app/AI/PendingActionStore.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class PendingActionStore
+{
+    private const CACHE_PREFIX = 'ai_pending_action:';
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function store(string $companyId, int $userId, string $toolName, array $arguments): string
+    {
+        $id = (string) Str::uuid();
+
+        Cache::put($this->cacheKey($id), [
+            'company_id' => $companyId,
+            'user_id' => $userId,
+            'tool' => $toolName,
+            'arguments' => $arguments,
+        ], now()->addMinutes($this->ttlMinutes()));
+
+        return $id;
+    }
+
+    /**
+     * @return array{company_id: string, user_id: int, tool: string, arguments: array<string, mixed>}|null
+     */
+    public function pull(string $id, string $companyId, int $userId): ?array
+    {
+        /** @var array{company_id: string, user_id: int, tool: string, arguments: array<string, mixed>}|null $payload */
+        $payload = Cache::get($this->cacheKey($id));
+
+        if ($payload === null) {
+            return null;
+        }
+
+        if ($payload['company_id'] !== $companyId || $payload['user_id'] !== $userId) {
+            return null;
+        }
+
+        Cache::forget($this->cacheKey($id));
+
+        return $payload;
+    }
+
+    public function forget(string $id): void
+    {
+        Cache::forget($this->cacheKey($id));
+    }
+
+    private function cacheKey(string $id): string
+    {
+        return self::CACHE_PREFIX.$id;
+    }
+
+    private function ttlMinutes(): int
+    {
+        return max(1, (int) config('ai.pending_action_ttl_minutes', 15));
+    }
+}

--- a/api/app/AI/PendingActionStore.php
+++ b/api/app/AI/PendingActionStore.php
@@ -61,6 +61,8 @@ class PendingActionStore
 
     private function ttlMinutes(): int
     {
-        return max(1, (int) config('ai.pending_action_ttl_minutes', 15));
+        $configured = config('ai.pending_action_ttl_minutes', 15);
+
+        return max(1, is_numeric($configured) ? (int) $configured : 15);
     }
 }

--- a/api/app/AI/WriteActionRunner.php
+++ b/api/app/AI/WriteActionRunner.php
@@ -113,11 +113,8 @@ class WriteActionRunner
 
         $code = array_key_exists('type', $arguments)
             ? $this->stringArgument($arguments, 'type', '')
-            : null;
-        if ($code === '') {
-            $code = null;
-        }
-        if ($code !== null && $code !== '') {
+            : '';
+        if ($code !== '') {
             $byCode = AbsenceType::query()
                 ->where('company_id', $companyId)
                 ->where('code', $code)

--- a/api/app/AI/WriteActionRunner.php
+++ b/api/app/AI/WriteActionRunner.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI;
+
+use App\Models\Absence;
+use App\Models\AbsenceType;
+use App\Models\Employee;
+use Illuminate\Support\Carbon;
+
+class WriteActionRunner
+{
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    public function run(string $toolName, array $arguments, string $companyId, int $userId): array
+    {
+        return match ($toolName) {
+            'create_absence' => $this->createAbsence($companyId, $userId, $arguments),
+            'approve_absence' => $this->approveAbsence($companyId, $userId, $arguments),
+            default => ['error' => "Write tool '{$toolName}' is not implemented."],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function createAbsence(string $companyId, int $userId, array $arguments): array
+    {
+        $employeeId = (int) ($arguments['employee_id'] ?? $userId);
+        $employee = Employee::query()
+            ->where('company_id', $companyId)
+            ->where('id', $employeeId)
+            ->first();
+
+        if ($employee === null) {
+            return ['error' => 'Employee not found'];
+        }
+
+        $startDate = Carbon::parse((string) ($arguments['start_date'] ?? now()->toDateString()));
+        $endDate = Carbon::parse((string) ($arguments['end_date'] ?? $startDate->toDateString()));
+        if ($endDate->lessThan($startDate)) {
+            return ['error' => 'end_date must be on or after start_date'];
+        }
+
+        $absenceType = $this->resolveAbsenceType($companyId, $arguments);
+
+        $absence = Absence::create([
+            'company_id' => $companyId,
+            'employee_id' => $employeeId,
+            'absence_type_id' => $absenceType?->id,
+            'start_date' => $startDate->toDateString(),
+            'end_date' => $endDate->toDateString(),
+            'days_count' => $startDate->diffInDays($endDate) + 1,
+            'status' => 'pending',
+            'reason' => isset($arguments['reason']) ? (string) $arguments['reason'] : null,
+        ]);
+
+        return [
+            'absence_id' => $absence->id,
+            'status' => $absence->status,
+            'employee_id' => $employeeId,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function approveAbsence(string $companyId, int $userId, array $arguments): array
+    {
+        $absenceId = (int) ($arguments['absence_id'] ?? 0);
+        $absence = Absence::query()
+            ->where('company_id', $companyId)
+            ->where('id', $absenceId)
+            ->first();
+
+        if ($absence === null) {
+            return ['error' => 'Absence not found'];
+        }
+
+        if ($absence->status !== 'pending') {
+            return ['error' => 'Absence is not pending approval'];
+        }
+
+        $absence->update([
+            'status' => 'approved',
+            'approved_by' => $userId,
+        ]);
+
+        return [
+            'absence_id' => $absence->id,
+            'status' => $absence->status,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    private function resolveAbsenceType(string $companyId, array $arguments): ?AbsenceType
+    {
+        if (isset($arguments['absence_type_id'])) {
+            return AbsenceType::query()
+                ->where('company_id', $companyId)
+                ->where('id', (int) $arguments['absence_type_id'])
+                ->first();
+        }
+
+        $code = isset($arguments['type']) ? (string) $arguments['type'] : null;
+        if ($code !== null && $code !== '') {
+            $byCode = AbsenceType::query()
+                ->where('company_id', $companyId)
+                ->where('code', $code)
+                ->first();
+            if ($byCode !== null) {
+                return $byCode;
+            }
+        }
+
+        return AbsenceType::query()->where('company_id', $companyId)->first();
+    }
+}

--- a/api/app/AI/WriteActionRunner.php
+++ b/api/app/AI/WriteActionRunner.php
@@ -30,7 +30,7 @@ class WriteActionRunner
      */
     private function createAbsence(string $companyId, int $userId, array $arguments): array
     {
-        $employeeId = (int) ($arguments['employee_id'] ?? $userId);
+        $employeeId = $this->intArgument($arguments, 'employee_id', $userId);
         $employee = Employee::query()
             ->where('company_id', $companyId)
             ->where('id', $employeeId)
@@ -40,8 +40,8 @@ class WriteActionRunner
             return ['error' => 'Employee not found'];
         }
 
-        $startDate = Carbon::parse((string) ($arguments['start_date'] ?? now()->toDateString()));
-        $endDate = Carbon::parse((string) ($arguments['end_date'] ?? $startDate->toDateString()));
+        $startDate = Carbon::parse($this->stringArgument($arguments, 'start_date', now()->toDateString()));
+        $endDate = Carbon::parse($this->stringArgument($arguments, 'end_date', $startDate->toDateString()));
         if ($endDate->lessThan($startDate)) {
             return ['error' => 'end_date must be on or after start_date'];
         }
@@ -56,7 +56,9 @@ class WriteActionRunner
             'end_date' => $endDate->toDateString(),
             'days_count' => $startDate->diffInDays($endDate) + 1,
             'status' => 'pending',
-            'reason' => isset($arguments['reason']) ? (string) $arguments['reason'] : null,
+            'reason' => array_key_exists('reason', $arguments)
+                ? ($this->stringArgument($arguments, 'reason', '') ?: null)
+                : null,
         ]);
 
         return [
@@ -72,7 +74,7 @@ class WriteActionRunner
      */
     private function approveAbsence(string $companyId, int $userId, array $arguments): array
     {
-        $absenceId = (int) ($arguments['absence_id'] ?? 0);
+        $absenceId = $this->intArgument($arguments, 'absence_id', 0);
         $absence = Absence::query()
             ->where('company_id', $companyId)
             ->where('id', $absenceId)
@@ -105,11 +107,16 @@ class WriteActionRunner
         if (isset($arguments['absence_type_id'])) {
             return AbsenceType::query()
                 ->where('company_id', $companyId)
-                ->where('id', (int) $arguments['absence_type_id'])
+                ->where('id', $this->intArgument($arguments, 'absence_type_id', 0))
                 ->first();
         }
 
-        $code = isset($arguments['type']) ? (string) $arguments['type'] : null;
+        $code = array_key_exists('type', $arguments)
+            ? $this->stringArgument($arguments, 'type', '')
+            : null;
+        if ($code === '') {
+            $code = null;
+        }
         if ($code !== null && $code !== '') {
             $byCode = AbsenceType::query()
                 ->where('company_id', $companyId)
@@ -121,5 +128,33 @@ class WriteActionRunner
         }
 
         return AbsenceType::query()->where('company_id', $companyId)->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    private function intArgument(array $arguments, string $key, int $default): int
+    {
+        if (! array_key_exists($key, $arguments)) {
+            return $default;
+        }
+
+        $value = $arguments[$key];
+
+        return is_numeric($value) ? (int) $value : $default;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    private function stringArgument(array $arguments, string $key, string $default): string
+    {
+        if (! array_key_exists($key, $arguments)) {
+            return $default;
+        }
+
+        $value = $arguments[$key];
+
+        return is_scalar($value) ? (string) $value : $default;
     }
 }

--- a/api/app/AI/WriteToolPolicy.php
+++ b/api/app/AI/WriteToolPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AI;
+
+class WriteToolPolicy
+{
+    /**
+     * @return list<string>
+     */
+    public function writeTools(): array
+    {
+        /** @var list<string> $tools */
+        $tools = config('ai.write_tools', []);
+
+        return $tools;
+    }
+
+    public function requiresConfirmation(string $toolName): bool
+    {
+        return in_array($toolName, $this->writeTools(), true);
+    }
+}

--- a/api/app/Http/Controllers/AI/AIGatewayController.php
+++ b/api/app/Http/Controllers/AI/AIGatewayController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\AI;
 
 use App\AI\DTOs\AIRequest;
+use App\AI\IntentEngine;
 use App\AI\Orchestrator;
+use App\AI\PendingActionStore;
 use App\Http\Controllers\Controller;
 use App\Models\Employee;
 use Illuminate\Http\JsonResponse;
@@ -12,7 +14,11 @@ use Illuminate\Support\Facades\DB;
 
 class AIGatewayController extends Controller
 {
-    public function __construct(private readonly Orchestrator $orchestrator) {}
+    public function __construct(
+        private readonly Orchestrator $orchestrator,
+        private readonly IntentEngine $intentEngine,
+        private readonly PendingActionStore $pendingActionStore,
+    ) {}
 
     public function chat(Request $request): JsonResponse
     {
@@ -75,6 +81,64 @@ class AIGatewayController extends Controller
         }
 
         return response()->json(['message' => 'Conversation deleted.']);
+    }
+
+    public function confirmAction(Request $request, string $pendingActionId): JsonResponse
+    {
+        /** @var Employee $user */
+        $user = $request->user();
+
+        $pending = $this->pendingActionStore->pull(
+            $pendingActionId,
+            (string) $user->company_id,
+            (int) $user->id,
+        );
+
+        if ($pending === null) {
+            abort(404, 'Pending action not found or expired.');
+        }
+
+        $result = $this->intentEngine->executeConfirmedWrite(
+            $pending['tool'],
+            $pending['arguments'],
+            (string) $user->company_id,
+            (int) $user->id,
+        );
+
+        if (isset($result['error'])) {
+            return response()->json(['error' => $result['error'], 'data' => $result], 422);
+        }
+
+        return response()->json([
+            'data' => [
+                'status' => 'executed',
+                'tool' => $pending['tool'],
+                'result' => $result,
+            ],
+        ]);
+    }
+
+    public function rejectAction(Request $request, string $pendingActionId): JsonResponse
+    {
+        /** @var Employee $user */
+        $user = $request->user();
+
+        $pending = $this->pendingActionStore->pull(
+            $pendingActionId,
+            (string) $user->company_id,
+            (int) $user->id,
+        );
+
+        if ($pending === null) {
+            abort(404, 'Pending action not found or expired.');
+        }
+
+        return response()->json([
+            'data' => [
+                'status' => 'rejected',
+                'tool' => $pending['tool'],
+            ],
+        ]);
     }
 
     public function tools(Request $request): JsonResponse

--- a/api/app/Http/Controllers/AI/AIGatewayController.php
+++ b/api/app/Http/Controllers/AI/AIGatewayController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\AI;
 
 use App\AI\DTOs\AIRequest;

--- a/api/config/ai.php
+++ b/api/config/ai.php
@@ -42,4 +42,17 @@ return [
     'agent' => [
         'max_steps' => (int) env('AI_AGENT_MAX_STEPS', 10),
     ],
+
+    'pending_action_ttl_minutes' => (int) env('AI_PENDING_ACTION_TTL_MINUTES', 15),
+
+    /** Tools that mutate data and require explicit user confirmation before execution. */
+    'write_tools' => [
+        'create_absence',
+        'approve_absence',
+        'create_employee',
+        'update_employee',
+        'check_in_employee',
+        'check_out_employee',
+        'create_salary_advance',
+    ],
 ];

--- a/api/config/ai.php
+++ b/api/config/ai.php
@@ -45,7 +45,7 @@ return [
 
     'pending_action_ttl_minutes' => (int) env('AI_PENDING_ACTION_TTL_MINUTES', 15),
 
-    /** Tools that mutate data and require explicit user confirmation before execution. */
+    // Tools that mutate data and require explicit user confirmation before execution.
     'write_tools' => [
         'create_absence',
         'approve_absence',

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -19,6 +19,8 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'throttle:ai-sensitive', AIFe
 
     Route::get('/chat/history', [AIGatewayController::class, 'history']);
     Route::delete('/chat/{conversationId}', [AIGatewayController::class, 'deleteConversation'])->whereNumber('conversationId');
+    Route::post('/actions/{pendingActionId}/confirm', [AIGatewayController::class, 'confirmAction']);
+    Route::post('/actions/{pendingActionId}/reject', [AIGatewayController::class, 'rejectAction']);
     Route::get('/tools', [AIGatewayController::class, 'tools']);
 
     // Phase 3 — Voice IA (Sprint 17-18)

--- a/api/tests/Feature/AIWriteActionConfirmationTest.php
+++ b/api/tests/Feature/AIWriteActionConfirmationTest.php
@@ -9,12 +9,14 @@ use App\AI\DTOs\ToolCall;
 use App\AI\IntentEngine;
 use App\AI\LLMClient;
 use App\AI\PendingActionStore;
+use App\AI\ToolRegistry;
 use App\Models\Absence;
 use App\Models\AbsenceType;
 use App\Models\AIToolRegistryEntry;
 use App\Models\Company;
 use App\Models\Employee;
 use Laravel\Sanctum\Sanctum;
+use stdClass;
 use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
 
@@ -40,7 +42,7 @@ class AIWriteActionConfirmationTest extends TestCase
         [$company, $employee] = $this->aiFixture();
         $this->seedAbsenceType($company->id);
         $this->registerWriteTool('create_absence');
-        $this->app->forgetInstance(\App\AI\ToolRegistry::class);
+        $this->app->forgetInstance(ToolRegistry::class);
 
         $engine = app(IntentEngine::class);
         $response = new AIResponse(
@@ -173,7 +175,7 @@ class AIWriteActionConfirmationTest extends TestCase
     {
         [$company, $employee] = $this->aiFixture();
         $this->registerWriteTool('create_absence');
-        $this->app->forgetInstance(\App\AI\ToolRegistry::class);
+        $this->app->forgetInstance(ToolRegistry::class);
         Sanctum::actingAs($employee);
         $this->fakeLlmClientWithWriteToolCall();
 
@@ -187,8 +189,7 @@ class AIWriteActionConfirmationTest extends TestCase
 
     private function fakeLlmClientWithWriteToolCall(): void
     {
-        $this->app->instance(LLMClient::class, new class implements LLMClient
-        {
+        $this->app->instance(LLMClient::class, new class implements LLMClient {
             public function chat(array $messages, array $tools = []): AIResponse
             {
                 return new AIResponse(
@@ -240,7 +241,7 @@ class AIWriteActionConfirmationTest extends TestCase
         AIToolRegistryEntry::create([
             'name' => $name,
             'description' => "Write tool {$name}",
-            'parameters' => ['type' => 'object', 'properties' => new \stdClass],
+            'parameters' => ['type' => 'object', 'properties' => new stdClass],
             'required_permissions' => [],
             'required_role' => 'manager',
             'module' => 'rh',

--- a/api/tests/Feature/AIWriteActionConfirmationTest.php
+++ b/api/tests/Feature/AIWriteActionConfirmationTest.php
@@ -11,6 +11,7 @@ use App\AI\LLMClient;
 use App\AI\PendingActionStore;
 use App\Models\Absence;
 use App\Models\AbsenceType;
+use App\Models\AIToolRegistryEntry;
 use App\Models\Company;
 use App\Models\Employee;
 use Laravel\Sanctum\Sanctum;
@@ -38,6 +39,8 @@ class AIWriteActionConfirmationTest extends TestCase
     {
         [$company, $employee] = $this->aiFixture();
         $this->seedAbsenceType($company->id);
+        $this->registerWriteTool('create_absence');
+        $this->app->forgetInstance(\App\AI\ToolRegistry::class);
 
         $engine = app(IntentEngine::class);
         $response = new AIResponse(
@@ -169,6 +172,8 @@ class AIWriteActionConfirmationTest extends TestCase
     public function test_orchestrator_returns_pending_confirmations_for_write_tools(): void
     {
         [$company, $employee] = $this->aiFixture();
+        $this->registerWriteTool('create_absence');
+        $this->app->forgetInstance(\App\AI\ToolRegistry::class);
         Sanctum::actingAs($employee);
         $this->fakeLlmClientWithWriteToolCall();
 
@@ -227,6 +232,19 @@ class AIWriteActionConfirmationTest extends TestCase
             'is_paid' => true,
             'deducts_leave' => true,
             'requires_proof' => false,
+        ]);
+    }
+
+    private function registerWriteTool(string $name): void
+    {
+        AIToolRegistryEntry::create([
+            'name' => $name,
+            'description' => "Write tool {$name}",
+            'parameters' => ['type' => 'object', 'properties' => new \stdClass],
+            'required_permissions' => [],
+            'required_role' => 'manager',
+            'module' => 'rh',
+            'active' => true,
         ]);
     }
 }

--- a/api/tests/Feature/AIWriteActionConfirmationTest.php
+++ b/api/tests/Feature/AIWriteActionConfirmationTest.php
@@ -189,7 +189,8 @@ class AIWriteActionConfirmationTest extends TestCase
 
     private function fakeLlmClientWithWriteToolCall(): void
     {
-        $this->app->instance(LLMClient::class, new class implements LLMClient {
+        $this->app->instance(LLMClient::class, new class implements LLMClient
+        {
             public function chat(array $messages, array $tools = []): AIResponse
             {
                 return new AIResponse(

--- a/api/tests/Feature/AIWriteActionConfirmationTest.php
+++ b/api/tests/Feature/AIWriteActionConfirmationTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\AI\DTOs\AIResponse;
+use App\AI\DTOs\ToolCall;
+use App\AI\IntentEngine;
+use App\AI\LLMClient;
+use App\AI\PendingActionStore;
+use App\Models\Absence;
+use App\Models\AbsenceType;
+use App\Models\Company;
+use App\Models\Employee;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class AIWriteActionConfirmationTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+        config(['ai.enabled' => true]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_write_tool_returns_confirmation_required_without_creating_absence(): void
+    {
+        [$company, $employee] = $this->aiFixture();
+        $this->seedAbsenceType($company->id);
+
+        $engine = app(IntentEngine::class);
+        $response = new AIResponse(
+            content: '',
+            toolCalls: [
+                new ToolCall('call_1', 'create_absence', [
+                    'start_date' => '2026-06-10',
+                    'end_date' => '2026-06-12',
+                    'reason' => 'Conges',
+                ]),
+            ],
+        );
+
+        $results = $engine->executeToolCalls($response, $company->id, $employee->id);
+        $payload = json_decode($results[0]->content, true);
+
+        $this->assertTrue($results[0]->success);
+        $this->assertSame('confirmation_required', $payload['status'] ?? null);
+        $this->assertNotEmpty($payload['pending_action_id'] ?? null);
+        $this->assertDatabaseCount('absences', 0);
+    }
+
+    public function test_confirm_action_executes_create_absence(): void
+    {
+        [$company, $employee] = $this->aiFixture();
+        $this->seedAbsenceType($company->id);
+        Sanctum::actingAs($employee);
+
+        $pendingId = app(PendingActionStore::class)->store(
+            $company->id,
+            $employee->id,
+            'create_absence',
+            [
+                'start_date' => '2026-06-10',
+                'end_date' => '2026-06-11',
+                'reason' => 'Conges',
+            ],
+        );
+
+        $this->postJson("/api/v1/ai/actions/{$pendingId}/confirm")
+            ->assertOk()
+            ->assertJsonPath('data.status', 'executed')
+            ->assertJsonPath('data.tool', 'create_absence')
+            ->assertJsonPath('data.result.status', 'pending');
+
+        $this->assertDatabaseHas('absences', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'status' => 'pending',
+        ]);
+    }
+
+    public function test_reject_action_does_not_create_absence(): void
+    {
+        [$company, $employee] = $this->aiFixture();
+        Sanctum::actingAs($employee);
+
+        $pendingId = app(PendingActionStore::class)->store(
+            $company->id,
+            $employee->id,
+            'create_absence',
+            [
+                'start_date' => '2026-06-10',
+                'end_date' => '2026-06-11',
+            ],
+        );
+
+        $this->postJson("/api/v1/ai/actions/{$pendingId}/reject")
+            ->assertOk()
+            ->assertJsonPath('data.status', 'rejected')
+            ->assertJsonPath('data.tool', 'create_absence');
+
+        $this->assertDatabaseCount('absences', 0);
+    }
+
+    public function test_confirm_action_is_scoped_to_authenticated_user(): void
+    {
+        [$company, $employee] = $this->aiFixture();
+        $other = Employee::factory()->create(['company_id' => $company->id]);
+        Sanctum::actingAs($other);
+
+        $pendingId = app(PendingActionStore::class)->store(
+            $company->id,
+            $employee->id,
+            'create_absence',
+            ['start_date' => '2026-06-10', 'end_date' => '2026-06-11'],
+        );
+
+        $this->postJson("/api/v1/ai/actions/{$pendingId}/confirm")->assertNotFound();
+        $this->assertDatabaseCount('absences', 0);
+    }
+
+    public function test_confirm_approve_absence_updates_status(): void
+    {
+        [$company, $manager] = $this->aiFixture();
+        $type = $this->seedAbsenceType($company->id);
+        $employee = Employee::factory()->create(['company_id' => $company->id, 'status' => 'active']);
+
+        $absence = Absence::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'absence_type_id' => $type->id,
+            'start_date' => '2026-06-01',
+            'end_date' => '2026-06-02',
+            'days_count' => 2,
+            'status' => 'pending',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $pendingId = app(PendingActionStore::class)->store(
+            $company->id,
+            $manager->id,
+            'approve_absence',
+            ['absence_id' => $absence->id],
+        );
+
+        $this->postJson("/api/v1/ai/actions/{$pendingId}/confirm")
+            ->assertOk()
+            ->assertJsonPath('data.result.status', 'approved');
+
+        $this->assertDatabaseHas('absences', [
+            'id' => $absence->id,
+            'status' => 'approved',
+            'approved_by' => $manager->id,
+        ]);
+    }
+
+    public function test_orchestrator_returns_pending_confirmations_for_write_tools(): void
+    {
+        [$company, $employee] = $this->aiFixture();
+        Sanctum::actingAs($employee);
+        $this->fakeLlmClientWithWriteToolCall();
+
+        $this->postJson('/api/v1/ai/chat', ['message' => 'Demande un conge'])
+            ->assertOk()
+            ->assertJsonPath('data.pending_confirmations.0.status', 'confirmation_required')
+            ->assertJsonPath('data.pending_confirmations.0.tool', 'create_absence');
+
+        $this->assertDatabaseCount('absences', 0);
+    }
+
+    private function fakeLlmClientWithWriteToolCall(): void
+    {
+        $this->app->instance(LLMClient::class, new class implements LLMClient
+        {
+            public function chat(array $messages, array $tools = []): AIResponse
+            {
+                return new AIResponse(
+                    content: 'Je prepare la demande.',
+                    toolCalls: [
+                        new ToolCall('call_1', 'create_absence', [
+                            'start_date' => '2026-06-10',
+                            'end_date' => '2026-06-12',
+                        ]),
+                    ],
+                    inputTokens: 5,
+                    outputTokens: 8,
+                    model: 'test-model',
+                );
+            }
+
+            public function provider(): string
+            {
+                return 'test';
+            }
+        });
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee}
+     */
+    private function aiFixture(): array
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        return [$company, $employee];
+    }
+
+    private function seedAbsenceType(string $companyId): AbsenceType
+    {
+        return AbsenceType::create([
+            'company_id' => $companyId,
+            'name' => 'Conges payes',
+            'code' => 'CP',
+            'is_paid' => true,
+            'deducts_leave' => true,
+            'requires_proof' => false,
+        ]);
+    }
+}

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -489,6 +489,13 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 - `DELETE /api/ai/chat/{conversationId}` supprime une conversation
 - Isolation tenant : chaque utilisateur ne voit que ses conversations dans son entreprise
 
+### Actions write IA avec confirmation
+- Les outils write (`create_absence`, `approve_absence`, etc.) retournent `confirmation_required` avec `pending_action_id` sans mutation immediate
+- `POST /api/v1/ai/actions/{pendingActionId}/confirm` execute l'action apres validation utilisateur
+- `POST /api/v1/ai/actions/{pendingActionId}/reject` annule l'action en attente
+- Isolation : un utilisateur ne peut confirmer que ses propres actions pending dans son tenant
+- Couverture Feature : `AIWriteActionConfirmationTest` (confirmation, rejet, approve_absence, orchestrator pending_confirmations)
+
 ### Tool Registry
 - `GET /api/ai/tools` liste les outils IA actifs (debug/admin)
 - Les outils sont filtrés par role (employee, manager, admin)

--- a/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
+++ b/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
@@ -41,10 +41,10 @@
 | A3 | Creer middleware `ApiVersion` | T-ARCH-09 | 1j | DONE |
 | A4 | Creer `docs/architecture/PARTITIONING.md` | T-ARCH-15 | 0.5j | MEDIUM |
 | A5 | DDD migration progressive controllers existants | T-ARCH-02 | 5j+ | LOW |
-| A6 | Tests Feature rapport RH dedies | T-MOD-H4 | 1j | MEDIUM |
-| A7 | Test Feature chaine hierarchique org chart | Plan 02 | 0.5j | LOW |
-| A8 | Export CSV audit logs | Plan 02 | 0.5j | LOW |
-| A9 | `.pre-commit-config.yaml` | T-CI-06 | 0.5j | MEDIUM |
+| A6 | Tests Feature rapport RH dedies | T-MOD-H4 | 1j | DONE |
+| A7 | Test Feature chaine hierarchique org chart | Plan 02 | 0.5j | DONE |
+| A8 | Export CSV audit logs | Plan 02 | 0.5j | DONE |
+| A9 | `.pre-commit-config.yaml` | T-CI-06 | 0.5j | DONE |
 | A10 | Documenter worker deployment (DEPLOYMENT_GUIDE) | T-ARCH-20 | 0.5j | MEDIUM |
 | A11 | Documentation API tracking dans OpenAPI | T-TRACK-14 | 1j | HIGH |
 
@@ -65,7 +65,7 @@
 |---|-------|--------|--------|----------|
 | C1 | Outils write avec confirmation | T-IA-15/16 | 2j | MEDIUM |
 | C2 | Dashboard admin analytics IA | T-IA-18 | 1j | LOW |
-| C3 | Tests actions write | T-IA-19 | 1j | MEDIUM |
+| C3 | Tests actions write | T-IA-19 | 1j | DONE |
 | C4 | Whisper API pour STT | T-IA-21 | 1j | LOW |
 | C5 | Edge TTS synthese vocale | T-IA-22 | 1j | LOW |
 | C6 | Pipeline voice complet | T-IA-23 | 2j | LOW |
@@ -208,6 +208,7 @@
 
 ### Iteration 3 — Tests Feature manquants + pre-commit
 **Cible** : A6, A7, A8, A9, C3
+**Statut** : COMPLETE (A6-A9, C3) — PR #463 + lot iteration 3 pre-commit/IA write (2026-05-15).
 **Contenu** :
 - Tests rapports RH dedies
 - Test chaine hierarchique org chart


### PR DESCRIPTION
## Summary
- Complete plan 15 iteration 3 (A9 + C3) after PR #463 (A6-A8).
- AI write tools require human confirmation via pending_action_id; confirm/reject endpoints.
- AIWriteActionConfirmationTest (6 tests) + orchestrator pending_confirmations.
- Pre-commit: Pint on staged API PHP, secrets baseline, hook polish.

## Test plan
- [x] PHP syntax on new files
- [ ] GitHub Actions backend + coverage green
- [ ] Spot-check POST /api/v1/ai/actions/{id}/confirm after chat proposes create_absence

Made with [Cursor](https://cursor.com)