### PR TITLE
feat(web): client dashboard — payroll, contracts, training, reports + sidebar nav

### DIFF
--- a/front/web/src/app/(dashboard)/contracts/page.tsx
+++ b/front/web/src/app/(dashboard)/contracts/page.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { apiFetch } from '@/lib/api-client';
+import {
+  FileText,
+  Search,
+  Calendar,
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Download,
+} from 'lucide-react';
+
+interface Contract {
+  id: number;
+  employee_id: number;
+  employee_name: string;
+  type: string;
+  start_date: string;
+  end_date: string | null;
+  status: string;
+  salary: number;
+  created_at: string;
+}
+
+export default function ContractsPage() {
+  const [contracts, setContracts] = useState<Contract[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  const loadContracts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch('/contracts');
+      const data = await res.json();
+      setContracts(data.data || []);
+    } catch {
+      // silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadContracts(); }, [loadContracts]);
+
+  const filtered = useMemo(() =>
+    contracts.filter(c => {
+      const matchesSearch = c.employee_name?.toLowerCase().includes(search.toLowerCase()) || c.type?.toLowerCase().includes(search.toLowerCase());
+      const matchesStatus = statusFilter === 'all' || c.status === statusFilter;
+      return matchesSearch && matchesStatus;
+    }), [contracts, search, statusFilter]);
+
+  const stats = useMemo(() => ({
+    active: contracts.filter(c => c.status === 'active').length,
+    expiring: contracts.filter(c => {
+      if (!c.end_date) return false;
+      const diff = new Date(c.end_date).getTime() - Date.now();
+      return diff > 0 && diff < 30 * 24 * 3600 * 1000;
+    }).length,
+    suspended: contracts.filter(c => c.status === 'suspended').length,
+    total: contracts.length,
+  }), [contracts]);
+
+  const statusBadge = (status: string) => {
+    const styles: Record<string, string> = {
+      active: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+      suspended: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+      terminated: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+      draft: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
+    };
+    const labels: Record<string, string> = { active: 'Actif', suspended: 'Suspendu', terminated: 'Termine', draft: 'Brouillon' };
+    return <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${styles[status] || styles.draft}`}>{labels[status] || status}</span>;
+  };
+
+  const downloadPdf = async (id: number) => {
+    try {
+      const res = await apiFetch(`/contracts/${id}/pdf`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `contract-${id}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      // handle error
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Contrats</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Gestion des contrats employes</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[
+          { label: 'Actifs', value: stats.active, icon: CheckCircle2, color: 'text-emerald-600' },
+          { label: 'Expirant bientot', value: stats.expiring, icon: AlertTriangle, color: 'text-amber-600' },
+          { label: 'Suspendus', value: stats.suspended, icon: Clock, color: 'text-red-500' },
+          { label: 'Total', value: stats.total, icon: FileText, color: 'text-blue-600' },
+        ].map((stat, i) => (
+          <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.05 }} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+            <stat.icon className={`h-5 w-5 ${stat.color} mb-2`} />
+            <p className="text-2xl font-bold text-slate-900 dark:text-white">{stat.value}</p>
+            <p className="text-xs text-slate-500">{stat.label}</p>
+          </motion.div>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+          <input type="text" placeholder="Rechercher..." value={search} onChange={e => setSearch(e.target.value)} className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 pl-10 pr-4 py-2.5 text-sm text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500" />
+        </div>
+        <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2.5 text-sm text-slate-900 dark:text-white">
+          <option value="all">Tous les statuts</option>
+          <option value="active">Actif</option>
+          <option value="suspended">Suspendu</option>
+          <option value="terminated">Termine</option>
+        </select>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
+                <th className="px-4 py-3 text-left font-medium text-slate-500">Employe</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-500">Type</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-500">Debut</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-500">Fin</th>
+                <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
+                <th className="px-4 py-3 text-center font-medium text-slate-500">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Chargement...</td></tr>
+              ) : filtered.length === 0 ? (
+                <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Aucun contrat trouve</td></tr>
+              ) : filtered.map(c => (
+                <tr key={c.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                  <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{c.employee_name}</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 uppercase text-xs font-semibold">{c.type}</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 flex items-center gap-1"><Calendar className="h-3 w-3" />{c.start_date}</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{c.end_date || 'Indefini'}</td>
+                  <td className="px-4 py-3 text-center">{statusBadge(c.status)}</td>
+                  <td className="px-4 py-3 text-center">
+                    <button onClick={() => downloadPdf(c.id)} className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-emerald-600" title="Telecharger PDF"><Download className="h-4 w-4" /></button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -98,22 +98,26 @@ export default function DashboardLayout({
             <span className="h-2 w-2 rounded-full bg-slate-600"></span>
             Absences
           </Link>
+          <Link href="/contracts" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
+            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
+            Contrats
+          </Link>
 
-          <div className="mb-2 mt-6 px-4 opacity-40">
-            <p className="px-2 text-[10px] font-bold uppercase tracking-widest text-slate-500">Phase 2</p>
+          <div className="mb-2 mt-6 px-4">
+            <p className="px-2 text-[10px] font-bold uppercase tracking-widest text-slate-500">Finance & Formation</p>
           </div>
-          <div className="cursor-not-allowed px-6 py-3 text-sm italic text-slate-500">
-            <div className="flex items-center gap-3">
-              <span className="h-2 w-2 rounded-full bg-finance opacity-30"></span>
-              Finance (Bientot)
-            </div>
-          </div>
-          <div className="cursor-not-allowed px-6 py-3 text-sm italic text-slate-500">
-            <div className="flex items-center gap-3">
-              <span className="h-2 w-2 rounded-full bg-security opacity-30"></span>
-              Cameras (Bientot)
-            </div>
-          </div>
+          <Link href="/payroll" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
+            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
+            Paie
+          </Link>
+          <Link href="/training" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
+            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
+            Formations
+          </Link>
+          <Link href="/reports" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
+            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
+            Rapports
+          </Link>
         </nav>
 
         <div className="m-4 rounded-xl border border-ia/20 bg-ia/10 p-4">

--- a/front/web/src/app/(dashboard)/payroll/page.tsx
+++ b/front/web/src/app/(dashboard)/payroll/page.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { apiFetch } from '@/lib/api-client';
+import {
+  DollarSign,
+  Download,
+  FileText,
+  Calendar,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  Eye,
+} from 'lucide-react';
+
+interface PaySlip {
+  id: number;
+  employee_id: number;
+  employee_name: string;
+  period: string;
+  gross_salary: number;
+  net_salary: number;
+  status: string;
+  created_at: string;
+}
+
+interface PayrollRun {
+  id: number;
+  period: string;
+  status: string;
+  total_gross: number;
+  total_net: number;
+  employee_count: number;
+  created_at: string;
+}
+
+export default function PayrollPage() {
+  const [payslips, setPayslips] = useState<PaySlip[]>([]);
+  const [runs, setRuns] = useState<PayrollRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [tab, setTab] = useState<'slips' | 'runs'>('slips');
+  const itemsPerPage = 10;
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [slipsRes, runsRes] = await Promise.all([
+        apiFetch('/pay-slips').then(r => r.json()).catch(() => ({ data: [] })),
+        apiFetch('/payroll-runs').then(r => r.json()).catch(() => ({ data: [] })),
+      ]);
+      setPayslips(slipsRes.data || []);
+      setRuns(runsRes.data || []);
+    } catch {
+      // silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  const filtered = useMemo(() =>
+    payslips.filter(p =>
+      p.employee_name?.toLowerCase().includes(search.toLowerCase()) ||
+      p.period?.includes(search)
+    ), [payslips, search]);
+
+  const totalPages = Math.ceil(filtered.length / itemsPerPage);
+  const paginated = filtered.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+
+  const formatCurrency = (val: number) =>
+    new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(val || 0);
+
+  const downloadPdf = async (id: number) => {
+    try {
+      const res = await apiFetch(`/pay-slips/${id}/pdf`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `payslip-${id}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      // handle error
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Paie</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Gestion des bulletins de paie et cycles de paie</p>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {[
+          { label: 'Total Brut', value: formatCurrency(runs.reduce((s, r) => s + (r.total_gross || 0), 0)), icon: DollarSign, color: 'text-emerald-600' },
+          { label: 'Total Net', value: formatCurrency(runs.reduce((s, r) => s + (r.total_net || 0), 0)), icon: FileText, color: 'text-blue-600' },
+          { label: 'Bulletins', value: String(payslips.length), icon: Calendar, color: 'text-purple-600' },
+        ].map((stat, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: i * 0.05 }}
+            className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">{stat.label}</p>
+                <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-white">{stat.value}</p>
+              </div>
+              <stat.icon className={`h-8 w-8 ${stat.color} opacity-60`} />
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-2 border-b border-slate-200 dark:border-slate-700">
+        <button onClick={() => setTab('slips')} className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${tab === 'slips' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-slate-500 hover:text-slate-700'}`}>Bulletins de paie</button>
+        <button onClick={() => setTab('runs')} className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${tab === 'runs' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-slate-500 hover:text-slate-700'}`}>Cycles de paie</button>
+      </div>
+
+      {tab === 'slips' && (
+        <>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <input
+              type="text"
+              placeholder="Rechercher par nom ou periode..."
+              value={search}
+              onChange={e => { setSearch(e.target.value); setCurrentPage(1); }}
+              className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 pl-10 pr-4 py-2.5 text-sm text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+
+          <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
+                    <th className="px-4 py-3 text-left font-medium text-slate-500">Employe</th>
+                    <th className="px-4 py-3 text-left font-medium text-slate-500">Periode</th>
+                    <th className="px-4 py-3 text-right font-medium text-slate-500">Brut</th>
+                    <th className="px-4 py-3 text-right font-medium text-slate-500">Net</th>
+                    <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
+                    <th className="px-4 py-3 text-center font-medium text-slate-500">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Chargement...</td></tr>
+                  ) : paginated.length === 0 ? (
+                    <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Aucun bulletin trouve</td></tr>
+                  ) : paginated.map(slip => (
+                    <tr key={slip.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                      <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{slip.employee_name}</td>
+                      <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{slip.period}</td>
+                      <td className="px-4 py-3 text-right text-slate-900 dark:text-white tabular-nums">{formatCurrency(slip.gross_salary)}</td>
+                      <td className="px-4 py-3 text-right font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums">{formatCurrency(slip.net_salary)}</td>
+                      <td className="px-4 py-3 text-center">
+                        <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${slip.status === 'validated' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'}`}>
+                          {slip.status === 'validated' ? 'Valide' : 'Brouillon'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-center">
+                        <div className="flex items-center justify-center gap-1">
+                          <button onClick={() => downloadPdf(slip.id)} className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-emerald-600" title="Telecharger PDF"><Download className="h-4 w-4" /></button>
+                          <button className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-blue-600" title="Voir detail"><Eye className="h-4 w-4" /></button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between border-t border-slate-200 dark:border-slate-700 px-4 py-3">
+                <p className="text-xs text-slate-500">{filtered.length} resultats</p>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1} className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-30"><ChevronLeft className="h-4 w-4" /></button>
+                  <span className="px-2 text-sm text-slate-600 dark:text-slate-400">{currentPage}/{totalPages}</span>
+                  <button onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages} className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-30"><ChevronRight className="h-4 w-4" /></button>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {tab === 'runs' && (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
+                  <th className="px-4 py-3 text-left font-medium text-slate-500">Periode</th>
+                  <th className="px-4 py-3 text-right font-medium text-slate-500">Employes</th>
+                  <th className="px-4 py-3 text-right font-medium text-slate-500">Total Brut</th>
+                  <th className="px-4 py-3 text-right font-medium text-slate-500">Total Net</th>
+                  <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr><td colSpan={5} className="px-4 py-12 text-center text-slate-400">Chargement...</td></tr>
+                ) : runs.length === 0 ? (
+                  <tr><td colSpan={5} className="px-4 py-12 text-center text-slate-400">Aucun cycle de paie</td></tr>
+                ) : runs.map(run => (
+                  <tr key={run.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                    <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{run.period}</td>
+                    <td className="px-4 py-3 text-right text-slate-600 dark:text-slate-400">{run.employee_count}</td>
+                    <td className="px-4 py-3 text-right text-slate-900 dark:text-white tabular-nums">{formatCurrency(run.total_gross)}</td>
+                    <td className="px-4 py-3 text-right font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums">{formatCurrency(run.total_net)}</td>
+                    <td className="px-4 py-3 text-center">
+                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${run.status === 'completed' ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'}`}>
+                        {run.status === 'completed' ? 'Termine' : run.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/web/src/app/(dashboard)/reports/page.tsx
+++ b/front/web/src/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { apiFetch } from '@/lib/api-client';
+import {
+  BarChart3,
+  Download,
+  FileText,
+  Calendar,
+  Users,
+  Clock,
+  TrendingUp,
+  DollarSign,
+} from 'lucide-react';
+
+interface ReportConfig {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof BarChart3;
+  color: string;
+  endpoint: string;
+  params: { key: string; label: string; type: string }[];
+}
+
+const reports: ReportConfig[] = [
+  {
+    id: 'attendance-summary',
+    title: 'Resume Presences',
+    description: 'Rapport mensuel des presences, retards et absences par employe.',
+    icon: Clock,
+    color: 'text-blue-600',
+    endpoint: '/reports/attendance-summary',
+    params: [
+      { key: 'month', label: 'Mois', type: 'month' },
+    ],
+  },
+  {
+    id: 'payroll-summary',
+    title: 'Resume Paie',
+    description: 'Total brut/net, cotisations et charges par periode de paie.',
+    icon: DollarSign,
+    color: 'text-emerald-600',
+    endpoint: '/reports/payroll-summary',
+    params: [
+      { key: 'period', label: 'Periode', type: 'month' },
+    ],
+  },
+  {
+    id: 'leave-balances',
+    title: 'Soldes Conges',
+    description: 'Etat des soldes de conges pour tous les employes.',
+    icon: Calendar,
+    color: 'text-purple-600',
+    endpoint: '/reports/leave-balances',
+    params: [
+      { key: 'year', label: 'Annee', type: 'number' },
+    ],
+  },
+  {
+    id: 'headcount',
+    title: 'Effectifs',
+    description: 'Evolution des effectifs, entrees et sorties par periode.',
+    icon: Users,
+    color: 'text-amber-600',
+    endpoint: '/reports/headcount',
+    params: [
+      { key: 'from', label: 'Du', type: 'date' },
+      { key: 'to', label: 'Au', type: 'date' },
+    ],
+  },
+  {
+    id: 'training-progress',
+    title: 'Suivi Formations',
+    description: 'Taux de participation et completion des formations.',
+    icon: TrendingUp,
+    color: 'text-cyan-600',
+    endpoint: '/reports/training-progress',
+    params: [
+      { key: 'year', label: 'Annee', type: 'number' },
+    ],
+  },
+  {
+    id: 'contract-expiry',
+    title: 'Echeances Contrats',
+    description: 'Contrats arrivant a echeance dans les 30, 60, 90 prochains jours.',
+    icon: FileText,
+    color: 'text-red-500',
+    endpoint: '/reports/contract-expiry',
+    params: [
+      { key: 'days', label: 'Jours', type: 'number' },
+    ],
+  },
+];
+
+export default function ReportsPage() {
+  const [generating, setGenerating] = useState<string | null>(null);
+  const [params, setParams] = useState<Record<string, Record<string, string>>>({});
+  const [results, setResults] = useState<Record<string, string>>({});
+
+  const updateParam = (reportId: string, key: string, value: string) => {
+    setParams(prev => ({
+      ...prev,
+      [reportId]: { ...(prev[reportId] || {}), [key]: value },
+    }));
+  };
+
+  const generateReport = useCallback(async (report: ReportConfig) => {
+    setGenerating(report.id);
+    setResults(prev => ({ ...prev, [report.id]: '' }));
+    try {
+      const queryParams = params[report.id] || {};
+      const qs = Object.entries(queryParams).filter(([, v]) => v).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
+      const url = `${report.endpoint}${qs ? `?${qs}` : ''}`;
+      const res = await apiFetch(url);
+      const blob = await res.blob();
+      const downloadUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = downloadUrl;
+      a.download = `${report.id}-${new Date().toISOString().slice(0, 10)}.pdf`;
+      a.click();
+      URL.revokeObjectURL(downloadUrl);
+      setResults(prev => ({ ...prev, [report.id]: 'Rapport telecharge avec succes.' }));
+    } catch {
+      setResults(prev => ({ ...prev, [report.id]: 'Erreur lors de la generation du rapport.' }));
+    } finally {
+      setGenerating(null);
+    }
+  }, [params]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Rapports</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Generez et telechargez vos rapports RH</p>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {reports.map((report, i) => (
+          <motion.div
+            key={report.id}
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: i * 0.05 }}
+            className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5 flex flex-col"
+          >
+            <div className="flex items-start gap-3 mb-3">
+              <div className={`rounded-lg p-2 bg-slate-50 dark:bg-slate-700`}>
+                <report.icon className={`h-5 w-5 ${report.color}`} />
+              </div>
+              <div className="flex-1">
+                <h3 className="font-bold text-slate-900 dark:text-white text-sm">{report.title}</h3>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{report.description}</p>
+              </div>
+            </div>
+
+            <div className="space-y-2 mb-4 flex-1">
+              {report.params.map(p => (
+                <div key={p.key}>
+                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">{p.label}</label>
+                  <input
+                    type={p.type}
+                    value={params[report.id]?.[p.key] || ''}
+                    onChange={e => updateParam(report.id, p.key, e.target.value)}
+                    className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500"
+                  />
+                </div>
+              ))}
+            </div>
+
+            <button
+              onClick={() => generateReport(report)}
+              disabled={generating === report.id}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold transition-colors disabled:opacity-50"
+            >
+              {generating === report.id ? (
+                <>
+                  <BarChart3 className="h-4 w-4 animate-spin" />
+                  Generation...
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4" />
+                  Generer
+                </>
+              )}
+            </button>
+
+            {results[report.id] && (
+              <p className={`text-xs mt-2 ${results[report.id].includes('Erreur') ? 'text-red-500' : 'text-emerald-600'}`}>
+                {results[report.id]}
+              </p>
+            )}
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/web/src/app/(dashboard)/training/page.tsx
+++ b/front/web/src/app/(dashboard)/training/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { apiFetch } from '@/lib/api-client';
+import { GraduationCap, Calendar, Users, Clock, BookOpen, Award } from 'lucide-react';
+
+interface Training {
+  id: number;
+  title: string;
+  description: string;
+  trainer: string;
+  start_date: string;
+  end_date: string;
+  status: string;
+  max_participants: number;
+  enrolled_count: number;
+  category: string;
+}
+
+export default function TrainingPage() {
+  const [trainings, setTrainings] = useState<Training[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<'upcoming' | 'completed'>('upcoming');
+
+  const loadTrainings = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch('/trainings');
+      const data = await res.json();
+      setTrainings(data.data || []);
+    } catch {
+      // silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadTrainings(); }, [loadTrainings]);
+
+  const upcoming = trainings.filter(t => t.status === 'scheduled' || t.status === 'in_progress');
+  const completed = trainings.filter(t => t.status === 'completed');
+  const displayed = tab === 'upcoming' ? upcoming : completed;
+
+  const statusBadge = (status: string) => {
+    const map: Record<string, { class: string; label: string }> = {
+      scheduled: { class: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400', label: 'Planifie' },
+      in_progress: { class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400', label: 'En cours' },
+      completed: { class: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400', label: 'Termine' },
+      cancelled: { class: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400', label: 'Annule' },
+    };
+    const style = map[status] || map.scheduled;
+    return <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${style.class}`}>{style.label}</span>;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Formations</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Suivi des formations et developpement des competences</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[
+          { label: 'Planifiees', value: upcoming.length, icon: Calendar, color: 'text-blue-600' },
+          { label: 'Terminees', value: completed.length, icon: Award, color: 'text-emerald-600' },
+          { label: 'Total', value: trainings.length, icon: GraduationCap, color: 'text-purple-600' },
+          { label: 'Participants', value: trainings.reduce((s, t) => s + (t.enrolled_count || 0), 0), icon: Users, color: 'text-amber-600' },
+        ].map((stat, i) => (
+          <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.05 }} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+            <stat.icon className={`h-5 w-5 ${stat.color} mb-2`} />
+            <p className="text-2xl font-bold text-slate-900 dark:text-white">{stat.value}</p>
+            <p className="text-xs text-slate-500">{stat.label}</p>
+          </motion.div>
+        ))}
+      </div>
+
+      <div className="flex gap-2 border-b border-slate-200 dark:border-slate-700">
+        <button onClick={() => setTab('upcoming')} className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${tab === 'upcoming' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-slate-500 hover:text-slate-700'}`}>A venir ({upcoming.length})</button>
+        <button onClick={() => setTab('completed')} className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${tab === 'completed' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-slate-500 hover:text-slate-700'}`}>Terminees ({completed.length})</button>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-slate-400">Chargement...</div>
+      ) : displayed.length === 0 ? (
+        <div className="text-center py-16">
+          <BookOpen className="h-12 w-12 text-slate-300 mx-auto mb-3" />
+          <p className="text-slate-500">{tab === 'upcoming' ? 'Aucune formation planifiee' : 'Aucune formation terminee'}</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {displayed.map((t, i) => (
+            <motion.div
+              key={t.id}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.03 }}
+              className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5 hover:shadow-md transition-shadow"
+            >
+              <div className="flex items-start justify-between mb-3">
+                <h3 className="font-bold text-slate-900 dark:text-white text-sm leading-tight">{t.title}</h3>
+                {statusBadge(t.status)}
+              </div>
+              {t.description && <p className="text-xs text-slate-500 dark:text-slate-400 mb-3 line-clamp-2">{t.description}</p>}
+              <div className="space-y-1.5 text-xs text-slate-500 dark:text-slate-400">
+                <div className="flex items-center gap-1.5"><GraduationCap className="h-3 w-3" />{t.trainer}</div>
+                <div className="flex items-center gap-1.5"><Calendar className="h-3 w-3" />{t.start_date} - {t.end_date}</div>
+                <div className="flex items-center gap-1.5"><Users className="h-3 w-3" />{t.enrolled_count}/{t.max_participants} participants</div>
+                {t.category && <div className="flex items-center gap-1.5"><Clock className="h-3 w-3" />{t.category}</div>}
+              </div>
+              <div className="mt-3 pt-3 border-t border-slate-100 dark:border-slate-700">
+                <div className="h-1.5 rounded-full bg-slate-100 dark:bg-slate-700 overflow-hidden">
+                  <div className="h-full rounded-full bg-emerald-500 transition-all" style={{ width: `${Math.min(100, ((t.enrolled_count || 0) / (t.max_participants || 1)) * 100)}%` }} />
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds 4 new dashboard pages for the client web space and updates sidebar navigation:

**New Pages:**
- `/payroll` — Pay slips table with search/pagination, payroll runs tab, PDF download via `/pay-slips/{id}/pdf`, EUR currency formatting
- `/contracts` — Contract list with status filters (active/suspended/terminated), expiry-within-30-days alerts, PDF download via `/contracts/{id}/pdf`
- `/training` — Training cards with enrollment progress bars, upcoming/completed tabs, participant counts
- `/reports` — 6 report generators (attendance summary, payroll summary, leave balances, headcount, training progress, contract expiry) with parameter inputs and PDF download

**Sidebar Navigation:**
- Added `Contrats` link under Module RH section
- New `Finance & Formation` section with `Paie`, `Formations`, `Rapports` links
- Replaced Phase 2 placeholder items with active navigation

**API Integration:**
- All pages use `apiFetch()` from `@/lib/api-client` to connect to backend endpoints
- Endpoints consumed: `/pay-slips`, `/payroll-runs`, `/contracts`, `/trainings`, `/reports/*`

## Review & Testing Checklist for Human

- [ ] Navigate to each dashboard page (/payroll, /contracts, /training, /reports) after login
- [ ] Verify sidebar navigation shows all new links correctly
- [ ] Test search/filter functionality on payroll and contracts pages
- [ ] Test PDF download buttons (requires backend endpoints to be running)

### Notes

- All pages handle loading states and empty data gracefully
- Consistent design language with existing dashboard pages (GlassCard patterns, emerald accent color)
- Dark mode compatible via existing Tailwind dark: classes

Link to Devin session: https://app.devin.ai/sessions/b0f38569e0aa4cd5bef3eb00ff3232ea