### PR TITLE
docs(api): document tracking fleet contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Les vues admin-dashboard ne doivent pas contenir de `catch {}` vide : `Web Lint` bloque avec `no-empty`. Ajouter au minimum un `console.warn(...)` explicite ou un etat d'erreur utilisateur selon le contexte.
 - Les tests Feature qui declenchent `AbsenceRequested`, `AbsenceApproved`, `AbsenceRejected`, `PayrollValidated` ou d'autres evenements metier peuvent passer par `WebhookListener`. Le schema de test MVP doit donc creer `webhook_endpoints` et `webhook_deliveries`, sinon PostgreSQL echoue avec `relation "webhook_endpoints" does not exist` avant meme les assertions.
 - Les contrats plateforme recents doivent rester dans `api/openapi.yaml`. Le workflow `OpenAPI CI` lance Redocly uniquement quand la spec ou son workflow changent ; corriger la spec plutot que laisser les frontends deviner les shapes `data` / `meta`.
+- Depuis v4.16.63, les contrats tracking/flotte sont aussi dans `api/openapi.yaml`. Pour toute evolution de `routes/modules/tracking.php`, garder la spec alignee sur les vrais champs Eloquent (`plate_number`, `traccar_*`, `assigned_driver_id`) et non sur les anciens noms generiques (`registration_number`, `tracker_id`).
 
 ### Audit 2026-05-13 - IA, RBAC et tenant runtime
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.63] - 2026-05-16
+
+### API Contracts — Tracking / flotte
+
+- OpenAPI : documentation complete des contrats tracking/flotte exposes par `routes/modules/tracking.php`.
+- Alignement spec/code : `plate_number`, enums vehicules, maintenance reelle (`oil_change|tire|brake|battery|inspection|repair|other`), pagination `data/meta`, sync Traccar et rapports flotte.
+- Ajout des routes manquantes dans la spec : `GET /vehicles/{id}/assignments`, `GET /vehicle-trips/{id}`, `PUT/DELETE /vehicle-maintenance/{id}`.
+
 ## [4.16.62] - 2026-05-16
 
 ### Mobile Flutter — Bulletins employe via API reelle

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -47,6 +47,8 @@ tags:
   - name: "Privacy"
   - name: "Kiosks"
   - name: "Cameras"
+  - name: "Vehicle Tracking"
+  - name: "Fleet Management"
 
 paths:
   /health:
@@ -2417,18 +2419,26 @@ paths:
           application/json:
             schema:
               type: object
-              required: [registration_number, brand, model]
+              required: [plate_number]
               properties:
-                registration_number:
+                plate_number:
                   type: string
                 brand:
                   type: string
+                  nullable: true
                 model:
                   type: string
+                  nullable: true
                 year:
                   type: integer
-                tracker_id:
-                  type: integer
+                  nullable: true
+                type:
+                  type: string
+                  enum: [car, van, truck, motorcycle, bus]
+                  nullable: true
+                fuel_type:
+                  type: string
+                  enum: [diesel, gasoline, electric, hybrid, lpg]
                   nullable: true
       responses:
         "201":
@@ -2471,12 +2481,17 @@ paths:
             schema:
               type: object
               properties:
-                registration_number:
+                plate_number:
                   type: string
                 brand:
                   type: string
+                  nullable: true
                 model:
                   type: string
+                  nullable: true
+                status:
+                  type: string
+                  enum: [active, maintenance, decommissioned]
       responses:
         "200":
           description: "Vehicule mis a jour"
@@ -2617,6 +2632,35 @@ paths:
         "200":
           description: "Vehicule desassigne"
 
+  /vehicles/{id}/assignments:
+    get:
+      tags: ["Vehicle Tracking"]
+      summary: "Historique des affectations conducteur"
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: "Affectations du vehicule"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+        "401":
+          $ref: "#/components/responses/Error401"
+        "404":
+          $ref: "#/components/responses/Error404"
+
   /vehicle-trips:
     get:
       tags: ["Vehicle Tracking"]
@@ -2626,6 +2670,33 @@ paths:
       responses:
         "200":
           description: "Liste paginee des trajets"
+
+  /vehicle-trips/{id}:
+    get:
+      tags: ["Vehicle Tracking"]
+      summary: "Detail d'un trajet"
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: "Detail trajet"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+        "401":
+          $ref: "#/components/responses/Error401"
+        "404":
+          $ref: "#/components/responses/Error404"
 
   /vehicle-alerts:
     get:
@@ -2673,21 +2744,121 @@ paths:
           application/json:
             schema:
               type: object
-              required: [vehicle_id, type, description]
+              required: [vehicle_id, type, service_date]
               properties:
                 vehicle_id:
                   type: integer
                 type:
                   type: string
-                  enum: [preventive, corrective, inspection]
+                  enum: [oil_change, tire, brake, battery, inspection, repair, other]
                 description:
                   type: string
-                scheduled_at:
+                  nullable: true
+                service_date:
                   type: string
-                  format: date-time
+                  format: date
+                next_service_date:
+                  type: string
+                  format: date
+                  nullable: true
+                cost:
+                  type: number
+                  nullable: true
+                currency:
+                  type: string
+                  nullable: true
       responses:
         "201":
           description: "Maintenance planifiee"
+
+  /vehicle-maintenance/{id}:
+    put:
+      tags: ["Vehicle Tracking"]
+      summary: "Modifier une maintenance"
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [oil_change, tire, brake, battery, inspection, repair, other]
+                description:
+                  type: string
+                  nullable: true
+                cost:
+                  type: number
+                  nullable: true
+                currency:
+                  type: string
+                  nullable: true
+                mileage_at_service:
+                  type: integer
+                  nullable: true
+                service_date:
+                  type: string
+                  format: date
+                next_service_date:
+                  type: string
+                  format: date
+                  nullable: true
+                next_service_mileage:
+                  type: integer
+                  nullable: true
+                provider:
+                  type: string
+                  nullable: true
+      responses:
+        "200":
+          description: "Maintenance mise a jour"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+        "401":
+          $ref: "#/components/responses/Error401"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Error422"
+    delete:
+      tags: ["Vehicle Tracking"]
+      summary: "Supprimer une maintenance"
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: "Maintenance supprimee"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "401":
+          $ref: "#/components/responses/Error401"
+        "404":
+          $ref: "#/components/responses/Error404"
 
   /tracking/sync-devices:
     post:
@@ -3014,6 +3185,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    Error422:
+      description: "Erreur de validation"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ValidationErrorResponse"
     Validation422:
       description: "Erreur de validation"
       content:
@@ -3029,24 +3206,55 @@ components:
           type: integer
         company_id:
           type: integer
-        registration_number:
+        plate_number:
           type: string
         brand:
           type: string
+          nullable: true
         model:
           type: string
+          nullable: true
         year:
           type: integer
           nullable: true
-        tracker_id:
-          type: integer
+        type:
+          type: string
+          enum: [car, van, truck, motorcycle, bus]
+          nullable: true
+        vin:
+          type: string
+          nullable: true
+        fuel_type:
+          type: string
+          enum: [diesel, gasoline, electric, hybrid, lpg]
           nullable: true
         status:
           type: string
-          enum: [active, maintenance, inactive]
-        current_driver_id:
+          enum: [active, maintenance, decommissioned]
+        mileage:
           type: integer
           nullable: true
+        insurance_expiry:
+          type: string
+          format: date
+          nullable: true
+        technical_control_expiry:
+          type: string
+          format: date
+          nullable: true
+        traccar_unique_id:
+          type: string
+          nullable: true
+        traccar_device_id:
+          type: integer
+          nullable: true
+        assigned_driver_id:
+          type: integer
+          nullable: true
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
         created_at:
           type: string
           format: date-time

--- a/docs/PLAN_ACTION/05_TRACKING_VEHICULES.md
+++ b/docs/PLAN_ACTION/05_TRACKING_VEHICULES.md
@@ -237,4 +237,4 @@ $schedule->command('tracking:check-insurance')->dailyAt('08:00');
 - [x] **T-TRACK-11** : Tests Feature sync Traccar — **FAIT** (couvert dans VehicleControllerTest)
 - [x] **T-TRACK-12** : Tests Feature alertes et maintenance — **FAIT** (`tests/Feature/FleetControllerTest.php`)
 - [x] **T-TRACK-13** : Ajouter le middleware `module.tracking` (feature flag) — **FAIT** (config/tracking.php enabled flag)
-- [ ] **T-TRACK-14** : Documentation API tracking dans openapi/v1.yaml — **RESTE** (endpoints tracking a documenter dans OpenAPI)
+- [x] **T-TRACK-14** : Documentation API tracking dans `api/openapi.yaml` — **FAIT** (contrats vehicules, affectations, trajets, alertes, maintenance, sync Traccar et rapports flotte documentes)

--- a/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
+++ b/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
@@ -46,7 +46,7 @@
 | A8 | Export CSV audit logs | Plan 02 | 0.5j | DONE |
 | A9 | `.pre-commit-config.yaml` | T-CI-06 | 0.5j | DONE |
 | A10 | Documenter worker deployment (DEPLOYMENT_GUIDE) | T-ARCH-20 | 0.5j | MEDIUM |
-| A11 | Documentation API tracking dans OpenAPI | T-TRACK-14 | 1j | HIGH |
+| A11 | Documentation API tracking dans OpenAPI | T-TRACK-14 | 1j | DONE |
 
 ### Categorie B — Monitoring & Observabilite
 
@@ -207,6 +207,9 @@
 - Documentation OpenAPI tracking + IA
 - Runbook alertes
 
+**Livraison incrementale 2026-05-16** :
+- **A11 DONE** : contrats tracking/flotte documentes dans `api/openapi.yaml` (vehicules, affectations, trajets, alertes, maintenance, sync Traccar, overview/live-map/reports).
+
 ### Iteration 3 — Tests Feature manquants + pre-commit
 **Cible** : A6, A7, A8, A9, C3
 **Statut** : COMPLETE (A6-A9, C3) — PR #463 + lot iteration 3 pre-commit/IA write (2026-05-15).
@@ -283,6 +286,7 @@
 - **2026-05-16 — Lot vitrine F** : page publique **`/changelog`** + liens footer (`/pricing`, `/blog`, changelog) dans `front/web`.
 - **2026-05-16 — Lot SEO F4 partiel** : sitemap dynamique enrichi (`/changelog`, `/privacy`, `/terms`).
 - **2026-05-16 — Lot mobile G1 partiel** : liste bulletins employe via **`GET /api/v1/me/pay-slips`** dans l’onglet paie des modules (`ModulesRepository` / `payrollsProvider`).
+- **2026-05-16 — Lot API contracts A11** : tracking/flotte aligne OpenAPI pour preparer admin/mobile/kiosk et integrateurs.
 
 **Contenu** :
 - Ecrans Flutter (bulletins, conges, notifs push)


### PR DESCRIPTION
## Summary
- align OpenAPI tracking vehicle fields with the Laravel controllers
- document missing fleet/tracking routes for assignments, trip detail, and maintenance update/delete
- mark Plan 15 A11 / T-TRACK-14 complete and capture the OpenAPI tracking note in AGENTS

## Validation
- python YAML parse + local OpenAPI reference check: 100 paths, 103 schemas, 0 missing refs
- git diff --check

Note: local Redocly could not run because Windows npm cache hit ENOSPC; OpenAPI CI will run it on GitHub.