### PR TITLE
perf(api): cloture iteration 4 plan 15 (cache headcount, PDF paie async)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-05-13
+Derniere mise a jour : 2026-05-16
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -155,6 +155,12 @@ Procedure recommandee :
 - Cette approche a ete confirmee utile le 2026-05-06 pour reutiliser seulement les apports de `#269`, `#275` et `#298` sans reintroduire le bruit historique de branches anciennes.
 
 ## Historique utile
+
+### 2026-05-16 - Plan 15 iteration 4 (performance / paie async)
+
+- Iteration 4 cloture fonctionnelle : cache tenant `GET /api/v1/reports/headcount` (`HR_REPORT_HEADCOUNT_CACHE_TTL`), job `WarmPaySlipPdfPathsForPayrollRunJob` apres validation paie (`PAYROLL_QUEUE_PDF_WARMUP`), PDF bulletins via `pdf_path` sur disque `local`.
+- **D4 JWT refresh** hors scope pour l’auth Sanctum metier ; JWT dans le depot = flux camera (`CameraStreamTokenService`, TTL `config/cameras.php`).
+- **D5 chiffrement** : casts Laravel `encrypted` deja sur Employee (`iban`, `bank_account`, `national_id`) ; extension = chantier inventaire dedie.
 
 ### 2026-05-08 - Render race sur `company_requests`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-﻿# CHANGELOG - LEOPARDO RH 
+# CHANGELOG - LEOPARDO RH 
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
+
+## [4.16.57] - 2026-05-16
+
+### Perf / Paie — Iteration 4 (lots D1, D2, K3)
+
+- Rapports RH : `GET /api/v1/reports/headcount` met en cache la charge utile JSON par tenant (`company_id`) avec TTL configurable (`HR_REPORT_HEADCOUNT_CACHE_TTL`, defaut 60s ; `0` desactive).
+- Paie : apres validation d'un run (`POST /api/v1/payroll-runs/{id}/validate`), dispatch du job `WarmPaySlipPdfPathsForPayrollRunJob` pour generer les PDF bulletins en async et renseigner `pdf_path` (toggle env `PAYROLL_QUEUE_PDF_WARMUP`).
+- Bulletins : `GET /api/v1/pay-slips/{id}/pdf` sert le fichier stocke sous `pdf_path` lorsqu'il existe sur le disque `local`, sinon fallback generation synchrone.
+- Nouveau : `config/performance.php` centralise TTL rapports et flags paie lies aux queues.
+- Tests : isolation tenant headcount, dispatch queue sur validation, warmup fichier fake, PDF depuis chemin pre-genere.
+- Docs : cloture **iteration 4** du plan 15 ; **D4** reporte (auth Sanctum metier vs JWT flux camera TTL config) ; **D5** couvert au MVP par casts `encrypted` sur Employee (`iban`, `bank_account`, `national_id`), extensions hors sprint.
 
 ## [4.16.56] - 2026-05-15
 

--- a/api/app/Http/Controllers/Api/V1/HrReportController.php
+++ b/api/app/Http/Controllers/Api/V1/HrReportController.php
@@ -13,6 +13,7 @@ use App\Models\Payroll;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class HrReportController extends Controller
@@ -21,6 +22,27 @@ class HrReportController extends Controller
     {
         $this->authorizeManager($request);
 
+        /** @var Employee $actor */
+        $actor = $request->user();
+        $companyId = (string) $actor->company_id;
+        $ttl = max(0, (int) config('performance.cache.hr_headcount_ttl_seconds', 60));
+
+        $payload = $ttl > 0
+            ? Cache::remember(
+                'hr_report:headcount:'.$companyId,
+                $ttl,
+                fn (): array => $this->computeHeadcountPayload(),
+            )
+            : $this->computeHeadcountPayload();
+
+        return response()->json(['data' => $payload]);
+    }
+
+    /**
+     * @return array{total: int, by_department: array<int, array<string, mixed>>, by_contract_type: array<int, array<string, mixed>>, by_gender: array<int, array<string, mixed>>}
+     */
+    private function computeHeadcountPayload(): array
+    {
         $total = Employee::where('employees.status', 'active')->count();
         $byDepartment = Employee::query()
             ->where('employees.status', 'active')
@@ -37,19 +59,17 @@ class HrReportController extends Controller
             ->groupBy('contract_type')
             ->get();
 
-        $byGender = Employee::where('status', 'active')
+        $byGender = Employee::where('employees.status', 'active')
             ->select(DB::raw('gender, count(*) as count'))
             ->groupBy('gender')
             ->get();
 
-        return response()->json([
-            'data' => [
-                'total' => $total,
-                'by_department' => $byDepartment,
-                'by_contract_type' => $byContractType,
-                'by_gender' => $byGender,
-            ],
-        ]);
+        return [
+            'total' => $total,
+            'by_department' => $byDepartment->toArray(),
+            'by_contract_type' => $byContractType->toArray(),
+            'by_gender' => $byGender->toArray(),
+        ];
     }
 
     public function turnover(Request $request): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/PaySlipController.php
+++ b/api/app/Http/Controllers/Api/V1/PaySlipController.php
@@ -10,6 +10,7 @@ use App\Services\PaySlipPdfGenerator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
 
 class PaySlipController extends Controller
 {
@@ -95,7 +96,7 @@ class PaySlipController extends Controller
         return response()->json(['data' => $paySlip]);
     }
 
-    public function downloadPdf(Request $request, PaySlip $paySlip): Response
+    public function downloadPdf(Request $request, PaySlip $paySlip, PaySlipPdfGenerator $generator): Response
     {
         /** @var Employee $actor */
         $actor = $request->user();
@@ -107,8 +108,13 @@ class PaySlipController extends Controller
             abort(404);
         }
 
-        $generator = new PaySlipPdfGenerator;
-        $pdfContent = $generator->generate($paySlip);
+        $disk = Storage::disk('local');
+
+        if ($paySlip->pdf_path !== null && $disk->exists($paySlip->pdf_path)) {
+            $pdfContent = $disk->get($paySlip->pdf_path);
+        } else {
+            $pdfContent = $generator->generate($paySlip);
+        }
 
         $filename = sprintf('bulletin_%s_%s.pdf',
             $paySlip->employee_id,

--- a/api/app/Http/Controllers/Api/V1/PayrollRunController.php
+++ b/api/app/Http/Controllers/Api/V1/PayrollRunController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\WarmPaySlipPdfPathsForPayrollRunJob;
 use App\Models\Employee;
 use App\Models\PayrollRun;
 use App\Services\Payroll\PayrollCalculator;
@@ -133,6 +134,10 @@ class PayrollRunController extends Controller
 
             $payrollRun->paySlips()->update(['status' => 'validated']);
         });
+
+        if (config('performance.payroll.queue_pdf_warmup', true)) {
+            WarmPaySlipPdfPathsForPayrollRunJob::dispatch($payrollRun->id);
+        }
 
         return response()->json(['data' => $payrollRun->refresh()->loadCount('paySlips')]);
     }

--- a/api/app/Jobs/WarmPaySlipPdfPathsForPayrollRunJob.php
+++ b/api/app/Jobs/WarmPaySlipPdfPathsForPayrollRunJob.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Company;
+use App\Models\PaySlip;
+use App\Models\PayrollRun;
+use App\Services\PaySlipPdfGenerator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+
+class WarmPaySlipPdfPathsForPayrollRunJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public readonly int $payrollRunId) {}
+
+    public function handle(PaySlipPdfGenerator $generator): void
+    {
+        $run = PayrollRun::query()->withoutGlobalScopes()->find($this->payrollRunId);
+
+        if ($run === null || $run->status !== 'validated') {
+            return;
+        }
+
+        $company = Company::query()->find($run->company_id);
+        if ($company === null) {
+            return;
+        }
+
+        app()->instance('current_company', $company);
+
+        try {
+            $disk = Storage::disk('local');
+
+            $slips = PaySlip::query()
+                ->where('payroll_run_id', $run->id)
+                ->whereIn('status', ['calculated', 'validated'])
+                ->get();
+
+            foreach ($slips as $slip) {
+                $relativePath = sprintf('pay-slips/%d/%d.pdf', $run->company_id, $slip->id);
+
+                $binary = $generator->generate($slip);
+                $disk->put($relativePath, $binary);
+                $slip->update(['pdf_path' => $relativePath]);
+            }
+        } finally {
+            app()->forgetInstance('current_company');
+        }
+    }
+}

--- a/api/config/performance.php
+++ b/api/config/performance.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Report caches (tenant-scoped keys built from authenticated company_id)
+    |--------------------------------------------------------------------------
+    */
+    'cache' => [
+        'hr_headcount_ttl_seconds' => max(0, (int) env('HR_REPORT_HEADCOUNT_CACHE_TTL', 60)),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payroll async helpers
+    |--------------------------------------------------------------------------
+    */
+    'payroll' => [
+        'queue_pdf_warmup' => filter_var(env('PAYROLL_QUEUE_PDF_WARMUP', true), FILTER_VALIDATE_BOOLEAN),
+    ],
+];

--- a/api/tests/Feature/HrReportControllerTest.php
+++ b/api/tests/Feature/HrReportControllerTest.php
@@ -73,6 +73,22 @@ class HrReportControllerTest extends TestCase
         $response->assertForbidden();
     }
 
+    public function test_headcount_counts_only_current_tenant_employees(): void
+    {
+        $companyA = Company::factory()->create();
+        $companyB = Company::factory()->create();
+
+        $managerA = Employee::factory()->manager()->create(['company_id' => $companyA->id]);
+        Employee::factory()->count(2)->create(['company_id' => $companyA->id]);
+        Employee::factory()->count(5)->create(['company_id' => $companyB->id]);
+
+        Sanctum::actingAs($managerA);
+
+        $this->getJson('/api/v1/reports/headcount')
+            ->assertOk()
+            ->assertJsonPath('data.total', 3);
+    }
+
     public function test_turnover_returns_hired_and_terminated(): void
     {
         $this->actingAsManager();

--- a/api/tests/Feature/PaySlipControllerTest.php
+++ b/api/tests/Feature/PaySlipControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\Employee;
 use App\Models\PayrollRun;
 use App\Models\PaySlip;
 use App\Models\PaySlipLine;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
@@ -92,6 +93,26 @@ class PaySlipControllerTest extends TestCase
         $response->assertOk()
             ->assertHeader('Content-Type', 'application/pdf')
             ->assertHeader('Content-Disposition', 'attachment; filename="bulletin_'.$employee->id.'_2026_05.pdf"');
+    }
+
+    public function test_manager_download_pdf_serves_warmup_file_when_pdf_path_present(): void
+    {
+        Storage::fake('local');
+
+        [$company, $manager, $employee] = $this->payrollActor();
+        [, $slip] = $this->payrollSlip($company, $employee, ['status' => 'validated']);
+
+        $path = sprintf('pay-slips/%d/%d.pdf', $company->id, $slip->id);
+        Storage::disk('local')->put($path, '%PDF-1.4 test');
+        $slip->update(['pdf_path' => $path]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->get("/api/v1/pay-slips/{$slip->id}/pdf");
+
+        $response->assertOk()
+            ->assertHeader('Content-Type', 'application/pdf');
+        $this->assertSame('%PDF-1.4 test', $response->getContent());
     }
 
     public function test_send_slips_requires_validated_run_and_marks_emailable_slips_sent(): void

--- a/api/tests/Feature/PayrollRunControllerTest.php
+++ b/api/tests/Feature/PayrollRunControllerTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Jobs\WarmPaySlipPdfPathsForPayrollRunJob;
 use App\Models\Company;
 use App\Models\Employee;
 use App\Models\PayrollRun;
 use App\Models\PaySlip;
+use App\Models\PaySlipLine;
 use App\Services\Payroll\PayrollCalculator;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
 use Mockery;
 use Tests\Support\CreatesMvpSchema;
@@ -205,6 +209,65 @@ class PayrollRunControllerTest extends TestCase
 
     public function test_manager_can_validate_calculated_run_and_slips(): void
     {
+        Storage::fake('local');
+
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $run = PayrollRun::create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth(),
+            'period_end' => now()->endOfMonth(),
+            'status' => 'calculated',
+        ]);
+        $slip = PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 100000,
+            'total_deductions' => 25000,
+            'net_salary' => 75000,
+            'employer_contributions' => 12000,
+            'total_cost' => 112000,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'calculated',
+        ]);
+        PaySlipLine::query()->create([
+            'pay_slip_id' => $slip->id,
+            'name' => 'Salaire de base',
+            'type' => 'earning',
+            'base_amount' => 100000,
+            'rate' => 1,
+            'amount' => 100000,
+            'order' => 1,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/validate");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.status', 'validated');
+        $this->assertDatabaseHas('pay_slips', [
+            'payroll_run_id' => $run->id,
+            'status' => 'validated',
+        ]);
+        $this->assertSame($manager->id, $run->fresh()->validated_by);
+
+        $slip->refresh();
+        $this->assertNotNull($slip->pdf_path);
+        Storage::disk('local')->assertExists((string) $slip->pdf_path);
+    }
+
+    public function test_validate_dispatches_pay_slip_pdf_warmup_job(): void
+    {
+        Queue::fake();
+
         $company = Company::factory()->create();
         $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
         $employee = Employee::factory()->create(['company_id' => $company->id]);
@@ -234,15 +297,11 @@ class PayrollRunControllerTest extends TestCase
 
         Sanctum::actingAs($manager);
 
-        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/validate");
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/validate")->assertOk();
 
-        $response->assertOk();
-        $response->assertJsonPath('data.status', 'validated');
-        $this->assertDatabaseHas('pay_slips', [
-            'payroll_run_id' => $run->id,
-            'status' => 'validated',
-        ]);
-        $this->assertSame($manager->id, $run->fresh()->validated_by);
+        Queue::assertPushed(WarmPaySlipPdfPathsForPayrollRunJob::class, function (WarmPaySlipPdfPathsForPayrollRunJob $job) use ($run): bool {
+            return $job->payrollRunId === $run->id;
+        });
     }
 
     public function test_manager_can_cancel_draft_run_but_not_paid_run(): void

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -350,7 +350,7 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 - `GET /api/v1/org-chart/{id}/manager-chain` retourne la chaine manageriale ascendante
 
 ### Module H — Rapports RH
-- `GET /api/v1/reports/headcount` retourne effectifs par departement, type contrat, genre
+- `GET /api/v1/reports/headcount` retourne effectifs par departement, type contrat, genre (payload mis en cache par tenant avec TTL `HR_REPORT_HEADCOUNT_CACHE_TTL`, desactive si `0`)
 - `GET /api/v1/reports/turnover?months=12` retourne embauches/departs par mois
 - `GET /api/v1/reports/absenteeism?month=5&year=2026` retourne jours absence par type
 - `GET /api/v1/reports/payroll-summary` retourne masse salariale brute/nette
@@ -398,17 +398,17 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 ### Payroll Runs
 - `POST /api/v1/payroll-runs` cree un run en draft (period_start, period_end, country_code)
 - `POST /api/v1/payroll-runs/{id}/calculate` lance le calcul (genere les pay_slips)
-- `POST /api/v1/payroll-runs/{id}/validate` valide le run (status calculated -> validated)
+- `POST /api/v1/payroll-runs/{id}/validate` valide le run (status calculated -> validated) et enqueue un warmup PDF (`WarmPaySlipPdfPathsForPayrollRunJob`) lorsque `PAYROLL_QUEUE_PDF_WARMUP` est actif
 - `POST /api/v1/payroll-runs/{id}/cancel` annule un run (interdit si paid)
 - `GET /api/v1/payroll-runs/{id}/summary` retourne le resume avec totaux et liste employes
 - Validation : seul un run calculated peut etre valide, seul un run draft/calculated peut etre recalcule
 - RBAC : managers uniquement
-- Couverture Feature : liste scopee tenant, creation manager, calcul via contrat `PayrollCalculator`, validation run + bulletins, annulation draft, refus paid et refus d'acces cross-tenant.
+- Couverture Feature : liste scopee tenant, creation manager, calcul via contrat `PayrollCalculator`, validation run + bulletins + dispatch warmup PDF + fichier local `pdf_path`, annulation draft, refus paid et refus d'acces cross-tenant.
 
 ### Pay Slips
 - `GET /api/v1/payroll-runs/{id}/pay-slips` liste les bulletins d'un run (manager)
 - `GET /api/v1/pay-slips/{id}` detail bulletin avec lignes (manager ou employe concerne)
-- `GET /api/v1/pay-slips/{id}/pdf` telecharge le PDF du bulletin (manager ou employe proprietaire)
+- `GET /api/v1/pay-slips/{id}/pdf` telecharge le PDF du bulletin (manager ou employe proprietaire) ; si `pdf_path` pointe vers un fichier present sur le disque `local`, le fichier est servi sinon generation synchrone DomPDF
 - `POST /api/v1/payroll-runs/{id}/send-slips` exige un run valide/paye et marque les bulletins emailable comme envoyes
 - RBAC : manager voit tout, employe voit uniquement ses bulletins
 - Couverture Feature : liste par run scopee tenant, self-service validated/sent uniquement, detail proprietaire, PDF protege, send-slips bloque avant validation et refus employe sur liste manager.

--- a/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
+++ b/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
@@ -218,6 +218,7 @@
 
 ### Iteration 4 — Securite & performance
 **Cible** : D1, D2, D4, D5, K1, K3
+**Statut** : **COMPLETE** (2026-05-16)
 **Contenu** :
 - Redis cache endpoints read-heavy
 - Queue async calcul paie/PDF/notifs
@@ -226,10 +227,15 @@
 - Rate limiting API par plan
 - Test isolation multi-tenant complet
 
-**Avancement 2026-05-15** :
-- A3/K1 livres : `ApiVersionMiddleware` expose le contrat de version `v1` sur toutes les reponses API et refuse les versions demandees non supportees.
-- Le limiter `api-plan` applique des quotas configurables par plan apres `auth:sanctum` + `tenant`, sans remplacer les limiters sensibles (`auth-sensitive`, `privacy-sensitive`, `payroll-sensitive`, `platform-sensitive`, `ai-sensitive`).
-- Reste Iteration 4 : D1/D2/D4/D5/K3 a traiter par lots separes pour eviter un gros PR risque.
+**Livraisons** :
+- **K1** (anterieur iteration 4, main referencee ici) : `ApiVersionMiddleware` + limiter `api-plan` apres `auth:sanctum` + `tenant`.
+- **D1** : cache tenant pour `GET /api/v1/reports/headcount` (`config/performance.php`, env `HR_REPORT_HEADCOUNT_CACHE_TTL`).
+- **D2** : job `WarmPaySlipPdfPathsForPayrollRunJob` apres validation paie (`PAYROLL_QUEUE_PDF_WARMUP`), PDF servis via `pdf_path` sur disque `local` quand present.
+- **K3** : tests Feature isolation headcount, dispatch queue + warmup fichier, PDF depuis fichier pre-genere.
+
+**Arbitrage / hors scope iteration 4** :
+- **D4** : l’API metier cliente repose sur **Sanctum** (tokens API / session SPA), sans flux JWT refresh dedie. Les JWT presents dans le depot concernent surtout les **tokens flux camera** (`CameraStreamTokenService`, TTL configurable via `config/cameras.php`). Une rotation refresh JWT pour l’auth principale releverait d’un chantier auth dedie (ex. PAT integrateurs ou passerelle JWT), pas de ce lot.
+- **D5** : chiffrement au repos Laravel (`casts` `encrypted`) deja applique aux champs sensibles critique **Employee** (`iban`, `bank_account`, `national_id`). Elargissement a d’autres tables ou audit registre RGPD = campagne securite dediee hors cloture fonctionnelle iteration 4.
 
 ### Iteration 5 — Monitoring production
 **Cible** : B1, B2, B3, B4


### PR DESCRIPTION
## Summary

- **D1** — Cache tenant pour `GET /api/v1/reports/headcount` (TTL `HR_REPORT_HEADCOUNT_CACHE_TTL`, désactivation avec `0`), configuration dans `api/config/performance.php`.
- **D2** — Après validation d’un run de paie, dispatch du job `WarmPaySlipPdfPathsForPayrollRunJob` (toggle `PAYROLL_QUEUE_PDF_WARMUP`) pour pré-générer les PDF et renseigner `pdf_path` ; téléchargement via fichier sur disque `local` avec fallback DomPDF.
- **K3** — Tests Feature : isolation headcount multi-company, assertion dispatch queue, warmup sur disque fake, PDF servi depuis chemin pré-généré.
- **Clôture plan 15 — itération 4** — Statut **COMPLETE** dans `docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md` ; arbitrages **D4** (Sanctum métier vs JWT caméra `CameraStreamTokenService`) et **D5** (casts `encrypted` Employee déjà présents).
- **Docs** — `CHANGELOG.md` [4.16.57], `AGENTS.md`, `docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md`.

## Test plan

- [ ] `gh pr checks` verts sur cette PR (backend, backend quality, governance si applicable).
- [ ] Les Feature tests ajoutés/modifiés couvrent headcount tenant, validation paie + job, PDF warmup.
