### PR TITLE
feat(ops): add launch observability gate

### DIFF
--- a/.github/workflows/launch-observability-smoke.yml
+++ b/.github/workflows/launch-observability-smoke.yml
@@ -1,0 +1,60 @@
+name: Launch Observability Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: "API Render base URL"
+        required: false
+        default: "https://gestionemployerbackend.onrender.com"
+      web_url:
+        description: "Public web/vitrine base URL"
+        required: false
+        default: "https://gestionemployer-backend.vercel.app"
+      admin_url:
+        description: "Admin dashboard base URL"
+        required: false
+        default: "https://leo-admin.pages.dev"
+      max_latency_ms:
+        description: "Maximum accepted latency per probe"
+        required: false
+        default: "2500"
+  schedule:
+    - cron: "*/30 * * * *"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: launch-observability-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Probe launch surfaces
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Run launch probes
+        env:
+          LAUNCH_MAX_P95_MS: ${{ github.event.inputs.max_latency_ms || '2500' }}
+        run: |
+          bash dev-hub/tools/launch-observability-smoke.sh \
+            "${{ github.event.inputs.api_url || 'https://gestionemployerbackend.onrender.com' }}" \
+            "${{ github.event.inputs.web_url || 'https://gestionemployer-backend.vercel.app' }}" \
+            "${{ github.event.inputs.admin_url || 'https://leo-admin.pages.dev' }}"
+
+      - name: Upload launch smoke report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: launch-observability-smoke-report
+          path: dev-hub/observability/reports/launch-observability-smoke.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Les pages vitrine conversion `/pricing`, `/demo` et `/integrations` utilisent `useVitrineLocale()` avec contenu FR/EN/TR/AR et `dir=rtl` pour l'arabe. Toute evolution marketing sur ces pages doit ajouter les 4 locales dans le meme changement.
 - Le blog vitrine utilise `getBlogPosts(locale)` / `getBlogPost(slug, locale)` et le rail `?lang=` pour les alternates sitemap/hreflang. Toute nouvelle entree blog doit conserver slug stable et champs localises FR/EN/TR/AR.
 - Les listes API critiques consommees par mobile/admin (`employees`, `absences`, `attendance`, `me/pay-slips`, `notifications`) doivent garder des filtres/tris allowlistes et couverts par `ApiListQueryContractTest`. Ne pas accepter de `sort_by` libre ou de champ SQL arbitraire.
+- Le workflow `Launch Observability Smoke` sonde API/docs/vitrine/admin toutes les 30 minutes et publie `launch-observability-smoke-report`. En cas de rouge pendant une campagne, suivre `docs/GESTION_PROJET/RUNBOOK_MARKETING_ROLLBACK.md` avant de toucher au code.
+- Le Plan 18 demarre la phase experience client : login reel vitrine -> espace manager, features par plan/role, pages de connexion modernes et smoke E2E staging. Toute evolution auth/client doit garder ce plan a jour.
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.115] - 2026-05-21
+
+### Added
+
+- Observabilite lancement : workflow `Launch Observability Smoke` planifie toutes les 30 minutes pour sonder API health, docs, vitrine et admin avec rapport JSON artefact.
+- Ops : dashboard de lancement `LAUNCH_OBSERVABILITY_DASHBOARD.md` et runbook `RUNBOOK_MARKETING_ROLLBACK.md` pour couper proprement acquisition, webhooks, queues et deploy en cas d'incident.
+- Roadmap : Plan 18 cree pour securiser la connexion client reelle, l'acces aux features par plan et la modernisation UX des pages de login.
+
+### Changed
+
+- Plan 17 : lot 17.5 marque livre avec surveillance lancement, alerting externe minimal et rollback marketing formalise.
+
 ## [4.16.114] - 2026-05-21
 
 ### Changed

--- a/dev-hub/tools/launch-observability-smoke.sh
+++ b/dev-hub/tools/launch-observability-smoke.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${1:-${LAUNCH_API_URL:-https://gestionemployerbackend.onrender.com}}"
+WEB_URL="${2:-${LAUNCH_WEB_URL:-https://gestionemployer-backend.vercel.app}}"
+ADMIN_URL="${3:-${LAUNCH_ADMIN_URL:-https://leo-admin.pages.dev}}"
+
+API_URL="${API_URL%/}"
+WEB_URL="${WEB_URL%/}"
+ADMIN_URL="${ADMIN_URL%/}"
+
+REPORT_DIR="${LAUNCH_REPORT_DIR:-dev-hub/observability/reports}"
+mkdir -p "${REPORT_DIR}"
+REPORT_FILE="${REPORT_DIR}/launch-observability-smoke.json"
+
+TIMEOUT="${LAUNCH_SMOKE_TIMEOUT_SECONDS:-15}"
+MAX_P95_MS="${LAUNCH_MAX_P95_MS:-2500}"
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  printf '%s' "${value}"
+}
+
+probe() {
+  local name="$1"
+  local url="$2"
+  local expected="${3:-200}"
+
+  local tmp status total_ms ok error
+  tmp="$(mktemp)"
+  status="$(curl --silent --show-error --location --max-time "${TIMEOUT}" \
+    -H 'Accept: application/json,text/html;q=0.9,*/*;q=0.8' \
+    -o "${tmp}" -w '%{http_code}' "${url}" 2>"${tmp}.err" || true)"
+  total_ms="$(curl --silent --location --max-time "${TIMEOUT}" \
+    -H 'Accept: application/json,text/html;q=0.9,*/*;q=0.8' \
+    -o /dev/null -w '%{time_total}' "${url}" 2>/dev/null || echo "0")"
+  total_ms="$(awk -v seconds="${total_ms}" 'BEGIN { printf "%d", seconds * 1000 }')"
+
+  if [[ "${status}" == "${expected}" && "${total_ms}" -le "${MAX_P95_MS}" ]]; then
+    ok=true
+    error=""
+  else
+    ok=false
+    error="$(cat "${tmp}.err" 2>/dev/null || true)"
+  fi
+
+  rm -f "${tmp}" "${tmp}.err"
+
+  printf '{"name":"%s","url":"%s","expected_status":%s,"status":%s,"latency_ms":%s,"ok":%s,"error":"%s"}' \
+    "$(json_escape "${name}")" \
+    "$(json_escape "${url}")" \
+    "${expected}" \
+    "${status:-0}" \
+    "${total_ms}" \
+    "${ok}" \
+    "$(json_escape "${error}")"
+}
+
+checks=()
+checks+=("$(probe "api_health" "${API_URL}/api/v1/health" 200)")
+checks+=("$(probe "api_docs" "${API_URL}/docs" 200)")
+checks+=("$(probe "api_docs_openapi" "${API_URL}/docs/openapi.yaml" 200)")
+checks+=("$(probe "web_vitrine" "${WEB_URL}" 200)")
+checks+=("$(probe "web_pricing" "${WEB_URL}/pricing" 200)")
+checks+=("$(probe "web_demo" "${WEB_URL}/demo" 200)")
+checks+=("$(probe "admin_login" "${ADMIN_URL}" 200)")
+
+failed=0
+for check in "${checks[@]}"; do
+  if ! grep -q '"ok":true' <<< "${check}"; then
+    failed=$((failed + 1))
+  fi
+done
+
+{
+  printf '{\n'
+  printf '  "generated_at": "%s",\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  printf '  "api_url": "%s",\n' "$(json_escape "${API_URL}")"
+  printf '  "web_url": "%s",\n' "$(json_escape "${WEB_URL}")"
+  printf '  "admin_url": "%s",\n' "$(json_escape "${ADMIN_URL}")"
+  printf '  "max_latency_ms": %s,\n' "${MAX_P95_MS}"
+  printf '  "failed": %s,\n' "${failed}"
+  printf '  "checks": [\n'
+  for i in "${!checks[@]}"; do
+    printf '    %s' "${checks[$i]}"
+    if [[ "${i}" -lt $((${#checks[@]} - 1)) ]]; then
+      printf ','
+    fi
+    printf '\n'
+  done
+  printf '  ]\n'
+  printf '}\n'
+} > "${REPORT_FILE}"
+
+cat "${REPORT_FILE}"
+
+if [[ "${failed}" -gt 0 ]]; then
+  echo "Launch observability smoke failed: ${failed} check(s) failed." >&2
+  exit 1
+fi
+
+echo "Launch observability smoke passed."

--- a/docs/GESTION_PROJET/RUNBOOK_MARKETING_ROLLBACK.md
+++ b/docs/GESTION_PROJET/RUNBOOK_MARKETING_ROLLBACK.md
@@ -1,0 +1,61 @@
+# RUNBOOK - ROLLBACK MARKETING
+
+Date : 2026-05-21
+
+## Objectif
+
+Stopper proprement l'acquisition et proteger l'experience client si la plateforme montre des signaux rouges pendant une campagne : API degradee, formulaires instables, CRM/email indisponible, queue saturee ou deploy defectueux.
+
+## Declencheurs
+
+- `Launch Observability Smoke` rouge sur API, vitrine ou admin.
+- Erreurs 5xx API > 3% pendant 10 minutes.
+- Queue depth > 100 pendant 15 minutes.
+- Leads captures mais non transmis CRM/email pendant plus de 15 minutes.
+- Login client ou admin impossible pour un compte valide.
+- Incident securite ou fuite potentielle.
+
+## Actions immediates
+
+1. Geler les nouvelles campagnes ads.
+2. Mettre en pause les posts planifies si l'incident touche signup/demo.
+3. Desactiver temporairement les CTA payants dans les campagnes, pas dans le code, sauf incident severe.
+4. Basculer la qualification lead en manuel : exporter logs `marketing.lead_captured` et traiter par email/interne.
+5. Notifier l'equipe support et sales avec statut, impact et prochaine mise a jour.
+
+## Actions techniques
+
+### API / Render
+
+1. Verifier `/api/v1/health`, `/api/v1/health/ready`, logs Render.
+2. Si regression recente : rollback Render vers le dernier deploy vert.
+3. Si queue saturee : redemarrer workers, puis verifier failed jobs.
+4. Si PDF paie congestione la queue : mettre `PAYROLL_QUEUE_PDF_WARMUP=false` temporairement et redeployer.
+
+### Vitrine / Vercel
+
+1. Verifier home, `/pricing`, `/demo`, `/signup`.
+2. Si regression frontend : rollback Vercel vers le dernier deploy vert.
+3. Si webhooks CRM/email echouent mais les formulaires repondent : garder le site ouvert et traiter les logs lead en manuel.
+
+### Admin / Cloudflare Pages
+
+1. Verifier la page login admin et le smoke auth si credentials de staging disponibles.
+2. Rollback Cloudflare Pages vers le deploy precedent si la SPA ne charge pas.
+3. Ne pas modifier `VITE_API_URL` sans verifier qu'il pointe bien vers `.../api/v1`.
+
+## Communication
+
+| Audience | Message |
+|---|---|
+| Interne sales/support | Etat, impact, consigne sur nouveaux leads |
+| Leads recents | Message simple si demo/signup touche |
+| Clients pilotes | Seulement si l'espace client ou API est impacte |
+
+## Reprise
+
+1. Tous les probes `Launch Observability Smoke` verts pendant 30 minutes.
+2. k6 smoke read-only vert si l'incident etait performance.
+3. Aucun failed job recurrent.
+4. Test manuel : signup, demande demo, login client, login admin.
+5. Reprise progressive des campagnes par canal, un canal a la fois.

--- a/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
+++ b/docs/PLAN_ACTION/17_PLAN_COVERAGE_LANCEMENT.md
@@ -46,9 +46,9 @@ Amener le socle API au niveau de confiance necessaire pour absorber les premiers
 
 ## Lot 17.5 — Observabilite lancement
 
-- [ ] Creer un tableau de bord lancement : health API, erreurs 5xx, temps p95, queue depth, jobs failed, leads demo.
-- [ ] Ajouter alerting externe pour `/api/v1/health`, `/docs`, vitrine et admin.
-- [ ] Formaliser le rollback marketing : comment stopper acquisition, queue, emails, webhooks et deploy.
+- [x] Creer un tableau de bord lancement : health API, erreurs 5xx, temps p95, queue depth, jobs failed, leads demo.
+- [x] Ajouter alerting externe pour `/api/v1/health`, `/docs`, vitrine et admin.
+- [x] Formaliser le rollback marketing : comment stopper acquisition, queue, emails, webhooks et deploy.
 
 ## Definition of done
 

--- a/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
+++ b/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
@@ -1,0 +1,51 @@
+# 18 - Plan experience client connexion et espace moderne
+
+Date : 2026-05-21
+
+## Objectif
+
+Garantir qu'un client peut reellement se connecter, comprendre son espace, acceder aux features de son plan et vivre une experience moderne, fluide et rassurante sur web, mobile et admin.
+
+## Lot 18.1 - Contrat connexion client reel
+
+- [ ] Verifier le parcours complet : vitrine -> login -> dashboard manager.
+- [ ] Tester identifiants valides, mauvais mot de passe, compte inactif, compte sans tenant, session expiree.
+- [ ] Garantir les redirections par role : manager principal, RH, comptable, employe, super admin.
+- [ ] Ajouter un smoke E2E preview qui valide login client + affichage des donnees dashboard non vides.
+- [ ] Documenter les variables d'environnement requises : API base, URL vitrine, URL admin, credentials demo/staging.
+
+## Lot 18.2 - Acces features par plan et par role
+
+- [ ] Afficher dans l'espace client les modules disponibles selon `features`/plan.
+- [ ] Bloquer proprement les modules non inclus avec message upgrade, jamais avec 404 confuse.
+- [ ] Verifier les features critiques : employees, attendance, absences, payroll, reports, billing, integrations.
+- [ ] Ajouter tests API + UI sur feature accessible, feature interdite, feature en trial.
+
+## Lot 18.3 - Modernisation login UX
+
+- [ ] Harmoniser les pages login web client, admin plateforme, mobile et kiosque.
+- [ ] Ajouter et tester : afficher/masquer mot de passe, etat loading, erreurs lisibles, recuperation mot de passe, acces demo si autorise.
+- [ ] Optimiser responsive mobile, contraste, navigation clavier, focus visible et ARIA.
+- [ ] Eviter les pages marketing dans le login : priorite a l'action, confiance, securite et clarte.
+
+## Lot 18.4 - Premiere experience apres connexion
+
+- [ ] Dashboard manager : etat de l'entreprise, actions prioritaires, onboarding incomplet, donnees RH recentes.
+- [ ] Employe : pointage, absences, bulletins, notifications, langue.
+- [ ] Super admin : sante plateforme, demandes clients, tenants a risque.
+- [ ] Kiosque : etat appareil, synchro, mode offline clair.
+
+## Lot 18.5 - Qualite et observabilite UX
+
+- [ ] Mesurer temps login -> dashboard utilisable.
+- [ ] Ajouter tracking evenements : login_success, login_failed, dashboard_loaded, feature_blocked, demo_user_selected.
+- [ ] Ajouter captures E2E Playwright sur login et dashboard.
+- [ ] Definir seuils Lighthouse/Web Vitals pour pages login et dashboard.
+
+## Definition of done
+
+- Un client manager peut se connecter depuis la vitrine et arriver dans un espace utile sans intervention technique.
+- Les roles voient uniquement leurs features et comprennent les limites de leur plan.
+- Les pages login sont modernes, accessibles, rapides et testees.
+- Les smoke tests staging couvrent API auth, web login client, admin login et mobile contract.
+- Toute regression de connexion bloque la PR ou le deploy.

--- a/docs/validation/LAUNCH_OBSERVABILITY_DASHBOARD.md
+++ b/docs/validation/LAUNCH_OBSERVABILITY_DASHBOARD.md
@@ -1,0 +1,62 @@
+# Launch Observability Dashboard
+
+Date : 2026-05-21
+
+## Objectif
+
+Donner une vue exploitable avant et pendant l'ouverture marketing publique. Ce tableau ne remplace pas Sentry/UptimeRobot/Better Stack, mais il fixe les signaux minimums a surveiller et le workflow GitHub qui les verifie toutes les 30 minutes.
+
+## Sources
+
+| Signal | Source canonique | Gate |
+|---|---|---|
+| Health API | `GET /api/v1/health` | `Launch Observability Smoke` |
+| Documentation API | `GET /docs` et `/docs/openapi.yaml` | `Launch Observability Smoke` |
+| Vitrine publique | URL Vercel + `/pricing` + `/demo` | `Launch Observability Smoke` |
+| Admin plateforme | URL Cloudflare Pages | `Launch Observability Smoke` |
+| Latence p95 read-only | `k6-load-smoke.yml` | manuel avant campagne |
+| Erreurs 5xx | Sentry / logs Render / Vercel logs | alerte externe |
+| Queue depth | `/api/v1/health` check `queue.size` + Render worker logs | alerte externe |
+| Jobs failed | table `failed_jobs` / logs Laravel | runbook alerting |
+| Leads demo/signup/newsletter/contact | logs structures `marketing.lead_captured` + webhooks CRM/email | suivi GTM quotidien |
+
+## Seuils de lancement
+
+| Indicateur | Vert | Orange | Rouge |
+|---|---:|---:|---:|
+| API health | 200 | degraded redis/storage | 503 ou timeout |
+| `/docs` | 200 | > 2500 ms | non 200 |
+| Vitrine home/pricing/demo | 200 | > 2500 ms | non 200 |
+| Admin login | 200 | > 2500 ms | non 200 |
+| p95 API core k6 | < 800 ms | 800-1500 ms | > 1500 ms |
+| 5xx API | < 1% | 1-3% | > 3% |
+| Queue depth | < 50 | 50-100 | > 100 pendant 15 min |
+| Failed jobs | 0 | 1-3 investigues | > 3 ou recurrence |
+| Leads demo non transmis CRM/email | 0 | webhook fail-soft ponctuel | recurrence > 15 min |
+
+## Workflow operationnel
+
+1. Avant campagne : lancer `Launch Observability Smoke` en manuel avec les trois URLs de production.
+2. Avant campagne : lancer `k6 Load Smoke - Leopardo RH` avec tokens manager/employe de staging si disponibles.
+3. Pendant campagne : surveiller les artifacts `launch-observability-smoke-report` et les alertes Sentry/UptimeRobot.
+4. Chaque matin : verifier les logs `marketing.lead_captured`, le CRM/email et les leads sans suivi.
+5. Si rouge : appliquer `RUNBOOK_MARKETING_ROLLBACK.md`.
+
+## Commandes locales
+
+```bash
+bash dev-hub/tools/launch-observability-smoke.sh \
+  https://gestionemployerbackend.onrender.com \
+  https://gestionemployer-backend.vercel.app \
+  https://leo-admin.pages.dev
+```
+
+## Variables utiles
+
+| Variable | Usage |
+|---|---|
+| `LAUNCH_MAX_P95_MS` | seuil de latence par probe dans le smoke |
+| `MARKETING_CRM_WEBHOOK_URL` | transmission CRM des leads |
+| `MARKETING_EMAIL_WEBHOOK_URL` | confirmation email / notification interne |
+| `MARKETING_LEAD_WEBHOOK_TOKEN` | secret Bearer pour webhooks marketing |
+| `PAYROLL_QUEUE_PDF_WARMUP` | desactivation temporaire du warmup PDF en cas de congestion queue |


### PR DESCRIPTION
## Summary
- add scheduled/manual launch observability smoke for API docs, vitrine and admin surfaces
- document launch dashboard signals, thresholds and marketing rollback process
- mark Plan 17.5 complete and create Plan 18 for real client login/features/modern UX

## Verification
- Git Bash syntax check: bash -n dev-hub/tools/launch-observability-smoke.sh
- git diff --cached --check