### PR TITLE
fix: align web staging playwright config

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -188,7 +188,7 @@ jobs:
         env:
           CI: true
           BASE_URL: ${{ github.event.inputs.staging_url || env.DEFAULT_STAGING_URL }}
-        run: npx playwright test
+        run: npx playwright test --project=chromium
 
       - name: Upload Playwright report
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Pour `front/zkteco-kiosk`, `apiBaseUrl` peut etre configure avec ou sans `/api/v1`; `app.js` normalise la base. Garder ce contrat pour eviter les URLs double-versionnees sur site client.
 - Le smoke E2E staging API doit tester les routes reelles du backend. Pour un check auth sans token, utiliser `/api/v1/auth/me`, pas `/api/v1/me`.
 - Les curls de smoke API doivent envoyer `Accept: application/json`; sinon Laravel peut retourner une redirection HTML `302 /login` au lieu du statut JSON attendu (`401`, `403`, etc.).
+- Pour l'E2E staging `front/web`, `BASE_URL` indique une cible distante : la config Playwright ne doit pas demarrer `npm run dev` dans ce cas, et le workflow doit rester aligne avec les navigateurs installes (`--project=chromium` si seul Chromium est installe).
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Tests : couverture Feature des exports dashboard admin ajoutee.
 - Fix CI : smoke E2E staging aligne sur la vraie route auth `/api/v1/auth/me`, pages blog Next 16 compatibles `params` asynchrones, et backup PostgreSQL sans dependance `awscli` via apt.
 - Fix CI : le smoke API staging envoie `Accept: application/json` afin de recevoir les vrais statuts API Laravel au lieu d'une redirection HTML vers `/login`.
+- Fix CI : l'E2E vitrine staging utilise `BASE_URL` sans demarrer Next localement et limite le run a Chromium, le navigateur installe par le workflow.
 - Docs/Tests : matrice contractuelle frontends/API ajoutee avec garde `FrontendApiContractTest` sur les routes critiques admin, mobile et kiosk.
 
 ## [4.16.80] - 2026-05-18

--- a/front/web/playwright.config.ts
+++ b/front/web/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+const shouldStartLocalServer = !process.env.BASE_URL;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -11,6 +14,8 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  timeout: 30_000,
+  globalTimeout: process.env.CI ? 300_000 : undefined,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -24,7 +29,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     /* Screenshot on failure */
@@ -72,9 +77,11 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: shouldStartLocalServer
+    ? {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+      }
+    : undefined,
 });


### PR DESCRIPTION
## Objectif
Stabiliser l'E2E staging vitrine apres le hotfix API: le workflow passait BASE_URL, mais Playwright demarrait quand meme Next en local et tentait tous les navigateurs alors que seul Chromium etait installe.

## Changements
- Playwright web utilise BASE_URL quand fourni et ne lance pas le serveur local dans ce cas.
- Ajout d'un timeout global CI pour eviter les runs E2E bloques.
- Le workflow staging limite la vitrine a --project=chromium, aligne avec l'installation du navigateur.
- Documentation AGENTS + CHANGELOG.

## Verifications locales
- front/web npm run lint OK.
- front/web npm run build OK.
- git diff --check OK.