### PR TITLE
fix: split staging E2E web target

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       staging_url:
-        description: "Staging base URL to test"
+        description: "API/admin staging base URL to test"
+        required: false
+        default: ""
+      web_staging_url:
+        description: "Web vitrine staging base URL to test"
         required: false
         default: ""
   workflow_run:
@@ -19,6 +23,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEFAULT_STAGING_URL: https://gestionemployerbackend.onrender.com
+  DEFAULT_WEB_STAGING_URL: https://gestionemployer-backend.vercel.app
 
 concurrency:
   group: e2e-staging-${{ github.ref }}
@@ -187,7 +192,7 @@ jobs:
         working-directory: front/web
         env:
           CI: true
-          BASE_URL: ${{ github.event.inputs.staging_url || env.DEFAULT_STAGING_URL }}
+          BASE_URL: ${{ github.event.inputs.web_staging_url || env.DEFAULT_WEB_STAGING_URL }}
         run: npx playwright test --project=chromium
 
       - name: Upload Playwright report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le smoke E2E staging API doit tester les routes reelles du backend. Pour un check auth sans token, utiliser `/api/v1/auth/me`, pas `/api/v1/me`.
 - Les curls de smoke API doivent envoyer `Accept: application/json`; sinon Laravel peut retourner une redirection HTML `302 /login` au lieu du statut JSON attendu (`401`, `403`, etc.).
 - Pour l'E2E staging `front/web`, `BASE_URL` indique une cible distante : la config Playwright ne doit pas demarrer `npm run dev` dans ce cas, et le workflow doit rester aligne avec les navigateurs installes (`--project=chromium` si seul Chromium est installe).
+- Le workflow `e2e-staging.yml` distingue l'URL API/admin Render (`DEFAULT_STAGING_URL`) de l'URL vitrine Vercel (`DEFAULT_WEB_STAGING_URL`). Ne pas pointer les tests landing `front/web` vers le backend API.
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix CI : smoke E2E staging aligne sur la vraie route auth `/api/v1/auth/me`, pages blog Next 16 compatibles `params` asynchrones, et backup PostgreSQL sans dependance `awscli` via apt.
 - Fix CI : le smoke API staging envoie `Accept: application/json` afin de recevoir les vrais statuts API Laravel au lieu d'une redirection HTML vers `/login`.
 - Fix CI : l'E2E vitrine staging utilise `BASE_URL` sans demarrer Next localement et limite le run a Chromium, le navigateur installe par le workflow.
+- Fix CI : l'E2E vitrine staging utilise une URL web separee (`DEFAULT_WEB_STAGING_URL`) au lieu de tester la landing page contre le backend Render.
 - Docs/Tests : matrice contractuelle frontends/API ajoutee avec garde `FrontendApiContractTest` sur les routes critiques admin, mobile et kiosk.
 
 ## [4.16.80] - 2026-05-18


### PR DESCRIPTION
## Summary
- separate the Render API/admin staging URL from the Vercel vitrine staging URL
- add a dedicated workflow_dispatch input for the web vitrine target
- document the CI routing rule so future runs do not test landing pages against the API backend

## Validation
- git diff --check
- curl https://gestionemployer-backend.vercel.app/ returned HTTP 200