### PR TITLE
feat(web): gate client modules by plan

### DIFF
--- a/.github/workflows/web-marketing-ci.yml
+++ b/.github/workflows/web-marketing-ci.yml
@@ -105,4 +105,4 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: https://gestionemployerbackend.onrender.com/api/v1
           PLAYWRIGHT_WEB_SERVER_COMMAND: npm run start
-        run: npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts --project=chromium --workers=1
+        run: npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts --project=chromium --workers=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis Plan 18, le login web client `/auth/login` doit afficher les erreurs `POST /api/v1/auth/login` localement. Dans `front/web/src/lib/api-client.ts`, ne pas rediriger automatiquement sur les `401` des endpoints de login, sinon les mauvais identifiants deviennent une session expiree confuse.
 - Le parcours client web critique est documente dans `docs/validation/CLIENT_LOGIN_READINESS.md` et couvert par `front/web/e2e/auth-client-smoke.spec.ts` : login manager, mauvais identifiants, session expiree, dashboard non vide et toggle mot de passe.
 - `NEXT_PUBLIC_ADMIN_URL` est la cible recommandee pour rediriger un `super_admin` qui arriverait sur le login client ; sans variable, le fallback reste `/dashboard` pour eviter un lien mort en preview.
+- Les feature gates du portail client vivent dans `front/web/src/lib/client-features.ts` et sont appliquees dans `front/web/src/app/(dashboard)/layout.tsx`. Ajouter un nouveau module client implique de declarer sa route, ses cles `capabilities`/`features`, ses roles autorises et un test Playwright dans `front/web/e2e/client-feature-gates.spec.ts`.
 
 ## Pieges connus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.117] - 2026-05-21
+
+### Added
+
+- Plan 18 : moteur UI `client-features` pour calculer les modules web client depuis les capabilities, les features entreprise/plan et le role utilisateur.
+- Web client : ecran upgrade explicite pour les modules non inclus afin d eviter les 404 confuses ou les pages metier cassees.
+
+### Changed
+
+- Web client : la navigation dashboard indique les modules actifs, en trial ou a upgrader, avec blocage role/plan centralise dans le layout.
+- CI vitrine : le smoke Playwright authentifie couvre aussi les feature gates client.
+
+### Tests
+
+- Web client : tests Playwright ajoutes pour module accessible, module verrouille, module trial et blocage role employe sur la paie manager.
+
 ## [4.16.116] - 2026-05-21
 
 ### Added

--- a/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
+++ b/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
@@ -16,10 +16,12 @@ Garantir qu'un client peut reellement se connecter, comprendre son espace, acced
 
 ## Lot 18.2 - Acces features par plan et par role
 
-- [ ] Afficher dans l'espace client les modules disponibles selon `features`/plan.
-- [ ] Bloquer proprement les modules non inclus avec message upgrade, jamais avec 404 confuse.
-- [ ] Verifier les features critiques : employees, attendance, absences, payroll, reports, billing, integrations.
-- [ ] Ajouter tests API + UI sur feature accessible, feature interdite, feature en trial.
+- [x] Afficher dans l'espace client les modules disponibles selon `features`/plan.
+- [x] Bloquer proprement les modules non inclus avec message upgrade, jamais avec 404 confuse.
+- [~] Verifier les features critiques : employees, attendance, absences, payroll, reports, billing, integrations.
+- [~] Ajouter tests API + UI sur feature accessible, feature interdite, feature en trial.
+
+Note 2026-05-21 : le portail client calcule les modules depuis les `capabilities`, les `features` entreprise/plan et le role utilisateur. Les tests UI couvrent module accessible, module interdit, module en trial et blocage role employe. Les tests API de gate serveur restent a etendre cote backend si de nouveaux endpoints feature-gated sont ajoutes.
 
 ## Lot 18.3 - Modernisation login UX
 

--- a/docs/validation/CLIENT_LOGIN_READINESS.md
+++ b/docs/validation/CLIENT_LOGIN_READINESS.md
@@ -32,8 +32,34 @@ Le smoke `front/web/e2e/auth-client-smoke.spec.ts` couvre maintenant :
 - mauvais identifiants avec message API lisible et maintien sur `/auth/login` ;
 - session expiree sur le dashboard avec purge du token local et retour login.
 
+## Acces features Plan 18.2
+
+Le portail client applique les modules visibles depuis trois sources, dans cet ordre :
+
+1. `auth/me.data.capabilities`
+2. `auth/me.data.company.features`
+3. `auth/me.data.plan.features`
+
+En absence de contrat explicite, le module reste disponible afin de ne pas couper les clients historiques. Une valeur `false`, `disabled`, `locked` ou equivalente bloque le module ; une valeur `trial` laisse le module utilisable avec un badge Trial.
+
+Modules controles cote UI :
+
+| Module | Route | Cles reconnues |
+| --- | --- | --- |
+| Employes | `/employees` | `employees`, `employee_management`, `can_view_employees`, `can_create_employees` |
+| Pointages | `/attendance` | `attendance`, `time_tracking`, `can_view_attendance` |
+| Absences | `/absences` | `absences`, `leave_management`, `can_view_absences` |
+| Contrats | `/contracts` | `contracts`, `can_view_contracts` |
+| Paie | `/payroll` | `payroll`, `pay_slips`, `can_view_payroll`, `can_manage_payroll` |
+| Formation | `/training` | `training`, `can_view_training` |
+| Rapports | `/reports` | `reports`, `analytics`, `can_view_reports` |
+| Facturation | navigation plan | `billing`, `can_manage_billing` |
+| Integrations | navigation plan | `integrations`, `api_access`, `webhooks`, `can_manage_integrations` |
+
+Les modules non inclus affichent une page d upgrade explicite au lieu de rendre la page metier ou de produire une 404.
+
 ## Points restants Plan 18
 
 - Ajouter la recuperation mot de passe reelle cote backend/web quand le flux email sera pret.
 - Brancher le tracking produit `login_success`, `login_failed`, `dashboard_loaded`.
-- Ajouter les verrous UI par feature/plan dans le dashboard client.
+- Completer les gates backend si un endpoint critique n applique pas encore les feature flags serveur.

--- a/front/web/e2e/client-feature-gates.spec.ts
+++ b/front/web/e2e/client-feature-gates.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const baseUser = {
+  id: 101,
+  first_name: 'Fatima',
+  last_name: 'Meziane',
+  email: 'fatima.meziane@techcorp-algerie.dz',
+  role: 'manager',
+  manager_role: 'principal',
+  language: 'fr',
+  is_rtl: false,
+};
+
+async function seedSession(page: Page, overrides: Record<string, unknown> = {}) {
+  await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+  await page.evaluate((user) => {
+    window.localStorage.setItem('auth_token', 'feature-gate-token');
+    window.localStorage.setItem('auth_user', JSON.stringify(user));
+  }, { ...baseUser, ...overrides });
+}
+
+test.describe('Client web feature gates', () => {
+  test('included module stays accessible from the client workspace', async ({ page }) => {
+    await page.route('**/api/v1/employees?per_page=12', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            {
+              id: 501,
+              first_name: 'Nadia',
+              last_name: 'Kaci',
+              email: 'nadia.kaci@techcorp-algerie.dz',
+              role: 'employee',
+              status: 'active',
+              matricule: 'EMP-501',
+            },
+          ],
+          meta: { total: 1 },
+        }),
+      });
+    });
+
+    await seedSession(page, {
+      capabilities: {
+        employees: true,
+        payroll: false,
+      },
+      company: {
+        id: 'company-1',
+        name: 'TechCorp Algerie SARL',
+        features: {
+          employees: true,
+          payroll: false,
+        },
+      },
+    });
+
+    await page.goto('/employees', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/employees$/);
+    await expect(page.locator('body')).toContainText('Total equipe');
+    await expect(page.locator('body')).toContainText('Nadia Kaci');
+  });
+
+  test('locked module shows an upgrade message instead of rendering a broken page', async ({ page }) => {
+    await seedSession(page, {
+      capabilities: {
+        employees: true,
+        payroll: false,
+      },
+      company: {
+        id: 'company-1',
+        name: 'TechCorp Algerie SARL',
+        features: {
+          employees: true,
+          payroll: false,
+        },
+      },
+    });
+
+    await page.goto('/payroll', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/payroll$/);
+    await expect(page.getByText('Module non inclus').first()).toBeVisible();
+    await expect(page.locator('body')).toContainText('Ce module n est pas inclus dans votre plan actuel.');
+    await expect(page.locator('body')).toContainText('Demander l activation');
+    await expect(page.locator('body')).not.toContainText('Gestion des bulletins de paie et cycles de paie');
+  });
+
+  test('trial module is visible as trial and remains usable', async ({ page }) => {
+    await seedSession(page, {
+      capabilities: {
+        reports: 'trial',
+      },
+      company: {
+        id: 'company-1',
+        name: 'TechCorp Algerie SARL',
+        features: {
+          reports: 'trial',
+        },
+      },
+    });
+
+    await page.goto('/reports', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/reports$/);
+    await expect(page.locator('aside')).toContainText('Trial');
+    await expect(page.locator('body')).toContainText('Generez et telechargez vos rapports RH');
+  });
+
+  test('employee role cannot open manager payroll even if the feature exists', async ({ page }) => {
+    await seedSession(page, {
+      role: 'employee',
+      manager_role: null,
+      capabilities: {
+        payroll: true,
+      },
+      company: {
+        id: 'company-1',
+        name: 'TechCorp Algerie SARL',
+        features: {
+          payroll: true,
+        },
+      },
+    });
+
+    await page.goto('/payroll', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByText('Module non inclus').first()).toBeVisible();
+    await expect(page.locator('body')).toContainText('Votre role actuel ne permet pas d acceder a ce module.');
+  });
+});

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -2,8 +2,10 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { LockKeyhole, Sparkles } from 'lucide-react';
 import { apiFetch } from '@/lib/api-client';
+import { getClientModuleAccess, getModuleAccessForPath, type ClientModuleAccess } from '@/lib/client-features';
 import {
   applyDocumentLocale,
   clearAuthSession,
@@ -22,6 +24,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const [storedUser, setStoredUser] = useState<StoredAuthUser | null>(null);
   const [mounted, setMounted] = useState(false);
   const [userOverride, setUserOverride] = useState<StoredAuthUser | null>(null);
@@ -29,6 +32,8 @@ export default function DashboardLayout({
   const user = userOverride ?? storedUser;
   const locale = localeOverride ?? normalizeLocale(user?.language);
   const labels = useMemo(() => getCopy(locale), [locale]);
+  const modules = useMemo(() => getClientModuleAccess(user), [user]);
+  const currentModule = useMemo(() => getModuleAccessForPath(pathname, user), [pathname, user]);
 
   useEffect(() => {
     setStoredUser(getStoredUser());
@@ -79,6 +84,13 @@ export default function DashboardLayout({
     return null;
   }
 
+  const navGroups = {
+    general: modules.filter((module) => module.group === 'general' && module.href),
+    hr: modules.filter((module) => module.group === 'hr' && module.href),
+    finance: modules.filter((module) => module.group === 'finance' && module.href),
+    platform: modules.filter((module) => module.group === 'platform'),
+  };
+
   return (
     <div className="flex min-h-screen bg-app-card">
       <aside className="hidden w-64 flex-col bg-slate-900 text-white md:flex">
@@ -91,56 +103,40 @@ export default function DashboardLayout({
           <div className="mb-2 px-4">
             <p className="px-2 text-[10px] font-bold uppercase tracking-widest text-slate-500">General</p>
           </div>
-          <Link href="/dashboard" className="flex items-center gap-3 border-r-4 border-rh bg-slate-800/50 px-6 py-3 transition-colors hover:bg-slate-800">
-            <span className="h-2 w-2 rounded-full bg-rh"></span>
-            {labels.dashboard.heading}
-          </Link>
+          {navGroups.general.map((module) => (
+            <SidebarLink key={module.key} module={module} active={pathname === module.href} />
+          ))}
 
           <div className="mb-2 mt-6 px-4">
             <p className="px-2 text-[10px] font-bold uppercase tracking-widest text-slate-500">Module RH</p>
           </div>
-          <Link href="/employees" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            {labels.dashboard.team}
-          </Link>
-          <Link href="/attendance" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            {labels.dashboard.attendance}
-          </Link>
-          <Link href="/absences" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            Absences
-          </Link>
-          <Link href="/contracts" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            Contrats
-          </Link>
+          {navGroups.hr.map((module) => (
+            <SidebarLink key={module.key} module={module} active={pathname === module.href} />
+          ))}
 
           <div className="mb-2 mt-6 px-4">
             <p className="px-2 text-[10px] font-bold uppercase tracking-widest text-slate-500">Finance & Formation</p>
           </div>
-          <Link href="/payroll" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            Paie
-          </Link>
-          <Link href="/training" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            Formations
-          </Link>
-          <Link href="/reports" className="flex items-center gap-3 px-6 py-3 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white">
-            <span className="h-2 w-2 rounded-full bg-slate-600"></span>
-            Rapports
-          </Link>
+          {navGroups.finance.map((module) => (
+            <SidebarLink key={module.key} module={module} active={pathname === module.href} />
+          ))}
         </nav>
 
-        <div className="m-4 rounded-xl border border-ia/20 bg-ia/10 p-4">
-          <div className="mb-2 flex items-center gap-2 text-ia">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
-            <span className="text-xs font-bold uppercase tracking-wider">Leo IA</span>
+        <div className="m-4 space-y-3 rounded-xl border border-ia/20 bg-ia/10 p-4">
+          <div className="flex items-center gap-2 text-ia">
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            <span className="text-xs font-bold uppercase tracking-wider">Modules du plan</span>
           </div>
-          <p className="text-[10px] leading-relaxed text-slate-400">
-            Leo arrive bientot sur le web pour vous aider a analyser vos donnees RH par simple commande vocale.
-          </p>
+          <div className="grid gap-2">
+            {navGroups.platform.map((module) => (
+              <div key={module.key} className="flex items-center justify-between gap-2 text-[11px] font-semibold text-slate-300">
+                <span>{module.label}</span>
+                <span className={`rounded-full px-2 py-0.5 text-[10px] ${module.enabled ? 'bg-emerald-400/15 text-emerald-200' : 'bg-slate-700 text-slate-400'}`}>
+                  {module.enabled ? (module.state === 'trial' ? 'Trial' : 'Actif') : 'Upgrade'}
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
 
         <div className="border-t border-slate-800 p-6">
@@ -184,9 +180,71 @@ export default function DashboardLayout({
           </div>
         </header>
         <main className="mx-auto w-full max-w-7xl p-8">
-          {children}
+          {currentModule && !currentModule.enabled ? (
+            <FeatureLockedPanel module={currentModule} />
+          ) : (
+            children
+          )}
         </main>
       </div>
     </div>
+  );
+}
+
+function SidebarLink({ module, active }: { module: ClientModuleAccess; active: boolean }) {
+  const className = [
+    'flex items-center justify-between gap-3 px-6 py-3 transition-colors',
+    active ? 'border-r-4 border-rh bg-slate-800/50 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white',
+    module.enabled ? '' : 'text-slate-500 hover:text-slate-300',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <Link href={module.href ?? '#'} className={className} aria-disabled={!module.enabled}>
+      <span className="flex items-center gap-3">
+        <span className={`h-2 w-2 rounded-full ${module.enabled ? 'bg-rh' : 'bg-slate-600'}`}></span>
+        {module.label}
+      </span>
+      {!module.enabled ? <LockKeyhole className="h-3.5 w-3.5" aria-label="Module non inclus" /> : null}
+      {module.enabled && module.state === 'trial' ? (
+        <span className="rounded-full bg-amber-300/15 px-2 py-0.5 text-[10px] font-bold text-amber-200">Trial</span>
+      ) : null}
+    </Link>
+  );
+}
+
+function FeatureLockedPanel({ module }: { module: ClientModuleAccess }) {
+  const reason = module.reason === 'role_locked'
+    ? 'Votre role actuel ne permet pas d acceder a ce module.'
+    : 'Ce module n est pas inclus dans votre plan actuel.';
+
+  return (
+    <section className="overflow-hidden rounded-3xl border border-amber-200 bg-white shadow-sm">
+      <div className="grid gap-6 p-6 lg:grid-cols-[1fr_280px] lg:items-center">
+        <div className="space-y-4">
+          <span className="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-amber-700">
+            <LockKeyhole className="h-4 w-4" aria-hidden="true" />
+            Module non inclus
+          </span>
+          <div>
+            <h1 className="text-3xl font-black text-slate-950">{module.upgradeLabel}</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              {reason} Leopardo RH garde l interface explicite afin d eviter les 404 confuses et les erreurs API inutiles.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            Demandez l activation au super administrateur de la plateforme ou passez sur un plan incluant ce module.
+          </div>
+        </div>
+        <div className="rounded-2xl bg-slate-950 p-5 text-white">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-teal-200">Plan & role</p>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Les modules visibles dans cet espace sont calcules depuis les droits, le plan de l entreprise et le role utilisateur.
+          </p>
+          <Link href="/contact?topic=upgrade" className="mt-5 inline-flex w-full items-center justify-center rounded-xl bg-teal-400 px-4 py-3 text-sm font-bold text-slate-950 transition hover:bg-teal-300">
+            Demander l activation
+          </Link>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/front/web/src/lib/client-features.ts
+++ b/front/web/src/lib/client-features.ts
@@ -1,0 +1,243 @@
+import type { StoredAuthUser } from '@/lib/i18n';
+
+export type ClientModuleKey =
+  | 'dashboard'
+  | 'employees'
+  | 'attendance'
+  | 'absences'
+  | 'contracts'
+  | 'payroll'
+  | 'training'
+  | 'reports'
+  | 'billing'
+  | 'integrations';
+
+export type FeatureState = 'available' | 'trial' | 'locked';
+
+export type ClientModule = {
+  key: ClientModuleKey;
+  href?: string;
+  label: string;
+  group: 'general' | 'hr' | 'finance' | 'platform';
+  capabilityKeys: string[];
+  featureKeys: string[];
+  allowedRoles: string[];
+  upgradeLabel: string;
+};
+
+export type ClientModuleAccess = ClientModule & {
+  state: FeatureState;
+  enabled: boolean;
+  reason: 'available' | 'trial' | 'feature_locked' | 'role_locked';
+};
+
+export const CLIENT_MODULES: ClientModule[] = [
+  {
+    key: 'dashboard',
+    href: '/dashboard',
+    label: 'Tableau de bord',
+    group: 'general',
+    capabilityKeys: ['can_view_dashboard', 'dashboard'],
+    featureKeys: ['dashboard', 'rh'],
+    allowedRoles: ['super_admin', 'admin', 'manager', 'employee'],
+    upgradeLabel: 'Tableau de bord',
+  },
+  {
+    key: 'employees',
+    href: '/employees',
+    label: 'Employes',
+    group: 'hr',
+    capabilityKeys: ['employees', 'can_view_employees', 'can_create_employees'],
+    featureKeys: ['employees', 'employee_management', 'rh'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Gestion des employes',
+  },
+  {
+    key: 'attendance',
+    href: '/attendance',
+    label: 'Pointages',
+    group: 'hr',
+    capabilityKeys: ['attendance', 'can_view_attendance'],
+    featureKeys: ['attendance', 'time_tracking', 'rh'],
+    allowedRoles: ['super_admin', 'admin', 'manager', 'employee'],
+    upgradeLabel: 'Pointage et presence',
+  },
+  {
+    key: 'absences',
+    href: '/absences',
+    label: 'Absences',
+    group: 'hr',
+    capabilityKeys: ['absences', 'can_view_absences'],
+    featureKeys: ['absences', 'leave_management', 'rh'],
+    allowedRoles: ['super_admin', 'admin', 'manager', 'employee'],
+    upgradeLabel: 'Absences et conges',
+  },
+  {
+    key: 'contracts',
+    href: '/contracts',
+    label: 'Contrats',
+    group: 'hr',
+    capabilityKeys: ['contracts', 'can_view_contracts'],
+    featureKeys: ['contracts', 'rh'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Contrats RH',
+  },
+  {
+    key: 'payroll',
+    href: '/payroll',
+    label: 'Paie',
+    group: 'finance',
+    capabilityKeys: ['payroll', 'can_view_payroll', 'can_manage_payroll'],
+    featureKeys: ['payroll', 'pay_slips'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Paie et bulletins',
+  },
+  {
+    key: 'training',
+    href: '/training',
+    label: 'Formations',
+    group: 'finance',
+    capabilityKeys: ['training', 'can_view_training'],
+    featureKeys: ['training'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Formation',
+  },
+  {
+    key: 'reports',
+    href: '/reports',
+    label: 'Rapports',
+    group: 'finance',
+    capabilityKeys: ['reports', 'can_view_reports'],
+    featureKeys: ['reports', 'analytics'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Rapports avances',
+  },
+  {
+    key: 'billing',
+    label: 'Facturation',
+    group: 'platform',
+    capabilityKeys: ['billing', 'can_manage_billing'],
+    featureKeys: ['billing'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Facturation',
+  },
+  {
+    key: 'integrations',
+    label: 'Integrations',
+    group: 'platform',
+    capabilityKeys: ['integrations', 'can_manage_integrations'],
+    featureKeys: ['integrations', 'api_access', 'webhooks'],
+    allowedRoles: ['super_admin', 'admin', 'manager'],
+    upgradeLabel: 'Integrations',
+  },
+];
+
+const ROUTE_TO_MODULE: Record<string, ClientModuleKey> = {
+  '/dashboard': 'dashboard',
+  '/employees': 'employees',
+  '/attendance': 'attendance',
+  '/absences': 'absences',
+  '/contracts': 'contracts',
+  '/payroll': 'payroll',
+  '/training': 'training',
+  '/reports': 'reports',
+};
+
+function normalizedRole(user?: StoredAuthUser | null): string {
+  if (!user?.role) {
+    return 'guest';
+  }
+
+  return user.role.toLowerCase();
+}
+
+function hasRoleAccess(module: ClientModule, user?: StoredAuthUser | null): boolean {
+  const role = normalizedRole(user);
+
+  if (role === 'manager') {
+    const managerRole = (user?.manager_role ?? '').toLowerCase();
+    if (module.key === 'billing' || module.key === 'integrations') {
+      return managerRole === 'principal';
+    }
+
+    return true;
+  }
+
+  return module.allowedRoles.includes(role);
+}
+
+function valueFor(keys: string[], values?: Record<string, unknown> | null): unknown {
+  if (!values) {
+    return undefined;
+  }
+
+  const matchedKey = keys.find((key) => Object.prototype.hasOwnProperty.call(values, key));
+  return matchedKey ? values[matchedKey] : undefined;
+}
+
+function stateFromValue(value: unknown): FeatureState | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (value === true || value === 'enabled' || value === 'available') {
+    return 'available';
+  }
+
+  if (value === 'trial') {
+    return 'trial';
+  }
+
+  return 'locked';
+}
+
+function resolveModuleState(module: ClientModule, user?: StoredAuthUser | null): FeatureState {
+  if (!user) {
+    return 'locked';
+  }
+
+  if (module.key === 'dashboard') {
+    return 'available';
+  }
+
+  const capabilityState = stateFromValue(valueFor(module.capabilityKeys, user.capabilities));
+  if (capabilityState) {
+    return capabilityState;
+  }
+
+  const companyFeatureState = stateFromValue(valueFor(module.featureKeys, user.company?.features));
+  if (companyFeatureState) {
+    return companyFeatureState;
+  }
+
+  const planFeatureState = stateFromValue(valueFor(module.featureKeys, user.plan?.features));
+  if (planFeatureState) {
+    return planFeatureState;
+  }
+
+  return 'available';
+}
+
+export function getClientModuleAccess(user?: StoredAuthUser | null): ClientModuleAccess[] {
+  return CLIENT_MODULES.map((module) => {
+    const roleAllowed = hasRoleAccess(module, user);
+    const state = resolveModuleState(module, user);
+    const enabled = roleAllowed && state !== 'locked';
+
+    return {
+      ...module,
+      state,
+      enabled,
+      reason: enabled ? state : roleAllowed ? 'feature_locked' : 'role_locked',
+    };
+  });
+}
+
+export function getModuleAccessForPath(pathname: string, user?: StoredAuthUser | null): ClientModuleAccess | null {
+  const moduleKey = ROUTE_TO_MODULE[pathname];
+  if (!moduleKey) {
+    return null;
+  }
+
+  return getClientModuleAccess(user).find((module) => module.key === moduleKey) ?? null;
+}

--- a/front/web/src/lib/i18n.ts
+++ b/front/web/src/lib/i18n.ts
@@ -10,6 +10,19 @@ export type StoredAuthUser = {
   is_rtl?: boolean;
   role?: string | null;
   manager_role?: string | null;
+  capabilities?: Record<string, unknown> | null;
+  company?: {
+    id?: number | string | null;
+    name?: string | null;
+    language?: string | null;
+    timezone?: string | null;
+    currency?: string | null;
+    features?: Record<string, unknown> | null;
+  } | null;
+  plan?: {
+    name?: string | null;
+    features?: Record<string, unknown> | null;
+  } | null;
 };
 
 export const SUPPORTED_LOCALES: AppLocale[] = ['fr', 'ar', 'tr', 'en'];


### PR DESCRIPTION
## Summary
- add a centralized client feature gate engine for capabilities, company/plan features and role access
- block unavailable dashboard modules with a clear upgrade panel instead of broken pages or confusing 404s
- extend authenticated web CI smokes with accessible, locked, trial and role-denied module scenarios

## Tests
- npm run lint (front/web)
- npx tsc --noEmit --pretty false (front/web)
- npm run build (front/web)
- npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts --project=chromium --workers=1 (front/web)