### PR TITLE
ci: force node 24 for k6 workflow

### DIFF
--- a/.github/workflows/k6-load-smoke.yml
+++ b/.github/workflows/k6-load-smoke.yml
@@ -27,6 +27,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: k6-load-smoke-${{ github.ref }}
   cancel-in-progress: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.114] - 2026-05-21
+
+### Changed
+
+- CI : le workflow k6 force les actions JavaScript en Node 24 pour eviter les annotations de deprecation Node 20.
+
 ## [4.16.113] - 2026-05-21
 
 ### Fixed


### PR DESCRIPTION
## Summary
- opt the k6 load smoke workflow into Node 24 for JavaScript actions
- add changelog entry

## Validation
- git diff --check
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\check-governance.ps1