### PR TITLE
fix: tolerate zero k6 vus input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.113] - 2026-05-21
+
+### Fixed
+
+- Performance : le smoke k6 borne les VUs a 1 minimum pour eviter un echec de configuration quand un workflow manuel recoit `0`.
+
 ## [4.16.112] - 2026-05-21
 
 ### Added

--- a/dev-hub/load/README.md
+++ b/dev-hub/load/README.md
@@ -99,6 +99,8 @@ Seuils : p95 dashboard < 1500 ms, liste/search employes < 1800 ms.
 | `MANAGER_DURATION` | `1m` | Duree manager |
 | `EMPLOYEE_DURATION` | `1m` | Duree employe |
 
+Les valeurs `*_VUS` inferieures a `1` sont normalisees a leur defaut pour respecter la configuration k6.
+
 ## Procedure de benchmark Plan 14
 
 1. Creer un tenant staging avec au moins 100 employes.

--- a/dev-hub/load/k6/api-core-smoke.js
+++ b/dev-hub/load/k6/api-core-smoke.js
@@ -10,24 +10,33 @@ const dashboardLatency = new Trend('dashboard_latency_ms');
 const attendanceLatency = new Trend('attendance_latency_ms');
 const payrollLatency = new Trend('payroll_latency_ms');
 
+function positiveInteger(value, fallback) {
+  const parsed = Number(value || fallback);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return Math.floor(parsed);
+}
+
 export const options = {
   scenarios: {
     health: {
       executor: 'constant-vus',
-      vus: Number(__ENV.HEALTH_VUS || 5),
+      vus: positiveInteger(__ENV.HEALTH_VUS, 5),
       duration: __ENV.HEALTH_DURATION || '1m',
       exec: 'healthScenario',
     },
     manager_read_paths: {
       executor: 'constant-vus',
-      vus: Number(__ENV.MANAGER_VUS || 5),
+      vus: positiveInteger(__ENV.MANAGER_VUS, 5),
       duration: __ENV.MANAGER_DURATION || '1m',
       exec: 'managerReadScenario',
       startTime: '5s',
     },
     employee_read_paths: {
       executor: 'constant-vus',
-      vus: Number(__ENV.EMPLOYEE_VUS || 5),
+      vus: positiveInteger(__ENV.EMPLOYEE_VUS, 5),
       duration: __ENV.EMPLOYEE_DURATION || '1m',
       exec: 'employeeReadScenario',
       startTime: '10s',


### PR DESCRIPTION
## Summary
- clamp k6 VU inputs to a minimum valid value so workflow_dispatch values like 0 do not break k6 configuration
- document the normalization in the load testing README
- add changelog entry

## Validation
- node --check dev-hub/load/k6/api-core-smoke.js
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1