### PR TITLE
fix: scope web staging E2E to smoke contract

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -193,7 +193,7 @@ jobs:
         env:
           CI: true
           BASE_URL: ${{ github.event.inputs.web_staging_url || env.DEFAULT_WEB_STAGING_URL }}
-        run: npx playwright test --project=chromium
+        run: npx playwright test e2e/staging-smoke.spec.ts --project=chromium
 
       - name: Upload Playwright report
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Les curls de smoke API doivent envoyer `Accept: application/json`; sinon Laravel peut retourner une redirection HTML `302 /login` au lieu du statut JSON attendu (`401`, `403`, etc.).
 - Pour l'E2E staging `front/web`, `BASE_URL` indique une cible distante : la config Playwright ne doit pas demarrer `npm run dev` dans ce cas, et le workflow doit rester aligne avec les navigateurs installes (`--project=chromium` si seul Chromium est installe).
 - Le workflow `e2e-staging.yml` distingue l'URL API/admin Render (`DEFAULT_STAGING_URL`) de l'URL vitrine Vercel (`DEFAULT_WEB_STAGING_URL`). Ne pas pointer les tests landing `front/web` vers le backend API.
+- Sur la vitrine, garder le gate staging limite a `front/web/e2e/staging-smoke.spec.ts`. Les tests de conversion complets manipulent des formulaires et des CTA plus profonds ; ils sont utiles en local/preview, mais trop fragiles et trop larges pour une cible publique de production.
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix CI : le smoke API staging envoie `Accept: application/json` afin de recevoir les vrais statuts API Laravel au lieu d'une redirection HTML vers `/login`.
 - Fix CI : l'E2E vitrine staging utilise `BASE_URL` sans demarrer Next localement et limite le run a Chromium, le navigateur installe par le workflow.
 - Fix CI : l'E2E vitrine staging utilise une URL web separee (`DEFAULT_WEB_STAGING_URL`) au lieu de tester la landing page contre le backend Render.
+- Fix CI : le gate vitrine staging lance une suite smoke dediee (`e2e/staging-smoke.spec.ts`) centree sur les contrats publics deployes, au lieu de rejouer les parcours de conversion complets contre la production.
 - Docs/Tests : matrice contractuelle frontends/API ajoutee avec garde `FrontendApiContractTest` sur les routes critiques admin, mobile et kiosk.
 
 ## [4.16.80] - 2026-05-18

--- a/front/web/e2e/staging-smoke.spec.ts
+++ b/front/web/e2e/staging-smoke.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test, type Page } from '@playwright/test';
+
+test.describe('Web vitrine staging smoke', () => {
+  const open = async (page: Page, path: string) => {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+  };
+
+  test('loads the public landing page with buyer-facing content', async ({ page }) => {
+    await open(page, '/');
+
+    await expect(page).toHaveTitle(/Leopardo RH/i);
+    await expect(page.locator('body')).toContainText(/Leopardo/i);
+    await expect(page.locator('body')).toContainText(/Pointage|paie|absences|Attendance|payroll|leave/i);
+    await expect(page.locator('body')).toContainText(/Fonctionnalites|Tarifs|Features|Pricing|FAQ/i);
+  });
+
+  test('exposes the main acquisition and login links', async ({ page }) => {
+    await open(page, '/');
+
+    const authLinks = page.locator('a[href="/auth/login"]');
+    await expect(authLinks.first()).toHaveAttribute('href', '/auth/login');
+    expect(await authLinks.count()).toBeGreaterThan(0);
+
+    await expect(page.locator('body')).toContainText(/Essai gratuit|Commencer gratuitement|Connexion|Free trial|Start free|Sign in/i);
+  });
+
+  test('keeps commercial and legal pages reachable', async ({ page }) => {
+    await open(page, '/pricing');
+    await expect(page.locator('body')).toContainText(/Starter|Business|Enterprise|Tarifs|Pricing/i);
+
+    await open(page, '/privacy');
+    await expect(page.locator('body')).toContainText(/Confidentialite|Privacy/i);
+
+    await open(page, '/terms');
+    await expect(page.locator('body')).toContainText(/Conditions|Terms|CGU/i);
+  });
+
+  test('keeps locale and newsletter entry points in the delivered HTML', async ({ page }) => {
+    await open(page, '/');
+
+    await expect(page.locator('body')).toContainText(/Francais|English|Turkce|العربية/i);
+
+    await expect(page.locator('input[type="email"]').first()).toHaveAttribute('placeholder', /email/i);
+    await expect(page.locator('form button[type="submit"]').first()).toContainText(/OK|Subscribe|Inscrire/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated web vitrine staging smoke suite for deployed public contracts
- run only that smoke suite in the post-deploy staging workflow
- document why full conversion tests remain local/preview scope instead of production staging

## Validation
- BASE_URL=https://gestionemployer-backend.vercel.app CI=true npx playwright test e2e/staging-smoke.spec.ts --project=chromium
- npm run lint (front/web)
- git diff --check