### PR TITLE
feat(web): improve first dashboard experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le parcours client web critique est documente dans `docs/validation/CLIENT_LOGIN_READINESS.md` et couvert par `front/web/e2e/auth-client-smoke.spec.ts` : login manager, mauvais identifiants, session expiree, dashboard non vide et toggle mot de passe.
 - `NEXT_PUBLIC_ADMIN_URL` est la cible recommandee pour rediriger un `super_admin` qui arriverait sur le login client ; sans variable, le fallback reste `/dashboard` pour eviter un lien mort en preview.
 - Les feature gates du portail client vivent dans `front/web/src/lib/client-features.ts` et sont appliquees dans `front/web/src/app/(dashboard)/layout.tsx`. Ajouter un nouveau module client implique de declarer sa route, ses cles `capabilities`/`features`, ses roles autorises et un test Playwright dans `front/web/e2e/client-feature-gates.spec.ts`.
+- Le dashboard client `front/web/src/app/(dashboard)/dashboard/page.tsx` est role-aware : manager charge les KPI tenant, employe evite les endpoints manager et affiche son espace personnel, super-admin est oriente vers la plateforme. Garder ce comportement dans les prochains lots Plan 18.
 
 ## Pieges connus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.118] - 2026-05-21
+
+### Changed
+
+- Web client : dashboard post-login enrichi avec etat entreprise, modules actifs/a upgrader et actions prioritaires manager.
+- Web client : premiere experience employee dediee pour pointage, absences, bulletins et preference langue.
+- Web client : experience super-admin clarifiee avec orientation vers le dashboard plateforme via `NEXT_PUBLIC_ADMIN_URL`.
+
+### Tests
+
+- Web client : smoke auth etendu pour verifier qu un employe hydrate depuis sa session arrive sur un dashboard employe utile.
+
 ## [4.16.117] - 2026-05-21
 
 ### Added

--- a/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
+++ b/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
@@ -34,10 +34,12 @@ Note 2026-05-21 : le login web client est modernise et couvert par Playwright. L
 
 ## Lot 18.4 - Premiere experience apres connexion
 
-- [ ] Dashboard manager : etat de l'entreprise, actions prioritaires, onboarding incomplet, donnees RH recentes.
-- [ ] Employe : pointage, absences, bulletins, notifications, langue.
-- [ ] Super admin : sante plateforme, demandes clients, tenants a risque.
+- [~] Dashboard manager : etat de l'entreprise, actions prioritaires, onboarding incomplet, donnees RH recentes.
+- [~] Employe : pointage, absences, bulletins, notifications, langue.
+- [~] Super admin : sante plateforme, demandes clients, tenants a risque.
 - [ ] Kiosque : etat appareil, synchro, mode offline clair.
+
+Note 2026-05-21 : le dashboard web client presente maintenant l entreprise, les actions prioritaires et les donnees RH recentes pour manager ; un espace employe dedie expose pointage, absences, bulletins et langue ; un super admin est oriente vers le dashboard plateforme. L onboarding incomplet, les notifications reelles et l etat kiosque restent a brancher avec les endpoints dedies.
 
 ## Lot 18.5 - Qualite et observabilite UX
 

--- a/docs/validation/CLIENT_LOGIN_READINESS.md
+++ b/docs/validation/CLIENT_LOGIN_READINESS.md
@@ -63,3 +63,4 @@ Les modules non inclus affichent une page d upgrade explicite au lieu de rendre 
 - Ajouter la recuperation mot de passe reelle cote backend/web quand le flux email sera pret.
 - Brancher le tracking produit `login_success`, `login_failed`, `dashboard_loaded`.
 - Completer les gates backend si un endpoint critique n applique pas encore les feature flags serveur.
+- Brancher l onboarding incomplet, les notifications temps reel et l etat kiosque lorsque les endpoints dedies seront stabilises.

--- a/front/web/e2e/auth-client-smoke.spec.ts
+++ b/front/web/e2e/auth-client-smoke.spec.ts
@@ -84,7 +84,7 @@ test.describe('Client web auth smoke', () => {
     await mockDashboardApis(page);
 
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByText(/Connexion a Leopardo RH|Sign in to Leopardo RH/).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in|se connecter/i })).toBeVisible();
     await page.getByLabel(/adresse email|email address/i).fill('fatima.meziane@techcorp-algerie.dz');
     await page.getByLabel(/^mot de passe$|^password$/i).fill('password123');
     await page.getByRole('button', { name: /afficher le mot de passe|show password/i }).click();
@@ -154,5 +154,41 @@ test.describe('Client web auth smoke', () => {
     await expect(page).toHaveURL(/\/auth\/login$/);
     await expect(page.locator('body')).toContainText(/Connexion a Leopardo RH|Sign in to Leopardo RH/);
     expect(await page.evaluate(() => window.localStorage.getItem('auth_token'))).toBeNull();
+  });
+
+  test('employee reaches a focused employee dashboard after session hydration', async ({ page }) => {
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await page.evaluate(() => {
+      window.localStorage.setItem('auth_token', 'employee-web-token');
+      window.localStorage.setItem('auth_user', JSON.stringify({
+        id: 301,
+        first_name: 'Karim',
+        last_name: 'Aouad',
+        email: 'karim.aouad@techcorp-algerie.dz',
+        role: 'employee',
+        manager_role: null,
+        language: 'fr',
+        is_rtl: false,
+        capabilities: {
+          attendance: true,
+          absences: true,
+        },
+        company: {
+          id: 'company-1',
+          name: 'TechCorp Algerie SARL',
+          features: {
+            attendance: true,
+            absences: true,
+          },
+        },
+      }));
+    });
+
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.locator('body')).toContainText('Espace employe');
+    await expect(page.locator('body')).toContainText('Pointage');
+    await expect(page.locator('body')).toContainText('Bulletins');
   });
 });

--- a/front/web/e2e/client-feature-gates.spec.ts
+++ b/front/web/e2e/client-feature-gates.spec.ts
@@ -106,7 +106,7 @@ test.describe('Client web feature gates', () => {
     await page.goto('/reports', { waitUntil: 'domcontentloaded' });
 
     await expect(page).toHaveURL(/\/reports$/);
-    await expect(page.locator('aside')).toContainText('Trial');
+    await expect(page.getByText('Trial').first()).toBeVisible();
     await expect(page.locator('body')).toContainText('Generez et telechargez vos rapports RH');
   });
 

--- a/front/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/front/web/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useSyncExternalStore } from 'react';
+import Link from 'next/link';
 import { motion } from 'framer-motion';
 import {
   Users,
@@ -15,9 +16,15 @@ import {
   Search,
   Download,
   CheckCircle2,
+  Building2,
+  ClipboardList,
+  FileCheck,
+  Languages,
+  ArrowRight,
 } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
-import { getPreferredLocale, type AppLocale } from '@/lib/i18n';
+import { getDisplayName, getPreferredLocale, getStoredUser, type AppLocale, type StoredAuthUser } from '@/lib/i18n';
+import { getClientModuleAccess } from '@/lib/client-features';
 
 const emptySubscribe = () => () => {};
 
@@ -90,19 +97,42 @@ const GlassCard = ({ children, className = '', delay = 0 }: { children: React.Re
 export default function DashboardPage() {
   const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [activeTab, setActiveTab] = useState('today');
+  const [user, setUser] = useState<StoredAuthUser | null>(null);
+  const [userLoaded, setUserLoaded] = useState(false);
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const [activities, setActivities] = useState<RecentActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const role = user?.role?.toLowerCase() ?? null;
+  const isEmployee = role === 'employee';
+  const isSuperAdmin = role === 'super_admin';
+  const companyName = user?.company?.name ?? 'Votre entreprise';
+  const modules = getClientModuleAccess(user);
+  const activeModules = modules.filter((module) => module.enabled && module.key !== 'dashboard').length;
+  const lockedModules = modules.filter((module) => !module.enabled).length;
 
   useEffect(() => {
     document.documentElement.lang = locale;
   }, [locale]);
 
   useEffect(() => {
+    setUser(getStoredUser());
+    setUserLoaded(true);
+  }, []);
+
+  useEffect(() => {
     let cancelled = false;
 
     async function loadDashboard() {
+      if (!userLoaded) {
+        return;
+      }
+
+      if (isEmployee || isSuperAdmin) {
+        setLoading(false);
+        return;
+      }
+
       setLoading(true);
       setLoadError(null);
 
@@ -140,7 +170,7 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isEmployee, isSuperAdmin, userLoaded]);
 
   const stats: DashboardStat[] = [
     {
@@ -193,6 +223,18 @@ export default function DashboardPage() {
       }))
     : [];
 
+  if (!userLoaded) {
+    return null;
+  }
+
+  if (isEmployee) {
+    return <EmployeeDashboard user={user} />;
+  }
+
+  if (isSuperAdmin) {
+    return <SuperAdminBridge user={user} />;
+  }
+
   return (
     <div className="space-y-6 p-6">
       <motion.div
@@ -227,6 +269,37 @@ export default function DashboardPage() {
           </button>
         </div>
       </motion.div>
+
+      <section className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-400">Entreprise</p>
+              <h2 className="mt-2 text-2xl font-black text-slate-950">{companyName}</h2>
+              <p className="mt-1 text-sm text-slate-500">
+                {activeModules} modules actifs, {lockedModules} a activer selon votre plan.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-center">
+              <div className="rounded-xl bg-emerald-50 px-4 py-3">
+                <p className="text-2xl font-black text-emerald-700">{activeModules}</p>
+                <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-900">Actifs</p>
+              </div>
+              <div className="rounded-xl bg-amber-50 px-4 py-3">
+                <p className="text-2xl font-black text-amber-700">{lockedModules}</p>
+                <p className="text-[10px] font-bold uppercase tracking-wider text-amber-900">Upgrade</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-950 p-5 text-white shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-teal-200">Actions prioritaires</p>
+          <div className="mt-4 grid gap-3 text-sm">
+            <PriorityAction label="Traiter les absences en attente" value={summary?.pending_absences ?? 0} href="/absences" />
+            <PriorityAction label="Verifier les presences du jour" value={summary?.today_attendance ?? 0} href="/attendance" />
+          </div>
+        </div>
+      </section>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         {stats.map((stat, index) => (
@@ -405,6 +478,88 @@ export default function DashboardPage() {
           </GlassCard>
         </div>
       </div>
+    </div>
+  );
+}
+
+function PriorityAction({ label, value, href }: { label: string; value: number; href: string }) {
+  return (
+    <Link href={href} className="flex items-center justify-between rounded-xl bg-white/10 px-4 py-3 transition hover:bg-white/15">
+      <span>{label}</span>
+      <span className="inline-flex items-center gap-2 font-bold text-teal-100">
+        {value}
+        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+      </span>
+    </Link>
+  );
+}
+
+function EmployeeDashboard({ user }: { user: StoredAuthUser | null }) {
+  const cards = [
+    { icon: CheckCircle2, title: 'Pointage', text: 'Voir votre etat du jour.', href: '/attendance' },
+    { icon: Calendar, title: 'Absences', text: 'Suivre vos demandes et soldes.', href: '/absences' },
+    { icon: FileCheck, title: 'Bulletins', text: 'Consulter vos documents de paie.', href: '/payroll' },
+    { icon: Languages, title: 'Langue', text: 'Votre interface suit vos preferences.', href: '/dashboard' },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-bold uppercase tracking-[0.16em] text-emerald-700">Espace employe</p>
+        <h1 className="mt-3 text-3xl font-black text-slate-950">Bonjour {getDisplayName(user)}</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+          Retrouvez vos actions utiles sans passer par les vues manager : pointage, absences, bulletins et langue.
+        </p>
+      </section>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {cards.map((card) => (
+          <Link key={card.title} href={card.href} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+            <card.icon className="h-7 w-7 text-emerald-600" aria-hidden="true" />
+            <h2 className="mt-4 text-lg font-bold text-slate-950">{card.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-500">{card.text}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SuperAdminBridge({ user }: { user: StoredAuthUser | null }) {
+  const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL;
+
+  return (
+    <div className="space-y-6 p-6">
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+          <Building2 className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <p className="mt-5 text-xs font-bold uppercase tracking-[0.16em] text-slate-500">Super admin</p>
+        <h1 className="mt-2 text-3xl font-black text-slate-950">Bonjour {getDisplayName(user)}</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+          Cette surface est optimisee pour les espaces clients. L administration plateforme se fait depuis le dashboard admin dedie.
+        </p>
+        {adminUrl ? (
+          <Link href={adminUrl} className="mt-5 inline-flex items-center gap-2 rounded-xl bg-slate-950 px-4 py-3 text-sm font-bold text-white transition hover:bg-slate-800">
+            Ouvrir le dashboard admin
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        ) : (
+          <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+            Configurez NEXT_PUBLIC_ADMIN_URL pour ajouter le lien direct vers l administration plateforme.
+          </div>
+        )}
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {['Sante plateforme', 'Demandes clients', 'Tenants a risque'].map((item) => (
+          <div key={item} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <ClipboardList className="h-6 w-6 text-slate-500" aria-hidden="true" />
+            <h2 className="mt-4 text-lg font-bold text-slate-950">{item}</h2>
+            <p className="mt-2 text-sm text-slate-500">Disponible dans le dashboard plateforme.</p>
+          </div>
+        ))}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enrich the manager dashboard with company status, active/upgrade module counts and priority actions
- add role-aware first dashboard experiences for employees and super-admin users
- extend client auth smokes with an employee dashboard hydration scenario

## Tests
- npm run lint (front/web)
- npx tsc --noEmit --pretty false (front/web)
- npm run build (front/web)
- npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts --project=chromium --workers=1 (front/web)