### PR TITLE
fix(sentry): guard against invalid DSN values + fix Vercel API rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.66] - 2026-05-17
+
+### Fix — Sentry DSN crash & deployment readiness
+
+- Fix : `api/config/sentry.php` — validation du DSN Sentry avant passage a `ClientBuilder`. Les valeurs booleennes (`"1"`, `"true"`) ou non-URL sont desormais ignorees (retour `null`) au lieu de crasher `OptionsResolver` avec `The option "dsn" with value "1" is invalid`.
+- Fix : `front/web/vercel.json` — correction du rewrite `/api/:path*` qui pointait vers `https://api.leopardo.com` (domaine inexistant) au lieu de `https://gestionemployerbackend.onrender.com`.
+
 ## [4.16.65] - 2026-05-16
 
 ### Gouvernance — Statut Plan 15

--- a/api/config/sentry.php
+++ b/api/config/sentry.php
@@ -6,7 +6,18 @@
  * @see https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/
  */
 return [
-    'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
+    'dsn' => (function () {
+        $dsn = env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN'));
+        // Guard against boolean-like values ("1", "true", "0", "false") that
+        // crash Symfony OptionsResolver with "The option dsn with value 1 is invalid".
+        if ($dsn === null || $dsn === '' || $dsn === '0' || $dsn === 'false') {
+            return null;
+        }
+        if (filter_var($dsn, FILTER_VALIDATE_URL) === false) {
+            return null;
+        }
+        return $dsn;
+    })(),
 
     'traces_sample_rate' => (float) env('SENTRY_TRACES_SAMPLE_RATE', 0.2),
 

--- a/api/config/sentry.php
+++ b/api/config/sentry.php
@@ -11,11 +11,14 @@ return [
         // Guard against boolean-like values ("1", "true", "0", "false") that
         // crash Symfony OptionsResolver with "The option dsn with value 1 is invalid".
         if ($dsn === null || $dsn === '' || $dsn === '0' || $dsn === 'false') {
+
             return null;
         }
         if (filter_var($dsn, FILTER_VALIDATE_URL) === false) {
+
             return null;
         }
+
         return $dsn;
     })(),
 

--- a/front/web/vercel.json
+++ b/front/web/vercel.json
@@ -72,7 +72,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "https://api.leopardo.com/api/:path*"
+      "destination": "https://gestionemployerbackend.onrender.com/api/:path*"
     }
   ],
   "cleanUrls": true,


### PR DESCRIPTION
## 📝 Description

Fixes the Render deployment crash caused by `SENTRY_LARAVEL_DSN` being set to `"1"` (a boolean-like value) instead of a valid Sentry DSN URL. Symfony's `OptionsResolver` rejects non-URL values, crashing `php artisan config:cache` during the Docker entrypoint before the app can boot.

Also fixes the Vercel web vitrine API rewrite which pointed to a non-existent `https://api.leopardo.com` domain instead of the actual Render backend.

### Changes

- **`api/config/sentry.php`**: Wraps DSN retrieval in a validation closure that returns `null` for empty, boolean-like (`"1"`, `"true"`, `"0"`, `"false"`), or non-URL values — allowing the app to boot gracefully when Sentry is misconfigured.
- **`front/web/vercel.json`**: Corrects `/api/:path*` rewrite destination to `https://gestionemployerbackend.onrender.com/api/:path*`.
- **`CHANGELOG.md`**: Adds v4.16.66 entry.

### Updates since last revision

- Added blank lines before `return` statements in the IIFE to satisfy Pint's `blank_line_before_statement` rule (style-only, no functional change).

## 🧪 How Has This Been Tested?

- [ ] Unit Tests
- [ ] Feature/Integration Tests
- [x] E2E / Manual Verification — verified the config logic handles `"1"`, `""`, `null`, and valid DSN URLs correctly; confirmed the Render URL in `vercel.json` matches `deploy-main.yml` and `DEPLOYMENT_GUIDE.md`.
- [x] CI — all 15 checks pass (Backend Tests, Pint, PHPStan/Larastan, Security Audit, Coverage, Governance Gates, CodeQL, Web Marketing Lint/Build, Vercel preview deploy).

## 🚩 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 👀 Key areas for reviewer attention

1. **IIFE in config array** (`sentry.php`): The immediately-invoked closure is valid PHP and its *result* (not the closure) gets serialized by `config:cache`. Please verify this is acceptable for the project's conventions.
2. **`filter_var` as URL gate**: `FILTER_VALIDATE_URL` is the primary guard against bogus DSN values like `"1"`. The explicit checks for `null`/`''`/`'0'`/`'false'` are a fast path for common no-op cases.
3. **Hardcoded Render URL in `vercel.json`**: Matches `deploy-main.yml` and `DEPLOYMENT_GUIDE.md`, but remains a hardcoded URL. If the backend domain changes, this file will need updating.
4. **No dedicated test for DSN validation**: The fix is defensive and all existing tests pass, but there is no unit test exercising the new closure with edge-case DSN values (e.g. `"1"`, `"true"`, empty string). Consider whether one should be added.

Link to Devin session: https://app.devin.ai/sessions/7a62287ce5754a679c29ff9e7fe682e9
Requested by: @kitokoh