### PR TITLE
feat: localize blog and SEO alternates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le workflow `e2e-staging.yml` distingue l'URL API/admin Render (`DEFAULT_STAGING_URL`) de l'URL vitrine Vercel (`DEFAULT_WEB_STAGING_URL`). Ne pas pointer les tests landing `front/web` vers le backend API.
 - Sur la vitrine, garder le gate staging limite a `front/web/e2e/staging-smoke.spec.ts`. Les tests de conversion complets manipulent des formulaires et des CTA plus profonds ; ils sont utiles en local/preview, mais trop fragiles et trop larges pour une cible publique de production.
 - Les pages vitrine conversion `/pricing`, `/demo` et `/integrations` utilisent `useVitrineLocale()` avec contenu FR/EN/TR/AR et `dir=rtl` pour l'arabe. Toute evolution marketing sur ces pages doit ajouter les 4 locales dans le meme changement.
+- Le blog vitrine utilise `getBlogPosts(locale)` / `getBlogPost(slug, locale)` et le rail `?lang=` pour les alternates sitemap/hreflang. Toute nouvelle entree blog doit conserver slug stable et champs localises FR/EN/TR/AR.
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.98] - 2026-05-21
+
+### Added
+
+- Vitrine : blog et articles localises en FR/EN/TR/AR via `getBlogPosts(locale)` / `getBlogPost(locale)`.
+- SEO : sitemap enrichi avec alternates/hreflang compatibles avec le rail `?lang=` et metadata canonical multilingue.
+- Vitrine : formulaire newsletter enrichi avec la locale courante pour qualifier les leads.
+
+### Changed
+
+- Vitrine : cartes blog, grille, article et newsletter acceptent des libelles localises pour dates, pagination, temps de lecture et messages formulaire.
+- Docs : Plan 17 mis a jour avec l'etat reel du sous-lot blog/SEO.
+
 ## [4.16.97] - 2026-05-21
 
 ### Added

--- a/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
+++ b/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
@@ -30,9 +30,11 @@ Amener le socle API au niveau de confiance necessaire pour absorber les premiers
 ## Lot 17.3 — Vitrine multilingue conversion
 
 - [x] Finaliser `/pricing`, `/demo` et `/integrations` en FR/EN/AR/TR avec support RTL arabe.
-- [ ] Auditer et finaliser `/blog` en FR/EN/AR/TR.
-- [ ] Ajouter schema.org, sitemap, robots et metadata par locale.
+- [x] Auditer et finaliser `/blog` en FR/EN/AR/TR.
+- [x] Ajouter alternates sitemap/hreflang et metadata canonical compatibles avec le rail `?lang=`.
+- [ ] Auditer schema.org par locale sur les contenus marketing dynamiques.
 - [x] Conserver le formulaire demo sur endpoint server-side `/api/forms/demo` et transmettre la locale courante.
+- [x] Conserver le formulaire newsletter sur endpoint server-side `/api/forms/newsletter` et transmettre la locale courante.
 - [ ] Ajouter observabilite metier explicite sur les leads demo/newsletter.
 
 ## Lot 17.4 — Mobile et kiosque readiness

--- a/front/web/src/app/(landing)/blog/[slug]/page.tsx
+++ b/front/web/src/app/(landing)/blog/[slug]/page.tsx
@@ -2,7 +2,9 @@
 
 import { use, useState } from 'react';
 import { Navbar, Footer, useScrollReveal, BlogArticle } from '@/modules/vitrine';
-import { blogPosts } from '@/modules/vitrine/data/blog';
+import { getBlogPost, getBlogPosts } from '@/modules/vitrine/data/blog';
+import { useVitrineLocale } from '@/modules/vitrine/lib/vitrine-locale';
+import type { AppLocale } from '@/lib/i18n';
 import { notFound } from 'next/navigation';
 
 interface BlogArticlePageProps {
@@ -11,28 +13,73 @@ interface BlogArticlePageProps {
   }>;
 }
 
+const articleCopy: Record<AppLocale, {
+  dateLocale: string;
+  readingTime: string;
+  tableOfContents: string;
+  authorRole: string;
+  relatedTitle: string;
+}> = {
+  fr: {
+    dateLocale: 'fr-FR',
+    readingTime: 'min de lecture',
+    tableOfContents: 'Table des matieres',
+    authorRole: 'Auteur et expert en gestion RH',
+    relatedTitle: 'Articles recommandes',
+  },
+  en: {
+    dateLocale: 'en-US',
+    readingTime: 'min read',
+    tableOfContents: 'Table of contents',
+    authorRole: 'Author and HR operations expert',
+    relatedTitle: 'Recommended articles',
+  },
+  tr: {
+    dateLocale: 'tr-TR',
+    readingTime: 'dk okuma',
+    tableOfContents: 'Icindekiler',
+    authorRole: 'Yazar ve IK operasyonlari uzmani',
+    relatedTitle: 'Onerilen yazilar',
+  },
+  ar: {
+    dateLocale: 'ar',
+    readingTime: 'دقيقة قراءة',
+    tableOfContents: 'جدول المحتويات',
+    authorRole: 'كاتب وخبير في عمليات الموارد البشرية',
+    relatedTitle: 'مقالات مقترحة',
+  },
+};
+
 export default function BlogArticlePage({ params }: BlogArticlePageProps) {
   const [isDark, setIsDark] = useState(false);
+  const { locale, direction } = useVitrineLocale();
+  const copy = articleCopy[locale] ?? articleCopy.fr;
   useScrollReveal();
   const { slug } = use(params);
 
-  // Find the post
-  const post = blogPosts.find((p) => p.slug === slug);
+  const post = getBlogPost(slug, locale);
 
   if (!post) {
     notFound();
   }
 
-  // Get related posts (same category, excluding current)
-  const relatedPosts = blogPosts.filter(
+  const relatedPosts = getBlogPosts(locale).filter(
     (p) => p.category === post.category && p.slug !== post.slug
   );
 
   return (
-    <div className={`min-h-screen transition-colors duration-500 ${isDark ? 'dark bg-slate-950' : 'bg-white'}`}>
+    <div dir={direction} className={`min-h-screen transition-colors duration-500 ${isDark ? 'dark bg-slate-950' : 'bg-white'}`}>
       <Navbar isDark={isDark} onToggleDark={() => setIsDark(!isDark)} />
 
-      <BlogArticle post={post} relatedPosts={relatedPosts} />
+      <BlogArticle
+        post={post}
+        relatedPosts={relatedPosts}
+        dateLocale={copy.dateLocale}
+        readingTimeLabel={copy.readingTime}
+        tableOfContentsLabel={copy.tableOfContents}
+        authorRoleLabel={copy.authorRole}
+        relatedTitle={copy.relatedTitle}
+      />
 
       <Footer />
     </div>

--- a/front/web/src/app/(landing)/blog/page.tsx
+++ b/front/web/src/app/(landing)/blog/page.tsx
@@ -9,17 +9,171 @@ import {
   useScrollReveal,
   BlogGrid,
 } from '@/modules/vitrine';
-import { blogPosts } from '@/modules/vitrine/data/blog';
+import { getBlogPosts } from '@/modules/vitrine/data/blog';
+import { useVitrineLocale } from '@/modules/vitrine/lib/vitrine-locale';
+import type { AppLocale } from '@/lib/i18n';
 import { NewsletterForm } from '@/components/NewsletterForm';
 import { motion } from 'framer-motion';
 import { BookOpen } from 'lucide-react';
 
+const blogCopy: Record<AppLocale, {
+  dateLocale: string;
+  readingTime: string;
+  hero: { headline: string; subheadline: string; cta: string; badge: string };
+  grid: { title: string; subtitle: string; badge: string; all: string; previous: string; next: string };
+  newsletter: { badge: string; title: string; description: string; note: string; placeholder: string; submit: string; submitting: string; success: string; error: string };
+  cta: { headline: string; subheadline: string; primary: string; secondary: string };
+}> = {
+  fr: {
+    dateLocale: 'fr-FR',
+    readingTime: 'min de lecture',
+    hero: {
+      headline: 'Blog et ressources RH',
+      subheadline: 'Guides, articles et conseils pour structurer vos RH, votre paie et votre croissance.',
+      cta: "S'inscrire a la newsletter",
+      badge: 'Contenu gratuit',
+    },
+    grid: {
+      title: 'Nos articles',
+      subtitle: 'Conseils pratiques pour equipes RH ambitieuses',
+      badge: 'Ressources',
+      all: 'Tous',
+      previous: 'Precedent',
+      next: 'Suivant',
+    },
+    newsletter: {
+      badge: 'Newsletter',
+      title: 'Recevez nos conseils hebdomadaires',
+      description: 'Articles, guides et retours terrain pour lancer une plateforme RH plus solide.',
+      note: 'Pas de spam, uniquement des conseils utiles. Desinscription facile.',
+      placeholder: 'Votre email',
+      submit: "S'inscrire",
+      submitting: 'Envoi...',
+      success: 'Inscription reussie !',
+      error: "Erreur lors de l'inscription",
+    },
+    cta: {
+      headline: 'Besoin d un avis expert ?',
+      subheadline: 'Contactez notre equipe pour cadrer vos priorites RH et digitales.',
+      primary: 'Nous contacter',
+      secondary: 'Essai gratuit',
+    },
+  },
+  en: {
+    dateLocale: 'en-US',
+    readingTime: 'min read',
+    hero: {
+      headline: 'HR blog and resources',
+      subheadline: 'Guides, articles and practical advice to structure HR, payroll and growth.',
+      cta: 'Join the newsletter',
+      badge: 'Free content',
+    },
+    grid: {
+      title: 'Latest articles',
+      subtitle: 'Practical insight for ambitious HR teams',
+      badge: 'Resources',
+      all: 'All',
+      previous: 'Previous',
+      next: 'Next',
+    },
+    newsletter: {
+      badge: 'Newsletter',
+      title: 'Get weekly HR insights',
+      description: 'Articles, guides and field notes to build a stronger HR platform.',
+      note: 'No spam, only useful advice. Unsubscribe anytime.',
+      placeholder: 'Your email',
+      submit: 'Subscribe',
+      submitting: 'Sending...',
+      success: 'Subscription confirmed!',
+      error: 'Unable to subscribe',
+    },
+    cta: {
+      headline: 'Need an expert opinion?',
+      subheadline: 'Talk to our team to clarify your HR and digital priorities.',
+      primary: 'Contact us',
+      secondary: 'Start free trial',
+    },
+  },
+  tr: {
+    dateLocale: 'tr-TR',
+    readingTime: 'dk okuma',
+    hero: {
+      headline: 'IK blogu ve kaynaklar',
+      subheadline: 'IK, bordro ve buyumeyi daha sistemli hale getirmek icin rehberler ve pratik oneriler.',
+      cta: 'Bultene katil',
+      badge: 'Ucretsiz icerik',
+    },
+    grid: {
+      title: 'Son yazilar',
+      subtitle: 'Iddiali IK ekipleri icin pratik icgoru',
+      badge: 'Kaynaklar',
+      all: 'Tumu',
+      previous: 'Onceki',
+      next: 'Sonraki',
+    },
+    newsletter: {
+      badge: 'Bulten',
+      title: 'Haftalik IK onerileri alin',
+      description: 'Daha saglam bir IK platformu kurmak icin yazilar, rehberler ve saha notlari.',
+      note: 'Spam yok, sadece faydali icerik. Isteyen herkes kolayca ayrilabilir.',
+      placeholder: 'E-posta adresiniz',
+      submit: 'Kaydol',
+      submitting: 'Gonderiliyor...',
+      success: 'Kayit tamamlandi!',
+      error: 'Kayit yapilamadi',
+    },
+    cta: {
+      headline: 'Uzman gorusune ihtiyaciniz var mi?',
+      subheadline: 'IK ve dijital onceliklerinizi netlestirmek icin ekibimizle gorusun.',
+      primary: 'Iletisime gec',
+      secondary: 'Ucretsiz dene',
+    },
+  },
+  ar: {
+    dateLocale: 'ar',
+    readingTime: 'دقيقة قراءة',
+    hero: {
+      headline: 'مدونة وموارد الموارد البشرية',
+      subheadline: 'أدلة ومقالات ونصائح عملية لتنظيم الموارد البشرية والرواتب والنمو.',
+      cta: 'اشترك في النشرة',
+      badge: 'محتوى مجاني',
+    },
+    grid: {
+      title: 'أحدث المقالات',
+      subtitle: 'رؤى عملية لفرق موارد بشرية طموحة',
+      badge: 'الموارد',
+      all: 'الكل',
+      previous: 'السابق',
+      next: 'التالي',
+    },
+    newsletter: {
+      badge: 'النشرة البريدية',
+      title: 'استلم نصائح أسبوعية للموارد البشرية',
+      description: 'مقالات وأدلة وتجارب عملية لبناء منصة موارد بشرية أقوى.',
+      note: 'بدون رسائل مزعجة، فقط نصائح مفيدة. يمكنك إلغاء الاشتراك بسهولة.',
+      placeholder: 'بريدك الإلكتروني',
+      submit: 'اشترك',
+      submitting: 'جار الإرسال...',
+      success: 'تم الاشتراك بنجاح!',
+      error: 'تعذر الاشتراك',
+    },
+    cta: {
+      headline: 'هل تحتاج إلى رأي خبير؟',
+      subheadline: 'تواصل مع فريقنا لتحديد أولويات الموارد البشرية والتحول الرقمي.',
+      primary: 'تواصل معنا',
+      secondary: 'ابدأ تجربة مجانية',
+    },
+  },
+};
+
 export default function BlogPage() {
   const [isDark, setIsDark] = useState(false);
+  const { locale, direction } = useVitrineLocale();
+  const copy = blogCopy[locale] ?? blogCopy.fr;
+  const posts = getBlogPosts(locale);
   useScrollReveal();
 
-  // Transform blog posts to match BlogCardProps
-  const blogCards = blogPosts.map((post) => ({
+  const blogCards = posts.map((post) => ({
     slug: post.slug,
     title: post.title,
     excerpt: post.excerpt,
@@ -30,43 +184,35 @@ export default function BlogPage() {
     readingTime: post.readingTime,
   }));
 
-  // Get unique categories
-  const categories = Array.from(new Set(blogPosts.map((post) => post.category)));
+  const categories = Array.from(new Set(posts.map((post) => post.category)));
 
   return (
-    <div className={`min-h-screen transition-colors duration-500 ${isDark ? 'dark bg-slate-950' : 'bg-white'}`}>
+    <div dir={direction} className={`min-h-screen transition-colors duration-500 ${isDark ? 'dark bg-slate-950' : 'bg-white'}`}>
       <Navbar isDark={isDark} onToggleDark={() => setIsDark(!isDark)} />
 
-      {/* Hero Section */}
       <HeroSection
-        headline="Blog & Resources"
-        subheadline="Guides, articles et conseils pour optimiser votre gestion RH"
-        ctaPrimary={{
-          text: 'S\'inscrire à la Newsletter',
-          href: '#newsletter',
-        }}
-        badge={{
-          text: 'Contenu Gratuit',
-          icon: <BookOpen className="w-3 h-3" />,
-        }}
+        headline={copy.hero.headline}
+        subheadline={copy.hero.subheadline}
+        ctaPrimary={{ text: copy.hero.cta, href: '#newsletter' }}
+        badge={{ text: copy.hero.badge, icon: <BookOpen className="w-3 h-3" /> }}
       />
 
-      {/* Blog Grid */}
       <BlogGrid
-        title="Nos Articles"
-        subtitle="Découvrez nos derniers articles"
+        title={copy.grid.title}
+        subtitle={copy.grid.subtitle}
         posts={blogCards}
         categories={categories}
         itemsPerPage={9}
-        showPagination={true}
-        showFilters={true}
-        badge={{
-          text: 'Ressources',
-          icon: <BookOpen className="w-3 h-3" />,
-        }}
+        showPagination
+        showFilters
+        allLabel={copy.grid.all}
+        previousLabel={copy.grid.previous}
+        nextLabel={copy.grid.next}
+        dateLocale={copy.dateLocale}
+        readingTimeLabel={copy.readingTime}
+        badge={{ text: copy.grid.badge, icon: <BookOpen className="w-3 h-3" /> }}
       />
 
-      {/* Newsletter Section */}
       <section id="newsletter" className="relative py-32 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/10 via-cyan-500/10 to-emerald-500/10 dark:from-emerald-500/5 dark:via-cyan-500/5 dark:to-emerald-500/5" />
 
@@ -80,38 +226,36 @@ export default function BlogPage() {
           >
             <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/[0.08] border border-emerald-500/15 text-emerald-700 dark:text-emerald-400 text-sm font-semibold mb-6">
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-              Newsletter
+              {copy.newsletter.badge}
             </div>
             <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
-              Recevez nos Conseils Hebdomadaires
+              {copy.newsletter.title}
             </h2>
             <p className="text-lg text-slate-600 dark:text-slate-400 mb-8 leading-relaxed">
-              Inscrivez-vous à notre newsletter pour recevoir les derniers articles, guides et conseils directement
-              dans votre boîte mail.
+              {copy.newsletter.description}
             </p>
 
-            {/* Newsletter Form */}
-            <NewsletterForm />
+            <NewsletterForm
+              locale={locale}
+              placeholder={copy.newsletter.placeholder}
+              submitLabel={copy.newsletter.submit}
+              submittingLabel={copy.newsletter.submitting}
+              successFallback={copy.newsletter.success}
+              errorFallback={copy.newsletter.error}
+            />
 
             <p className="text-sm text-slate-500 dark:text-slate-400 mt-4">
-              Pas de spam, juste des conseils utiles. Désinscription facile.
+              {copy.newsletter.note}
             </p>
           </motion.div>
         </div>
       </section>
 
-      {/* CTA Section */}
       <CTASection
-        headline="Besoin d'Aide?"
-        subheadline="Contactez notre équipe pour des conseils personnalisés"
-        ctaPrimary={{
-          text: 'Nous Contacter',
-          href: '/contact',
-        }}
-        ctaSecondary={{
-          text: 'Essai gratuit',
-          href: '/signup',
-        }}
+        headline={copy.cta.headline}
+        subheadline={copy.cta.subheadline}
+        ctaPrimary={{ text: copy.cta.primary, href: '/contact' }}
+        ctaSecondary={{ text: copy.cta.secondary, href: '/signup' }}
         background="gradient"
       />
 

--- a/front/web/src/app/sitemap.ts
+++ b/front/web/src/app/sitemap.ts
@@ -2,26 +2,53 @@ import type { MetadataRoute } from 'next';
 import { getAllPosts } from '@/lib/mdx';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://leopardo.com';
+const locales = ['fr', 'en', 'tr', 'ar'] as const;
+
+function localizedAlternates(path: string) {
+  const cleanPath = path === '/' ? '' : path;
+
+  return {
+    languages: Object.fromEntries(
+      locales.map((locale) => [
+        locale,
+        locale === 'fr'
+          ? `${siteUrl}${cleanPath || '/'}`
+          : `${siteUrl}${cleanPath || '/'}?lang=${locale}`,
+      ])
+    ),
+  };
+}
+
+function page(path: string, lastModified: Date, changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency'], priority: number): MetadataRoute.Sitemap[number] {
+  return {
+    url: `${siteUrl}${path === '/' ? '/' : path}`,
+    lastModified,
+    changeFrequency,
+    priority,
+    alternates: localizedAlternates(path),
+  };
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const today = new Date();
 
   const staticPages: MetadataRoute.Sitemap = [
-    { url: `${siteUrl}/`, lastModified: today, changeFrequency: 'weekly', priority: 1.0 },
-    { url: `${siteUrl}/employes`, lastModified: today, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${siteUrl}/documents`, lastModified: today, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${siteUrl}/comptabilite`, lastModified: today, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${siteUrl}/marketing`, lastModified: today, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${siteUrl}/pricing`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${siteUrl}/demo`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${siteUrl}/about`, lastModified: today, changeFrequency: 'monthly', priority: 0.7 },
-    { url: `${siteUrl}/changelog`, lastModified: today, changeFrequency: 'weekly', priority: 0.65 },
-    { url: `${siteUrl}/blog`, lastModified: today, changeFrequency: 'weekly', priority: 0.8 },
-    { url: `${siteUrl}/privacy`, lastModified: today, changeFrequency: 'yearly', priority: 0.4 },
-    { url: `${siteUrl}/terms`, lastModified: today, changeFrequency: 'yearly', priority: 0.4 },
-    { url: `${siteUrl}/guides/rh-startup`, lastModified: today, changeFrequency: 'monthly', priority: 0.7 },
-    { url: `${siteUrl}/guides/checklist-paie`, lastModified: today, changeFrequency: 'monthly', priority: 0.7 },
-    { url: `${siteUrl}/guides/planning-employes`, lastModified: today, changeFrequency: 'monthly', priority: 0.7 },
+    page('/', today, 'weekly', 1.0),
+    page('/employes', today, 'weekly', 0.9),
+    page('/documents', today, 'weekly', 0.9),
+    page('/comptabilite', today, 'weekly', 0.9),
+    page('/marketing', today, 'weekly', 0.9),
+    page('/pricing', today, 'monthly', 0.8),
+    page('/demo', today, 'monthly', 0.8),
+    page('/integrations', today, 'monthly', 0.75),
+    page('/about', today, 'monthly', 0.7),
+    page('/changelog', today, 'weekly', 0.65),
+    page('/blog', today, 'weekly', 0.8),
+    page('/privacy', today, 'yearly', 0.4),
+    page('/terms', today, 'yearly', 0.4),
+    page('/guides/rh-startup', today, 'monthly', 0.7),
+    page('/guides/checklist-paie', today, 'monthly', 0.7),
+    page('/guides/planning-employes', today, 'monthly', 0.7),
   ];
 
   const blogPosts = getAllPosts();
@@ -30,6 +57,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     lastModified: post.date ? new Date(post.date) : today,
     changeFrequency: 'monthly' as const,
     priority: 0.6,
+    alternates: localizedAlternates(`/blog/${post.slug}`),
   }));
 
   return [...staticPages, ...blogPages];

--- a/front/web/src/components/NewsletterForm.tsx
+++ b/front/web/src/components/NewsletterForm.tsx
@@ -4,7 +4,23 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { CheckCircle } from 'lucide-react';
 
-export function NewsletterForm() {
+interface NewsletterFormProps {
+  locale?: string;
+  placeholder?: string;
+  submitLabel?: string;
+  submittingLabel?: string;
+  successFallback?: string;
+  errorFallback?: string;
+}
+
+export function NewsletterForm({
+  locale = 'fr',
+  placeholder = 'Votre email',
+  submitLabel = "S'inscrire",
+  submittingLabel = 'Envoi...',
+  successFallback = 'Inscription reussie !',
+  errorFallback = "Erreur lors de l'inscription",
+}: NewsletterFormProps) {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
@@ -19,6 +35,7 @@ export function NewsletterForm() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           email,
+          locale,
           page: typeof window !== 'undefined' ? window.location.pathname : '/blog',
           timestamp: new Date().toISOString(),
         }),
@@ -27,15 +44,15 @@ export function NewsletterForm() {
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.message || 'Erreur lors de l\'inscription');
+        throw new Error(data.message || errorFallback);
       }
 
       setStatus('success');
-      setMessage(data.message || 'Inscription reussie !');
+      setMessage(data.message || successFallback);
       setEmail('');
     } catch (err) {
       setStatus('error');
-      setMessage(err instanceof Error ? err.message : 'Une erreur est survenue');
+      setMessage(err instanceof Error ? err.message : errorFallback);
     }
   };
 
@@ -66,7 +83,7 @@ export function NewsletterForm() {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          placeholder="Votre email"
+          placeholder={placeholder}
           required
           disabled={status === 'loading'}
           className="flex-1 px-4 py-3 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 transition-all disabled:opacity-50"
@@ -76,7 +93,7 @@ export function NewsletterForm() {
           disabled={status === 'loading'}
           className="px-6 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-400 text-white font-bold transition-colors whitespace-nowrap"
         >
-          {status === 'loading' ? 'Envoi...' : "S'inscrire"}
+          {status === 'loading' ? submittingLabel : submitLabel}
         </button>
       </motion.form>
 

--- a/front/web/src/modules/vitrine/components/sections/BlogArticle.tsx
+++ b/front/web/src/modules/vitrine/components/sections/BlogArticle.tsx
@@ -12,10 +12,23 @@ import { BlogPost } from '@/modules/vitrine/data/blog';
 export interface BlogArticleProps {
   post: BlogPost;
   relatedPosts: BlogPost[];
+  dateLocale?: string;
+  readingTimeLabel?: string;
+  tableOfContentsLabel?: string;
+  authorRoleLabel?: string;
+  relatedTitle?: string;
 }
 
-export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
-  const formattedDate = new Date(post.date).toLocaleDateString('fr-FR', {
+export function BlogArticle({
+  post,
+  relatedPosts,
+  dateLocale = 'fr-FR',
+  readingTimeLabel = 'min de lecture',
+  tableOfContentsLabel = 'Table des matieres',
+  authorRoleLabel = 'Auteur et expert en gestion RH',
+  relatedTitle = 'Articles recommandes',
+}: BlogArticleProps) {
+  const formattedDate = new Date(post.date).toLocaleDateString(dateLocale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -139,7 +152,7 @@ export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
               </div>
               <div className="flex items-center gap-2">
                 <Clock className="w-4 h-4" />
-                {post.readingTime} min de lecture
+                {post.readingTime} {readingTimeLabel}
               </div>
             </div>
 
@@ -173,7 +186,7 @@ export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
               {tableOfContents.length > 0 && (
                 <div className="sticky top-24 mb-8 p-6 rounded-xl bg-slate-50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-800">
                   <h3 className="text-sm font-bold text-slate-900 dark:text-white mb-4 uppercase tracking-wider">
-                    Table des Matières
+                    {tableOfContentsLabel}
                   </h3>
                   <ul className="space-y-2">
                     {tableOfContents.map((item) => (
@@ -204,7 +217,7 @@ export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
                   {post.author.name}
                 </h4>
                 <p className="text-sm text-slate-600 dark:text-slate-400">
-                  Auteur et expert en gestion RH
+                  {authorRoleLabel}
                 </p>
               </div>
             </motion.div>
@@ -246,7 +259,7 @@ export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
               className="text-center mb-16"
             >
               <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
-                Articles Recommandés
+                {relatedTitle}
               </h2>
             </motion.div>
 

--- a/front/web/src/modules/vitrine/components/sections/BlogCard.tsx
+++ b/front/web/src/modules/vitrine/components/sections/BlogCard.tsx
@@ -18,6 +18,8 @@ export interface BlogCardProps {
   category: string;
   readingTime?: number;
   index?: number;
+  dateLocale?: string;
+  readingTimeLabel?: string;
 }
 
 export function BlogCard({
@@ -30,8 +32,10 @@ export function BlogCard({
   category,
   readingTime,
   index = 0,
+  dateLocale = 'fr-FR',
+  readingTimeLabel = 'min de lecture',
 }: BlogCardProps) {
-  const formattedDate = new Date(date).toLocaleDateString('fr-FR', {
+  const formattedDate = new Date(date).toLocaleDateString(dateLocale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -75,7 +79,7 @@ export function BlogCard({
                 <Calendar className="w-3.5 h-3.5" />
                 {formattedDate}
               </div>
-              {readingTime && <span>{readingTime} min de lecture</span>}
+              {readingTime && <span>{readingTime} {readingTimeLabel}</span>}
             </div>
 
             {/* Title */}

--- a/front/web/src/modules/vitrine/components/sections/BlogGrid.tsx
+++ b/front/web/src/modules/vitrine/components/sections/BlogGrid.tsx
@@ -16,6 +16,11 @@ export interface BlogGridProps {
   itemsPerPage?: number;
   showPagination?: boolean;
   showFilters?: boolean;
+  allLabel?: string;
+  previousLabel?: string;
+  nextLabel?: string;
+  dateLocale?: string;
+  readingTimeLabel?: string;
 }
 
 export function BlogGrid({
@@ -27,6 +32,11 @@ export function BlogGrid({
   itemsPerPage = 9,
   showPagination = true,
   showFilters = true,
+  allLabel = 'Tous',
+  previousLabel = 'Precedent',
+  nextLabel = 'Suivant',
+  dateLocale = 'fr-FR',
+  readingTimeLabel = 'min de lecture',
 }: BlogGridProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -102,7 +112,7 @@ export function BlogGrid({
                   : 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-white hover:bg-slate-200 dark:hover:bg-slate-700'
               }`}
             >
-              Tous ({posts.length})
+              {allLabel} ({posts.length})
             </button>
             {uniqueCategories.map((category) => {
               const count = posts.filter((post) => post.category === category).length;
@@ -126,7 +136,13 @@ export function BlogGrid({
         {/* Blog Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
           {paginatedPosts.map((post, index) => (
-            <BlogCard key={post.slug} {...post} index={index} />
+            <BlogCard
+              key={post.slug}
+              {...post}
+              index={index}
+              dateLocale={dateLocale}
+              readingTimeLabel={readingTimeLabel}
+            />
           ))}
         </div>
 
@@ -144,7 +160,7 @@ export function BlogGrid({
               disabled={currentPage === 1}
               className="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
             >
-              Précédent
+              {previousLabel}
             </button>
 
             {Array.from({ length: totalPages }).map((_, i) => {
@@ -169,7 +185,7 @@ export function BlogGrid({
               disabled={currentPage === totalPages}
               className="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
             >
-              Suivant
+              {nextLabel}
             </button>
           </motion.div>
         )}

--- a/front/web/src/modules/vitrine/data/blog.ts
+++ b/front/web/src/modules/vitrine/data/blog.ts
@@ -1,3 +1,5 @@
+import type { AppLocale } from '@/lib/i18n';
+
 export interface BlogPost {
   slug: string;
   title: string;
@@ -592,3 +594,706 @@ Investir dans la formation de vos employés est un investissement dans l'avenir 
     tags: ['formation', 'développement', 'compétences', 'apprentissage'],
   },
 ];
+
+type LocalizedBlogPostFields = Pick<BlogPost, 'title' | 'excerpt' | 'content' | 'category' | 'tags'>;
+
+const localizedBlogPosts: Partial<Record<AppLocale, Record<string, LocalizedBlogPostFields>>> = {
+  en: {
+    'guide-complet-gestion-rh-startup': {
+      title: 'Complete guide: HR management for startups',
+      excerpt: 'Build a reliable HR foundation from the first hires without slowing down growth.',
+      category: 'HR',
+      tags: ['startup', 'HR', 'hiring', 'operations'],
+      content: `# Complete guide: HR management for startups
+
+## Why HR matters early
+
+Startup teams move fast, but people operations cannot stay informal forever. Clear roles, contracts, onboarding and performance rituals protect the company while helping employees understand how to succeed.
+
+## Build the foundation
+
+- Define the roles you need before hiring.
+- Document compensation, leave and approval rules.
+- Centralize employee records and access rights.
+- Prepare onboarding checklists for every new joiner.
+
+## Automate before volume arrives
+
+Use software for attendance, leave, documents and payroll before spreadsheets become the bottleneck. Automation reduces errors and gives managers reliable data.
+
+## Conclusion
+
+A startup with disciplined HR foundations scales faster because every hire enters a clear, secure and measurable operating system.`,
+    },
+    'automatiser-paie-excel-vers-logiciel': {
+      title: 'From Excel to payroll software: practical migration guide',
+      excerpt: 'Move payroll from spreadsheets to automation with less risk and better traceability.',
+      category: 'Payroll',
+      tags: ['payroll', 'excel', 'automation', 'migration'],
+      content: `# From Excel to payroll software: practical migration guide
+
+## Why spreadsheets become risky
+
+Payroll spreadsheets are flexible, but they are hard to audit, hard to secure and easy to break. As soon as the team grows, manual formulas create compliance and payment risks.
+
+## Migration steps
+
+- List every payroll input currently managed in Excel.
+- Clean employee, contract and bank details.
+- Run one parallel payroll cycle before switching.
+- Keep a rollback export for the first production month.
+
+## What to automate first
+
+Start with gross-to-net calculation, payslip generation, bank exports and social declarations. These steps give the fastest reliability gain.
+
+## Conclusion
+
+A controlled migration turns payroll into a predictable process instead of a monthly emergency.`,
+    },
+    'tendances-rh-2024': {
+      title: 'HR trends leaders should watch',
+      excerpt: 'Hybrid work, employee experience, skills and automation are reshaping HR operations.',
+      category: 'Trends',
+      tags: ['trends', 'HR', 'future', 'automation'],
+      content: `# HR trends leaders should watch
+
+## The direction of modern HR
+
+Companies need flexible work models, better employee experience and stronger operational data. HR is becoming a strategic operating system, not only an administrative function.
+
+## Key trends
+
+- Hybrid and distributed team management.
+- Skills development and internal mobility.
+- AI-assisted HR support with human validation.
+- Real-time dashboards for attendance, leave and payroll.
+
+## Conclusion
+
+Teams that invest in structured HR data and automation will move faster with fewer compliance surprises.`,
+    },
+    'productivite-5-conseils-economiser-temps': {
+      title: '5 ways to save time in HR administration',
+      excerpt: 'Reduce repetitive HR work and give managers faster access to reliable data.',
+      category: 'Productivity',
+      tags: ['productivity', 'time', 'HR', 'automation'],
+      content: `# 5 ways to save time in HR administration
+
+## 1. Automate recurring tasks
+
+Attendance imports, leave balances, payroll reports and document reminders should not depend on manual follow-up.
+
+## 2. Centralize data
+
+One source of truth avoids duplicate files and conflicting employee records.
+
+## 3. Use approval workflows
+
+Clear approvals prevent lost requests and reduce back-and-forth messages.
+
+## 4. Give managers self-service views
+
+Managers need team data without asking HR for every report.
+
+## 5. Measure what slows the team
+
+Track delays, errors and manual workload, then automate the highest-volume workflows first.`,
+    },
+    'conformite-rgpd-donnees-employes': {
+      title: 'GDPR compliance: protecting employee data',
+      excerpt: 'A practical guide to secure sensitive HR data with clear governance.',
+      category: 'Security',
+      tags: ['GDPR', 'privacy', 'security', 'employee data'],
+      content: `# GDPR compliance: protecting employee data
+
+## Employee data is sensitive
+
+HR platforms process identity, payroll, contracts, performance and attendance data. This requires clear access control and traceability.
+
+## Practical controls
+
+- Limit access by role and tenant.
+- Encrypt sensitive fields and backups.
+- Keep audit logs for critical actions.
+- Provide export and deletion request workflows.
+
+## Conclusion
+
+Privacy compliance is stronger when it is built into daily workflows instead of handled manually after incidents.`,
+    },
+    'culture-entreprise-engagement-employes': {
+      title: 'Company culture: improving employee engagement',
+      excerpt: 'Create rituals and feedback loops that help employees stay aligned and motivated.',
+      category: 'Engagement',
+      tags: ['culture', 'engagement', 'feedback', 'retention'],
+      content: `# Company culture: improving employee engagement
+
+## Culture is operational
+
+Engagement grows when employees understand goals, receive feedback and see consistent management rituals.
+
+## Practical levers
+
+- Share priorities clearly.
+- Recognize contributions often.
+- Measure engagement with short surveys.
+- Train managers on regular one-to-one conversations.
+
+## Conclusion
+
+Strong culture is built through repeatable habits, not occasional speeches.`,
+    },
+    'pointage-biometrique-avantages': {
+      title: 'Biometric attendance: benefits and safeguards',
+      excerpt: 'Understand where biometric attendance helps and which privacy controls must be in place.',
+      category: 'Attendance',
+      tags: ['attendance', 'biometrics', 'security', 'kiosk'],
+      content: `# Biometric attendance: benefits and safeguards
+
+## Why companies adopt it
+
+Biometric terminals reduce buddy punching, speed up shift tracking and improve payroll accuracy.
+
+## Required safeguards
+
+- Obtain explicit employee consent where required.
+- Limit biometric data access.
+- Keep device sync logs.
+- Provide fallback attendance methods.
+
+## Conclusion
+
+Biometric attendance is powerful when security, consent and auditability are designed from day one.`,
+    },
+    'gestion-absences-congés-efficace': {
+      title: 'Efficient leave and absence management',
+      excerpt: 'Build a clear approval workflow and avoid leave balance conflicts.',
+      category: 'Leave',
+      tags: ['leave', 'absence', 'approval', 'balance'],
+      content: `# Efficient leave and absence management
+
+## The common problem
+
+Leave requests often get lost in messages, while balances become difficult to trust.
+
+## A better workflow
+
+- Define request, approval and cancellation rules.
+- Give managers team calendars.
+- Recalculate balances automatically.
+- Notify employees at every status change.
+
+## Conclusion
+
+Clear absence workflows reduce disputes and give managers better planning visibility.`,
+    },
+    'recrutement-digital-sourcing-talents': {
+      title: 'Digital recruiting: sourcing better talent',
+      excerpt: 'Organize candidates, interviews and decisions in a measurable hiring pipeline.',
+      category: 'Recruiting',
+      tags: ['recruiting', 'sourcing', 'candidates', 'pipeline'],
+      content: `# Digital recruiting: sourcing better talent
+
+## Recruiting needs structure
+
+Without a shared pipeline, candidate data spreads across emails and spreadsheets.
+
+## What to track
+
+- Job posts and channels.
+- Candidate stages and notes.
+- Interview feedback.
+- Time-to-hire and offer conversion.
+
+## Conclusion
+
+A digital hiring pipeline improves speed, fairness and reporting.`,
+    },
+    'formation-developpement-competences': {
+      title: 'Training and skills development',
+      excerpt: 'Turn training plans into measurable skill growth for employees and managers.',
+      category: 'Training',
+      tags: ['training', 'skills', 'development', 'learning'],
+      content: `# Training and skills development
+
+## Why skills planning matters
+
+Growth creates new roles and new expectations. Training plans help teams adapt before gaps become blockers.
+
+## Build a useful program
+
+- Map required skills by role.
+- Track training attendance.
+- Connect evaluations to development plans.
+- Measure completion and impact.
+
+## Conclusion
+
+Training becomes strategic when it is linked to roles, performance and future workforce needs.`,
+    },
+  },
+  tr: {
+    'guide-complet-gestion-rh-startup': {
+      title: 'Startup lar icin IK yonetimi rehberi',
+      excerpt: 'Ilk ise alimlardan itibaren saglam ve olceklenebilir bir IK temeli kurun.',
+      category: 'IK',
+      tags: ['startup', 'IK', 'ise alim', 'operasyon'],
+      content: `# Startup lar icin IK yonetimi rehberi
+
+## Erken donemde IK neden onemlidir
+
+Hizli buyuyen ekiplerde roller, sozlesmeler, izin kurallari ve onboarding net olmazsa operasyon cabuk dagilir.
+
+## Temel adimlar
+
+- Ihtiyac duyulan rolleri ise alimdan once netlestirin.
+- Maas, izin ve onay kurallarini yazili hale getirin.
+- Calisan kayitlarini ve erisimleri merkezi tutun.
+- Her yeni calisan icin onboarding listesi hazirlayin.
+
+## Sonuc
+
+Saglam IK temeli kuran startup lar daha hizli buyur ve daha az operasyon riski tasir.`,
+    },
+    'automatiser-paie-excel-vers-logiciel': {
+      title: 'Excel den bordro yazilimina gecis rehberi',
+      excerpt: 'Bordroyu elektronik tablolardan otomasyona daha az riskle tasiyin.',
+      category: 'Bordro',
+      tags: ['bordro', 'excel', 'otomasyon', 'gecis'],
+      content: `# Excel den bordro yazilimina gecis rehberi
+
+## Excel neden riskli hale gelir
+
+Excel esnektir ama denetimi, guvenligi ve olceklenmesi zordur. Ekip buyudukce manuel formul hatalari artar.
+
+## Gecis adimlari
+
+- Mevcut bordro girdilerini listeleyin.
+- Calisan, sozlesme ve banka bilgilerini temizleyin.
+- Ilk ay paralel hesaplama yapin.
+- Canli gecis icin geri donus dosyasi saklayin.
+
+## Sonuc
+
+Kontrollu gecis bordroyu aylik kriz olmaktan cikarip olculebilir surece donusturur.`,
+    },
+    'tendances-rh-2024': {
+      title: 'IK liderlerinin izlemesi gereken trendler',
+      excerpt: 'Hibrit calisma, yetenek gelisimi ve otomasyon IK operasyonlarini degistiriyor.',
+      category: 'Trendler',
+      tags: ['trendler', 'IK', 'gelecek', 'otomasyon'],
+      content: `# IK liderlerinin izlemesi gereken trendler
+
+## Modern IK yonu
+
+Sirketler esnek calisma, daha iyi calisan deneyimi ve daha guclu operasyon verisi bekliyor.
+
+## One cikan basliklar
+
+- Hibrit ekip yonetimi.
+- Yetkinlik gelisimi ve ic mobilite.
+- Insan onayli yapay zeka destekli IK.
+- Gercek zamanli IK panelleri.
+
+## Sonuc
+
+Yapisal IK verisine yatirim yapan ekipler daha hizli ve daha guvenli olceklenir.`,
+    },
+    'productivite-5-conseils-economiser-temps': {
+      title: 'IK operasyonunda zaman kazandiran 5 yol',
+      excerpt: 'Tekrarlayan isleri azaltin ve yoneticilere guvenilir veriye hizli erisim verin.',
+      category: 'Verimlilik',
+      tags: ['verimlilik', 'zaman', 'IK', 'otomasyon'],
+      content: `# IK operasyonunda zaman kazandiran 5 yol
+
+## Otomasyonla baslayin
+
+Devam verisi, izin bakiyesi, bordro raporu ve belge hatirlatmalari manuel takip edilmemelidir.
+
+## Veriyi merkezilestirin
+
+Tek kaynak, tekrar dosyalari ve celisen kayitlari azaltir.
+
+## Onay akislarini netlestirin
+
+Net onaylar kaybolan talepleri ve mesaj trafigini azaltir.
+
+## Sonuc
+
+En cok tekrar eden akislar otomatiklestiginde IK stratejik ise daha fazla zaman ayirir.`,
+    },
+    'conformite-rgpd-donnees-employes': {
+      title: 'KVKK/GDPR: calisan verilerini koruma',
+      excerpt: 'Hassas IK verilerini net yonetisim ve guvenlik kontrolleriyle koruyun.',
+      category: 'Guvenlik',
+      tags: ['gizlilik', 'guvenlik', 'calisan verisi', 'uyum'],
+      content: `# KVKK/GDPR: calisan verilerini koruma
+
+## IK verisi hassastir
+
+Kimlik, bordro, sozlesme, performans ve devam verileri guclu erisim kontrolu gerektirir.
+
+## Pratik kontroller
+
+- Erisimi role ve tenant a gore sinirlayin.
+- Hassas alanlari sifreleyin.
+- Kritik islemleri denetim kaydina alin.
+- Veri dis aktarim ve silme taleplerini yonetin.
+
+## Sonuc
+
+Gizlilik gunluk is akislarina gomuldugunde daha guvenilir hale gelir.`,
+    },
+    'culture-entreprise-engagement-employes': {
+      title: 'Sirket kulturu ve calisan bagliligi',
+      excerpt: 'Calisanlari hizali ve motive tutan rituel ve geri bildirim donguleri kurun.',
+      category: 'Baglilik',
+      tags: ['kultur', 'baglilik', 'geri bildirim', 'elde tutma'],
+      content: `# Sirket kulturu ve calisan bagliligi
+
+## Kultur operasyoneldir
+
+Baglilik, hedefler net oldugunda, geri bildirim duzenli verildiginde ve yonetim ritulleri tutarli oldugunda artar.
+
+## Pratik kaldiraclar
+
+- Oncelikleri acik paylasin.
+- Katkilari duzenli takdir edin.
+- Kisa anketlerle bagliligi olcun.
+- Yoneticileri bire bir gorusmelere hazirlayin.
+
+## Sonuc
+
+Guclu kultur tek seferlik mesajlarla degil, tekrarlanabilir aliskanliklarla kurulur.`,
+    },
+    'pointage-biometrique-avantages': {
+      title: 'Biyometrik devam takibi: faydalar ve korumalar',
+      excerpt: 'Biyometrik takibin nerede deger kattigini ve hangi gizlilik kontrollerinin gerektigini anlayin.',
+      category: 'Devam',
+      tags: ['devam', 'biyometri', 'guvenlik', 'kiosk'],
+      content: `# Biyometrik devam takibi: faydalar ve korumalar
+
+## Neden kullanilir
+
+Biyometrik cihazlar baskasi yerine giris yapmayi azaltir, vardiya takibini hizlandirir ve bordro dogrulugunu artirir.
+
+## Gerekli korumalar
+
+- Gerekli durumlarda acik riza alin.
+- Biyometrik veriye erisimi sinirlayin.
+- Cihaz senkronizasyon loglarini tutun.
+- Alternatif devam yontemleri saglayin.
+
+## Sonuc
+
+Biyometrik takip, guvenlik ve denetlenebilirlik bastan tasarlandiginda guclu bir arac olur.`,
+    },
+    'gestion-absences-congés-efficace': {
+      title: 'Etkili izin ve devamsizlik yonetimi',
+      excerpt: 'Net onay akisi kurun ve izin bakiyesi uyusmazliklarini azaltin.',
+      category: 'Izin',
+      tags: ['izin', 'devamsizlik', 'onay', 'bakiye'],
+      content: `# Etkili izin ve devamsizlik yonetimi
+
+## Yaygin sorun
+
+Izin talepleri mesajlarda kaybolur, bakiyeler ise zamanla guvenilmez hale gelir.
+
+## Daha iyi akis
+
+- Talep, onay ve iptal kurallarini belirleyin.
+- Yoneticilere ekip takvimi verin.
+- Bakiyeleri otomatik guncelleyin.
+- Her durum degisikliginde calisani bilgilendirin.
+
+## Sonuc
+
+Net izin akislarindan hem calisan hem yonetici kazanir.`,
+    },
+    'recrutement-digital-sourcing-talents': {
+      title: 'Dijital ise alim: daha iyi yetenek bulma',
+      excerpt: 'Adaylari, mulakatlari ve karar sureclerini olculebilir bir pipeline icinde yonetin.',
+      category: 'Ise alim',
+      tags: ['ise alim', 'aday', 'pipeline', 'sourcing'],
+      content: `# Dijital ise alim: daha iyi yetenek bulma
+
+## Ise alim yapisal veri ister
+
+Ortak pipeline olmazsa aday verisi e-posta ve dosyalara dagilir.
+
+## Ne izlenmeli
+
+- Ilanlar ve kaynak kanallari.
+- Aday asamalari ve notlar.
+- Mulakat geri bildirimleri.
+- Ise alim suresi ve teklif donusumu.
+
+## Sonuc
+
+Dijital pipeline hiz, adalet ve raporlama kalitesini artirir.`,
+    },
+    'formation-developpement-competences': {
+      title: 'Egitim ve yetkinlik gelisimi',
+      excerpt: 'Egitim planlarini calisan ve yoneticiler icin olculebilir yetkinlik gelisimine donusturun.',
+      category: 'Egitim',
+      tags: ['egitim', 'yetkinlik', 'gelisim', 'ogrenme'],
+      content: `# Egitim ve yetkinlik gelisimi
+
+## Neden onemli
+
+Buyume yeni roller ve yeni beklentiler getirir. Egitim planlari eksikler sorun olmadan once ekipleri hazirlar.
+
+## Program kurmak
+
+- Role gore gerekli yetkinlikleri haritalayin.
+- Egitim katilimini izleyin.
+- Degerlendirmeleri gelisim planlarina baglayin.
+- Tamamlama ve etkiyi olcun.
+
+## Sonuc
+
+Egitim, roller ve performansla baglandiginda stratejik hale gelir.`,
+    },
+  },
+  ar: {
+    'guide-complet-gestion-rh-startup': {
+      title: 'دليل إدارة الموارد البشرية للشركات الناشئة',
+      excerpt: 'ابن أساسا منظما للموارد البشرية منذ أول توظيف وبدون إبطاء النمو.',
+      category: 'الموارد البشرية',
+      tags: ['شركة ناشئة', 'موارد بشرية', 'توظيف', 'عمليات'],
+      content: `# دليل إدارة الموارد البشرية للشركات الناشئة
+
+## لماذا تبدأ مبكرا
+
+عندما ينمو الفريق بسرعة تصبح العقود والأدوار والإجازات والتأهيل عناصر ضرورية لحماية الشركة والموظفين.
+
+## الأساس العملي
+
+- حدد الأدوار قبل التوظيف.
+- وثق قواعد الرواتب والإجازات والموافقات.
+- اجعل ملفات الموظفين والصلاحيات مركزية.
+- جهز قائمة تأهيل لكل موظف جديد.
+
+## الخلاصة
+
+الشركة الناشئة التي تبني أساسا واضحا للموارد البشرية تتوسع بسرعة وبمخاطر أقل.`,
+    },
+    'automatiser-paie-excel-vers-logiciel': {
+      title: 'من Excel إلى برنامج رواتب: دليل الانتقال',
+      excerpt: 'انقل الرواتب من الجداول اليدوية إلى الأتمتة مع تتبع أفضل ومخاطر أقل.',
+      category: 'الرواتب',
+      tags: ['رواتب', 'Excel', 'أتمتة', 'انتقال'],
+      content: `# من Excel إلى برنامج رواتب: دليل الانتقال
+
+## لماذا تصبح الجداول خطرة
+
+الجداول مرنة لكنها صعبة التدقيق والحماية. ومع نمو الفريق تزيد أخطاء الصيغ والحسابات.
+
+## خطوات الانتقال
+
+- احصر كل بيانات الرواتب الحالية.
+- نظف بيانات الموظفين والعقود والحسابات البنكية.
+- شغل دورة رواتب موازية قبل الاعتماد الكامل.
+- احتفظ بملف رجوع للشهر الأول.
+
+## الخلاصة
+
+الانتقال المنظم يجعل الرواتب عملية قابلة للتوقع بدل أزمة شهرية.`,
+    },
+    'tendances-rh-2024': {
+      title: 'اتجاهات الموارد البشرية التي يجب مراقبتها',
+      excerpt: 'العمل الهجين، تجربة الموظف، المهارات والأتمتة تعيد تشكيل عمليات الموارد البشرية.',
+      category: 'اتجاهات',
+      tags: ['اتجاهات', 'موارد بشرية', 'مستقبل', 'أتمتة'],
+      content: `# اتجاهات الموارد البشرية التي يجب مراقبتها
+
+## اتجاه الموارد البشرية الحديثة
+
+تحتاج الشركات إلى نماذج عمل مرنة وتجربة موظف أفضل وبيانات تشغيلية أدق.
+
+## أهم الاتجاهات
+
+- إدارة الفرق الهجينة والموزعة.
+- تطوير المهارات والتنقل الداخلي.
+- دعم موارد بشرية بالذكاء الاصطناعي مع تحقق بشري.
+- لوحات بيانات فورية للحضور والإجازات والرواتب.
+
+## الخلاصة
+
+الفرق التي تبني بيانات منظمة وأتمتة قوية ستنمو بسرعة وبمفاجآت أقل.`,
+    },
+    'productivite-5-conseils-economiser-temps': {
+      title: '5 طرق لتوفير الوقت في إدارة الموارد البشرية',
+      excerpt: 'قلل الأعمال المتكررة وامنح المديرين وصولا أسرع إلى بيانات موثوقة.',
+      category: 'الإنتاجية',
+      tags: ['إنتاجية', 'وقت', 'موارد بشرية', 'أتمتة'],
+      content: `# 5 طرق لتوفير الوقت في إدارة الموارد البشرية
+
+## أتمتة المهام المتكررة
+
+الحضور، أرصدة الإجازات، تقارير الرواتب وتذكيرات المستندات لا يجب أن تعتمد على المتابعة اليدوية.
+
+## مركزية البيانات
+
+مصدر واحد للحقيقة يقلل الملفات المكررة والسجلات المتضاربة.
+
+## مسارات موافقة واضحة
+
+الموافقات الواضحة تقلل الطلبات الضائعة والرسائل المتكررة.
+
+## الخلاصة
+
+عندما تتم أتمتة أكثر الأعمال تكرارا يستطيع فريق الموارد البشرية التركيز على العمل الاستراتيجي.`,
+    },
+    'conformite-rgpd-donnees-employes': {
+      title: 'الامتثال للخصوصية وحماية بيانات الموظفين',
+      excerpt: 'دليل عملي لحماية بيانات الموارد البشرية الحساسة بحوكمة واضحة.',
+      category: 'الأمان',
+      tags: ['خصوصية', 'أمان', 'بيانات الموظفين', 'امتثال'],
+      content: `# الامتثال للخصوصية وحماية بيانات الموظفين
+
+## بيانات الموظفين حساسة
+
+تعالج أنظمة الموارد البشرية الهوية والرواتب والعقود والأداء والحضور، ولذلك تحتاج إلى صلاحيات دقيقة.
+
+## ضوابط عملية
+
+- حدد الوصول حسب الدور والشركة.
+- شفر الحقول الحساسة والنسخ الاحتياطية.
+- احتفظ بسجلات تدقيق للأفعال المهمة.
+- وفر مسارات تصدير وحذف البيانات.
+
+## الخلاصة
+
+تصبح الخصوصية أقوى عندما تكون جزءا من العمل اليومي وليس إجراء بعد الحوادث.`,
+    },
+    'culture-entreprise-engagement-employes': {
+      title: 'ثقافة الشركة ورفع تفاعل الموظفين',
+      excerpt: 'ابن عادات واضحة وتغذية راجعة منتظمة تساعد الموظفين على البقاء منسجمين ومتحمسين.',
+      category: 'التفاعل',
+      tags: ['ثقافة', 'تفاعل', 'تغذية راجعة', 'احتفاظ'],
+      content: `# ثقافة الشركة ورفع تفاعل الموظفين
+
+## الثقافة ممارسة يومية
+
+يزداد التفاعل عندما يفهم الموظفون الأهداف ويتلقون ملاحظات منتظمة ويرون طقوس إدارة ثابتة.
+
+## أدوات عملية
+
+- شارك الأولويات بوضوح.
+- قدر المساهمات بانتظام.
+- قس التفاعل باستبيانات قصيرة.
+- درب المديرين على لقاءات فردية منتظمة.
+
+## الخلاصة
+
+الثقافة القوية تبنى بالعادات المتكررة وليس بالخطابات فقط.`,
+    },
+    'pointage-biometrique-avantages': {
+      title: 'الحضور البيومتري: الفوائد والضوابط',
+      excerpt: 'افهم أين يفيد الحضور البيومتري وما ضوابط الخصوصية المطلوبة.',
+      category: 'الحضور',
+      tags: ['حضور', 'بيومتري', 'أمان', 'كشك'],
+      content: `# الحضور البيومتري: الفوائد والضوابط
+
+## لماذا تعتمد عليه الشركات
+
+تقلل الأجهزة البيومترية تسجيل الحضور بالنيابة، وتسرع تتبع المناوبات، وتحسن دقة الرواتب.
+
+## ضوابط ضرورية
+
+- احصل على موافقة صريحة عند الحاجة.
+- قلل الوصول إلى البيانات البيومترية.
+- احتفظ بسجلات مزامنة الأجهزة.
+- وفر طرق حضور بديلة.
+
+## الخلاصة
+
+يكون الحضور البيومتري فعالا عندما تصمم الخصوصية والتدقيق منذ البداية.`,
+    },
+    'gestion-absences-congés-efficace': {
+      title: 'إدارة فعالة للإجازات والغيابات',
+      excerpt: 'ابن مسار موافقة واضحا وتجنب تضارب أرصدة الإجازات.',
+      category: 'الإجازات',
+      tags: ['إجازات', 'غياب', 'موافقة', 'رصيد'],
+      content: `# إدارة فعالة للإجازات والغيابات
+
+## المشكلة الشائعة
+
+تضيع طلبات الإجازة في الرسائل وتصبح الأرصدة غير موثوقة مع الوقت.
+
+## مسار أفضل
+
+- حدد قواعد الطلب والموافقة والإلغاء.
+- وفر للمديرين تقويم فريق واضحا.
+- حدث الأرصدة آليا.
+- أبلغ الموظف بكل تغيير في الحالة.
+
+## الخلاصة
+
+مسارات الإجازة الواضحة تقلل النزاعات وتحسن التخطيط.`,
+    },
+    'recrutement-digital-sourcing-talents': {
+      title: 'التوظيف الرقمي وجذب المواهب',
+      excerpt: 'نظم المرشحين والمقابلات والقرارات داخل مسار توظيف قابل للقياس.',
+      category: 'التوظيف',
+      tags: ['توظيف', 'مرشحون', 'مصادر', 'مسار'],
+      content: `# التوظيف الرقمي وجذب المواهب
+
+## التوظيف يحتاج تنظيما
+
+بدون مسار مشترك تتوزع بيانات المرشحين بين البريد والجداول.
+
+## ما يجب تتبعه
+
+- الإعلانات وقنوات المصدر.
+- مراحل المرشحين والملاحظات.
+- ملاحظات المقابلات.
+- مدة التوظيف ونسبة قبول العروض.
+
+## الخلاصة
+
+مسار التوظيف الرقمي يحسن السرعة والعدالة وجودة التقارير.`,
+    },
+    'formation-developpement-competences': {
+      title: 'التكوين وتطوير المهارات',
+      excerpt: 'حوّل خطط التكوين إلى نمو مهارات قابل للقياس للموظفين والمديرين.',
+      category: 'التكوين',
+      tags: ['تكوين', 'مهارات', 'تطوير', 'تعلم'],
+      content: `# التكوين وتطوير المهارات
+
+## لماذا التخطيط للمهارات مهم
+
+النمو يخلق أدوارا وتوقعات جديدة. تساعد خطط التكوين الفرق على الاستعداد قبل ظهور الفجوات.
+
+## بناء برنامج مفيد
+
+- اربط المهارات المطلوبة بكل دور.
+- تتبع حضور التكوين.
+- صل التقييمات بخطط التطوير.
+- قس الإنجاز والأثر.
+
+## الخلاصة
+
+يصبح التكوين استراتيجيا عندما يرتبط بالأدوار والأداء واحتياجات المستقبل.`,
+    },
+  },
+};
+
+export function getBlogPosts(locale: AppLocale): BlogPost[] {
+  const overrides = localizedBlogPosts[locale];
+
+  if (!overrides) {
+    return blogPosts;
+  }
+
+  return blogPosts.map((post) => ({
+    ...post,
+    ...(overrides[post.slug] ?? {}),
+  }));
+}
+
+export function getBlogPost(slug: string, locale: AppLocale): BlogPost | undefined {
+  return getBlogPosts(locale).find((post) => post.slug === slug);
+}

--- a/front/web/src/modules/vitrine/lib/seo.ts
+++ b/front/web/src/modules/vitrine/lib/seo.ts
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 const siteName = process.env.NEXT_PUBLIC_SITE_NAME || "Leopardo";
+const supportedLocales = ["fr", "en", "tr", "ar"] as const;
 
 export interface SEOMetadata {
   title: string;
@@ -22,6 +23,20 @@ export interface SEOMetadata {
 export function generateMetadata(seo: SEOMetadata): Metadata {
   const url = seo.canonical || siteUrl;
   const image = seo.ogImage || `${siteUrl}/og-image.png`;
+  const path = (() => {
+    try {
+      const parsed = new URL(url, siteUrl);
+      return parsed.pathname === "/" ? "/" : parsed.pathname;
+    } catch {
+      return "/";
+    }
+  })();
+  const localizedAlternates = Object.fromEntries(
+    supportedLocales.map((locale) => [
+      locale,
+      locale === "fr" ? url : `${siteUrl}${path === "/" ? "/" : path}?lang=${locale}`,
+    ])
+  );
 
   return {
     title: seo.title,
@@ -54,6 +69,7 @@ export function generateMetadata(seo: SEOMetadata): Metadata {
     },
     alternates: {
       canonical: url,
+      languages: localizedAlternates,
     },
   };
 }

--- a/front/web/src/modules/vitrine/lib/vitrine-locale.ts
+++ b/front/web/src/modules/vitrine/lib/vitrine-locale.ts
@@ -524,6 +524,15 @@ function getCurrentLocale(): AppLocale {
     return 'fr'
   }
 
+  const urlLocale = new URLSearchParams(window.location.search).get('lang')
+    ?? new URLSearchParams(window.location.search).get('locale')
+
+  if (urlLocale) {
+    const normalized = normalizeLocale(urlLocale)
+    storePreferredLocale(normalized)
+    return normalized
+  }
+
   return normalizeLocale(getPreferredLocale())
 }
 


### PR DESCRIPTION
## Summary
- localize blog listing and article views in FR/EN/TR/AR
- add locale-aware newsletter payloads and labels
- enrich sitemap/SEO alternates for the ?lang= locale rail
- update Plan 17, changelog and agent notes

## Verification
- node .\node_modules\eslint\bin\eslint.js src/app/(landing)/blog/page.tsx src/app/(landing)/blog/[slug]/page.tsx src/app/sitemap.ts src/modules/vitrine/data/blog.ts src/modules/vitrine/components/sections/BlogGrid.tsx src/modules/vitrine/components/sections/BlogCard.tsx src/modules/vitrine/components/sections/BlogArticle.tsx src/components/NewsletterForm.tsx src/modules/vitrine/lib/seo.ts src/modules/vitrine/lib/vitrine-locale.ts --max-warnings 0
- node .\node_modules\typescript\bin\tsc --noEmit --pretty false --skipLibCheck
- npm run build