### PR TITLE
docs(plan): sync completed architecture tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.65] - 2026-05-16
+
+### Gouvernance — Statut Plan 15
+
+- Plan 15 / Plan 01 : realignement des statuts A1, A2 et A4 en DONE, car `CONVENTIONS.md`, `docs/api/VERSIONING.md` et `docs/architecture/PARTITIONING.md` sont deja presents sur `main`.
+
 ## [4.16.64] - 2026-05-16
 
 ### DevOps — Worker deployment

--- a/docs/PLAN_ACTION/01_ARCHITECTURE_FONDATIONS.md
+++ b/docs/PLAN_ACTION/01_ARCHITECTURE_FONDATIONS.md
@@ -88,7 +88,7 @@ L'API actuelle est en `/api/v1/`. Pour la stabilite long terme :
 ### Taches
 
 - [ ] **T-ARCH-09** : Ajouter le middleware `ApiVersion` qui lit le header Accept et resout la version
-- [ ] **T-ARCH-10** : Documenter la politique de deprecation dans `docs/api/VERSIONING.md`
+- [x] **T-ARCH-10** : Documenter la politique de deprecation dans `docs/api/VERSIONING.md` — **FAIT**
 
 ---
 
@@ -137,7 +137,7 @@ L'API actuelle est en `/api/v1/`. Pour la stabilite long terme :
 
 - [x] **T-ARCH-11** : Creer `.editorconfig` a la racine — **FAIT** (`.editorconfig` existe avec UTF-8, LF)
 - [x] **T-ARCH-12** : Ajouter `phpstan.neon` avec level 6 minimum pour les nouveaux modules — **FAIT** (`phpstan.neon` + `phpstan-baseline.neon` + CI diff-gate)
-- [ ] **T-ARCH-13** : Creer `CONVENTIONS.md` a la racine avec les regles ci-dessus
+- [x] **T-ARCH-13** : Creer `CONVENTIONS.md` a la racine avec les regles ci-dessus — **FAIT**
 
 ---
 
@@ -171,7 +171,7 @@ A activer uniquement en mode Schema (Enterprise). Pas pour le mode Shared.
 ### Taches
 
 - [x] **T-ARCH-14** : Creer la migration d'index de performance — **FAIT** (`2026_05_10_000008_add_performance_indexes.php`)
-- [ ] **T-ARCH-15** : Documenter la strategie de partitioning dans `docs/architecture/PARTITIONING.md`
+- [x] **T-ARCH-15** : Documenter la strategie de partitioning dans `docs/architecture/PARTITIONING.md` — **FAIT**
 - [x] **T-ARCH-16** : Ajouter des query scopes optimises sur les modeles — **FAIT** (scopes `active()`, `forPeriod()` trouves sur Contract, EmployeeLoan, Feature, Project, SalaryAdvance)
 
 ---

--- a/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
+++ b/docs/PLAN_ACTION/15_PLAN_EXECUTION_CONSOLIDE.md
@@ -36,10 +36,10 @@
 
 | # | Tache | Source | Effort | Priorite |
 |---|-------|--------|--------|----------|
-| A1 | Creer `CONVENTIONS.md` | T-ARCH-13 | 0.5j | HIGH |
-| A2 | Creer `docs/api/VERSIONING.md` | T-ARCH-10 | 0.5j | HIGH |
+| A1 | Creer `CONVENTIONS.md` | T-ARCH-13 | 0.5j | DONE |
+| A2 | Creer `docs/api/VERSIONING.md` | T-ARCH-10 | 0.5j | DONE |
 | A3 | Creer middleware `ApiVersion` | T-ARCH-09 | 1j | DONE |
-| A4 | Creer `docs/architecture/PARTITIONING.md` | T-ARCH-15 | 0.5j | MEDIUM |
+| A4 | Creer `docs/architecture/PARTITIONING.md` | T-ARCH-15 | 0.5j | DONE |
 | A5 | DDD migration progressive controllers existants | T-ARCH-02 | 5j+ | LOW |
 | A6 | Tests Feature rapport RH dedies | T-MOD-H4 | 1j | DONE |
 | A7 | Test Feature chaine hierarchique org chart | Plan 02 | 0.5j | DONE |
@@ -208,6 +208,7 @@
 - Runbook alertes
 
 **Livraison incrementale 2026-05-16** :
+- **A1/A2/A4 DONE** : `CONVENTIONS.md`, `docs/api/VERSIONING.md` et `docs/architecture/PARTITIONING.md` existent sur `main` ; statut Plan 15 realigne.
 - **A10 DONE** : `DEPLOYMENT_GUIDE.md` cree pour API Render, workers queues, scheduler, Supervisor, checks post-deploy et rollback.
 - **A11 DONE** : contrats tracking/flotte documentes dans `api/openapi.yaml` (vehicules, affectations, trajets, alertes, maintenance, sync Traccar, overview/live-map/reports).
 


### PR DESCRIPTION
## Summary
- mark Plan 15 A1/A2/A4 as DONE because the canonical files already exist on main
- mark Plan 01 T-ARCH-10/13/15 as complete
- update changelog for the governance/status correction

## Validation
- git diff --check