### PR TITLE
test: cover dashboard activity contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.108] - 2026-05-21
+
+### Tests
+
+- Contrats frontend/API : ajout de `/api/v1/dashboard/recent-activity` dans la matrice canonique et le garde `FrontendApiContractTest`.
+
 ## [4.16.107] - 2026-05-21
 
 ### Docs

--- a/api/tests/Feature/FrontendApiContractTest.php
+++ b/api/tests/Feature/FrontendApiContractTest.php
@@ -37,6 +37,7 @@ class FrontendApiContractTest extends TestCase
             'mobile device token register' => ['POST', 'api/v1/device-tokens'],
             'mobile device token unregister' => ['DELETE', 'api/v1/device-tokens'],
             'admin dashboard summary' => ['GET', 'api/v1/dashboard/summary'],
+            'admin dashboard recent activity' => ['GET', 'api/v1/dashboard/recent-activity'],
             'admin audit export' => ['GET', 'api/v1/audit-logs/export-csv'],
             'admin employees export' => ['GET', 'api/v1/export/employees'],
             'admin contracts export' => ['GET', 'api/v1/export/contracts'],

--- a/docs/validation/FRONTEND_API_CONTRACT_MATRIX.md
+++ b/docs/validation/FRONTEND_API_CONTRACT_MATRIX.md
@@ -30,7 +30,8 @@ Objectif : garder les frontends admin, mobile et kiosk alignes avec le backend L
 | Mobile | Tout marquer lu | `PUT /api/v1/notifications/read-all` | authentifie | `FrontendApiContractTest` |
 | Mobile | Enregistrer push token | `POST /api/v1/device-tokens` | authentifie | `FrontendApiContractTest` |
 | Mobile | Supprimer push token | `DELETE /api/v1/device-tokens` | authentifie | `FrontendApiContractTest` |
-| Admin client | Resume dashboard | `GET /api/v1/dashboard/summary` | manager | `FrontendApiContractTest` |
+| Admin client | Resume dashboard | `GET /api/v1/dashboard/summary` | manager | `DashboardControllerTest`, `FrontendApiContractTest` |
+| Admin client | Activite recente dashboard | `GET /api/v1/dashboard/recent-activity` | manager | `DashboardControllerTest`, `FrontendApiContractTest` |
 | Admin client | Export audit | `GET /api/v1/audit-logs/export-csv` | manager/admin | `FrontendApiContractTest` |
 | Admin client | Export employes | `GET /api/v1/export/employees` | manager | `ExportControllerTest`, `FrontendApiContractTest` |
 | Admin client | Export contrats | `GET /api/v1/export/contracts` | manager | `ExportControllerTest`, `FrontendApiContractTest` |


### PR DESCRIPTION
## Summary
- add dashboard recent activity to the frontend/API contract matrix
- add the route existence guard to FrontendApiContractTest
- note the contract update in CHANGELOG

## Validation
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1

Local PHP is unavailable on this Windows host, so the Laravel contract test is validated by GitHub Actions.