### PR TITLE
feat(web): add client UX observability

### DIFF
--- a/.github/workflows/web-marketing-ci.yml
+++ b/.github/workflows/web-marketing-ci.yml
@@ -105,4 +105,12 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: https://gestionemployerbackend.onrender.com/api/v1
           PLAYWRIGHT_WEB_SERVER_COMMAND: npm run start
-        run: npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts --project=chromium --workers=1
+        run: npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts e2e/client-visual-smoke.spec.ts --project=chromium --workers=1
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-client-playwright-report
+          path: front/web/playwright-report
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - `NEXT_PUBLIC_ADMIN_URL` est la cible recommandee pour rediriger un `super_admin` qui arriverait sur le login client ; sans variable, le fallback reste `/dashboard` pour eviter un lien mort en preview.
 - Les feature gates du portail client vivent dans `front/web/src/lib/client-features.ts` et sont appliquees dans `front/web/src/app/(dashboard)/layout.tsx`. Ajouter un nouveau module client implique de declarer sa route, ses cles `capabilities`/`features`, ses roles autorises et un test Playwright dans `front/web/e2e/client-feature-gates.spec.ts`.
 - Le dashboard client `front/web/src/app/(dashboard)/dashboard/page.tsx` est role-aware : manager charge les KPI tenant, employe evite les endpoints manager et affiche son espace personnel, super-admin est oriente vers la plateforme. Garder ce comportement dans les prochains lots Plan 18.
+- Depuis v4.16.119, l observabilite UX client est contractuelle : `trackClientEvent` emet `login_success`, `login_failed`, `dashboard_loaded`, `feature_blocked`, `demo_user_selected` et les tests Playwright les verifient. Ne pas brancher un outil tiers directement dans les composants ; ajouter d abord un endpoint/backend stable ou adapter `front/web/src/lib/client-analytics.ts`.
+- Le kiosque ZKTeco emet `leopardo:kiosk-status` et affiche la derniere synchronisation. Garder cet etat offline-first lisible lors des evolutions kiosk/bridge, car c est le signal terrain principal pour les clients.
 
 ## Pieges connus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.119] - 2026-05-21
+
+### Added
+
+- Plan 18 : observabilite UX client avec evenements `login_success`, `login_failed`, `dashboard_loaded`, `feature_blocked` et `demo_user_selected`.
+- Web client : captures Playwright login/dashboard attachees au rapport CI `web-client-playwright-report`.
+- Documentation : `CLIENT_UX_OBSERVABILITY.md` formalise les evenements, seuils Web Vitals/Lighthouse et objectifs login -> dashboard.
+
+### Changed
+
+- CI vitrine : le smoke authentifie execute aussi les captures visuelles client et publie le rapport Playwright.
+- Lighthouse vitrine : la page `/auth/login` rejoint les URLs auditees.
+- Kiosque ZKTeco : etat offline clarifie avec derniere synchronisation lisible et evenement navigateur `leopardo:kiosk-status`.
+
+### Tests
+
+- Web client : Playwright verifie les evenements analytics critiques et le temps dashboard utilisable sous 5 secondes en environnement mocke.
+
 ## [4.16.118] - 2026-05-21
 
 ### Changed

--- a/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
+++ b/docs/PLAN_ACTION/18_PLAN_EXPERIENCE_CLIENT_CONNEXION.md
@@ -37,16 +37,18 @@ Note 2026-05-21 : le login web client est modernise et couvert par Playwright. L
 - [~] Dashboard manager : etat de l'entreprise, actions prioritaires, onboarding incomplet, donnees RH recentes.
 - [~] Employe : pointage, absences, bulletins, notifications, langue.
 - [~] Super admin : sante plateforme, demandes clients, tenants a risque.
-- [ ] Kiosque : etat appareil, synchro, mode offline clair.
+- [x] Kiosque : etat appareil, synchro, mode offline clair.
 
-Note 2026-05-21 : le dashboard web client presente maintenant l entreprise, les actions prioritaires et les donnees RH recentes pour manager ; un espace employe dedie expose pointage, absences, bulletins et langue ; un super admin est oriente vers le dashboard plateforme. L onboarding incomplet, les notifications reelles et l etat kiosque restent a brancher avec les endpoints dedies.
+Note 2026-05-21 : le dashboard web client presente maintenant l entreprise, les actions prioritaires et les donnees RH recentes pour manager ; un espace employe dedie expose pointage, absences, bulletins et langue ; un super admin est oriente vers le dashboard plateforme. Le kiosque affiche l etat appareil, la file locale, le mode offline et la derniere synchronisation. L onboarding incomplet et les notifications reelles restent a brancher avec les endpoints dedies.
 
 ## Lot 18.5 - Qualite et observabilite UX
 
-- [ ] Mesurer temps login -> dashboard utilisable.
-- [ ] Ajouter tracking evenements : login_success, login_failed, dashboard_loaded, feature_blocked, demo_user_selected.
-- [ ] Ajouter captures E2E Playwright sur login et dashboard.
-- [ ] Definir seuils Lighthouse/Web Vitals pour pages login et dashboard.
+- [x] Mesurer temps login -> dashboard utilisable.
+- [x] Ajouter tracking evenements : login_success, login_failed, dashboard_loaded, feature_blocked, demo_user_selected.
+- [x] Ajouter captures E2E Playwright sur login et dashboard.
+- [x] Definir seuils Lighthouse/Web Vitals pour pages login et dashboard.
+
+Note 2026-05-21 : le portail web emet maintenant les evenements `leopardo:analytics` via `trackClientEvent`, couverts par Playwright. Les captures login/dashboard sont attachees au rapport CI `web-client-playwright-report`, et les seuils UX sont formalises dans `docs/validation/CLIENT_UX_OBSERVABILITY.md`. La page login est ajoutee au contrat Lighthouse. Le kiosque expose aussi un evenement `leopardo:kiosk-status` et une derniere synchronisation lisible pour clarifier l etat offline.
 
 ## Definition of done
 
@@ -55,3 +57,4 @@ Note 2026-05-21 : le dashboard web client presente maintenant l entreprise, les 
 - Les pages login sont modernes, accessibles, rapides et testees.
 - Les smoke tests staging couvrent API auth, web login client, admin login et mobile contract.
 - Toute regression de connexion bloque la PR ou le deploy.
+- Lot 18 web client : livre fonctionnellement. Les reliquats futurs sont des integrations serveur/ops dediees : endpoint analytics persistant, contrats backend pour compte inactif/sans tenant et endpoints notifications/onboarding/kiosque avances.

--- a/docs/validation/CLIENT_LOGIN_READINESS.md
+++ b/docs/validation/CLIENT_LOGIN_READINESS.md
@@ -61,6 +61,6 @@ Les modules non inclus affichent une page d upgrade explicite au lieu de rendre 
 ## Points restants Plan 18
 
 - Ajouter la recuperation mot de passe reelle cote backend/web quand le flux email sera pret.
-- Brancher le tracking produit `login_success`, `login_failed`, `dashboard_loaded`.
+- Persister le tracking produit cote backend/data warehouse quand l endpoint analytics sera stabilise ; le tracking navigateur local est deja couvert dans `CLIENT_UX_OBSERVABILITY.md`.
 - Completer les gates backend si un endpoint critique n applique pas encore les feature flags serveur.
-- Brancher l onboarding incomplet, les notifications temps reel et l etat kiosque lorsque les endpoints dedies seront stabilises.
+- Brancher l onboarding incomplet et les notifications temps reel lorsque les endpoints dedies seront stabilises.

--- a/docs/validation/CLIENT_UX_OBSERVABILITY.md
+++ b/docs/validation/CLIENT_UX_OBSERVABILITY.md
@@ -1,0 +1,39 @@
+# Client UX Observability - Plan 18
+
+Date : 2026-05-21
+
+## Objectif
+
+Mesurer le parcours client critique `login -> dashboard utilisable` sans dependre d'un fournisseur analytics externe. Le portail web emet des evenements navigateur stables, verifies par Playwright, qui pourront ensuite etre relayes vers le backend, un CRM ou un data warehouse.
+
+## Evenements contractuels
+
+| Evenement | Surface | Declenchement | Proprietes minimales |
+| --- | --- | --- | --- |
+| `login_success` | `front/web` | Apres `POST /auth/login` + `GET /auth/me` valides | `duration_ms`, `role`, `manager_role`, `locale`, `target`, `company_id` |
+| `login_failed` | `front/web` | Erreur login lisible sans redirection automatique | `duration_ms`, `status`, `code` |
+| `dashboard_loaded` | `front/web` | Dashboard manager/employe/super-admin utilisable | `duration_ms`, `surface`, `role`, `company_id`, `active_modules`, `locked_modules` |
+| `feature_blocked` | `front/web` | Module masque par plan ou role | `module`, `reason`, `state` |
+| `demo_user_selected` | `front/web` | Selection d'un compte demo | `role`, `country`, `email_domain` |
+| `leopardo:kiosk-status` | `front/zkteco-kiosk` | Rafraichissement etat bridge local | `online`, `queue_count`, `device_code`, `last_sync_at` |
+
+## Seuils UX
+
+| Parcours | Seuil bloquant CI | Objectif production p75 | Notes |
+| --- | ---: | ---: | --- |
+| Login API + `auth/me` + redirection dashboard mockee | `< 5000 ms` | `< 2500 ms` | Mesure Playwright via `login_success` puis `dashboard_loaded`. |
+| Dashboard manager mocke utilisable | `< 5000 ms` | `< 2000 ms` | Les endpoints dashboard reels doivent etre caches/optimises si p75 depasse le seuil. |
+| Login page Lighthouse LCP | `< 2500 ms` | `< 2000 ms` | Ajoute dans `front/web/lighthouserc.json`. |
+| Login/dashboard CLS | `< 0.10` | `< 0.05` | Aucune carte dynamique ne doit pousser brutalement le contenu principal. |
+| Interaction principale INP | `< 200 ms` | `< 150 ms` | A suivre via Web Vitals quand l endpoint analytics sera branche. |
+
+## Gardes automatiques
+
+- `front/web/e2e/auth-client-smoke.spec.ts` verifie `login_success`, `login_failed`, `dashboard_loaded` et `demo_user_selected`.
+- `front/web/e2e/client-feature-gates.spec.ts` verifie `feature_blocked` pour plan bloque et role bloque.
+- `front/web/e2e/client-visual-smoke.spec.ts` attache des captures Playwright de la page login et du dashboard dans le rapport CI.
+- `.github/workflows/web-marketing-ci.yml` publie le rapport Playwright `web-client-playwright-report`.
+
+## Prochaine evolution
+
+Brancher `trackClientEvent` sur un endpoint backend dedie, par exemple `POST /api/v1/client-events`, avec rate limiting, minimisation PII et correlation `request_id`. Tant que cet endpoint n'est pas stabilise, les evenements restent locaux et testables pour eviter un couplage fragile avec le marketing ou un outil tiers.

--- a/front/web/e2e/auth-client-smoke.spec.ts
+++ b/front/web/e2e/auth-client-smoke.spec.ts
@@ -1,5 +1,13 @@
 import { expect, test, type Page } from '@playwright/test';
 
+type AnalyticsWindow = Window & {
+  __LEOPARDO_ANALYTICS_EVENTS__?: Array<{
+    name: string;
+    timestamp: string;
+    properties: Record<string, string | number | boolean | null>;
+  }>;
+};
+
 const managerUser = {
   id: 101,
   first_name: 'Fatima',
@@ -57,10 +65,22 @@ async function mockDashboardApis(page: Page) {
   });
 }
 
+async function captureAnalytics(page: Page) {
+  await page.addInitScript(() => {
+    (window as AnalyticsWindow).__LEOPARDO_ANALYTICS_EVENTS__ = [];
+  });
+}
+
+async function analyticsEvents(page: Page) {
+  return page.evaluate(() => (window as AnalyticsWindow).__LEOPARDO_ANALYTICS_EVENTS__ ?? []);
+}
+
 test.describe('Client web auth smoke', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('employee or HR manager can sign in and reach a tenant-backed dashboard', async ({ page }) => {
+    await captureAnalytics(page);
+
     await page.route('**/api/v1/auth/login', async (route) => {
       await route.fulfill({
         status: 200,
@@ -97,9 +117,23 @@ test.describe('Client web auth smoke', () => {
     await expect(page.locator('body')).toContainText('6');
     await expect(page.locator('body')).toContainText('7 total');
     await expect(page.locator('body')).toContainText('employee.updated');
+
+    await expect.poll(async () => {
+      const events = await analyticsEvents(page);
+      return events.map((event) => event.name);
+    }).toEqual(expect.arrayContaining(['login_success', 'dashboard_loaded']));
+
+    const events = await analyticsEvents(page);
+    const loginEvent = events.find((event) => event.name === 'login_success');
+    const dashboardEvent = events.find((event) => event.name === 'dashboard_loaded');
+    expect(loginEvent?.properties.role).toBe('manager');
+    expect(dashboardEvent?.properties.surface).toBe('manager');
+    expect(Number(dashboardEvent?.properties.duration_ms)).toBeLessThan(5000);
   });
 
   test('invalid credentials stay on login with a readable API error', async ({ page }) => {
+    await captureAnalytics(page);
+
     await page.route('**/api/v1/auth/login', async (route) => {
       await route.fulfill({
         status: 401,
@@ -115,6 +149,8 @@ test.describe('Client web auth smoke', () => {
 
     await expect(page).toHaveURL(/\/auth\/login$/);
     await expect(page.getByText('Identifiants invalides.')).toBeVisible();
+    const events = await analyticsEvents(page);
+    expect(events.find((event) => event.name === 'login_failed')?.properties.status).toBe(401);
   });
 
   test('expired dashboard session clears storage and returns to login', async ({ page }) => {
@@ -157,6 +193,8 @@ test.describe('Client web auth smoke', () => {
   });
 
   test('employee reaches a focused employee dashboard after session hydration', async ({ page }) => {
+    await captureAnalytics(page);
+
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
     await page.evaluate(() => {
       window.localStorage.setItem('auth_token', 'employee-web-token');
@@ -190,5 +228,24 @@ test.describe('Client web auth smoke', () => {
     await expect(page.locator('body')).toContainText('Espace employe');
     await expect(page.locator('body')).toContainText('Pointage');
     await expect(page.locator('body')).toContainText('Bulletins');
+
+    await expect.poll(async () => {
+      const events = await analyticsEvents(page);
+      return events.map((event) => event.name);
+    }).toContain('dashboard_loaded');
+  });
+
+  test('demo account selection emits an analytics event and hydrates credentials', async ({ page }) => {
+    await captureAnalytics(page);
+
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await page.getByRole('button', { name: /try a demo account|acces demo|accès démo|demo access/i }).click();
+    await page.getByRole('button', { name: /Ahmed Benali/i }).click();
+
+    await expect(page.getByLabel(/adresse email|email address/i)).toHaveValue('ahmed.benali@techcorp-algerie.dz');
+    await expect(page.getByLabel(/^mot de passe$|^password$/i)).toHaveValue('password123');
+
+    const events = await analyticsEvents(page);
+    expect(events.find((event) => event.name === 'demo_user_selected')?.properties.country).toBe('DZ');
   });
 });

--- a/front/web/e2e/client-feature-gates.spec.ts
+++ b/front/web/e2e/client-feature-gates.spec.ts
@@ -1,5 +1,13 @@
 import { expect, test, type Page } from '@playwright/test';
 
+type AnalyticsWindow = Window & {
+  __LEOPARDO_ANALYTICS_EVENTS__?: Array<{
+    name: string;
+    timestamp: string;
+    properties: Record<string, string | number | boolean | null>;
+  }>;
+};
+
 const baseUser = {
   id: 101,
   first_name: 'Fatima',
@@ -12,11 +20,19 @@ const baseUser = {
 };
 
 async function seedSession(page: Page, overrides: Record<string, unknown> = {}) {
+  await page.addInitScript(() => {
+    (window as AnalyticsWindow).__LEOPARDO_ANALYTICS_EVENTS__ = [];
+  });
+
   await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
   await page.evaluate((user) => {
     window.localStorage.setItem('auth_token', 'feature-gate-token');
     window.localStorage.setItem('auth_user', JSON.stringify(user));
   }, { ...baseUser, ...overrides });
+}
+
+async function analyticsEvents(page: Page) {
+  return page.evaluate(() => (window as AnalyticsWindow).__LEOPARDO_ANALYTICS_EVENTS__ ?? []);
 }
 
 test.describe('Client web feature gates', () => {
@@ -87,6 +103,11 @@ test.describe('Client web feature gates', () => {
     await expect(page.locator('body')).toContainText('Ce module n est pas inclus dans votre plan actuel.');
     await expect(page.locator('body')).toContainText('Demander l activation');
     await expect(page.locator('body')).not.toContainText('Gestion des bulletins de paie et cycles de paie');
+
+    const events = await analyticsEvents(page);
+    const blockedEvent = events.find((event) => event.name === 'feature_blocked');
+    expect(blockedEvent?.properties.module).toBe('payroll');
+    expect(blockedEvent?.properties.reason).toBe('feature_locked');
   });
 
   test('trial module is visible as trial and remains usable', async ({ page }) => {
@@ -130,5 +151,7 @@ test.describe('Client web feature gates', () => {
 
     await expect(page.getByText('Module non inclus').first()).toBeVisible();
     await expect(page.locator('body')).toContainText('Votre role actuel ne permet pas d acceder a ce module.');
+    const events = await analyticsEvents(page);
+    expect(events.find((event) => event.name === 'feature_blocked')?.properties.reason).toBe('role_locked');
   });
 });

--- a/front/web/e2e/client-visual-smoke.spec.ts
+++ b/front/web/e2e/client-visual-smoke.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const visualUser = {
+  id: 101,
+  first_name: 'Fatima',
+  last_name: 'Meziane',
+  email: 'fatima.meziane@techcorp-algerie.dz',
+  role: 'manager',
+  manager_role: 'principal',
+  language: 'fr',
+  is_rtl: false,
+  capabilities: {
+    can_view_dashboard: true,
+    employees: true,
+    attendance: true,
+    absences: true,
+    payroll: true,
+    reports: true,
+  },
+  company: {
+    id: 'company-1',
+    name: 'TechCorp Algerie SARL',
+    language: 'fr',
+    timezone: 'Africa/Algiers',
+    currency: 'DZD',
+    features: {
+      employees: true,
+      attendance: true,
+      absences: true,
+      payroll: true,
+      reports: true,
+    },
+  },
+};
+
+async function mockDashboard(page: Page) {
+  await page.route('**/api/v1/dashboard/summary', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          employees_total: 32,
+          employees_active: 29,
+          departments: 5,
+          today_attendance: 24,
+          pending_absences: 3,
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/dashboard/recent-activity**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          {
+            id: 1,
+            action: 'absence.approved',
+            auditable_type: 'App\\Models\\Absence',
+            created_at: '2026-05-21T10:00:00Z',
+          },
+        ],
+      }),
+    });
+  });
+}
+
+test.describe('Client visual smoke attachments', () => {
+  test('captures login and dashboard reference screenshots', async ({ page }, testInfo) => {
+    await mockDashboard(page);
+
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await testInfo.attach('client-login-page', {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+
+    await page.evaluate((user) => {
+      window.localStorage.setItem('auth_token', 'visual-smoke-token');
+      window.localStorage.setItem('auth_user', JSON.stringify(user));
+    }, visualUser);
+
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('body')).toContainText('TechCorp Algerie SARL');
+    await expect(page.locator('body')).toContainText('absence.approved');
+
+    await testInfo.attach('client-dashboard-page', {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+  });
+});

--- a/front/web/lighthouserc.json
+++ b/front/web/lighthouserc.json
@@ -9,7 +9,8 @@
         "http://localhost:3000/marketing",
         "http://localhost:3000/pricing",
         "http://localhost:3000/about",
-        "http://localhost:3000/blog"
+        "http://localhost:3000/blog",
+        "http://localhost:3000/auth/login"
       ],
       "numberOfRuns": 1,
       "settings": {

--- a/front/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/front/web/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import {
@@ -23,6 +23,7 @@ import {
   ArrowRight,
 } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
+import { trackClientEvent } from '@/lib/client-analytics';
 import { getDisplayName, getPreferredLocale, getStoredUser, type AppLocale, type StoredAuthUser } from '@/lib/i18n';
 import { getClientModuleAccess } from '@/lib/client-features';
 
@@ -103,6 +104,8 @@ export default function DashboardPage() {
   const [activities, setActivities] = useState<RecentActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const dashboardStartRef = useRef<number>(0);
+  const dashboardTrackedRef = useRef(false);
   const role = user?.role?.toLowerCase() ?? null;
   const isEmployee = role === 'employee';
   const isSuperAdmin = role === 'super_admin';
@@ -116,9 +119,28 @@ export default function DashboardPage() {
   }, [locale]);
 
   useEffect(() => {
+    dashboardStartRef.current = performance.now();
     setUser(getStoredUser());
     setUserLoaded(true);
   }, []);
+
+  const trackDashboardLoaded = useCallback((extra: Record<string, unknown> = {}) => {
+    if (dashboardTrackedRef.current) {
+      return;
+    }
+
+    dashboardTrackedRef.current = true;
+    trackClientEvent('dashboard_loaded', {
+      duration_ms: Math.round(performance.now() - dashboardStartRef.current),
+      role: user?.role ?? null,
+      manager_role: user?.manager_role ?? null,
+      company_id: user?.company?.id ?? null,
+      company_name: user?.company?.name ?? null,
+      active_modules: activeModules,
+      locked_modules: lockedModules,
+      ...extra,
+    });
+  }, [activeModules, lockedModules, user]);
 
   useEffect(() => {
     let cancelled = false;
@@ -130,6 +152,7 @@ export default function DashboardPage() {
 
       if (isEmployee || isSuperAdmin) {
         setLoading(false);
+        trackDashboardLoaded({ surface: isEmployee ? 'employee' : 'super_admin' });
         return;
       }
 
@@ -155,9 +178,18 @@ export default function DashboardPage() {
           pending_absences: Number(summaryPayload.data?.pending_absences ?? 0),
         });
         setActivities(Array.isArray(activityPayload.data) ? activityPayload.data : []);
+        trackDashboardLoaded({
+          surface: 'manager',
+          employees_active: Number(summaryPayload.data?.employees_active ?? 0),
+          pending_absences: Number(summaryPayload.data?.pending_absences ?? 0),
+        });
       } catch (error) {
         if (cancelled) return;
         setLoadError(error instanceof ApiError ? error.message : 'Impossible de charger les donnees du dashboard.');
+        trackDashboardLoaded({
+          surface: 'manager',
+          status: 'error',
+        });
       } finally {
         if (!cancelled) {
           setLoading(false);
@@ -170,7 +202,7 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [isEmployee, isSuperAdmin, userLoaded]);
+  }, [isEmployee, isSuperAdmin, trackDashboardLoaded, userLoaded]);
 
   const stats: DashboardStat[] = [
     {

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { LockKeyhole, Sparkles } from 'lucide-react';
 import { apiFetch } from '@/lib/api-client';
+import { trackClientEvent } from '@/lib/client-analytics';
 import { getClientModuleAccess, getModuleAccessForPath, type ClientModuleAccess } from '@/lib/client-features';
 import {
   applyDocumentLocale,
@@ -216,6 +217,14 @@ function FeatureLockedPanel({ module }: { module: ClientModuleAccess }) {
   const reason = module.reason === 'role_locked'
     ? 'Votre role actuel ne permet pas d acceder a ce module.'
     : 'Ce module n est pas inclus dans votre plan actuel.';
+
+  useEffect(() => {
+    trackClientEvent('feature_blocked', {
+      module: module.key,
+      reason: module.reason,
+      state: module.state,
+    });
+  }, [module.key, module.reason, module.state]);
 
   return (
     <section className="overflow-hidden rounded-3xl border border-amber-200 bg-white shadow-sm">

--- a/front/web/src/app/auth/login/page.tsx
+++ b/front/web/src/app/auth/login/page.tsx
@@ -15,6 +15,7 @@ import {
   X,
 } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
+import { trackClientEvent } from '@/lib/client-analytics';
 import {
   applyDocumentLocale,
   getCopy,
@@ -97,6 +98,7 @@ export default function LoginPage() {
     e.preventDefault();
     setSubmitting(true);
     setError(null);
+    const startedAt = performance.now();
 
     try {
       const loginResponse = await apiFetch('/auth/login', {
@@ -127,14 +129,38 @@ export default function LoginPage() {
 
       storeAuthSession(token, user);
       applyDocumentLocale(normalizeLocale(user.language), user.is_rtl);
-      goToPostLoginTarget(resolvePostLoginTarget(user), router);
+      const target = resolvePostLoginTarget(user);
+      trackClientEvent('login_success', {
+        duration_ms: Math.round(performance.now() - startedAt),
+        role: user.role,
+        manager_role: user.manager_role ?? null,
+        locale: normalizeLocale(user.language),
+        target,
+        company_id: user.company?.id ?? null,
+      });
+      goToPostLoginTarget(target, router);
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);
+        trackClientEvent('login_failed', {
+          duration_ms: Math.round(performance.now() - startedAt),
+          status: err.status,
+          code: err.code ?? null,
+        });
       } else if (err instanceof Error) {
         setError(err.message);
+        trackClientEvent('login_failed', {
+          duration_ms: Math.round(performance.now() - startedAt),
+          status: null,
+          code: err.name,
+        });
       } else {
         setError(labels.login.errors.generic);
+        trackClientEvent('login_failed', {
+          duration_ms: Math.round(performance.now() - startedAt),
+          status: null,
+          code: 'unknown',
+        });
       }
     } finally {
       setSubmitting(false);
@@ -168,11 +194,16 @@ export default function LoginPage() {
     },
   ], []);
 
-  const selectDemoUser = useCallback((demoEmail: string, demoPassword: string) => {
+  const selectDemoUser = useCallback((demoEmail: string, demoPassword: string, role?: string | null, country?: string | null) => {
     setEmail(demoEmail);
     setPassword(demoPassword);
     setError(null);
     setShowDemoModal(false);
+    trackClientEvent('demo_user_selected', {
+      role: role ?? null,
+      country: country ?? null,
+      email_domain: demoEmail.split('@')[1] ?? null,
+    });
   }, []);
 
   if (!mounted) return null;
@@ -371,7 +402,7 @@ export default function LoginPage() {
                               key={user.email}
                               type="button"
                               className="w-full rounded-xl border border-slate-200 p-4 text-left transition hover:border-teal-300 hover:bg-teal-50/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
-                              onClick={() => selectDemoUser(user.email, user.password)}
+                              onClick={() => selectDemoUser(user.email, user.password, user.managerRole ?? user.role, company.country)}
                             >
                               <div className="flex items-center justify-between gap-3">
                                 <span className="font-semibold text-slate-950">{user.name}</span>

--- a/front/web/src/lib/client-analytics.ts
+++ b/front/web/src/lib/client-analytics.ts
@@ -1,0 +1,64 @@
+'use client';
+
+export type ClientAnalyticsEventName =
+  | 'login_success'
+  | 'login_failed'
+  | 'dashboard_loaded'
+  | 'feature_blocked'
+  | 'demo_user_selected';
+
+export type ClientAnalyticsPayload = {
+  name: ClientAnalyticsEventName;
+  timestamp: string;
+  properties: Record<string, string | number | boolean | null>;
+};
+
+declare global {
+  interface Window {
+    __LEOPARDO_ANALYTICS_EVENTS__?: Array<{
+      name: string;
+      timestamp: string;
+      properties: Record<string, string | number | boolean | null>;
+    }>;
+  }
+}
+
+function sanitizeValue(value: unknown): string | number | boolean | null {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return String(value);
+}
+
+export function trackClientEvent(
+  name: ClientAnalyticsEventName,
+  properties: Record<string, unknown> = {},
+): ClientAnalyticsPayload | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const sanitizedProperties = Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => [key, sanitizeValue(value)]),
+  );
+
+  const payload: ClientAnalyticsPayload = {
+    name,
+    timestamp: new Date().toISOString(),
+    properties: sanitizedProperties,
+  };
+
+  window.__LEOPARDO_ANALYTICS_EVENTS__ = [
+    ...(window.__LEOPARDO_ANALYTICS_EVENTS__ ?? []),
+    payload,
+  ].slice(-100);
+
+  window.dispatchEvent(new CustomEvent('leopardo:analytics', { detail: payload }));
+
+  return payload;
+}

--- a/front/zkteco-kiosk/app.js
+++ b/front/zkteco-kiosk/app.js
@@ -17,6 +17,7 @@ const CONFIG = {
 const state = {
   status: null,
   currentTab: 'punch',
+  lastStatusRefreshAt: null,
 };
 
 // ── Selectors ────────────────────────────────────────
@@ -28,6 +29,7 @@ const els = {
   locationLabel: $('#locationLabel'),
   deviceCode: $('#deviceCode'),
   queueCount: $('#queueCount'),
+  lastSyncAt: $('#lastSyncAt'),
   identifier: $('#identifier'),
   biometricType: $('#biometricType'),
   statusBox: $('#statusBox'),
@@ -106,6 +108,10 @@ function renderStatus() {
   els.locationLabel.textContent = state.status.location_label || 'Entree principale';
   els.deviceCode.textContent = state.status.device_code || '-';
   els.queueCount.textContent = `${state.status.queue_count || 0} evenement(s) en attente`;
+  if (els.lastSyncAt) {
+    const lastSync = state.status.last_sync_at || state.status.last_synced_at || state.lastStatusRefreshAt;
+    els.lastSyncAt.textContent = lastSync ? formatDateTime(lastSync) : 'Aucune synchronisation confirmee';
+  }
 
   const ok = state.status.online === true;
   els.syncDot.classList.toggle('ok', ok);
@@ -113,15 +119,28 @@ function renderStatus() {
   els.syncLabel.textContent = ok
     ? 'Connexion OK - synchronisation auto active'
     : `Mode offline - sync plus tard (${state.status.last_error || 'reseau indisponible'})`;
+
+  window.dispatchEvent(new CustomEvent('leopardo:kiosk-status', {
+    detail: {
+      online: ok,
+      queue_count: Number(state.status.queue_count || 0),
+      device_code: state.status.device_code || CONFIG.deviceCode || null,
+      last_sync_at: state.status.last_sync_at || state.status.last_synced_at || null,
+    },
+  }));
 }
 
 async function refreshStatus() {
   try {
     const payload = await fetchJson(`${CONFIG.localBridgeUrl}/status`);
     state.status = payload.data;
+    state.lastStatusRefreshAt = new Date().toISOString();
     renderStatus();
   } catch (error) {
     setStatus('#statusBox', error.message || 'Bridge local indisponible.', true);
+    if (els.lastSyncAt) {
+      els.lastSyncAt.textContent = 'Bridge local indisponible';
+    }
   }
 }
 
@@ -320,6 +339,21 @@ function formatTime(isoString) {
     return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
   } catch {
     return isoString.substring(11, 16) || '-';
+  }
+}
+
+function formatDateTime(isoString) {
+  if (!isoString) return '-';
+  try {
+    return new Date(isoString).toLocaleString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return String(isoString);
   }
 }
 

--- a/front/zkteco-kiosk/index.html
+++ b/front/zkteco-kiosk/index.html
@@ -231,6 +231,8 @@
             <dd>ZKTeco / HID / bridge local offline-first</dd>
             <dt>File locale</dt>
             <dd id="queueCount">0 evenement en attente</dd>
+            <dt>Derniere synchronisation</dt>
+            <dd id="lastSyncAt">Verification en cours</dd>
           </dl>
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- add client-side UX analytics contract for login, dashboard, feature gates and demo account selection
- add Playwright assertions and visual screenshot attachments for client login/dashboard
- clarify kiosk offline sync status and document Plan 18 UX thresholds

## Tests
- npm run lint
- npx tsc --noEmit --pretty false
- npm run build
- npx playwright test e2e/auth-client-smoke.spec.ts e2e/client-feature-gates.spec.ts e2e/client-visual-smoke.spec.ts --project=chromium --workers=1
- npx playwright test e2e/manager-workday-smoke.spec.ts --project=chromium --workers=1