### PR TITLE
test: add auth e2e smokes

### DIFF
--- a/.github/workflows/web-marketing-ci.yml
+++ b/.github/workflows/web-marketing-ci.yml
@@ -98,4 +98,4 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: https://gestionemployerbackend.onrender.com/api/v1
           PLAYWRIGHT_WEB_SERVER_COMMAND: npm run build && npm run start
-        run: npx playwright test e2e/marketing-funnel.spec.ts --project=chromium
+        run: npx playwright test e2e/marketing-funnel.spec.ts e2e/auth-client-smoke.spec.ts --project=chromium

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ Procedure recommandee :
 - Le bouton demo de `front/admin-dashboard/` doit rester limite aux comptes super-admin plateforme : ce frontend appelle `/api/v1/platform/auth/login`, donc les comptes RH/employes tenant doivent rester sur `front/web` ou mobile.
 - Pour prouver un login pret marche, tester le contrat complet `login -> token -> /auth/me` et `platform/login -> token -> /platform/auth/me`, pas seulement la presence d'un token dans la reponse.
 - Sur `front/web`, `npm audit fix --force` peut proposer des regressions majeures incoherentes (ex. downgrade Next). Preferer un patch mineur cible, relancer lint/build, puis documenter les advisories restantes si elles dependent d'un upstream non corrige.
+- Ne pas utiliser `useSyncExternalStore` avec un getter qui parse `localStorage` et retourne un nouvel objet a chaque snapshot : React peut boucler en erreur #185. Hydrater l'utilisateur stocke via `useState` + `useEffect`, puis tester le parcours login -> dashboard avec Playwright.
 
 ### 2026-05-18 - Nettoyage depot distant Devin/GTM/mobile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.105] - 2026-05-21
+
+### Tests
+
+- Web client : smoke Playwright ajoute pour verifier le flux login RH/employe `auth/login -> auth/me -> dashboard` avec donnees dashboard tenant mockees.
+- Admin plateforme : smoke Playwright ajoute pour verifier le flux login super-admin `platform/auth/login -> platform/auth/me -> dashboard`.
+- CI vitrine : le job `Web Marketing Funnel E2E` execute aussi le smoke auth client afin de bloquer les regressions de connexion web avant merge.
+- Client web : correction d'une boucle de rendu du layout dashboard provoquee par un snapshot `useSyncExternalStore` non stable sur l'utilisateur stocke.
+
 ## [4.16.104] - 2026-05-21
 
 ### Changed

--- a/front/admin-dashboard/e2e/platform-auth-smoke.spec.js
+++ b/front/admin-dashboard/e2e/platform-auth-smoke.spec.js
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test'
+
+test('platform administrator can sign in and reach the admin dashboard', async ({ page }) => {
+  let loginRequestSeen = false
+
+  await page.route('**/api/v1/platform/auth/login', async (route) => {
+    loginRequestSeen = true
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          id: 1,
+          name: 'Super Administrateur',
+          email: 'admin@leopardo-rh.com',
+          role: 'super_admin',
+          two_fa_enabled: false,
+        },
+        token: 'platform-admin-token',
+        token_type: 'Bearer',
+      }),
+    })
+  })
+
+  await page.route('**/api/v1/platform/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          id: 1,
+          name: 'Super Administrateur',
+          email: 'admin@leopardo-rh.com',
+          role: 'super_admin',
+          two_fa_enabled: false,
+        },
+      }),
+    })
+  })
+
+  await page.goto('/login')
+  await page.getByLabel(/Adresse email/i).fill('admin@leopardo-rh.com')
+  await page.locator('#password').fill('password123')
+  await page.getByRole('button', { name: /^Se connecter$/i }).click()
+
+  await expect(page).toHaveURL(/\/$/)
+  await expect(page.locator('body')).toContainText(/Tableau de bord|Dashboard/i)
+  await expect(page.locator('body')).toContainText(/Cockpit plateforme|Synthese commerciale/i)
+  expect(loginRequestSeen).toBe(true)
+})
+
+test('platform demo selector does not advertise tenant employee accounts', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByRole('button', { name: /Acces Demo/i }).click()
+
+  await expect(page.locator('body')).toContainText('Super Administrateur')
+  await expect(page.locator('body')).toContainText(/reserve aux administrateurs plateforme/i)
+  await expect(page.locator('body')).not.toContainText('Ahmed Benali')
+  await expect(page.locator('body')).not.toContainText('karim.aouad@techcorp-algerie.dz')
+})

--- a/front/web/e2e/auth-client-smoke.spec.ts
+++ b/front/web/e2e/auth-client-smoke.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Client web auth smoke', () => {
+  test('employee or HR manager can sign in and reach a tenant-backed dashboard', async ({ page }) => {
+    await page.route('**/api/v1/auth/login', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            id: 101,
+            first_name: 'Fatima',
+            last_name: 'Meziane',
+            email: 'fatima.meziane@techcorp-algerie.dz',
+            role: 'manager',
+            manager_role: 'rh',
+            language: 'fr',
+            is_rtl: false,
+          },
+          token: 'client-web-token',
+          token_type: 'Bearer',
+        }),
+      });
+    });
+
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            id: 101,
+            first_name: 'Fatima',
+            last_name: 'Meziane',
+            email: 'fatima.meziane@techcorp-algerie.dz',
+            role: 'manager',
+            manager_role: 'rh',
+            language: 'fr',
+            is_rtl: false,
+            capabilities: {
+              can_view_dashboard: true,
+              can_create_employees: true,
+            },
+            company: {
+              id: 'company-1',
+              name: 'TechCorp Algerie SARL',
+              language: 'fr',
+              timezone: 'Africa/Algiers',
+              currency: 'DZD',
+            },
+          },
+        }),
+      });
+    });
+
+    await page.route('**/api/v1/dashboard/summary', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            employees_total: 7,
+            employees_active: 6,
+            departments: 3,
+            today_attendance: 4,
+            pending_absences: 2,
+          },
+        }),
+      });
+    });
+
+    await page.route('**/api/v1/dashboard/recent-activity?limit=5', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            {
+              id: 1,
+              action: 'employee.updated',
+              auditable_type: 'App\\Models\\Employee',
+              created_at: '2026-05-21T10:00:00Z',
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/auth/login');
+    await page.getByPlaceholder(/email/i).fill('fatima.meziane@techcorp-algerie.dz');
+    await page.getByPlaceholder(/password|mot de passe/i).fill('password123');
+    await page.getByRole('button', { name: /sign in|se connecter/i }).click();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.locator('body')).toContainText('Tableau de bord');
+    await expect(page.locator('body')).toContainText('6');
+    await expect(page.locator('body')).toContainText('7 total');
+    await expect(page.locator('body')).toContainText('employee.updated');
+  });
+});

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiFetch } from '@/lib/api-client';
 import {
@@ -16,15 +16,14 @@ import {
   type StoredAuthUser,
 } from '@/lib/i18n';
 
-const emptySubscribe = () => () => {};
-
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const router = useRouter();
-  const storedUser = useSyncExternalStore<StoredAuthUser | null>(emptySubscribe, getStoredUser, () => null);
+  const [storedUser, setStoredUser] = useState<StoredAuthUser | null>(null);
+  const [mounted, setMounted] = useState(false);
   const [userOverride, setUserOverride] = useState<StoredAuthUser | null>(null);
   const [localeOverride, setLocaleOverride] = useState<AppLocale | null>(null);
   const user = userOverride ?? storedUser;
@@ -32,12 +31,21 @@ export default function DashboardLayout({
   const labels = useMemo(() => getCopy(locale), [locale]);
 
   useEffect(() => {
+    setStoredUser(getStoredUser());
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     if (!user) {
       router.replace('/auth/login');
       return;
     }
     applyDocumentLocale(locale, user.is_rtl);
-  }, [locale, router, user]);
+  }, [locale, mounted, router, user]);
 
   const handleLogout = () => {
     clearAuthSession();
@@ -65,6 +73,10 @@ export default function DashboardLayout({
     setLocaleOverride(normalizeLocale(payload.data.language));
     applyDocumentLocale(normalizeLocale(payload.data.language), payload.data.is_rtl);
   };
+
+  if (!mounted) {
+    return null;
+  }
 
   return (
     <div className="flex min-h-screen bg-app-card">


### PR DESCRIPTION
## Observation
- Existing Playwright coverage loaded login pages but did not prove the full UI login journey into protected spaces.
- The new client web smoke exposed a real post-login dashboard render loop caused by a non-stable localStorage snapshot.

## Changes
- add client web Playwright smoke for auth/login -> auth/me -> dashboard with tenant dashboard data.
- add admin-dashboard Playwright smoke for platform/auth/login -> platform/auth/me -> admin dashboard.
- ensure the web marketing E2E CI runs the client auth smoke alongside the funnel smoke.
- fix dashboard layout hydration by replacing object-returning useSyncExternalStore with stable state hydration.
- document the lesson in AGENTS.md and CHANGELOG.md.

## Validation
- npm run lint (front/web)
- npm run build (front/web)
- PLAYWRIGHT_WEB_SERVER_COMMAND='npm run start' npx playwright test e2e/auth-client-smoke.spec.ts --project=chromium
- npx playwright test e2e/platform-auth-smoke.spec.js
- npm run lint (front/admin-dashboard; existing warnings only, exit 0)

## Notes
- Local web Playwright first failed because the smoke found React error #185 on /dashboard; fixed in this PR.
- A separate first run hit ENOSPC from local Turbopack dev artifacts; rerun used production start after cleanup.