### PR TITLE
feat(api): harden critical list contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Les composants vitrine utilises avec `react-hook-form` doivent forwarder leur `ref` vers le vrai champ HTML. Le bug corrige sur `Input` provoquait des submissions sans valeur reelle malgre des champs visuellement remplis.
 - Les pages vitrine conversion `/pricing`, `/demo` et `/integrations` utilisent `useVitrineLocale()` avec contenu FR/EN/TR/AR et `dir=rtl` pour l'arabe. Toute evolution marketing sur ces pages doit ajouter les 4 locales dans le meme changement.
 - Le blog vitrine utilise `getBlogPosts(locale)` / `getBlogPost(slug, locale)` et le rail `?lang=` pour les alternates sitemap/hreflang. Toute nouvelle entree blog doit conserver slug stable et champs localises FR/EN/TR/AR.
+- Les listes API critiques consommees par mobile/admin (`employees`, `absences`, `attendance`, `me/pay-slips`, `notifications`) doivent garder des filtres/tris allowlistes et couverts par `ApiListQueryContractTest`. Ne pas accepter de `sort_by` libre ou de champ SQL arbitraire.
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.103] - 2026-05-21
+
+### Added
+
+- API : contrats de listes RH critiques renforces pour `employees`, `absences`, `attendance`, `me/pay-slips` et `notifications` avec tests JSON de pagination, filtres, tri allowliste, payload vide et validation d'erreur.
+- Mobile : tests de payload detailles ajoutes pour les conges, bulletins et notifications afin de figer les champs consommes avant lancement marketing.
+
+### Changed
+
+- API : filtres et tris des listes frontends critiques sont maintenant valides par allowlist pour eviter les parametres libres non scalables ou risqués.
+
 ## [4.16.102] - 2026-05-22
 
 ### Added 

--- a/api/app/Http/Controllers/Api/V1/AbsenceController.php
+++ b/api/app/Http/Controllers/Api/V1/AbsenceController.php
@@ -64,8 +64,15 @@ class AbsenceController extends Controller
                 ->where('end_date', '>=', $periodStart->toDateString());
         }
 
-        $perPage = $request->integer('per_page', 15);
-        $paginated = $query->orderByDesc('created_at')->paginate($perPage);
+        $validated = $request->validated();
+        $perPage = (int) ($validated['per_page'] ?? 15);
+        $sortBy = (string) ($validated['sort_by'] ?? 'created_at');
+        $sortDir = (string) ($validated['sort_dir'] ?? 'desc');
+
+        $paginated = $query
+            ->orderBy($sortBy, $sortDir)
+            ->orderByDesc('id')
+            ->paginate($perPage);
 
         return response()->json([
             'data' => $paginated->map(fn ($a) => $this->serialize($a)),

--- a/api/app/Http/Controllers/Api/V1/AttendanceController.php
+++ b/api/app/Http/Controllers/Api/V1/AttendanceController.php
@@ -167,9 +167,7 @@ class AttendanceController extends Controller
 
         $query = AttendanceLog::query()
             ->with(['employee:id,first_name,last_name,matricule,photo_path'])
-            ->select(['id', 'employee_id', 'date', 'check_in', 'check_out', 'hours_worked', 'overtime_hours', 'status', 'method', 'source_device_code', 'late_minutes'])
-            ->orderByDesc('date')
-            ->orderByDesc('id');
+            ->select(['id', 'employee_id', 'date', 'check_in', 'check_out', 'hours_worked', 'overtime_hours', 'status', 'method', 'source_device_code', 'late_minutes']);
 
         if ($target) {
             $query->where('employee_id', $target->id);
@@ -185,10 +183,18 @@ class AttendanceController extends Controller
         if (! empty($validated['date_to'])) {
             $query->where('date', '<=', $validated['date_to']);
         }
+        if (! empty($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
 
         $perPage = $validated['per_page'] ?? 20;
+        $sortBy = (string) ($validated['sort_by'] ?? 'date');
+        $sortDir = (string) ($validated['sort_dir'] ?? 'desc');
 
-        $paginator = $query->paginate($perPage);
+        $paginator = $query
+            ->orderBy($sortBy, $sortDir)
+            ->orderByDesc('id')
+            ->paginate($perPage);
 
         return AttendanceLogResource::collection($paginator)->response();
 

--- a/api/app/Http/Controllers/Api/V1/EmployeeController.php
+++ b/api/app/Http/Controllers/Api/V1/EmployeeController.php
@@ -14,6 +14,7 @@ use App\Http\Resources\Api\V1\EmployeeResource;
 use App\Models\Employee;
 use App\Services\DataAccessAuditLogger;
 use App\Services\EmployeeService;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -51,8 +52,21 @@ class EmployeeController extends Controller
 
         $this->authorize('viewAny', Employee::class);
 
-        $perPage = max(1, min(100, (int) request()->integer('per_page', 20)));
-        $paginator = Employee::query()
+        $validated = $request->validate([
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'status' => ['nullable', 'in:active,archived,suspended'],
+            'role' => ['nullable', 'in:employee,manager,admin,super_admin'],
+            'search' => ['nullable', 'string', 'max:100'],
+            'sort_by' => ['nullable', 'in:id,first_name,last_name,email,role,status'],
+            'sort_dir' => ['nullable', 'in:asc,desc'],
+        ]);
+
+        $perPage = (int) ($validated['per_page'] ?? 20);
+        $sortBy = (string) ($validated['sort_by'] ?? 'id');
+        $sortDir = (string) ($validated['sort_dir'] ?? 'asc');
+
+        $query = Employee::query()
             ->with(['company:id,name,language,timezone,currency,features'])
             ->select([
                 'id',
@@ -68,7 +82,29 @@ class EmployeeController extends Controller
                 'contract_start',
                 'preferred_language',
                 'extra_data',
-            ])
+            ]);
+
+        if (! empty($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
+
+        if (! empty($validated['role'])) {
+            $query->where('role', $validated['role']);
+        }
+
+        if (! empty($validated['search'])) {
+            $needle = '%'.addcslashes((string) $validated['search'], '%_\\').'%';
+            $query->where(function (Builder $query) use ($needle): void {
+                $query
+                    ->where('first_name', 'like', $needle)
+                    ->orWhere('last_name', 'like', $needle)
+                    ->orWhere('email', 'like', $needle)
+                    ->orWhere('matricule', 'like', $needle);
+            });
+        }
+
+        $paginator = $query
+            ->orderBy($sortBy, $sortDir)
             ->orderBy('id')
             ->paginate($perPage);
 

--- a/api/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/api/app/Http/Controllers/Api/V1/NotificationController.php
@@ -14,9 +14,28 @@ class NotificationController extends Controller
         /** @var Employee $user */
         $user = $request->user();
 
-        $notifications = $user->notifications()
-            ->orderByDesc('created_at')
-            ->paginate($request->integer('per_page', 20));
+        $validated = $request->validate([
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'type' => ['nullable', 'string', 'max:80'],
+            'unread' => ['nullable', 'boolean'],
+            'sort_dir' => ['nullable', 'in:asc,desc'],
+        ]);
+
+        $query = $user->notifications();
+
+        if (! empty($validated['type'])) {
+            $query->where('type', $validated['type']);
+        }
+
+        if ($request->has('unread') && $request->boolean('unread')) {
+            $query->where('is_read', false);
+        }
+
+        $notifications = $query
+            ->orderBy('created_at', (string) ($validated['sort_dir'] ?? 'desc'))
+            ->orderByDesc('id')
+            ->paginate((int) ($validated['per_page'] ?? 20));
 
         return response()->json([
             'data' => $notifications->items(),

--- a/api/app/Http/Controllers/Api/V1/PaySlipController.php
+++ b/api/app/Http/Controllers/Api/V1/PaySlipController.php
@@ -30,6 +30,9 @@ class PaySlipController extends Controller
             'payroll_run_id' => 'sometimes|nullable|integer',
             'status' => 'sometimes|nullable|string|in:calculated,validated,sent',
             'per_page' => 'sometimes|integer|min:1|max:100',
+            'page' => 'sometimes|integer|min:1',
+            'sort_by' => 'sometimes|nullable|string|in:period_start,period_end,net_salary,status,id',
+            'sort_dir' => 'sometimes|nullable|string|in:asc,desc',
         ]);
 
         $query = PaySlip::query()
@@ -52,9 +55,14 @@ class PaySlipController extends Controller
             $query->where('status', $validated['status']);
         }
 
-        $perPage = $validated['per_page'] ?? 50;
+        $perPage = (int) ($validated['per_page'] ?? 50);
+        $sortBy = (string) ($validated['sort_by'] ?? 'period_start');
+        $sortDir = (string) ($validated['sort_dir'] ?? 'desc');
 
-        $slips = $query->orderByDesc('period_start')->orderByDesc('id')->paginate($perPage);
+        $slips = $query
+            ->orderBy($sortBy, $sortDir)
+            ->orderByDesc('id')
+            ->paginate($perPage);
 
         return response()->json([
             'data' => $slips->items(),
@@ -114,12 +122,27 @@ class PaySlipController extends Controller
         /** @var Employee $actor */
         $actor = $request->user();
 
+        $validated = $request->validate([
+            'status' => 'sometimes|nullable|string|in:validated,sent',
+            'per_page' => 'sometimes|integer|min:1|max:100',
+            'page' => 'sometimes|integer|min:1',
+            'sort_by' => 'sometimes|nullable|string|in:period_start,period_end,net_salary,status,id',
+            'sort_dir' => 'sometimes|nullable|string|in:asc,desc',
+        ]);
+
+        $statuses = ! empty($validated['status'])
+            ? [(string) $validated['status']]
+            : ['validated', 'sent'];
+        $sortBy = (string) ($validated['sort_by'] ?? 'period_start');
+        $sortDir = (string) ($validated['sort_dir'] ?? 'desc');
+
         $slips = PaySlip::where('employee_id', $actor->id)
             ->where('company_id', $actor->company_id)
-            ->whereIn('status', ['validated', 'sent'])
+            ->whereIn('status', $statuses)
             ->with('payrollRun:id,period_start,period_end,country_code')
-            ->orderByDesc('period_start')
-            ->paginate($request->integer('per_page', 12));
+            ->orderBy($sortBy, $sortDir)
+            ->orderByDesc('id')
+            ->paginate((int) ($validated['per_page'] ?? 12));
 
         return response()->json([
             'data' => $slips->items(),

--- a/api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Absence/AbsenceIndexRequest.php
@@ -25,6 +25,9 @@ class AbsenceIndexRequest extends FormRequest
             'month' => ['nullable', 'integer', 'between:1,12'],
             'year' => ['nullable', 'integer', 'min:2000'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'sort_by' => ['nullable', 'in:created_at,start_date,end_date,status,days_count'],
+            'sort_dir' => ['nullable', 'in:asc,desc'],
         ];
     }
 

--- a/api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php
+++ b/api/app/Http/Requests/Api/V1/Attendance/AttendanceIndexRequest.php
@@ -21,10 +21,13 @@ class AttendanceIndexRequest extends FormRequest
                 'min:1',
                 Rule::exists('employees', 'id')->where('company_id', $this->user()?->company_id),
             ],
+            'status' => ['nullable', 'in:ontime,late,absent,incomplete'],
             'date_from' => ['nullable', 'date_format:Y-m-d'],
             'date_to' => ['nullable', 'date_format:Y-m-d'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
             'page' => ['nullable', 'integer', 'min:1'],
+            'sort_by' => ['nullable', 'in:date,check_in,check_out,status,id'],
+            'sort_dir' => ['nullable', 'in:asc,desc'],
         ];
     }
 }

--- a/api/tests/Feature/Contracts/ApiListQueryContractTest.php
+++ b/api/tests/Feature/Contracts/ApiListQueryContractTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Tests\Feature\Contracts;
+
+use App\Models\Absence;
+use App\Models\AbsenceType;
+use App\Models\AttendanceLog;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\Notification;
+use App\Models\PayrollRun;
+use App\Models\PaySlip;
+use App\Models\PaySlipLine;
+use Illuminate\Support\Carbon;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class ApiListQueryContractTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_employees_index_supports_validated_filters_sorting_pagination_and_empty_payloads(): void
+    {
+        [$company, $manager] = $this->actors();
+
+        Employee::factory()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Amina',
+            'last_name' => 'Zed',
+            'email' => 'amina.zed@example.test',
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        Employee::factory()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Amina',
+            'last_name' => 'Alpha',
+            'email' => 'amina.alpha@example.test',
+            'role' => 'employee',
+            'status' => 'archived',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson('/api/v1/employees?search=Amina&status=active&sort_by=last_name&sort_dir=desc&per_page=5');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.email', 'amina.zed@example.test')
+            ->assertJsonPath('meta.per_page', 5)
+            ->assertJsonPath('meta.total', 1);
+
+        $this->getJson('/api/v1/employees?search=not-found&per_page=5')
+            ->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+
+        $this->getJson('/api/v1/employees?sort_by=password_hash')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['sort_by']);
+    }
+
+    public function test_absences_index_supports_filters_sorting_pagination_and_empty_payloads(): void
+    {
+        [$company, $manager, $employee] = $this->actors();
+        $type = AbsenceType::factory()->create(['company_id' => $company->id, 'name' => 'Paid leave', 'code' => 'CP']);
+
+        Absence::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'absence_type_id' => $type->id,
+            'start_date' => '2026-06-20',
+            'end_date' => '2026-06-21',
+            'days_count' => 2,
+            'status' => 'approved',
+        ]);
+        Absence::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'absence_type_id' => $type->id,
+            'start_date' => '2026-06-10',
+            'end_date' => '2026-06-10',
+            'days_count' => 1,
+            'status' => 'pending',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson('/api/v1/absences?status=approved&sort_by=start_date&sort_dir=asc&per_page=10');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.status', 'approved')
+            ->assertJsonPath('data.0.absence_type.code', 'CP')
+            ->assertJsonPath('meta.total', 1);
+
+        $this->getJson('/api/v1/absences?month=1&year=2026&per_page=10')
+            ->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+
+        $this->getJson('/api/v1/absences?sort_by=employee_id')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['sort_by']);
+    }
+
+    public function test_attendance_index_supports_status_filter_sorting_pagination_and_empty_payloads(): void
+    {
+        [$company, $manager, $employee] = $this->actors();
+
+        AttendanceLog::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-01',
+            'check_in' => Carbon::parse('2026-05-01 08:00:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-01 16:00:00', 'UTC'),
+            'status' => 'ontime',
+        ]);
+        AttendanceLog::factory()->late()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-02',
+            'check_in' => Carbon::parse('2026-05-02 08:30:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-02 16:00:00', 'UTC'),
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson('/api/v1/attendance?status=late&date_from=2026-05-01&date_to=2026-05-31&sort_by=date&sort_dir=asc&per_page=10');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.status', 'late')
+            ->assertJsonPath('data.0.employee.id', $employee->id)
+            ->assertJsonPath('meta.total', 1);
+
+        $this->getJson('/api/v1/attendance?status=absent&date_from=2026-05-01&date_to=2026-05-31')
+            ->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+
+        $this->getJson('/api/v1/attendance?sort_by=company_id')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['sort_by']);
+    }
+
+    public function test_mobile_pay_slip_list_and_detail_payloads_are_filterable_and_stable(): void
+    {
+        [$company, , $employee] = $this->actors();
+        [, $validated] = $this->payrollSlip($company, $employee, ['status' => 'validated', 'net_salary' => 90000]);
+        $this->payrollSlip($company, $employee, ['status' => 'sent', 'net_salary' => 110000]);
+        $this->payrollSlip($company, $employee, ['status' => 'calculated', 'net_salary' => 120000]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/v1/me/pay-slips?status=validated&sort_by=net_salary&sort_dir=asc&per_page=10')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $validated->id)
+            ->assertJsonPath('data.0.status', 'validated')
+            ->assertJsonPath('meta.total', 1);
+
+        $this->getJson("/api/v1/me/pay-slips/{$validated->id}")
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'payroll_run_id',
+                    'employee_id',
+                    'period_start',
+                    'period_end',
+                    'gross_salary',
+                    'total_deductions',
+                    'net_salary',
+                    'status',
+                    'lines' => [
+                        '*' => [
+                            'id',
+                            'name',
+                            'type',
+                            'amount',
+                            'order',
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->getJson('/api/v1/me/pay-slips?status=calculated')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_notifications_index_supports_mobile_filters_and_payload_shape(): void
+    {
+        [$company, , $employee] = $this->actors();
+
+        Notification::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'type' => 'absence',
+            'title' => 'Absence approved',
+            'body' => 'Your absence was approved.',
+            'data' => ['absence_id' => 10],
+            'is_read' => false,
+            'created_at' => Carbon::parse('2026-05-10 10:00:00', 'UTC'),
+        ]);
+        Notification::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'type' => 'payroll',
+            'title' => 'Payslip ready',
+            'body' => 'Your payslip is ready.',
+            'is_read' => true,
+            'read_at' => Carbon::parse('2026-05-11 10:00:00', 'UTC'),
+            'created_at' => Carbon::parse('2026-05-11 10:00:00', 'UTC'),
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/v1/notifications?unread=1&type=absence&sort_dir=asc&per_page=10')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.type', 'absence')
+            ->assertJsonPath('data.0.is_read', false)
+            ->assertJsonPath('meta.unread_count', 1)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'company_id',
+                        'employee_id',
+                        'type',
+                        'title',
+                        'body',
+                        'data',
+                        'is_read',
+                        'read_at',
+                        'created_at',
+                    ],
+                ],
+                'meta' => [
+                    'current_page',
+                    'last_page',
+                    'per_page',
+                    'total',
+                    'unread_count',
+                ],
+            ]);
+
+        $this->getJson('/api/v1/notifications?type=unknown')
+            ->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0);
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee, 2: Employee}
+     */
+    private function actors(): array
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create([
+            'company_id' => $company->id,
+            'email' => fake()->unique()->safeEmail(),
+        ]);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => fake()->unique()->safeEmail(),
+        ]);
+
+        return [$company, $manager, $employee];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array{0: PayrollRun, 1: PaySlip}
+     */
+    private function payrollSlip(Company $company, Employee $employee, array $overrides = []): array
+    {
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'status' => 'validated',
+            'employee_count' => 1,
+            'total_gross' => 120000,
+            'total_deductions' => 22000,
+            'total_net' => 98000,
+        ]);
+
+        $slip = PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 120000,
+            'total_deductions' => 22000,
+            'net_salary' => $overrides['net_salary'] ?? 98000,
+            'employer_contributions' => 31200,
+            'total_cost' => 151200,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => $overrides['status'] ?? 'validated',
+        ]);
+
+        PaySlipLine::query()->create([
+            'pay_slip_id' => $slip->id,
+            'name' => 'Base salary',
+            'type' => 'earning',
+            'base_amount' => 120000,
+            'rate' => 1,
+            'amount' => 120000,
+            'order' => 1,
+        ]);
+
+        return [$run, $slip];
+    }
+}

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -39,6 +39,8 @@ Note 2026-05-14 : les endpoints sensibles utilisent des limiters nommes configur
 
 Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version`, `X-API-Supported-Versions`) et refuse un `X-API-Version` non supporte. Les routes authentifiees tenant portent aussi un limiter `api-plan` configurable par plan commercial ; garder un test `429` dedie sur un plan Starter avec seuil abaisse en test.
 
+Note 2026-05-21 : les listes critiques consommees par mobile/admin (`employees`, `absences`, `attendance`, `me/pay-slips`, `notifications`) doivent conserver pagination, filtres, tri allowliste, payload vide et erreurs de validation couverts par `ApiListQueryContractTest`. Aucun `sort_by` libre ne doit atteindre une requete SQL.
+
 ## Matrice complete des scenarios backend
 
 ### 1. Sante technique et bootstrap
@@ -90,6 +92,7 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 ### 5. Employes et organisation
 
 - Liste employees avec pagination, tri, filtre
+- Liste employees refuse les tris non allowlistes et retourne un payload vide stable quand la recherche ne matche rien
 - Organigramme retourne uniquement les employes du tenant courant et construit l'arbre sans scans repetes par noeud
 - Chaine manager et subordonnes refusent les IDs hors tenant
 - Creation employee avec validations metier
@@ -105,6 +108,7 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 - Double check-in interdit
 - Check-out sans check-in interdit
 - Historique presence retourne des donnees coherentes
+- Historique presence supporte filtre statut, intervalle de dates, tri allowliste, pagination et payload vide
 - Resume du jour correct selon fuseau et etat
 - Conflits ou doublons geres sans corruption des donnees
 - `GET /attendance/anomalies` retourne un resume d'impact business (`late_minutes`, sorties manquantes, corrections, actions critiques)
@@ -118,12 +122,15 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 - Solde mis a jour correctement
 - Chevauchement de periodes refuse
 - Consultation historique des demandes par role
+- Liste absences supporte filtres statut/periode/employe, tri allowliste, pagination et payload vide
 - Employee ne peut pas valider sa propre demande sans permission speciale
 - Liste paginee `GET /api/v1/absences` expose pour le dashboard manager les champs derives `employee_name` et `type` (nom du type d'absence) en plus des relations `absence_type` / `absenceType`
 
 ### 8. Paie / finance
 
 - Acces bulletins par employee
+- Liste `GET /api/v1/me/pay-slips` supporte filtre statut `validated|sent`, tri allowliste, pagination et refuse les statuts internes `calculated`
+- Detail `GET /api/v1/me/pay-slips/{id}` expose les lignes du bulletin dans un payload stable pour mobile
 - Acces synthese payroll par finance / HR
 - Refus d'acces payroll pour roles non autorises
 - Calculs exposes sans fuite inter-tenant
@@ -150,6 +157,7 @@ Note 2026-05-15 : l'API expose maintenant des headers de version (`X-API-Version
 ### 10. Notifications / evenements / audit
 
 - Evenement metier declenche la notification attendue
+- Liste notifications supporte filtre `type`, filtre `unread`, tri chronologique allowliste, pagination, `unread_count` et payload vide stable
 - Endpoint de lecture marque lu / non lu correctement
 - Journalisation des actions sensibles disponible si prevue
 - `AuditLogger` listener ecoute les 8 domain events et ecrit dans `audit_logs`

--- a/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
+++ b/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
@@ -25,7 +25,7 @@ Amener le socle API au niveau de confiance necessaire pour absorber les premiers
 
 - [x] Ajouter des tests de contrat JSON pour les endpoints consommes par admin-dashboard, mobile et kiosque.
 - [x] Verifier les erreurs standardisees `error`, `message`, `localized_message` et `errors`.
-- [ ] Verifier pagination, filtres, tri et payloads vides sur les listes RH critiques.
+- [x] Verifier pagination, filtres, tri et payloads vides sur les listes RH critiques : `employees`, `absences`, `attendance`, `me/pay-slips`, `notifications`.
 
 ## Lot 17.3 — Vitrine multilingue conversion
 
@@ -42,7 +42,7 @@ Amener le socle API au niveau de confiance necessaire pour absorber les premiers
 - [x] Ajouter les contrats d'existence routes pour les parcours mobile prioritaires : conges, bulletins, notifications push et pointage.
 - [x] Ajouter les contrats kiosk : post-pointage, QR code, sync offline, affichage infos employe et soldes conges.
 - [x] Documenter les endpoints obligatoires par frontend dans `docs/validation/FRONTEND_API_CONTRACT_MATRIX.md`.
-- [ ] Ajouter des tests JSON payload mobile detailles pour conges, bulletins et notifications.
+- [x] Ajouter des tests JSON payload mobile detailles pour conges, bulletins et notifications.
 
 ## Lot 17.5 — Observabilite lancement
 

--- a/docs/validation/FRONTEND_API_CONTRACT_MATRIX.md
+++ b/docs/validation/FRONTEND_API_CONTRACT_MATRIX.md
@@ -16,16 +16,16 @@ Objectif : garder les frontends admin, mobile et kiosk alignes avec le backend L
 | Mobile | Pointage entree | `POST /api/v1/attendance/check-in` | employe | `Attendance\CheckInTest`, `FrontendApiContractTest` |
 | Mobile | Pointage sortie | `POST /api/v1/attendance/check-out` | employe | `FrontendApiContractTest` |
 | Mobile | Pointage du jour | `GET /api/v1/attendance/today` | employe/manager | `Attendance\TodayAndHistoryTest`, `FrontendApiContractTest` |
-| Mobile | Historique pointage | `GET /api/v1/attendance` | employe/manager | `Attendance\TodayAndHistoryTest`, `FrontendApiContractTest` |
-| Mobile | Liste absences | `GET /api/v1/absences` | employe/manager | `Absences\AbsenceIndexTest`, `FrontendApiContractTest` |
+| Mobile | Historique pointage | `GET /api/v1/attendance` | employe/manager | `Attendance\TodayAndHistoryTest`, `ApiListQueryContractTest`, `FrontendApiContractTest` |
+| Mobile | Liste absences | `GET /api/v1/absences` | employe/manager | `Absences\AbsenceIndexTest`, `ApiListQueryContractTest`, `FrontendApiContractTest` |
 | Mobile | Demande absence | `POST /api/v1/absences` | employe | `Absences\AbsenceStoreTest`, `FrontendApiContractTest` |
 | Mobile | Detail absence | `GET /api/v1/absences/{absence}` | employe/manager | `Absences\AbsenceShowTest`, `FrontendApiContractTest` |
 | Mobile | Annulation absence | `DELETE /api/v1/absences/{absence}` | employe/manager | `FrontendApiContractTest` |
 | Mobile | Soldes conges | `GET /api/v1/me/leave-balances` | employe | `FrontendApiContractTest` |
-| Mobile | Bulletins employe | `GET /api/v1/me/pay-slips` | employe | `FrontendApiContractTest` |
-| Mobile | Detail bulletin | `GET /api/v1/me/pay-slips/{paySlip}` | employe | `FrontendApiContractTest` |
+| Mobile | Bulletins employe | `GET /api/v1/me/pay-slips` | employe | `ApiListQueryContractTest`, `FrontendApiContractTest` |
+| Mobile | Detail bulletin | `GET /api/v1/me/pay-slips/{paySlip}` | employe | `ApiListQueryContractTest`, `FrontendApiContractTest` |
 | Mobile | PDF bulletin | `GET /api/v1/me/pay-slips/{paySlip}/pdf` | employe | `FrontendApiContractTest` |
-| Mobile | Notifications | `GET /api/v1/notifications` | authentifie | `FrontendApiContractTest` |
+| Mobile | Notifications | `GET /api/v1/notifications` | authentifie | `ApiListQueryContractTest`, `FrontendApiContractTest` |
 | Mobile | Marquer notification lue | `PUT /api/v1/notifications/{notification}/read` | authentifie | `FrontendApiContractTest` |
 | Mobile | Tout marquer lu | `PUT /api/v1/notifications/read-all` | authentifie | `FrontendApiContractTest` |
 | Mobile | Enregistrer push token | `POST /api/v1/device-tokens` | authentifie | `FrontendApiContractTest` |


### PR DESCRIPTION
## Summary
- add allowlisted filters/sorting/pagination contracts for critical API lists consumed by mobile/admin
- cover employees, absences, attendance, employee pay slips and notifications with payload/empty/error tests
- update Plan 17, frontend API matrix, changelog and AGENTS operational notes

## Verification
- php -l on modified controllers and new contract test
- git diff --check
- local PHPUnit could not run because this Windows workspace has no Composer binary and api/vendor is incomplete; GitHub Actions remains the source of truth for the full backend suite