### PR TITLE
fix: send JSON accept header in staging smoke

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -91,7 +91,7 @@ jobs:
             local url="$2"
             local expected_status="${3:-200}"
             echo -n "Testing ${name}... "
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' "${url}" || echo "000")
+            STATUS=$(curl -s -H 'Accept: application/json' -o /dev/null -w '%{http_code}' "${url}" || echo "000")
             if [[ "${STATUS}" == "${expected_status}" ]]; then
               echo "OK (${STATUS})"
             else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Pour `front/admin-dashboard`, `VITE_API_URL` doit pointer vers la base versionnee (`.../api/v1`). Le client Axios normalise les anciens appels `/v1/*`; ne pas revenir a des `window.open('/api/v1/...')` pour les exports, car cela casse sur Cloudflare Pages et perd le bearer token.
 - Pour `front/zkteco-kiosk`, `apiBaseUrl` peut etre configure avec ou sans `/api/v1`; `app.js` normalise la base. Garder ce contrat pour eviter les URLs double-versionnees sur site client.
 - Le smoke E2E staging API doit tester les routes reelles du backend. Pour un check auth sans token, utiliser `/api/v1/auth/me`, pas `/api/v1/me`.
+- Les curls de smoke API doivent envoyer `Accept: application/json`; sinon Laravel peut retourner une redirection HTML `302 /login` au lieu du statut JSON attendu (`401`, `403`, etc.).
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix : kiosk ZKTeco normalise `apiBaseUrl` pour eviter `.../api/v1/api/v1/...` quand la config contient deja la version API.
 - Tests : couverture Feature des exports dashboard admin ajoutee.
 - Fix CI : smoke E2E staging aligne sur la vraie route auth `/api/v1/auth/me`, pages blog Next 16 compatibles `params` asynchrones, et backup PostgreSQL sans dependance `awscli` via apt.
+- Fix CI : le smoke API staging envoie `Accept: application/json` afin de recevoir les vrais statuts API Laravel au lieu d'une redirection HTML vers `/login`.
 - Docs/Tests : matrice contractuelle frontends/API ajoutee avec garde `FrontendApiContractTest` sur les routes critiques admin, mobile et kiosk.
 
 ## [4.16.80] - 2026-05-18


### PR DESCRIPTION
## Objectif
Corriger le smoke E2E staging API post-merge: Laravel redirige vers /login sans header JSON, donc le test recevait 302 au lieu du 401 API attendu.

## Changement
- Ajoute Accept: application/json aux curls de smoke API.
- Documente la lecon dans AGENTS.md et CHANGELOG.md.

## Verification
- curl avec Accept: application/json sur /api/v1/auth/me retourne 401.
- git diff --check OK.