### PR TITLE
fix(web): use Vercel rewrite proxy for API calls + improve demo login UX

### DIFF
--- a/front/web/src/app/auth/login/page.tsx
+++ b/front/web/src/app/auth/login/page.tsx
@@ -94,10 +94,14 @@ export default function LoginPage() {
     applyDocumentLocale(nextLocale);
   };
 
-  const performLogin = useCallback(async (loginEmail: string, loginPassword: string, deviceName = 'Web App') => {
+  const [coldStartHint, setColdStartHint] = useState(false);
+
+  const performLogin = useCallback(async (loginEmail: string, loginPassword: string, deviceName = 'Web App', retryCount = 0) => {
     setSubmitting(true);
     setError(null);
     const startedAt = performance.now();
+
+    const coldStartTimer = setTimeout(() => setColdStartHint(true), 5000);
 
     try {
       const loginResponse = await apiFetch('/auth/login', {
@@ -139,6 +143,19 @@ export default function LoginPage() {
       });
       goToPostLoginTarget(target, router);
     } catch (err) {
+      const isTimeout = err instanceof ApiError && err.code === 'TIMEOUT';
+      const isNetworkError = err instanceof TypeError && err.message.includes('fetch');
+
+      if ((isTimeout || isNetworkError) && retryCount < 1) {
+        clearTimeout(coldStartTimer);
+        setColdStartHint(true);
+        setError(locale === 'fr'
+          ? 'Le serveur demarre, nouvelle tentative en cours...'
+          : 'Server is waking up, retrying...');
+        await new Promise(r => setTimeout(r, 3000));
+        return performLogin(loginEmail, loginPassword, deviceName, retryCount + 1);
+      }
+
       if (err instanceof ApiError) {
         setError(err.message);
         trackClientEvent('login_failed', {
@@ -162,9 +179,11 @@ export default function LoginPage() {
         });
       }
     } finally {
+      clearTimeout(coldStartTimer);
+      setColdStartHint(false);
       setSubmitting(false);
     }
-  }, [labels.login.errors.generic, labels.login.errors.missingToken, labels.login.errors.missingUser, router]);
+  }, [labels.login.errors.generic, labels.login.errors.missingToken, labels.login.errors.missingUser, locale, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -357,6 +376,14 @@ export default function LoginPage() {
                 {submitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <LockKeyhole className="h-4 w-4" aria-hidden="true" />}
                 {submitting ? labels.login.loading : labels.login.submit}
               </button>
+
+              {coldStartHint && submitting ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                  {locale === 'fr'
+                    ? 'Le serveur de demo se reveille, cela peut prendre jusqu a 30 secondes...'
+                    : 'Demo server is waking up, this may take up to 30 seconds...'}
+                </div>
+              ) : null}
 
               <button
                 type="button"

--- a/front/web/src/lib/api-client.ts
+++ b/front/web/src/lib/api-client.ts
@@ -12,9 +12,27 @@ import {
 const LOCAL_API_BASE_URL = 'http://localhost:8000/api/v1';
 const DEPLOYED_API_BASE_URL = 'https://gestionemployerbackend.onrender.com/api/v1';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NODE_ENV === 'production' ? DEPLOYED_API_BASE_URL : LOCAL_API_BASE_URL);
+/**
+ * On Vercel, use the rewrite proxy (/api/v1/...) to avoid CORS issues
+ * and Render cold-start timeouts. The rewrite in vercel.json forwards
+ * /api/:path* to the Render backend transparently.
+ */
+const VERCEL_PROXY_BASE_URL = '/api/v1';
+
+function resolveApiBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL;
+  }
+  if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production') {
+    return VERCEL_PROXY_BASE_URL;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    return DEPLOYED_API_BASE_URL;
+  }
+  return LOCAL_API_BASE_URL;
+}
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 export class ApiError extends Error {
   status: number;
@@ -32,7 +50,8 @@ export async function apiFetch(endpoint: string, options: RequestInit = {}) {
   const token = typeof window !== 'undefined' ? localStorage.getItem(AUTH_TOKEN_KEY) : null;
   const isLoginRequest = endpoint === '/auth/login' || endpoint === '/platform/auth/login';
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 20000);
+  const timeoutMs = isLoginRequest ? 45000 : 20000;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   const headers = {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## 📝 Description

Fixes the inability to log in via demo accounts from the Vercel-deployed web vitrine. Two root causes are addressed:

### 1. CORS — API base URL routing (`api-client.ts`)
In production browser context, API calls now use the **relative path** `/api/v1` instead of the direct Render URL (`https://gestionemployerbackend.onrender.com/api/v1`). This leverages the existing Vercel rewrite rule in `vercel.json` (`/api/:path*` → Render), making all API calls same-origin and eliminating CORS failures entirely. Server-side rendering still uses the direct URL as a fallback.

A new `resolveApiBaseUrl()` function handles the resolution:
- `NEXT_PUBLIC_API_URL` env var → highest priority override
- Browser + production → `/api/v1` (Vercel proxy)
- SSR + production → direct Render URL
- Development → `localhost:8000`

### 2. Cold-start resilience (`login/page.tsx`)
Render's free tier can take 30+ seconds to cold-start. The login flow now:
- Bumps the login request timeout from 20s → 45s (login requests only)
- Automatically retries once (after 3s delay) on timeout or network errors
- Shows an amber "server is waking up" banner after 5s of waiting

**Part of Lot 3** in the iterative vitrine improvements series. Related PRs:
- PR #553 — Lot 1: Mobile Flutter attendance redesign + dark theme settings
- PR #554 — Lot 2: Web vitrine trusted brands marquee section

## 🧪 How Has This Been Tested?

- [ ] Unit Tests
- [ ] Feature/Integration Tests
- [ ] E2E / Manual Verification

> Should be verified on the Vercel preview deployment by clicking a demo user and confirming login succeeds (may require waiting for Render cold-start on first attempt).

## 🚩 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## 🔍 Key areas for human review

1. **`resolveApiBaseUrl()` is evaluated at module load time** — uses `typeof window !== 'undefined'` to distinguish browser vs SSR. This works for `'use client'` pages, but verify no server-only code path imports `api-client.ts` expecting the direct Render URL.
2. **Network error detection is fragile** — `err instanceof TypeError && err.message.includes('fetch')` may not match all browsers' fetch-failure messages. Consider whether a broader `TypeError` catch (without the message check) would be safer, or test across Safari/Firefox.
3. **Cold-start hint only has fr/en copy** — the app supports 4 locales (fr/en/tr/ar). Turkish and Arabic users will see the English fallback string. May want to add tr/ar translations.
4. **Single retry** — `retryCount < 1` means only one retry. If Render takes longer than ~45s × 2 attempts, the user still gets a failure. This is a reasonable trade-off but worth confirming.

Link to Devin session: https://app.devin.ai/sessions/7a62287ce5754a679c29ff9e7fe682e9