### PR TITLE
ci: add backend jobs contract workflow

### DIFF
--- a/.github/workflows/backend-jobs-ci.yml
+++ b/.github/workflows/backend-jobs-ci.yml
@@ -1,0 +1,196 @@
+name: Backend Jobs CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'api/app/Jobs/**'
+      - 'api/app/Listeners/**'
+      - 'api/app/Services/WebhookDispatcher.php'
+      - 'api/app/Services/PayrollService.php'
+      - 'api/app/Http/Controllers/Api/V1/PayrollRunController.php'
+      - 'api/tests/Feature/QueueJobsTest.php'
+      - 'api/tests/Feature/PayrollRunControllerTest.php'
+      - '.github/workflows/backend-jobs-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'api/app/Jobs/**'
+      - 'api/app/Listeners/**'
+      - 'api/app/Services/WebhookDispatcher.php'
+      - 'api/app/Services/PayrollService.php'
+      - 'api/app/Http/Controllers/Api/V1/PayrollRunController.php'
+      - 'api/tests/Feature/QueueJobsTest.php'
+      - 'api/tests/Feature/PayrollRunControllerTest.php'
+      - '.github/workflows/backend-jobs-ci.yml'
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: backend-jobs-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jobs-and-queues:
+    name: Jobs & Queues Contracts
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: leopardo_test
+          POSTGRES_USER: leopardo_user
+          POSTGRES_PASSWORD: leopardo_pass_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: pdo, pdo_pgsql, pdo_sqlite, sqlite3, redis, bcmath, mbstring, xml, zip, gd
+          tools: composer:v2
+          coverage: none
+
+      - name: Resolve Composer cache directory
+        id: composer-cache
+        working-directory: ./api
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-php84-${{ hashFiles('api/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-php84-
+
+      - name: Install Composer dependencies
+        working-directory: ./api
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Prepare environment
+        working-directory: ./api
+        run: |
+          cat > .env <<'EOF'
+          APP_NAME=LeopardoRH
+          APP_ENV=testing
+          APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+          APP_DEBUG=true
+          APP_URL=http://localhost
+
+          DB_CONNECTION=pgsql
+          DB_HOST=127.0.0.1
+          DB_PORT=5432
+          DB_DATABASE=leopardo_test
+          DB_USERNAME=leopardo_user
+          DB_PASSWORD=leopardo_pass_test
+          DB_SEARCH_PATH=shared_tenants,public
+
+          CACHE_STORE=array
+          QUEUE_CONNECTION=sync
+          SESSION_DRIVER=array
+          REDIS_HOST=127.0.0.1
+          REDIS_PORT=6379
+          EOF
+
+      - name: Bootstrap migration repositories
+        working-directory: ./api
+        run: |
+          php <<'PHP'
+          <?php
+          $dsn = 'pgsql:host=127.0.0.1;port=5432;dbname=leopardo_test';
+          $pdo = new PDO($dsn, 'leopardo_user', 'leopardo_pass_test', [
+              PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+          ]);
+          $pdo->exec(<<<'SQL'
+          CREATE SCHEMA IF NOT EXISTS shared_tenants;
+          CREATE TABLE IF NOT EXISTS public.migrations (
+              id serial PRIMARY KEY,
+              migration varchar(255) NOT NULL,
+              batch integer NOT NULL
+          );
+          CREATE TABLE IF NOT EXISTS shared_tenants.migrations (
+              id serial PRIMARY KEY,
+              migration varchar(255) NOT NULL,
+              batch integer NOT NULL
+          );
+          SQL);
+          echo "Migration repositories ensured for jobs CI.\n";
+          PHP
+
+      - name: Run public migrations
+        working-directory: ./api
+        run: DB_SEARCH_PATH=public php artisan migrate --path=database/migrations/public --force --isolated
+
+      - name: Run tenant migrations
+        working-directory: ./api
+        run: DB_SEARCH_PATH=shared_tenants php artisan migrate --path=database/migrations/tenant --force --isolated
+
+      - name: Run queue contract tests
+        id: queue_contracts
+        working-directory: ./api
+        env:
+          DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
+          DB_DATABASE: leopardo_test
+          DB_SEARCH_PATH: public,shared_tenants
+        run: php artisan test tests/Feature/QueueJobsTest.php --log-junit=storage/test-results/jobs-queue.xml
+
+      - name: Run payroll warmup dispatch contract
+        id: payroll_warmup_contract
+        working-directory: ./api
+        env:
+          DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
+          DB_DATABASE: leopardo_test
+          DB_SEARCH_PATH: public,shared_tenants
+          PAYROLL_QUEUE_PDF_WARMUP: "true"
+        run: php artisan test tests/Feature/PayrollRunControllerTest.php --filter=test_validate_dispatches_pay_slip_pdf_warmup_job --log-junit=storage/test-results/jobs-payroll-warmup.xml
+
+      - name: Build jobs CI summary
+        if: always()
+        working-directory: ./api
+        run: |
+          mkdir -p storage/test-results
+          {
+            echo "- Queue contract tests: ${{ steps.queue_contracts.outcome }}"
+            echo "- Payroll PDF warmup dispatch: ${{ steps.payroll_warmup_contract.outcome }}"
+            echo "- Queues covered: payroll, notifications, payroll PDF warmup"
+          } > storage/test-results/jobs-ci-summary.md
+          cat storage/test-results/jobs-ci-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload jobs CI artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-jobs-ci-reports
+          path: |
+            api/storage/test-results/jobs-*.xml
+            api/storage/test-results/jobs-ci-summary.md
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Pour Composer en CI, preferer un cache base sur `composer.lock` ou le cache officiel plutot qu'un cache brut de `vendor/`.
 - Pour la coverage backend, mesurer puis activer un seuil progressif ; ne pas imposer `60%` d'un coup sans baseline reelle.
 - Le workflow `coverage-gate.yml` doit creer `api/storage/coverage` avant tout `tee` vers `storage/coverage/summary.txt`. Depuis v4.16.94, son seuil par defaut est `56%` (coverage mesuree 56,14% sur PR #510); viser `60%` via un lot de tests backend cible avant tout nouveau ratchet.
+- Le workflow `backend-jobs-ci.yml` couvre les contrats queues/jobs critiques (`QueueJobsTest` et warmup PDF paie). Toute modification de `api/app/Jobs/**`, listeners d'evenements ou dispatch paie doit garder ce workflow vert.
 - Le runbook backup existe deja dans `docs/GESTION_PROJET/RUNBOOK_BACKUP_RESTORE.md` ; en cas de plan CI/CD, penser mise a jour/allegement avant creation d'une nouvelle doc.
 - Le depot porte deux surfaces frontend distinctes : `admin-dashboard/` pour la plateforme interne et `web/` pour la vitrine / portail manager Next.js. Ne pas confondre les workflows ni les URLs de deploiement.
 - Pour `admin-dashboard/`, garder `web-ci.yml` cible sur `admin-dashboard/**` avec lint/build/Playwright.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.95] - 2026-05-20
+
+### Added
+
+- CI : workflow dedie `Backend Jobs CI` pour tester les contrats queues/jobs (`QueueJobsTest` + warmup PDF paie).
+- Docs : creation du `docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md` pour piloter le prochain vrai lot avant lancement marketing.
+- Docs : synchronisation des items `T-ARCH-19` et `T-CI-07` avec l'etat reel du depot.
+
 ## [4.16.94] - 2026-05-20
 
 ### Changed — Plan 16 finalisation coverage

--- a/docs/PLAN_ACTION/01_ARCHITECTURE_FONDATIONS.md
+++ b/docs/PLAN_ACTION/01_ARCHITECTURE_FONDATIONS.md
@@ -202,7 +202,7 @@ Jobs a mettre en queue :
 
 - [x] **T-ARCH-17** : Creer les Job classes dans `app/Jobs/` — **FAIT** (`app/Jobs/DispatchWebhook.php` implementant ShouldQueue)
 - [x] **T-ARCH-18** : Configurer `config/queue.php` avec les queues nommees — **FAIT** (`config/queue.php` configure)
-- [ ] **T-ARCH-19** : Ajouter le workflow CI pour tester les jobs
+- [x] **T-ARCH-19** : Ajouter le workflow CI pour tester les jobs — **FAIT** (`.github/workflows/backend-jobs-ci.yml` couvre les contrats queues + warmup PDF paie)
 - [x] **T-ARCH-20** : Documenter le setup worker dans `DEPLOYMENT_GUIDE.md` (Render Worker) — **FAIT**
 
 ---

--- a/docs/PLAN_ACTION/08_TESTS_CI_CD.md
+++ b/docs/PLAN_ACTION/08_TESTS_CI_CD.md
@@ -408,7 +408,7 @@ repos:
 - [x] **T-CI-04** : Creer le workflow deploy staging — **FAIT** (`deploy-staging.yml`)
 - [x] **T-CI-05** : Configurer les seuils de coverage progressifs — **FAIT** (`coverage-gate.yml` seuil 55%, cible 60%)
 - [x] **T-CI-06** : Ajouter `.pre-commit-config.yaml` — **FAIT** (`.pre-commit-config.yaml` avec trailing-whitespace, end-of-file-fixer, check-yaml, check-json, detect-secrets)
-- [ ] **T-CI-07** : Ajouter les badges CI/coverage au README.md — **RESTE**
+- [x] **T-CI-07** : Ajouter les badges CI/coverage au README.md — **FAIT** (badges CI, coverage, security, licence, PHP et Flutter presents dans `README.md`)
 - [ ] **T-CI-08** : Configurer les branch protection rules sur GitHub — **RESTE** (config GitHub UI)
 - [x] **T-CI-09** : Creer les factories manquantes pour les nouveaux modeles — **FAIT** (factories dans `database/factories/`)
 - [x] **T-CI-10** : Ecrire les tests Feature pour tous les nouveaux modules — **FAIT** (60+ test files dans `tests/Feature/`)

--- a/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
+++ b/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
@@ -1,0 +1,47 @@
+# 17 — Plan d'execution coverage et lancement
+
+**Date :** 2026-05-20  
+**Positionnement :** dernier lot technique avant acceleration marketing publique.
+
+## Objectif
+
+Amener le socle API au niveau de confiance necessaire pour absorber les premiers volumes marketing sans casser les parcours critiques. Le plan 17 ne reconstruit pas l'existant : il augmente la fiabilite mesurable, ferme les angles morts restants et prepare la prochaine hausse de seuil coverage.
+
+## Lot 17.1 — Coverage backend 60%
+
+- [ ] Ajouter des tests cibles sur les services et controllers les plus critiques non couverts.
+- [ ] Priorite : paie, absences, attendance, notifications, webhooks, billing, onboarding.
+- [ ] Mesurer la coverage statement apres chaque PR et ne monter `DEFAULT_BACKEND_COVERAGE_MIN` a `60` qu'apres un run CI vert >= 60%.
+- [ ] Publier la mesure dans `CHANGELOG.md` et `AGENTS.md`.
+
+## Lot 17.2 — Contrats API frontends
+
+- [ ] Ajouter des tests de contrat JSON pour les endpoints consommes par admin-dashboard, vitrine, mobile et kiosque.
+- [ ] Verifier les erreurs standardisees `message`, `errors`, `code`, `request_id`.
+- [ ] Verifier pagination, filtres, tri et payloads vides sur les listes RH critiques.
+
+## Lot 17.3 — Vitrine multilingue conversion
+
+- [ ] Finaliser `/pricing`, `/demo`, `/integrations`, `/blog` en FR/EN/AR/TR.
+- [ ] Ajouter schema.org, sitemap, robots et metadata par locale.
+- [ ] Brancher les formulaires demo/newsletter sur une API ou un endpoint server-side observable.
+
+## Lot 17.4 — Mobile et kiosque readiness
+
+- [ ] Ajouter les parcours mobile prioritaires : conges, bulletins, notifications push.
+- [ ] Ajouter les contrats kiosk : post-pointage, QR code, affichage infos employe.
+- [ ] Documenter les endpoints obligatoires par frontend.
+
+## Lot 17.5 — Observabilite lancement
+
+- [ ] Creer un tableau de bord lancement : health API, erreurs 5xx, temps p95, queue depth, jobs failed, leads demo.
+- [ ] Ajouter alerting externe pour `/api/v1/health`, `/docs`, vitrine et admin.
+- [ ] Formaliser le rollback marketing : comment stopper acquisition, queue, emails, webhooks et deploy.
+
+## Definition of done
+
+- CI verte sur backend, coverage, jobs, admin, vitrine, OpenAPI, security.
+- Coverage backend >= 60% avant ratchet du seuil.
+- Aucun endpoint frontend critique sans test de contrat.
+- Les plans d'action historiques distinguent clairement code livre, operations externes et backlog strategique.
+- Le release readiness report est mis a jour avant annonce marketing.


### PR DESCRIPTION
## Summary\n- add a dedicated Backend Jobs CI workflow for queue/job contracts\n- run QueueJobsTest and the payroll PDF warmup dispatch contract when jobs/listeners/payroll dispatch code changes\n- mark T-ARCH-19 and T-CI-07 as completed in PLAN_ACTION\n- create Plan 17 for coverage/API/frontend/mobile launch readiness\n\n## Validation\n- git diff --check\n- reviewed workflow structure locally\n\n## Notes\n- Local Windows PHP lacks the full Composer/OpenSSL setup, so GitHub Actions remains the source of truth for executing the Laravel test job.