### PR TITLE
feat(admin-dashboard): alignement paie et conges API v1 (iteration 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-# CHANGELOG - LEOPARDO RH 
+﻿# CHANGELOG - LEOPARDO RH 
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
+
+## [4.16.58] - 2026-05-16
+
+### Admin-dashboard — Iteration 6 (lot paie / conges)
+
+- Paie (`PayrollView`) : chargement pagine des runs, bulletins agrégés par run (`pay-slips`), calcul/validation reels, résumé run (`summary`), PDF via axios blob authentifié, export CSV navigateur (sans routes `/export/*` fictives).
+- Congés (`LeavesView`) : soldes et politiques via API reelles ; approbation `PUT /absences/{id}/approve`, refus `PUT .../reject` avec `rejected_reason` ; pagination absences absorbée côté SPA.
+- API : liste absences enrichie (`employee_name`, `type`) pour les tableaux manager.
 
 ## [4.16.57] - 2026-05-16
 

--- a/api/app/Http/Controllers/Api/V1/AbsenceController.php
+++ b/api/app/Http/Controllers/Api/V1/AbsenceController.php
@@ -37,7 +37,10 @@ class AbsenceController extends Controller
                 'created_at',
                 'updated_at',
             ])
-            ->with('absenceType:id,name,code,deducts_leave');
+            ->with([
+                'absenceType:id,name,code,deducts_leave',
+                'employee:id,first_name,last_name',
+            ]);
 
         // RBAC: employee sees only own absences
         if (! $actor->isManager()) {
@@ -172,6 +175,12 @@ class AbsenceController extends Controller
                 'code' => $absence->absenceType->code,
                 'deducts_leave' => $absence->absenceType->deducts_leave,
             ] : null,
+            'employee_name' => $absence->relationLoaded('employee') && $absence->employee !== null
+                ? trim(($absence->employee->first_name ?? '').' '.($absence->employee->last_name ?? ''))
+                : null,
+            'type' => $absence->relationLoaded('absenceType') && $absence->absenceType !== null
+                ? $absence->absenceType->name
+                : null,
             'start_date' => $absence->start_date?->toDateString(),
             'end_date' => $absence->end_date?->toDateString(),
             'days_count' => $absence->days_count,

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -119,6 +119,7 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 - Chevauchement de periodes refuse
 - Consultation historique des demandes par role
 - Employee ne peut pas valider sa propre demande sans permission speciale
+- Liste paginee `GET /api/v1/absences` expose pour le dashboard manager les champs derives `employee_name` et `type` (nom du type d'absence) en plus des relations `absence_type` / `absenceType`
 
 ### 8. Paie / finance
 

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS.md
@@ -78,6 +78,15 @@ Donner une base de scenarios stable pour le dashboard `front/admin-dashboard/`, 
 - les actions approuver/rejeter envoient `PATCH /api/v1/platform/company-requests/{id}` avec notes internes
 - une demande deja traitee ne propose plus d'action de decision
 
+### 8. Paie et conges (tenant manager)
+
+- La vue `/payroll` charge les runs via `GET /api/v1/payroll-runs` (pagination absorbee cote SPA), agrege les bulletins via `GET /api/v1/payroll-runs/{id}/pay-slips`, actions Calculer/Valider via POST calculate/validate
+- Le resume run utilise `GET /api/v1/payroll-runs/{id}/summary`
+- Le telechargement PDF bulletin passe par la session axios (`Authorization`) avec `responseType: blob`, pas par lien nu `/api/...`
+- Les exports CSV paie sont generes cote navigateur depuis les lignes chargees (pas de routes `/export/*` inventees)
+- La vue `/leaves` charge `GET /api/v1/absences`, `GET /api/v1/leave-balances`, `GET /api/v1/leave-policies`
+- Approbation / refus utilisent `PUT /api/v1/absences/{id}/approve` et `PUT .../reject` avec corps `{ rejected_reason }`
+
 ## Artefacts obligatoires
 
 - rapport HTML Playwright
@@ -98,7 +107,7 @@ En revanche, elles doivent etre conservees automatiquement en cas d'echec Playwr
 
 ## Extension i18n enterprise
 
-### 8. Locales, dictionnaires et direction
+### Locales enterprise (extension)
 
 - Les dictionnaires generes dans `front/admin-dashboard/src/i18n/locales/` restent synchronises avec `shared/i18n/locales/`
 - Une locale variante (`fr-CA`, `en-GB`, `ar-SA`) est normalisee sans casser le rendu

--- a/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
+++ b/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
@@ -247,6 +247,7 @@
 
 ### Iteration 6 — Frontend admin dashboard (ecrans prioritaires)
 **Cible** : E10, E11, E1, E2
+**Avancement 2026-05-16** : premier lot alignement SPA — `front/admin-dashboard/src/views/payroll/PayrollView.vue` et `.../leaves/LeavesView.vue` sur les endpoints `/api/v1/payroll-runs`, `/pay-slips`, `/absences` (PUT approve/reject), `/leave-balances`, `/leave-policies`.
 **Contenu** :
 - Composants partages (DataTable, MetricCard, etc.)
 - Layout navigation nouveaux modules

--- a/front/admin-dashboard/src/views/leaves/LeavesView.vue
+++ b/front/admin-dashboard/src/views/leaves/LeavesView.vue
@@ -2,15 +2,16 @@
   <div class="space-y-6">
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
       <StatsCard title="Demandes en attente" :value="stats.pending" icon="ChartBarIcon" color="yellow" />
-      <StatsCard title="Approuvees ce mois" :value="stats.approved" icon="ChartBarIcon" color="green" />
-      <StatsCard title="Taux d'absence" :value="stats.absence_rate + '%'" icon="UsersIcon" color="blue" />
-      <StatsCard title="Jours restants (moy)" :value="stats.avg_balance" icon="ChartBarIcon" color="purple" />
+      <StatsCard title="Approuvees ce mois" :value="stats.approved_this_month" icon="ChartBarIcon" color="green" />
+      <StatsCard title="Demandes (total charge)" :value="stats.total_requests" icon="UsersIcon" color="blue" />
+      <StatsCard title="Solde restant (moy.)" :value="stats.avg_balance" icon="ChartBarIcon" color="purple" />
     </div>
 
     <div class="flex gap-2">
       <button
         v-for="tab in tabs"
         :key="tab.key"
+        type="button"
         :class="[
           'rounded-md px-4 py-2 text-sm font-medium',
           activeTab === tab.key ? 'bg-indigo-600 text-white' : 'bg-white text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50'
@@ -36,7 +37,7 @@
         <StatusBadge :status="value" />
       </template>
       <template #cell-days="{ row }">
-        {{ computeDays(row.start_date, row.end_date) }}j
+        {{ formatDays(row) }}
       </template>
       <template #row-actions="{ row }">
         <ApprovalWidget
@@ -62,8 +63,12 @@
     />
 
     <div v-else class="rounded-lg bg-white p-6 shadow">
-      <h2 class="mb-4 text-lg font-semibold text-gray-900">Politiques de conges</h2>
-      <div v-if="loading" class="text-sm text-gray-500">Chargement...</div>
+      <h2 class="mb-4 text-lg font-semibold text-gray-900">
+        Politiques de conges
+      </h2>
+      <div v-if="loading" class="text-sm text-gray-500">
+        Chargement...
+      </div>
       <div v-else class="space-y-3">
         <div
           v-for="policy in policies"
@@ -71,12 +76,23 @@
           class="flex items-center justify-between rounded-md border border-gray-200 p-4"
         >
           <div>
-            <p class="font-medium text-gray-900">{{ policy.name }}</p>
-            <p class="text-sm text-gray-500">{{ policy.days_per_year }}j/an &middot; Accumulation : {{ policy.accrual_type }}</p>
+            <p class="font-medium text-gray-900">
+              {{ policy.name }}
+            </p>
+            <p class="text-sm text-gray-500">
+              {{ formatPolicyDetail(policy) }}
+            </p>
           </div>
-          <StatusBadge :status="policy.is_active ? 'active' : 'draft'" />
+          <span
+            class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium"
+            :class="policy.active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-700'"
+          >
+            {{ policy.active ? 'Actif' : 'Inactive' }}
+          </span>
         </div>
-        <div v-if="policies.length === 0" class="text-sm text-gray-400">Aucune politique configuree.</div>
+        <div v-if="policies.length === 0" class="text-sm text-gray-400">
+          Aucune politique configuree.
+        </div>
       </div>
     </div>
   </div>
@@ -97,12 +113,17 @@ const balances = ref([])
 const policies = ref([])
 const activeTab = ref('requests')
 
-const stats = ref({ pending: 0, approved: 0, absence_rate: 0, avg_balance: 0 })
+const stats = ref({
+  pending: 0,
+  approved_this_month: 0,
+  total_requests: 0,
+  avg_balance: 0,
+})
 
 const tabs = [
   { key: 'requests', label: 'Demandes' },
   { key: 'balances', label: 'Soldes' },
-  { key: 'policies', label: 'Politiques' }
+  { key: 'policies', label: 'Politiques' },
 ]
 
 const requestColumns = [
@@ -117,36 +138,117 @@ const requestColumns = [
 const balanceColumns = [
   { key: 'employee_name', label: 'Employe', sortable: true },
   { key: 'policy_name', label: 'Politique', sortable: true },
-  { key: 'total_days', label: 'Total', sortable: true },
+  { key: 'total_days', label: 'Potentiel', sortable: true },
   { key: 'used_days', label: 'Utilises', sortable: true },
   { key: 'remaining_days', label: 'Restants', sortable: true },
 ]
 
-function computeDays(start, end) {
+function computeCalendarDays(start, end) {
   if (!start || !end) return '-'
   const diff = new Date(end) - new Date(start)
   return Math.ceil(diff / (1000 * 60 * 60 * 24)) + 1
+}
+
+function formatDays(row) {
+  if (row.days_count != null && row.days_count !== '') {
+    return `${row.days_count}j`
+  }
+  const d = computeCalendarDays(row.start_date, row.end_date)
+  return d === '-' ? '-' : `${d}j`
+}
+
+function formatPolicyDetail(policy) {
+  const amt = policy.accrual_amount ?? '-'
+  const typ = policy.accrual_type ?? '-'
+  const carry = policy.carry_forward ? ' · Report autorise' : ''
+  return `${amt} j (${typ})${carry}`
+}
+
+function absenceTypeName(row) {
+  return row.type || row.absence_type?.name || row.absenceType?.name || '-'
+}
+
+async function fetchPaginated(resourceUrl, params = {}) {
+  const rows = []
+  let page = 1
+  let lastPage = 1
+  const perPage = params.per_page ?? 80
+
+  do {
+    const res = await api.get(resourceUrl, { params: { ...params, page, per_page: perPage } })
+    rows.push(...(res.data.data || []))
+    lastPage = Number(res.data.meta?.last_page) || 1
+    page++
+  } while (page <= lastPage && page <= 30)
+
+  return rows
+}
+
+function mapBalanceRow(b) {
+  let employeeName = ''
+  if (b.employee && (b.employee.first_name || b.employee.last_name)) {
+    employeeName = `${b.employee.first_name ?? ''} ${b.employee.last_name ?? ''}`.trim()
+  }
+  const typeLabel = (b.absence_type || b.absenceType)?.name ?? '-'
+  const balance = Number(b.balance) || 0
+  const used = Number(b.used) || 0
+  const pending = Number(b.pending) || 0
+
+  return {
+    employee_name: employeeName || (b.employee_id ? `Employe #${b.employee_id}` : ''),
+    policy_name: typeLabel,
+    total_days: balance + used + pending,
+    used_days: used,
+    remaining_days: balance,
+  }
+}
+
+function isCurrentMonthIso(iso) {
+  if (!iso) return false
+  const d = new Date(iso)
+  const n = new Date()
+  return d.getFullYear() === n.getFullYear() && d.getMonth() === n.getMonth()
 }
 
 async function fetchData() {
   loading.value = true
   error.value = ''
   try {
-    const [absRes, balRes, polRes] = await Promise.all([
-      api.get('/v1/absences'),
-      api.get('/v1/leave-balances').catch(() => ({ data: { data: [] } })),
-      api.get('/v1/leave-policies').catch(() => ({ data: { data: [] } })),
-    ])
-    requests.value = absRes.data.data || absRes.data || []
-    balances.value = balRes.data.data || balRes.data || []
-    policies.value = polRes.data.data || polRes.data || []
+    const absRaw = await fetchPaginated('/v1/absences', { per_page: 80 }).catch(() => [])
+    requests.value = absRaw.map(a => ({
+      ...a,
+      type: absenceTypeName(a),
+      employee_name: a.employee_name || '-',
+    }))
+
+    let balRaw = []
+    try {
+      const balRes = await api.get('/v1/leave-balances')
+      balRaw = balRes.data.data || []
+    } catch {
+      balRaw = []
+    }
+    balances.value = balRaw.map(mapBalanceRow)
+
+    let polRaw = []
+    try {
+      const polRes = await api.get('/v1/leave-policies')
+      polRaw = polRes.data.data || []
+    } catch {
+      polRaw = []
+    }
+    policies.value = polRaw
+
     const pending = requests.value.filter(r => r.status === 'pending')
-    const approved = requests.value.filter(r => r.status === 'approved')
+    const approvedMonth = requests.value.filter(r => r.status === 'approved' && isCurrentMonthIso(r.updated_at))
+
     stats.value = {
       pending: pending.length,
-      approved: approved.length,
-      absence_rate: balances.value.length > 0 ? Math.round(approved.length / balances.value.length * 100) : 0,
-      avg_balance: balances.value.length > 0 ? Math.round(balances.value.reduce((s, b) => s + (b.remaining_days || 0), 0) / balances.value.length) : 0,
+      approved_this_month: approvedMonth.length,
+      total_requests: requests.value.length,
+      avg_balance: balances.value.length > 0
+        ? Math.round(balances.value.reduce((s, b) => s + (Number(b.remaining_days) || 0), 0) / balances.value.length)
+        : 0,
     }
   } catch {
     error.value = 'Impossible de charger les donnees de conges.'
@@ -157,21 +259,44 @@ async function fetchData() {
 
 async function approveRequest(id) {
   try {
-    await api.post(`/v1/absences/${id}/approve`)
-    fetchData()
+    await api.put(`/v1/absences/${id}/approve`)
+    await fetchData()
   } catch (err) {
     console.warn('Failed to approve leave request', err)
   }
 }
+
 async function rejectRequest(id, comment) {
   try {
-    await api.post(`/v1/absences/${id}/reject`, { comment })
-    fetchData()
+    await api.put(`/v1/absences/${id}/reject`, { rejected_reason: comment })
+    await fetchData()
   } catch (err) {
     console.warn('Failed to reject leave request', err)
   }
 }
-function exportBalances() { window.open('/api/v1/export/leave-balances?format=csv', '_blank') }
+
+function escapeCsvCell(value) {
+  const s = String(value ?? '')
+  if (/[;"'\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+function exportBalances() {
+  const header = ['employe', 'politique', 'potentiel', 'utilises', 'restants']
+  const lines = balances.value.map(b =>
+    [b.employee_name, b.policy_name, b.total_days, b.used_days, b.remaining_days].map(escapeCsvCell).join(';'),
+  )
+  const bom = '\ufeff'
+  const blob = new Blob([bom + [header.join(';'), ...lines].join('\n')], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'leave-balances.csv'
+  a.click()
+  URL.revokeObjectURL(url)
+}
 
 onMounted(fetchData)
 </script>

--- a/front/admin-dashboard/src/views/payroll/PayrollView.vue
+++ b/front/admin-dashboard/src/views/payroll/PayrollView.vue
@@ -3,14 +3,74 @@
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
       <StatsCard title="Runs ce mois" :value="stats.runs_this_month" icon="ChartBarIcon" color="blue" />
       <StatsCard title="Bulletins generes" :value="stats.slips_generated" icon="UsersIcon" color="green" />
-      <StatsCard title="Masse salariale" :value="formattedMasse" icon="CurrencyEuroIcon" color="purple" />
+      <StatsCard title="Masse salariale (runs charges)" :value="formattedMasse" icon="CurrencyEuroIcon" color="purple" />
       <StatsCard title="En attente validation" :value="stats.pending_validation" icon="ChartBarIcon" color="yellow" />
+    </div>
+
+    <div v-if="runSummary" class="rounded-lg border border-indigo-200 bg-indigo-50/60 p-4 shadow-sm">
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 class="font-semibold text-gray-900">
+            Resume du run {{ runSummary.run?.id }}
+          </h3>
+          <p class="mt-1 text-sm text-gray-600">
+            {{ formatPeriod(runSummary.run?.period_start, runSummary.run?.period_end) }}
+            · Statut {{ runSummary.run?.status }}
+          </p>
+        </div>
+        <button type="button" class="text-sm font-medium text-gray-600 hover:text-gray-900" @click="runSummary = null">
+          Fermer
+        </button>
+      </div>
+      <dl class="mt-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+        <div>
+          <dt class="text-gray-500">
+            Brut
+          </dt>
+          <dd class="font-medium">
+            {{ formatCurrency(runSummary.total_gross) }}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">
+            Retenues
+          </dt>
+          <dd class="font-medium">
+            {{ formatCurrency(runSummary.total_deductions) }}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">
+            Net
+          </dt>
+          <dd class="font-medium">
+            {{ formatCurrency(runSummary.total_net) }}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">
+            Employes
+          </dt>
+          <dd class="font-medium">
+            {{ runSummary.employee_count }}
+          </dd>
+        </div>
+      </dl>
+      <div v-if="(runSummary.slips || []).length" class="mt-4 max-h-48 overflow-y-auto border-t border-indigo-100 pt-3">
+        <ul class="space-y-1 text-sm">
+          <li v-for="s in runSummary.slips" :key="s.id" class="flex justify-between gap-2">
+            <span>{{ slipEmployeeLabel(s) }}</span>
+            <span class="font-medium">{{ formatCurrency(s.net_salary) }}</span>
+          </li>
+        </ul>
+      </div>
     </div>
 
     <div class="flex gap-2">
       <button
         v-for="tab in tabs"
         :key="tab.key"
+        type="button"
         :class="[
           'rounded-md px-4 py-2 text-sm font-medium',
           activeTab === tab.key ? 'bg-indigo-600 text-white' : 'bg-white text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50'
@@ -42,13 +102,13 @@
       </template>
       <template #row-actions="{ row }">
         <div class="flex justify-end gap-2">
-          <button v-if="row.status === 'draft'" class="text-sm font-medium text-indigo-600 hover:text-indigo-800" @click="calculateRun(row.id)">
+          <button v-if="row.status === 'draft'" type="button" class="text-sm font-medium text-indigo-600 hover:text-indigo-800" @click="calculateRun(row.id)">
             Calculer
           </button>
-          <button v-if="row.status === 'calculated'" class="text-sm font-medium text-green-600 hover:text-green-800" @click="validateRun(row.id)">
+          <button v-if="row.status === 'calculated'" type="button" class="text-sm font-medium text-green-600 hover:text-green-800" @click="validateRun(row.id)">
             Valider
           </button>
-          <button class="text-sm font-medium text-gray-600 hover:text-gray-800" @click="viewRun(row.id)">
+          <button type="button" class="text-sm font-medium text-gray-600 hover:text-gray-800" @click="viewRun(row.id)">
             Detail
           </button>
         </div>
@@ -72,9 +132,9 @@
         {{ formatCurrency(value) }}
       </template>
       <template #row-actions="{ row }">
-        <a :href="`/api/v1/pay-slips/${row.id}/pdf`" target="_blank" class="text-sm font-medium text-indigo-600 hover:text-indigo-800">
+        <button type="button" class="text-sm font-medium text-indigo-600 hover:text-indigo-800" @click="downloadPaySlipPdf(row.id)">
           PDF
-        </a>
+        </button>
       </template>
     </DataTable>
   </div>
@@ -92,12 +152,13 @@ const error = ref('')
 const runs = ref([])
 const slips = ref([])
 const activeTab = ref('runs')
+const runSummary = ref(null)
 
 const stats = ref({ runs_this_month: 0, slips_generated: 0, total_net: 0, pending_validation: 0 })
 
 const tabs = [
   { key: 'runs', label: 'Runs de paie' },
-  { key: 'slips', label: 'Bulletins' }
+  { key: 'slips', label: 'Bulletins' },
 ]
 
 const runColumns = [
@@ -118,35 +179,116 @@ const slipColumns = [
 
 const runStatusMap = {
   draft: { label: 'Brouillon', color: 'gray' },
+  calculating: { label: 'Calcul...', color: 'yellow' },
   calculated: { label: 'Calcule', color: 'yellow' },
   validated: { label: 'Valide', color: 'green' },
+  paid: { label: 'Paye', color: 'green' },
   cancelled: { label: 'Annule', color: 'red' },
 }
 
 const formattedMasse = computed(() => formatCurrency(stats.value.total_net))
 
 function formatCurrency(value) {
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(value || 0)
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(Number(value) || 0)
+}
+
+function formatPeriod(start, end) {
+  if (!start || !end) return '-'
+  const a = typeof start === 'string' ? start.slice(0, 10) : start
+  const b = typeof end === 'string' ? end.slice(0, 10) : end
+  return `${a} → ${b}`
+}
+
+function slipEmployeeLabel(slip) {
+  const e = slip?.employee
+  if (e?.first_name || e?.last_name) {
+    return `${e.first_name ?? ''} ${e.last_name ?? ''}`.trim()
+  }
+  return slip?.employee_id ? `Employe #${slip.employee_id}` : '-'
+}
+
+async function fetchAllPayrollRuns() {
+  const perPage = 50
+  const first = await api.get('/v1/payroll-runs', { params: { per_page: perPage, page: 1 } })
+  const meta = first.data.meta || {}
+  let items = [...(first.data.data || [])]
+  const lastPage = Math.min(Number(meta.last_page) || 1, 25)
+
+  for (let page = 2; page <= lastPage; page++) {
+    const res = await api.get('/v1/payroll-runs', { params: { per_page: perPage, page } })
+    items.push(...(res.data.data || []))
+  }
+
+  return items
+}
+
+function mapRunRow(raw) {
+  return {
+    id: raw.id,
+    reference: `RUN-${raw.id}`,
+    period: formatPeriod(raw.period_start, raw.period_end),
+    employees_count: raw.pay_slips_count ?? 0,
+    total_net: raw.total_net ?? 0,
+    status: raw.status,
+    period_start: raw.period_start,
+    period_end: raw.period_end,
+  }
+}
+
+async function fetchPaySlipsForRuns(runRows) {
+  const aggregated = []
+  for (const run of runRows) {
+    try {
+      const res = await api.get(`/v1/payroll-runs/${run.id}/pay-slips`, { params: { per_page: 500 } })
+      const batch = res.data.data || []
+      const ref = run.reference
+      for (const slip of batch) {
+        aggregated.push({
+          id: slip.id,
+          payroll_run_reference: ref,
+          employee_name: slipEmployeeLabel(slip),
+          reference: `SLIP-${slip.id}`,
+          period: formatPeriod(slip.period_start, slip.period_end),
+          net_pay: slip.net_salary ?? 0,
+          created_at: slip.created_at ? String(slip.created_at).slice(0, 10) : '-',
+        })
+      }
+    } catch {
+      /* ignore erreurs par run */
+    }
+  }
+  return aggregated
+}
+
+function currentMonthBounds() {
+  const now = new Date()
+  return { y: now.getFullYear(), m: now.getMonth() }
+}
+
+function runStartsThisMonth(run) {
+  const { y, m } = currentMonthBounds()
+  const d = run.period_start ? new Date(run.period_start) : null
+  return d && d.getFullYear() === y && d.getMonth() === m
 }
 
 async function fetchData() {
   loading.value = true
   error.value = ''
   try {
-    const [runsRes, slipsRes] = await Promise.all([
-      api.get('/v1/payroll-runs'),
-      api.get('/v1/pay-slips'),
-    ])
-    runs.value = runsRes.data.data || runsRes.data || []
-    slips.value = slipsRes.data.data || slipsRes.data || []
+    const rawRuns = await fetchAllPayrollRuns()
+    runs.value = rawRuns.map(mapRunRow)
+
+    slips.value = await fetchPaySlipsForRuns(runs.value)
+
     stats.value = {
-      runs_this_month: runs.value.length,
+      runs_this_month: runs.value.filter(runStartsThisMonth).length,
       slips_generated: slips.value.length,
-      total_net: runs.value.reduce((s, r) => s + (r.total_net || 0), 0),
+      total_net: rawRuns.reduce((s, r) => s + (Number(r.total_net) || 0), 0),
       pending_validation: runs.value.filter(r => r.status === 'calculated').length,
     }
   } catch (e) {
     error.value = 'Impossible de charger les donnees de paie.'
+    console.warn('PayrollView fetch failed', e)
   } finally {
     loading.value = false
   }
@@ -155,22 +297,82 @@ async function fetchData() {
 async function calculateRun(id) {
   try {
     await api.post(`/v1/payroll-runs/${id}/calculate`)
-    fetchData()
+    await fetchData()
   } catch (err) {
     console.warn('Failed to calculate payroll run', err)
   }
 }
+
 async function validateRun(id) {
   try {
     await api.post(`/v1/payroll-runs/${id}/validate`)
-    fetchData()
+    await fetchData()
   } catch (err) {
     console.warn('Failed to validate payroll run', err)
   }
 }
-function viewRun(id) { /* TODO: navigate to detail */ }
-function exportRuns() { window.open('/api/v1/export/payroll-runs?format=csv', '_blank') }
-function exportSlips() { window.open('/api/v1/export/pay-slips?format=csv', '_blank') }
+
+async function viewRun(id) {
+  try {
+    const res = await api.get(`/v1/payroll-runs/${id}/summary`)
+    runSummary.value = res.data.data
+  } catch (err) {
+    console.warn('Failed to load payroll summary', err)
+  }
+}
+
+function escapeCsvCell(value) {
+  const s = String(value ?? '')
+  if (/[;"'\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+function downloadCsv(filename, headerRow, lines) {
+  const bom = '\ufeff'
+  const blob = new Blob([bom + [headerRow.join(';'), ...lines].join('\n')], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function exportRuns() {
+  const header = ['reference', 'periode', 'employes', 'net_total', 'statut']
+  const lines = runs.value.map(r =>
+    [r.reference, r.period, r.employees_count, r.total_net, r.status].map(escapeCsvCell).join(';'),
+  )
+  downloadCsv('payroll-runs.csv', header, lines)
+}
+
+function exportSlips() {
+  const header = ['bulletin', 'run', 'employe', 'periode', 'net', 'cree_le']
+  const lines = slips.value.map(s =>
+    [s.reference, s.payroll_run_reference, s.employee_name, s.period, s.net_pay, s.created_at].map(escapeCsvCell).join(';'),
+  )
+  downloadCsv('pay-slips.csv', header, lines)
+}
+
+async function downloadPaySlipPdf(id) {
+  try {
+    const res = await api.get(`/v1/pay-slips/${id}/pdf`, {
+      responseType: 'blob',
+      headers: { Accept: 'application/pdf' },
+    })
+    const blob = res.data instanceof Blob ? res.data : new Blob([res.data])
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `bulletin_${id}.pdf`
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch (err) {
+    console.warn('Failed to download pay slip PDF', err)
+  }
+}
 
 onMounted(fetchData)
 </script>


### PR DESCRIPTION
## Summary

- **`PayrollView`** : données réelles (`GET /api/v1/payroll-runs` avec pagination absorbée côté SPA, bulletins via `GET /api/v1/payroll-runs/{id}/pay-slips`), actions **Calculer** / **Valider**, panneau **résumé** (`GET .../summary`), **PDF** avec `axios` + `Authorization` (`responseType: blob`), exports **CSV** générés dans le navigateur (plus de routes `/export/*` fictives ni lien PDF sans jeton).
- **`LeavesView`** : **PUT** `/api/v1/absences/{id}/approve` et **PUT** `.../reject` avec `{ rejected_reason }`, chargement **`/leave-balances`** et **`/leave-policies`**, pagination des absences côté SPA, colonnes soldes alignées sur le schéma (`balance`, `used`, `pending`).
- **API** : liste **`GET /api/v1/absences`** enrichie avec `employee_name` et `type` (compatibilité : relations existantes inchangées).

## Test plan

- [ ] Lint / build `front/admin-dashboard/` (CI Web admin).
- [ ] Manuel : connexion manager tenant → `/payroll` et `/leaves` ; PDF bulletin ; approuver / refuser une absence en attente.
