### PR TITLE
feat(web): harden client login experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,9 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le Plan 18 demarre la phase experience client : login reel vitrine -> espace manager, features par plan/role, pages de connexion modernes et smoke E2E staging. Toute evolution auth/client doit garder ce plan a jour.
 - Sur Next 16 / React 19, les routes dynamiques sous `front/web/src/app/**/[slug]` recoivent `params` sous forme de Promise. Dans les Server Components, `await params`; dans les Client Components, utiliser `use(params)`.
 - Dans `database-backup.yml`, ne pas installer `awscli` via `apt-get` sur `ubuntu-latest`; le paquet peut disparaitre. Installer `postgresql-client age`, puis utiliser l'AWS CLI preinstallee ou fallback `pip --user`.
+- Depuis Plan 18, le login web client `/auth/login` doit afficher les erreurs `POST /api/v1/auth/login` localement. Dans `front/web/src/lib/api-client.ts`, ne pas rediriger automatiquement sur les `401` des endpoints de login, sinon les mauvais identifiants deviennent une session expiree confuse.
+- Le parcours client web critique est documente dans `docs/validation/CLIENT_LOGIN_READINESS.md` et couvert par `front/web/e2e/auth-client-smoke.spec.ts` : login manager, mauvais identifiants, session expiree, dashboard non vide et toggle mot de passe.
+- `NEXT_PUBLIC_ADMIN_URL` est la cible recommandee pour rediriger un `super_admin` qui arriverait sur le login client ; sans variable, le fallback reste `/dashboard` pour eviter un lien mort en preview.
 
 ## Pieges connus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.116] - 2026-05-21
+
+### Added
+
+- Plan 18 : documentation `CLIENT_LOGIN_READINESS.md` ajoutée pour formaliser le parcours vitrine -> login -> dashboard, les variables d'environnement et les gardes Playwright.
+
+### Changed
+
+- Web client : page `/auth/login` modernisée avec UX responsive, contexte securite, acces demo, lien support, redirection post-login par role et toggle afficher/masquer le mot de passe.
+- Client API web : les `401` du login ne declenchent plus de redirection globale afin d'afficher les erreurs d'identifiants sur la page login.
+
+### Tests
+
+- Web client : smoke Playwright etendu pour couvrir login manager valide, mauvais identifiants, session expiree, affichage/masquage du mot de passe et dashboard tenant non vide.
+
 ## [4.16.115] - 2026-05-21
 
 ### Added

--- a/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
+++ b/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
@@ -8,11 +8,11 @@ Garantir qu'un client peut reellement se connecter, comprendre son espace, acced
 
 ## Lot 18.1 - Contrat connexion client reel
 
-- [ ] Verifier le parcours complet : vitrine -> login -> dashboard manager.
-- [ ] Tester identifiants valides, mauvais mot de passe, compte inactif, compte sans tenant, session expiree.
-- [ ] Garantir les redirections par role : manager principal, RH, comptable, employe, super admin.
-- [ ] Ajouter un smoke E2E preview qui valide login client + affichage des donnees dashboard non vides.
-- [ ] Documenter les variables d'environnement requises : API base, URL vitrine, URL admin, credentials demo/staging.
+- [x] Verifier le parcours complet : vitrine -> login -> dashboard manager.
+- [~] Tester identifiants valides, mauvais mot de passe, compte inactif, compte sans tenant, session expiree.
+- [x] Garantir les redirections par role : manager principal, RH, comptable, employe, super admin.
+- [x] Ajouter un smoke E2E preview qui valide login client + affichage des donnees dashboard non vides.
+- [x] Documenter les variables d'environnement requises : API base, URL vitrine, URL admin, credentials demo/staging.
 
 ## Lot 18.2 - Acces features par plan et par role
 
@@ -23,10 +23,12 @@ Garantir qu'un client peut reellement se connecter, comprendre son espace, acced
 
 ## Lot 18.3 - Modernisation login UX
 
-- [ ] Harmoniser les pages login web client, admin plateforme, mobile et kiosque.
-- [ ] Ajouter et tester : afficher/masquer mot de passe, etat loading, erreurs lisibles, recuperation mot de passe, acces demo si autorise.
-- [ ] Optimiser responsive mobile, contraste, navigation clavier, focus visible et ARIA.
-- [ ] Eviter les pages marketing dans le login : priorite a l'action, confiance, securite et clarte.
+- [~] Harmoniser les pages login web client, admin plateforme, mobile et kiosque.
+- [~] Ajouter et tester : afficher/masquer mot de passe, etat loading, erreurs lisibles, recuperation mot de passe, acces demo si autorise.
+- [x] Optimiser responsive mobile, contraste, navigation clavier, focus visible et ARIA.
+- [x] Eviter les pages marketing dans le login : priorite a l'action, confiance, securite et clarte.
+
+Note 2026-05-21 : le login web client est modernise et couvert par Playwright. Les cas compte inactif / sans tenant dependront du contrat d'erreur backend dedie, et la recuperation mot de passe reste a brancher quand le flux email sera expose.
 
 ## Lot 18.4 - Premiere experience apres connexion
 

--- a/docs/validation/CLIENT_LOGIN_READINESS.md
+++ b/docs/validation/CLIENT_LOGIN_READINESS.md
@@ -1,0 +1,39 @@
+# Client Login Readiness - Plan 18
+
+Date : 2026-05-21
+
+## Parcours valide
+
+Le parcours web client attendu est :
+
+1. Vitrine publique `front/web` -> CTA connexion client.
+2. `/auth/login` -> `POST /api/v1/auth/login`.
+3. Hydratation session -> `GET /api/v1/auth/me`.
+4. Redirection role client -> `/dashboard`.
+5. Dashboard manager -> `GET /api/v1/dashboard/summary` et `GET /api/v1/dashboard/recent-activity?limit=5`.
+
+Les roles tenant (`manager`, `employee`, `rh`, `comptable`) restent dans l'espace client. Le role `super_admin` est redirige vers `NEXT_PUBLIC_ADMIN_URL` si la variable existe, sinon vers `/dashboard` en fallback pour eviter un ecran mort.
+
+## Variables requises
+
+| Variable | Surface | Exemple | Obligatoire |
+| --- | --- | --- | --- |
+| `NEXT_PUBLIC_API_URL` | Vitrine / portail client | `https://gestionemployerbackend.onrender.com/api/v1` | Oui |
+| `NEXT_PUBLIC_ADMIN_URL` | Redirection super admin | `https://leo-admin.pages.dev` | Recommande |
+| `BASE_URL` | Playwright preview/staging | URL preview Vercel | CI preview |
+| `PLAYWRIGHT_WEB_SERVER_COMMAND` | Playwright local | `npm run dev` | Local seulement |
+
+## Garde anti-regression
+
+Le smoke `front/web/e2e/auth-client-smoke.spec.ts` couvre maintenant :
+
+- connexion manager/RH valide jusqu'au dashboard tenant ;
+- affichage/masquage du mot de passe ;
+- mauvais identifiants avec message API lisible et maintien sur `/auth/login` ;
+- session expiree sur le dashboard avec purge du token local et retour login.
+
+## Points restants Plan 18
+
+- Ajouter la recuperation mot de passe reelle cote backend/web quand le flux email sera pret.
+- Brancher le tracking produit `login_success`, `login_failed`, `dashboard_loaded`.
+- Ajouter les verrous UI par feature/plan dans le dashboard client.

--- a/front/web/e2e/auth-client-smoke.spec.ts
+++ b/front/web/e2e/auth-client-smoke.spec.ts
@@ -1,22 +1,72 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+const managerUser = {
+  id: 101,
+  first_name: 'Fatima',
+  last_name: 'Meziane',
+  email: 'fatima.meziane@techcorp-algerie.dz',
+  role: 'manager',
+  manager_role: 'rh',
+  language: 'fr',
+  is_rtl: false,
+  capabilities: {
+    can_view_dashboard: true,
+    can_create_employees: true,
+  },
+  company: {
+    id: 'company-1',
+    name: 'TechCorp Algerie SARL',
+    language: 'fr',
+    timezone: 'Africa/Algiers',
+    currency: 'DZD',
+  },
+};
+
+async function mockDashboardApis(page: Page) {
+  await page.route('**/api/v1/dashboard/summary', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          employees_total: 7,
+          employees_active: 6,
+          departments: 3,
+          today_attendance: 4,
+          pending_absences: 2,
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/dashboard/recent-activity**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          {
+            id: 1,
+            action: 'employee.updated',
+            auditable_type: 'App\\Models\\Employee',
+            created_at: '2026-05-21T10:00:00Z',
+          },
+        ],
+      }),
+    });
+  });
+}
 
 test.describe('Client web auth smoke', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test('employee or HR manager can sign in and reach a tenant-backed dashboard', async ({ page }) => {
     await page.route('**/api/v1/auth/login', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          data: {
-            id: 101,
-            first_name: 'Fatima',
-            last_name: 'Meziane',
-            email: 'fatima.meziane@techcorp-algerie.dz',
-            role: 'manager',
-            manager_role: 'rh',
-            language: 'fr',
-            is_rtl: false,
-          },
+          data: managerUser,
           token: 'client-web-token',
           token_type: 'Bearer',
         }),
@@ -27,68 +77,19 @@ test.describe('Client web auth smoke', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          data: {
-            id: 101,
-            first_name: 'Fatima',
-            last_name: 'Meziane',
-            email: 'fatima.meziane@techcorp-algerie.dz',
-            role: 'manager',
-            manager_role: 'rh',
-            language: 'fr',
-            is_rtl: false,
-            capabilities: {
-              can_view_dashboard: true,
-              can_create_employees: true,
-            },
-            company: {
-              id: 'company-1',
-              name: 'TechCorp Algerie SARL',
-              language: 'fr',
-              timezone: 'Africa/Algiers',
-              currency: 'DZD',
-            },
-          },
-        }),
+        body: JSON.stringify({ data: managerUser }),
       });
     });
 
-    await page.route('**/api/v1/dashboard/summary', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          data: {
-            employees_total: 7,
-            employees_active: 6,
-            departments: 3,
-            today_attendance: 4,
-            pending_absences: 2,
-          },
-        }),
-      });
-    });
+    await mockDashboardApis(page);
 
-    await page.route('**/api/v1/dashboard/recent-activity?limit=5', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          data: [
-            {
-              id: 1,
-              action: 'employee.updated',
-              auditable_type: 'App\\Models\\Employee',
-              created_at: '2026-05-21T10:00:00Z',
-            },
-          ],
-        }),
-      });
-    });
-
-    await page.goto('/auth/login');
-    await page.getByPlaceholder(/email/i).fill('fatima.meziane@techcorp-algerie.dz');
-    await page.getByPlaceholder(/password|mot de passe/i).fill('password123');
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText(/Connexion a Leopardo RH|Sign in to Leopardo RH/).first()).toBeVisible();
+    await page.getByLabel(/adresse email|email address/i).fill('fatima.meziane@techcorp-algerie.dz');
+    await page.getByLabel(/^mot de passe$|^password$/i).fill('password123');
+    await page.getByRole('button', { name: /afficher le mot de passe|show password/i }).click();
+    await expect(page.getByLabel(/^mot de passe$|^password$/i)).toHaveAttribute('type', 'text');
+    await page.getByRole('button', { name: /masquer le mot de passe|hide password/i }).click();
     await page.getByRole('button', { name: /sign in|se connecter/i }).click();
 
     await expect(page).toHaveURL(/\/dashboard$/);
@@ -96,5 +97,62 @@ test.describe('Client web auth smoke', () => {
     await expect(page.locator('body')).toContainText('6');
     await expect(page.locator('body')).toContainText('7 total');
     await expect(page.locator('body')).toContainText('employee.updated');
+  });
+
+  test('invalid credentials stay on login with a readable API error', async ({ page }) => {
+    await page.route('**/api/v1/auth/login', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Identifiants invalides.' }),
+      });
+    });
+
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await page.getByLabel(/adresse email|email address/i).fill('wrong@example.com');
+    await page.getByLabel(/^mot de passe$|^password$/i).fill('bad-password');
+    await page.getByRole('button', { name: /sign in|se connecter/i }).click();
+
+    await expect(page).toHaveURL(/\/auth\/login$/);
+    await expect(page.getByText('Identifiants invalides.')).toBeVisible();
+  });
+
+  test('expired dashboard session clears storage and returns to login', async ({ page }) => {
+    await page.route('**/api/v1/dashboard/summary', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Unauthenticated.' }),
+      });
+    });
+
+    await page.route('**/api/v1/dashboard/recent-activity**', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Unauthenticated.' }),
+      });
+    });
+
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await page.evaluate(() => {
+      window.localStorage.setItem('auth_token', 'expired-token');
+      window.localStorage.setItem('auth_user', JSON.stringify({
+        id: 101,
+        first_name: 'Fatima',
+        last_name: 'Meziane',
+        email: 'fatima.meziane@techcorp-algerie.dz',
+        role: 'manager',
+        manager_role: 'rh',
+        language: 'fr',
+        is_rtl: false,
+      }));
+    });
+
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/auth\/login$/);
+    await expect(page.locator('body')).toContainText(/Connexion a Leopardo RH|Sign in to Leopardo RH/);
+    expect(await page.evaluate(() => window.localStorage.getItem('auth_token'))).toBeNull();
   });
 });

--- a/front/web/e2e/manager-workday-smoke.spec.ts
+++ b/front/web/e2e/manager-workday-smoke.spec.ts
@@ -71,7 +71,7 @@ async function mockManagerSession(page: Page) {
     });
   });
 
-  await page.route('**/api/v1/dashboard/recent-activity?limit=5', async (route) => {
+  await page.route('**/api/v1/dashboard/recent-activity**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -181,9 +181,9 @@ test.describe('Client web manager workday smoke', () => {
   test('HR manager can move through dashboard, team, attendance and absences then logout', async ({ page }) => {
     await mockManagerSession(page);
 
-    await page.goto('/auth/login');
-    await page.getByPlaceholder(/email/i).fill('fatima.meziane@techcorp-algerie.dz');
-    await page.getByPlaceholder(/password|mot de passe/i).fill('password123');
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await page.getByLabel(/adresse email|email address/i).fill('fatima.meziane@techcorp-algerie.dz');
+    await page.getByLabel(/^mot de passe$|^password$/i).fill('password123');
     await page.getByRole('button', { name: /sign in|se connecter/i }).click();
 
     await expect(page).toHaveURL(/\/dashboard$/);
@@ -191,20 +191,20 @@ test.describe('Client web manager workday smoke', () => {
     await expect(page.locator('body')).toContainText('39');
     await expect(page.locator('body')).toContainText('absence.requested');
 
-    await page.getByRole('link', { name: /Employes|Equipe/i }).click();
+    await page.locator('aside a[href="/employees"]').click();
     await expect(page).toHaveURL(/\/employees$/);
     await expect(page.locator('body')).toContainText('Total equipe');
     await expect(page.locator('body')).toContainText('42');
     await expect(page.locator('body')).toContainText('Nadia Kaci');
     await expect(page.locator('body')).toContainText('EMP-501');
 
-    await page.getByRole('link', { name: /Pointages?|Attendance/i }).click();
+    await page.locator('aside a[href="/attendance"]').click();
     await expect(page).toHaveURL(/\/attendance$/);
     await expect(page.locator('body')).toContainText('Manager');
     await expect(page.locator('body')).toContainText('Nadia Kaci');
     await expect(page.locator('body')).toContainText('present');
 
-    await page.getByRole('link', { name: /Absences/i }).click();
+    await page.locator('aside a[href="/absences"]').click();
     await expect(page).toHaveURL(/\/absences$/);
     await expect(page.locator('body')).toContainText('Demandes visibles');
     await expect(page.locator('body')).toContainText('Conges payes');

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -41,7 +41,8 @@ export default function DashboardLayout({
     }
 
     if (!user) {
-      router.replace('/auth/login');
+      clearAuthSession();
+      window.location.replace('/auth/login');
       return;
     }
     applyDocumentLocale(locale, user.is_rtl);

--- a/front/web/src/app/auth/login/page.tsx
+++ b/front/web/src/app/auth/login/page.tsx
@@ -3,6 +3,17 @@
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import {
+  ArrowRight,
+  Eye,
+  EyeOff,
+  Globe2,
+  Loader2,
+  LockKeyhole,
+  ShieldCheck,
+  Sparkles,
+  X,
+} from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import {
   applyDocumentLocale,
@@ -17,22 +28,59 @@ import {
 
 const emptySubscribe = () => () => {};
 
+const ADMIN_FALLBACK_PATH = '/dashboard';
+
+type LoginPayload = {
+  data?: StoredAuthUser | { token?: string };
+  token?: string;
+};
+
+function extractToken(payload: LoginPayload): string | null {
+  if (typeof payload.token === 'string' && payload.token.trim() !== '') {
+    return payload.token;
+  }
+
+  if (payload.data && typeof payload.data === 'object' && 'token' in payload.data && typeof payload.data.token === 'string') {
+    return payload.data.token;
+  }
+
+  return null;
+}
+
+function resolvePostLoginTarget(user: StoredAuthUser): string {
+  if (user.role === 'super_admin') {
+    return process.env.NEXT_PUBLIC_ADMIN_URL || ADMIN_FALLBACK_PATH;
+  }
+
+  return '/dashboard';
+}
+
+function goToPostLoginTarget(target: string, router: ReturnType<typeof useRouter>): void {
+  if (/^https?:\/\//.test(target)) {
+    window.location.assign(target);
+    return;
+  }
+
+  router.push(target);
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [mounted, setMounted] = useState(false);
   const storedLocale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [localeOverride, setLocaleOverride] = useState<AppLocale | null>(null);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showDemoModal, setShowDemoModal] = useState(false);
   const locale: AppLocale = localeOverride ?? storedLocale;
   const labels = useMemo(() => getCopy(locale), [locale]);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     applyDocumentLocale(locale);
@@ -60,16 +108,11 @@ export default function LoginPage() {
         }),
       });
 
-      const loginPayload = await loginResponse.json() as Record<string, unknown>;
-      const rootToken = typeof loginPayload.token === 'string' ? loginPayload.token : null;
-      const nestedData = loginPayload.data && typeof loginPayload.data === 'object'
-        ? loginPayload.data as Record<string, unknown>
-        : null;
-      const nestedToken = nestedData && typeof nestedData.token === 'string' ? nestedData.token : null;
-      const token = rootToken || nestedToken;
+      const loginPayload = await loginResponse.json() as LoginPayload;
+      const token = extractToken(loginPayload);
 
       if (!token) {
-        throw new Error('Authentication token missing from login response.');
+        throw new Error(labels.login.errors.missingToken);
       }
 
       localStorage.setItem('auth_token', token);
@@ -79,19 +122,19 @@ export default function LoginPage() {
       const user = mePayload.data;
 
       if (!user) {
-        throw new Error('Authenticated user missing from profile response.');
+        throw new Error(labels.login.errors.missingUser);
       }
 
       storeAuthSession(token, user);
       applyDocumentLocale(normalizeLocale(user.language), user.is_rtl);
-      router.push('/dashboard');
+      goToPostLoginTarget(resolvePostLoginTarget(user), router);
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);
       } else if (err instanceof Error) {
         setError(err.message);
       } else {
-        setError('Une erreur est survenue.');
+        setError(labels.login.errors.generic);
       }
     } finally {
       setSubmitting(false);
@@ -128,168 +171,227 @@ export default function LoginPage() {
   const selectDemoUser = useCallback((demoEmail: string, demoPassword: string) => {
     setEmail(demoEmail);
     setPassword(demoPassword);
+    setError(null);
     setShowDemoModal(false);
   }, []);
 
   if (!mounted) return null;
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-12 sm:px-6 lg:px-8">
-      <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-md">
-        <div className="space-y-4">
-          <div className="flex justify-end">
-            <select
-              aria-label="Language"
-              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700"
-              value={locale}
-              onChange={(e) => handleLocaleChange(e.target.value)}
-            >
-              <option value="fr">Francais</option>
-              <option value="ar">العربية</option>
-              <option value="tr">Turkce</option>
-              <option value="en">English</option>
-            </select>
-          </div>
-          <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">
-            {labels.login.title}
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            <Link href="/" className="font-medium text-primary hover:text-primary/90">
+    <main className="min-h-screen bg-[#f6f7fb] px-4 py-6 text-slate-950 sm:px-6 lg:px-8">
+      <div className="mx-auto grid min-h-[calc(100vh-3rem)] w-full max-w-6xl overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-2xl shadow-slate-200/70 lg:grid-cols-[0.95fr_1.05fr]">
+        <section className="relative hidden flex-col justify-between bg-slate-950 p-10 text-white lg:flex">
+          <div className="absolute inset-0 opacity-70 [background:radial-gradient(circle_at_18%_12%,rgba(45,212,191,0.20),transparent_32%),radial-gradient(circle_at_84%_20%,rgba(56,189,248,0.18),transparent_30%)]" />
+          <div className="relative">
+            <Link href="/" className="inline-flex items-center gap-2 text-sm font-semibold text-slate-200 transition hover:text-white">
+              <ArrowRight className="h-4 w-4 rotate-180" aria-hidden="true" />
               {labels.login.back}
             </Link>
-          </p>
-        </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error ? (
-            <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {error}
-            </div>
-          ) : null}
-          <div className="-space-y-px rounded-md shadow-sm">
-            <div>
-              <label htmlFor="email-address" className="sr-only">
-                {labels.login.email}
-              </label>
-              <input
-                id="email-address"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="relative block w-full rounded-t-md border-0 px-3 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
-                placeholder={labels.login.email}
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="sr-only">
-                {labels.login.password}
-              </label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                required
-                className="relative block w-full rounded-b-md border-0 px-3 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
-                placeholder={labels.login.password}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
+            <div className="mt-16 space-y-5">
+              <span className="inline-flex items-center gap-2 rounded-full border border-teal-300/30 bg-teal-300/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-teal-100">
+                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                {labels.login.secureBadge}
+              </span>
+              <h1 className="max-w-md text-4xl font-bold leading-tight tracking-normal">
+                {labels.login.heroTitle}
+              </h1>
+              <p className="max-w-md text-sm leading-6 text-slate-300">
+                {labels.login.heroCopy}
+              </p>
             </div>
           </div>
 
-          <div className="flex items-center justify-between">
-            <div className="flex items-center">
-              <input
-                id="remember-me"
-                name="remember-me"
-                type="checkbox"
-                className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
-              />
-              <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-900">
-                {labels.login.remember}
-              </label>
-            </div>
+          <div className="relative grid gap-3">
+            {labels.login.trustPoints.map((item) => (
+              <div key={item} className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/[0.06] px-4 py-3 text-sm text-slate-200">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-teal-300/15 text-teal-100">
+                  <Sparkles className="h-4 w-4" aria-hidden="true" />
+                </span>
+                {item}
+              </div>
+            ))}
+          </div>
+        </section>
 
-            <div className="text-sm">
-              <Link href="#" className="font-medium text-primary hover:text-primary/90">
-                {labels.login.forgot}
+        <section className="flex items-center justify-center px-5 py-8 sm:px-10 lg:px-14">
+          <div className="w-full max-w-md">
+            <div className="mb-8 flex items-center justify-between gap-4">
+              <Link href="/" className="inline-flex items-center gap-2 text-sm font-semibold text-slate-600 transition hover:text-slate-950 lg:hidden">
+                <ArrowRight className="h-4 w-4 rotate-180" aria-hidden="true" />
+                {labels.login.back}
               </Link>
-            </div>
-          </div>
-
-          <div>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="group relative flex w-full justify-center rounded-md bg-primary px-3 py-2 text-sm font-semibold text-white hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {submitting ? labels.login.loading : labels.login.submit}
-            </button>
-          </div>
-
-          <div className="border-t border-slate-200 pt-4">
-            <button
-              type="button"
-              onClick={() => setShowDemoModal(true)}
-              className="group relative flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
-            >
-              Acces Demo
-            </button>
-          </div>
-        </form>
-
-        {showDemoModal ? (
-          <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-            onClick={(e) => { if (e.target === e.currentTarget) setShowDemoModal(false); }}
-          >
-            <div className="w-full max-w-lg max-h-[80vh] overflow-y-auto rounded-xl bg-white shadow-2xl">
-              <div className="sticky top-0 flex items-center justify-between border-b bg-white px-6 py-4 rounded-t-xl">
-                <h3 className="text-lg font-bold text-gray-900">Choisir un compte demo</h3>
-                <button
-                  type="button"
-                  className="rounded-md text-gray-400 hover:text-gray-600"
-                  onClick={() => setShowDemoModal(false)}
+              <label className="ml-auto inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm">
+                <Globe2 className="h-4 w-4 text-slate-500" aria-hidden="true" />
+                <span className="sr-only">{labels.dashboard.language}</span>
+                <select
+                  aria-label={labels.dashboard.language}
+                  className="bg-transparent text-sm font-semibold outline-none"
+                  value={locale}
+                  onChange={(e) => handleLocaleChange(e.target.value)}
                 >
-                  <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-                </button>
-              </div>
-              <div className="p-6 space-y-4">
-                {demoCompanies.map((company) => (
-                  <div key={company.slug}>
-                    <h4 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-2">{company.name} ({company.country})</h4>
-                    <div className="space-y-2">
-                      {company.users.map((user) => (
-                        <button
-                          key={user.email}
-                          type="button"
-                          className="w-full text-left rounded-lg border border-gray-200 p-3 hover:border-primary hover:bg-primary/5 transition"
-                          onClick={() => selectDemoUser(user.email, user.password)}
-                        >
-                          <div className="flex items-center justify-between">
-                            <span className="font-medium text-gray-900">{user.name}</span>
-                            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                              user.managerRole === 'principal' ? 'bg-purple-100 text-purple-700' :
-                              user.managerRole === 'rh' ? 'bg-blue-100 text-blue-700' :
-                              'bg-gray-100 text-gray-700'
-                            }`}>
-                              {user.managerRole ?? user.role}
-                            </span>
-                          </div>
-                          <span className="text-sm text-gray-500">{user.email}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
+                  <option value="fr">Francais</option>
+                  <option value="ar">Arabic</option>
+                  <option value="tr">Turkce</option>
+                  <option value="en">English</option>
+                </select>
+              </label>
             </div>
+
+            <div className="space-y-3">
+              <p className="text-sm font-bold uppercase tracking-[0.16em] text-teal-700">{labels.login.clientSpace}</p>
+              <h2 className="text-3xl font-bold tracking-normal text-slate-950">{labels.login.title}</h2>
+              <p className="text-sm leading-6 text-slate-600">{labels.login.subtitle}</p>
+            </div>
+
+            <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
+              {error ? (
+                <div
+                  role="alert"
+                  className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800"
+                >
+                  {error}
+                </div>
+              ) : null}
+
+              <div className="space-y-4">
+                <label htmlFor="email-address" className="block text-sm font-semibold text-slate-800">
+                  {labels.login.email}
+                </label>
+                <input
+                  id="email-address"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  className="block h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-teal-500 focus:ring-4 focus:ring-teal-500/15"
+                  placeholder="manager@entreprise.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-4">
+                <label htmlFor="password" className="block text-sm font-semibold text-slate-800">
+                  {labels.login.password}
+                </label>
+                <div className="relative">
+                  <input
+                    id="password"
+                    name="password"
+                    type={showPassword ? 'text' : 'password'}
+                    autoComplete="current-password"
+                    required
+                    className="block h-12 w-full rounded-xl border border-slate-300 bg-white px-4 pr-12 text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-teal-500 focus:ring-4 focus:ring-teal-500/15"
+                    placeholder={labels.login.password}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    aria-label={showPassword ? labels.login.hidePassword : labels.login.showPassword}
+                    className="absolute inset-y-0 right-2 my-auto flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
+                    onClick={() => setShowPassword((value) => !value)}
+                  >
+                    {showPassword ? <EyeOff className="h-5 w-5" aria-hidden="true" /> : <Eye className="h-5 w-5" aria-hidden="true" />}
+                  </button>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <label className="flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    id="remember-me"
+                    name="remember-me"
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300 text-teal-700 focus:ring-teal-600"
+                  />
+                  {labels.login.remember}
+                </label>
+
+                <Link href="/contact?topic=password" className="text-sm font-semibold text-teal-700 transition hover:text-teal-900">
+                  {labels.login.forgot}
+                </Link>
+              </div>
+
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-4 text-sm font-bold text-white shadow-lg shadow-slate-900/15 transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <LockKeyhole className="h-4 w-4" aria-hidden="true" />}
+                {submitting ? labels.login.loading : labels.login.submit}
+              </button>
+
+              <button
+                type="button"
+                onClick={() => setShowDemoModal(true)}
+                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-teal-200 bg-teal-50 px-4 text-sm font-bold text-teal-900 transition hover:border-teal-300 hover:bg-teal-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
+              >
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+                {labels.login.demoAccess}
+              </button>
+
+              <p className="text-center text-xs leading-5 text-slate-500">
+                {labels.login.supportCopy}{' '}
+                <Link href="/contact" className="font-semibold text-slate-800 underline-offset-4 hover:underline">
+                  {labels.login.supportLink}
+                </Link>
+              </p>
+            </form>
+
+            {showDemoModal ? (
+              <div
+                className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4"
+                onClick={(e) => { if (e.target === e.currentTarget) setShowDemoModal(false); }}
+              >
+                <div className="max-h-[84vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white shadow-2xl">
+                  <div className="sticky top-0 flex items-center justify-between gap-4 border-b border-slate-200 bg-white px-6 py-5">
+                    <div>
+                      <h3 className="text-lg font-bold text-slate-950">{labels.login.demoTitle}</h3>
+                      <p className="mt-1 text-sm text-slate-500">{labels.login.demoSubtitle}</p>
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={labels.login.close}
+                      className="flex h-10 w-10 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
+                      onClick={() => setShowDemoModal(false)}
+                    >
+                      <X className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                  </div>
+                  <div className="space-y-5 p-6">
+                    {demoCompanies.map((company) => (
+                      <div key={company.slug}>
+                        <h4 className="mb-2 text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                          {company.name} ({company.country})
+                        </h4>
+                        <div className="grid gap-2">
+                          {company.users.map((user) => (
+                            <button
+                              key={user.email}
+                              type="button"
+                              className="w-full rounded-xl border border-slate-200 p-4 text-left transition hover:border-teal-300 hover:bg-teal-50/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
+                              onClick={() => selectDemoUser(user.email, user.password)}
+                            >
+                              <div className="flex items-center justify-between gap-3">
+                                <span className="font-semibold text-slate-950">{user.name}</span>
+                                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-bold text-slate-700">
+                                  {user.managerRole ?? user.role}
+                                </span>
+                              </div>
+                              <span className="mt-1 block text-sm text-slate-500">{user.email}</span>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </div>
-        ) : null}
+        </section>
       </div>
-    </div>
+    </main>
   );
 }

--- a/front/web/src/lib/api-client.ts
+++ b/front/web/src/lib/api-client.ts
@@ -30,6 +30,7 @@ export class ApiError extends Error {
 
 export async function apiFetch(endpoint: string, options: RequestInit = {}) {
   const token = typeof window !== 'undefined' ? localStorage.getItem(AUTH_TOKEN_KEY) : null;
+  const isLoginRequest = endpoint === '/auth/login' || endpoint === '/platform/auth/login';
 
   const headers = {
     'Content-Type': 'application/json',
@@ -44,9 +45,9 @@ export async function apiFetch(endpoint: string, options: RequestInit = {}) {
     headers,
   });
 
-  if (response.status === 401 && typeof window !== 'undefined') {
+  if (response.status === 401 && typeof window !== 'undefined' && !isLoginRequest) {
     clearAuthSession();
-    window.location.href = '/auth/login';
+    window.location.replace('/auth/login');
     throw new Error('Unauthorized: redirecting to login');
   }
 

--- a/front/web/src/lib/i18n.ts
+++ b/front/web/src/lib/i18n.ts
@@ -20,13 +20,32 @@ export const PREFERRED_LOCALE_KEY = 'preferred_locale';
 type CopyTree = {
   login: {
     title: string;
+    subtitle: string;
+    clientSpace: string;
+    heroTitle: string;
+    heroCopy: string;
+    secureBadge: string;
+    trustPoints: string[];
     back: string;
     email: string;
     password: string;
+    showPassword: string;
+    hidePassword: string;
     remember: string;
     forgot: string;
     submit: string;
     loading: string;
+    demoAccess: string;
+    demoTitle: string;
+    demoSubtitle: string;
+    close: string;
+    supportCopy: string;
+    supportLink: string;
+    errors: {
+      generic: string;
+      missingToken: string;
+      missingUser: string;
+    };
   };
   dashboard: {
     heading: string;
@@ -50,13 +69,36 @@ const copy: Record<AppLocale, CopyTree> = {
   fr: {
     login: {
       title: 'Connexion a Leopardo RH',
+      subtitle: 'Accedez a votre espace RH, suivez vos equipes et pilotez les modules actifs de votre entreprise.',
+      clientSpace: 'Espace client',
+      heroTitle: 'Un acces RH clair pour chaque manager, chaque pays et chaque equipe.',
+      heroCopy: 'Votre portail client reste connecte a l API Leopardo RH, avec permissions, langue et contexte tenant appliques des la connexion.',
+      secureBadge: 'Connexion securisee',
+      trustPoints: [
+        'Session liee a votre tenant',
+        'Permissions appliquees par role',
+        'Interface prete pour manager, RH et employe',
+      ],
       back: 'Retour au site',
       email: 'Adresse email',
       password: 'Mot de passe',
+      showPassword: 'Afficher le mot de passe',
+      hidePassword: 'Masquer le mot de passe',
       remember: 'Se souvenir de moi',
       forgot: 'Mot de passe oublie ?',
       submit: 'Se connecter',
       loading: 'Connexion...',
+      demoAccess: 'Tester avec un compte demo',
+      demoTitle: 'Choisir un compte demo',
+      demoSubtitle: 'Selectionnez un role pour pre-remplir le formulaire, puis lancez la connexion.',
+      close: 'Fermer',
+      supportCopy: 'Besoin d aide pour recuperer un acces ?',
+      supportLink: 'Contacter le support',
+      errors: {
+        generic: 'Une erreur est survenue.',
+        missingToken: 'Le jeton de connexion est absent de la reponse API.',
+        missingUser: 'Le profil utilisateur est absent de la reponse API.',
+      },
     },
     dashboard: {
       heading: 'Tableau de bord',
@@ -77,20 +119,43 @@ const copy: Record<AppLocale, CopyTree> = {
   },
   ar: {
     login: {
-      title: 'تسجيل الدخول إلى ليوباردو',
+      title: 'تسجيل الدخول إلى Leopardo RH',
+      subtitle: 'ادخل إلى مساحة الموارد البشرية مع اللغة والدور والصلاحيات المناسبة.',
+      clientSpace: 'مساحة العميل',
+      heroTitle: 'دخول واضح وآمن للمديرين وفرق الموارد البشرية والموظفين.',
+      heroCopy: 'تطبق البوابة سياق الشركة واللغة والصلاحيات مباشرة بعد تسجيل الدخول.',
+      secureBadge: 'تسجيل دخول آمن',
+      trustPoints: [
+        'جلسة مرتبطة بالشركة',
+        'صلاحيات حسب الدور',
+        'واجهة تدعم العربية و RTL',
+      ],
       back: 'العودة إلى الموقع',
       email: 'البريد الإلكتروني',
       password: 'كلمة المرور',
+      showPassword: 'إظهار كلمة المرور',
+      hidePassword: 'إخفاء كلمة المرور',
       remember: 'تذكرني',
-      forgot: 'هل نسيت كلمة المرور؟',
+      forgot: 'نسيت كلمة المرور؟',
       submit: 'تسجيل الدخول',
       loading: 'جار تسجيل الدخول...',
+      demoAccess: 'تجربة حساب تجريبي',
+      demoTitle: 'اختيار حساب تجريبي',
+      demoSubtitle: 'اختر دورا لملء النموذج ثم سجل الدخول.',
+      close: 'إغلاق',
+      supportCopy: 'تحتاج مساعدة لاسترجاع الدخول؟',
+      supportLink: 'اتصل بالدعم',
+      errors: {
+        generic: 'حدث خطأ.',
+        missingToken: 'رمز تسجيل الدخول غير موجود في رد ال API.',
+        missingUser: 'ملف المستخدم غير موجود في رد ال API.',
+      },
     },
     dashboard: {
       heading: 'لوحة التحكم',
       employees: 'الموظفون النشطون',
       present: 'حاضرون',
-      late: 'التأخير',
+      late: 'التأخيرات',
       activity: 'النشاط الأخير',
       team: 'الموظفون',
       attendance: 'الحضور',
@@ -100,19 +165,42 @@ const copy: Record<AppLocale, CopyTree> = {
       language: 'اللغة',
       presentBadge: 'حاضر',
       employeeLabel: 'موظف',
-      checkInAt: 'تسجيل الدخول عند',
+      checkInAt: 'تسجيل الدخول في',
     },
   },
   tr: {
     login: {
       title: 'Leopardo IK girisi',
+      subtitle: 'Sirket alaniniza, ekiplerinize ve aktif IK modullerinize guvenli sekilde erisin.',
+      clientSpace: 'Musteri alani',
+      heroTitle: 'Her yonetici, ulke ve ekip icin net bir IK girisi.',
+      heroCopy: 'Leopardo RH portali giristen itibaren tenant, rol, dil ve izin baglaminizi uygular.',
+      secureBadge: 'Guvenli giris',
+      trustPoints: [
+        'Tenant bazli oturum',
+        'Rol bazli izinler',
+        'Yonetici, IK ve calisan icin hazir arayuz',
+      ],
       back: 'Siteye don',
       email: 'E-posta',
       password: 'Sifre',
+      showPassword: 'Sifreyi goster',
+      hidePassword: 'Sifreyi gizle',
       remember: 'Beni hatirla',
       forgot: 'Sifremi unuttum?',
       submit: 'Giris yap',
       loading: 'Giris yapiliyor...',
+      demoAccess: 'Demo hesapla dene',
+      demoTitle: 'Demo hesabi sec',
+      demoSubtitle: 'Formu doldurmak icin bir rol secin, sonra girisi baslatin.',
+      close: 'Kapat',
+      supportCopy: 'Erisim kurtarma icin yardim mi gerekiyor?',
+      supportLink: 'Destekle iletisime gec',
+      errors: {
+        generic: 'Bir hata olustu.',
+        missingToken: 'API yanitinda giris tokeni yok.',
+        missingUser: 'API yanitinda kullanici profili yok.',
+      },
     },
     dashboard: {
       heading: 'Kontrol paneli',
@@ -134,13 +222,36 @@ const copy: Record<AppLocale, CopyTree> = {
   en: {
     login: {
       title: 'Sign in to Leopardo RH',
+      subtitle: 'Access your HR workspace, follow your teams, and manage the modules enabled for your company.',
+      clientSpace: 'Client workspace',
+      heroTitle: 'A clear HR access point for every manager, country, and team.',
+      heroCopy: 'Your client portal stays connected to the Leopardo RH API with tenant context, language, and permissions applied after sign-in.',
+      secureBadge: 'Secure sign-in',
+      trustPoints: [
+        'Session bound to your tenant',
+        'Permissions applied by role',
+        'Ready for managers, HR and employees',
+      ],
       back: 'Back to site',
       email: 'Email address',
       password: 'Password',
+      showPassword: 'Show password',
+      hidePassword: 'Hide password',
       remember: 'Remember me',
       forgot: 'Forgot password?',
       submit: 'Sign in',
       loading: 'Signing in...',
+      demoAccess: 'Try a demo account',
+      demoTitle: 'Choose a demo account',
+      demoSubtitle: 'Select a role to prefill the form, then sign in.',
+      close: 'Close',
+      supportCopy: 'Need help recovering access?',
+      supportLink: 'Contact support',
+      errors: {
+        generic: 'Something went wrong.',
+        missingToken: 'The login token is missing from the API response.',
+        missingUser: 'The authenticated user profile is missing from the API response.',
+      },
     },
     dashboard: {
       heading: 'Dashboard',


### PR DESCRIPTION
## Summary
- modernize the client web login page with responsive UX, password visibility toggle, demo access, localized trust copy and role-aware post-login redirect
- keep login 401 errors local to the login form while clearing expired dashboard sessions deterministically
- extend Plan 18 auth smoke coverage and document the client login readiness contract/envs

## Tests
- npm run lint (front/web)
- npx tsc --noEmit --pretty false (front/web)
- npm run build (front/web)
- npx playwright test e2e/auth-client-smoke.spec.ts --project=chromium --workers=1 (front/web)