### PR TITLE
feat(mobile): design coherence — AppColors system, API cold-start retry, ErrorState widget

### DIFF
--- a/front/mobile/lib/core/api/api_client.dart
+++ b/front/mobile/lib/core/api/api_client.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:leopardo_rh/core/storage/app_preferences.dart';
 import 'package:leopardo_rh/core/storage/secure_storage.dart';
 import 'package:leopardo_rh/core/api/api_exceptions.dart';
 import 'package:leopardo_rh/core/api/mock_interceptor.dart';
+
+typedef RetryCallback = void Function(int attempt, Object error);
 
 class ApiClient {
   static const String _defaultRemoteBaseUrl =
@@ -12,6 +16,12 @@ class ApiClient {
       'http://10.0.2.2:8000/api/v1';
   static const String _defaultLocalLoopbackBaseUrl =
       'http://127.0.0.1:8000/api/v1';
+
+  static const int _defaultMaxRetries = 2;
+  static const int _loginMaxRetries = 3;
+  static const Duration _defaultTimeout = Duration(seconds: 20);
+  static const Duration _loginTimeout = Duration(seconds: 60);
+
   final Dio _dio;
   final SecureStorage _storage;
   final AppPreferences _preferences;
@@ -21,8 +31,8 @@ class ApiClient {
     : _dio = Dio(
         BaseOptions(
           baseUrl: resolveBaseUrl(),
-          connectTimeout: const Duration(seconds: 20),
-          receiveTimeout: const Duration(seconds: 20),
+          connectTimeout: _defaultTimeout,
+          receiveTimeout: _defaultTimeout,
           headers: {'Accept': 'application/json'},
         ),
       ) {
@@ -93,6 +103,78 @@ class ApiClient {
         return _defaultLocalLoopbackBaseUrl;
     }
   }
+
+  /// Performs a request with automatic retry for cold-start (502/503/504)
+  /// and network errors. Uses extended timeouts for login requests.
+  Future<Response<T>> requestWithRetry<T>(
+    String path, {
+    String method = 'GET',
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    bool isLoginRequest = false,
+    RetryCallback? onRetry,
+  }) async {
+    final maxRetries = isLoginRequest ? _loginMaxRetries : _defaultMaxRetries;
+    final timeout = isLoginRequest ? _loginTimeout : _defaultTimeout;
+
+    Object? lastError;
+
+    for (int attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        final response = await _dio.request<T>(
+          path,
+          data: data,
+          queryParameters: queryParameters,
+          options: (options ?? Options()).copyWith(
+            method: method,
+            sendTimeout: timeout,
+            receiveTimeout: timeout,
+          ),
+        );
+
+        final statusCode = response.statusCode ?? 0;
+        if (_isColdStartStatus(statusCode) && attempt < maxRetries) {
+          onRetry?.call(attempt + 1, ApiException(
+            'Server returned $statusCode',
+            statusCode: statusCode,
+            code: 'COLD_START',
+          ));
+          await _backoff(attempt);
+          continue;
+        }
+
+        return response;
+      } on DioException catch (e) {
+        lastError = e;
+
+        final isColdStart = _isColdStartStatus(e.response?.statusCode ?? 0);
+        final isTimeout = e.type == DioExceptionType.connectionTimeout ||
+            e.type == DioExceptionType.receiveTimeout ||
+            e.type == DioExceptionType.sendTimeout;
+        final isNetwork = e.type == DioExceptionType.connectionError;
+
+        if ((isColdStart || isTimeout || isNetwork) && attempt < maxRetries) {
+          onRetry?.call(attempt + 1, e);
+          await _backoff(attempt);
+          continue;
+        }
+
+        rethrow;
+      }
+    }
+
+    if (lastError is DioException) {
+      throw lastError;
+    }
+    throw ApiException('Request failed after retries');
+  }
+
+  bool _isColdStartStatus(int statusCode) =>
+      statusCode == 502 || statusCode == 503 || statusCode == 504;
+
+  Future<void> _backoff(int attempt) =>
+      Future.delayed(Duration(milliseconds: (3000 * (attempt + 1)).clamp(0, 10000)));
 
   DioException _handleError(DioException e) {
     String message = "Impossible de se connecter au serveur";

--- a/front/mobile/lib/core/theme/app_colors.dart
+++ b/front/mobile/lib/core/theme/app_colors.dart
@@ -33,6 +33,11 @@ class AppColors {
   static const Color iaLight = Color(0xFFEDE9FE); // violet-100
   static const Color iaDark = Color(0xFF5B21B6); // violet-800
 
+  /// Cabinet numerique — documents et dossiers.
+  static const Color cabinet = Color(0xFF8B6914); // gold/amber
+  static const Color cabinetLight = Color(0xFFFEF3C7); // amber-100
+  static const Color cabinetDark = Color(0xFF6B4F10); // darker gold
+
   // ─── Semantique (alerte / succes / info) ────────────────────────────────
   static const Color success = Color(0xFF10B981);
   static const Color warning = Color(0xFFF59E0B);
@@ -103,6 +108,9 @@ class AppColors {
       case 'ia':
       case 'leo_ai':
         return ia;
+      case 'cabinet':
+      case 'documents':
+        return cabinet;
       default:
         return textMuted;
     }
@@ -121,6 +129,9 @@ class AppColors {
       case 'ia':
       case 'leo_ai':
         return iaLight;
+      case 'cabinet':
+      case 'documents':
+        return cabinetLight;
       default:
         return borderLight;
     }

--- a/front/mobile/lib/core/widgets/error_state.dart
+++ b/front/mobile/lib/core/widgets/error_state.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
+
+/// Consistent error display widget for API failures and exceptions.
+///
+/// Matches the EmptyState pattern but with error-specific styling
+/// and an optional retry action.
+class ErrorState extends StatelessWidget {
+  const ErrorState({
+    super.key,
+    required this.message,
+    this.onRetry,
+    this.icon,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon ?? Icons.error_outline_rounded,
+              size: 56,
+              color: AppColors.danger,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: AppTypography.bodySmall.copyWith(
+                color: AppColors.danger,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Reessayer'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.rh,
+                  side: BorderSide(color: AppColors.borderFor(context)),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/front/mobile/lib/features/absences/screens/absence_list_screen.dart
+++ b/front/mobile/lib/features/absences/screens/absence_list_screen.dart
@@ -86,7 +86,7 @@ class AbsenceListScreen extends ConsumerWidget {
               (e, _) => Center(
                 child: Text(
                   e.toString(),
-                  style: const TextStyle(color: Colors.red),
+                  style: const TextStyle(color: AppColors.danger),
                 ),
               ),
         ),
@@ -101,7 +101,7 @@ class AbsenceListScreen extends ConsumerWidget {
       case 'pending':
         return AppColors.info;
       case 'rejected':
-        return Colors.red;
+        return AppColors.danger;
       default:
         return AppColors.textMutedDark;
     }

--- a/front/mobile/lib/features/approvals/screens/approval_screen.dart
+++ b/front/mobile/lib/features/approvals/screens/approval_screen.dart
@@ -225,7 +225,7 @@ class _ApprovalScreenState extends ConsumerState<ApprovalScreen> {
               height: 400,
               child: Center(
                 child:
-                    Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                    Text(e.toString(), style: const TextStyle(color: AppColors.danger)),
               ),
             ),
           ),

--- a/front/mobile/lib/features/auth/data/auth_repository.dart
+++ b/front/mobile/lib/features/auth/data/auth_repository.dart
@@ -13,9 +13,11 @@ class AuthRepository {
   AuthRepository(this.apiClient, this.storage, this.preferences);
 
   Future<Map<String, dynamic>> login(String email, String password) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/auth/login',
+      method: 'POST',
       data: {'email': email, 'password': password, 'device_name': 'Mobile App'},
+      isLoginRequest: true,
     );
 
     final data = response.data as Map<String, dynamic>;

--- a/front/mobile/lib/features/auth/screens/login_screen.dart
+++ b/front/mobile/lib/features/auth/screens/login_screen.dart
@@ -231,7 +231,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                           icon: const Icon(Icons.group_outlined),
                           label: const Text('Acces Demo'),
                           style: ElevatedButton.styleFrom(
-                            backgroundColor: const Color(0xFF059669),
+                            backgroundColor: AppColors.rhDark,
                             foregroundColor: Colors.white,
                           ),
                         ),

--- a/front/mobile/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile/lib/features/cabinet/screens/cabinet_screen.dart
@@ -44,7 +44,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
           children: [
             Icon(
               isRoot ? Icons.door_sliding_outlined : Icons.folder_open,
-              color: const Color(0xFF8B6914),
+              color: AppColors.cabinet,
               size: 24,
             ),
             const SizedBox(width: 10),
@@ -71,7 +71,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
             colors: [
               AppColors.tint(
                 context,
-                const Color(0xFF8B6914),
+                AppColors.cabinet,
                 lightAlpha: 0.06,
               ),
               background,
@@ -183,7 +183,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
 
   Widget _buildFab(Color text) {
     return FloatingActionButton(
-      backgroundColor: const Color(0xFF8B6914),
+      backgroundColor: AppColors.cabinet,
       foregroundColor: Colors.white,
       onPressed: () => _showAddMenu(),
       child: const Icon(Icons.add),
@@ -206,7 +206,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                   width: 40,
                   height: 4,
                   decoration: BoxDecoration(
-                    color: Colors.grey.shade300,
+                    color: AppColors.borderLight,
                     borderRadius: BorderRadius.circular(2),
                   ),
                 ),
@@ -214,7 +214,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 ListTile(
                   leading: const Icon(
                     Icons.create_new_folder_outlined,
-                    color: Color(0xFF8B6914),
+                    color: AppColors.cabinet,
                   ),
                   title: const Text('Nouveau dossier'),
                   onTap: () {
@@ -225,7 +225,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 ListTile(
                   leading: const Icon(
                     Icons.upload_file_outlined,
-                    color: Color(0xFF8B6914),
+                    color: AppColors.cabinet,
                   ),
                   title: const Text('Ajouter un document'),
                   subtitle: const Text('Depuis vos fichiers ou la camera'),
@@ -328,7 +328,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 const SizedBox(height: 16),
                 ListTile(
                   contentPadding: EdgeInsets.zero,
-                  leading: const Icon(Icons.link, color: Color(0xFF8B6914)),
+                  leading: const Icon(Icons.link, color: AppColors.cabinet),
                   title: const Text('Creer un lien de partage'),
                   onTap: () async {
                     Navigator.pop(ctx);
@@ -400,7 +400,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 child: const Text('Annuler'),
               ),
               FilledButton(
-                style: FilledButton.styleFrom(backgroundColor: Colors.red),
+                style: FilledButton.styleFrom(backgroundColor: AppColors.danger),
                 onPressed: () async {
                   Navigator.pop(ctx);
                   final repo = ref.read(cabinetRepositoryProvider);
@@ -453,12 +453,12 @@ class _FolderTile extends StatelessWidget {
                   width: 44,
                   height: 44,
                   decoration: BoxDecoration(
-                    color: const Color(0xFF8B6914).withValues(alpha: 0.12),
+                    color: AppColors.cabinet.withValues(alpha: 0.12),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: const Icon(
                     Icons.folder,
-                    color: Color(0xFF8B6914),
+                    color: AppColors.cabinet,
                     size: 24,
                   ),
                 ),
@@ -514,9 +514,9 @@ class _DocumentTile extends StatelessWidget {
   }
 
   Color get _iconColor {
-    if (document.isPdf) return Colors.red.shade700;
-    if (document.isImage) return Colors.blue.shade700;
-    return Colors.grey.shade700;
+    if (document.isPdf) return AppColors.danger;
+    if (document.isImage) return AppColors.info;
+    return AppColors.textMuted;
   }
 
   @override
@@ -569,13 +569,13 @@ class _DocumentTile extends StatelessWidget {
             ),
             IconButton(
               icon: const Icon(Icons.share_outlined, size: 20),
-              color: const Color(0xFF8B6914),
+              color: AppColors.cabinet,
               tooltip: 'Partager',
               onPressed: onShare,
             ),
             IconButton(
               icon: const Icon(Icons.delete_outline, size: 20),
-              color: Colors.red.shade400,
+              color: AppColors.danger,
               tooltip: 'Supprimer',
               onPressed: onDelete,
             ),

--- a/front/mobile/lib/features/contracts/screens/contract_screen.dart
+++ b/front/mobile/lib/features/contracts/screens/contract_screen.dart
@@ -110,7 +110,7 @@ class ContractScreen extends ConsumerWidget {
             child: SizedBox(
               height: 400,
               child: Center(
-                child: Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                child: Text(e.toString(), style: const TextStyle(color: AppColors.danger)),
               ),
             ),
           ),

--- a/front/mobile/lib/features/evaluations/screens/evaluation_list_screen.dart
+++ b/front/mobile/lib/features/evaluations/screens/evaluation_list_screen.dart
@@ -72,7 +72,7 @@ class EvaluationListScreen extends ConsumerWidget {
             (e, _) => Center(
               child: Text(
                 e.toString(),
-                style: const TextStyle(color: Colors.red),
+                style: const TextStyle(color: AppColors.danger),
               ),
             ),
       ),

--- a/front/mobile/lib/features/expenses/screens/expense_list_screen.dart
+++ b/front/mobile/lib/features/expenses/screens/expense_list_screen.dart
@@ -242,7 +242,7 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
               height: 400,
               child: Center(
                 child:
-                    Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                    Text(e.toString(), style: const TextStyle(color: AppColors.danger)),
               ),
             ),
           ),

--- a/front/mobile/lib/features/notifications/screens/notification_list_screen.dart
+++ b/front/mobile/lib/features/notifications/screens/notification_list_screen.dart
@@ -120,7 +120,7 @@ class NotificationListScreen extends ConsumerWidget {
             (e, _) => Center(
               child: Text(
                 e.toString(),
-                style: const TextStyle(color: Colors.red),
+                style: const TextStyle(color: AppColors.danger),
               ),
             ),
       ),

--- a/front/mobile/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/front/mobile/lib/features/onboarding/screens/onboarding_screen.dart
@@ -199,7 +199,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               height: 400,
               child: Center(
                 child:
-                    Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                    Text(e.toString(), style: const TextStyle(color: AppColors.danger)),
               ),
             ),
           ),

--- a/front/mobile/lib/features/organigramme/screens/organigramme_screen.dart
+++ b/front/mobile/lib/features/organigramme/screens/organigramme_screen.dart
@@ -76,7 +76,7 @@ class OrganigrammeScreen extends ConsumerWidget {
           error: (e, _) => Center(
             child: Text(
               e.toString(),
-              style: const TextStyle(color: Colors.red),
+              style: const TextStyle(color: AppColors.danger),
             ),
           ),
         ),

--- a/front/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
+++ b/front/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
@@ -44,7 +44,7 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Erreur: ${e.toString()}'),
-            backgroundColor: Colors.red,
+            backgroundColor: AppColors.danger,
           ),
         );
       }
@@ -172,7 +172,7 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
               child: Center(
                 child: Text(
                   e.toString(),
-                  style: const TextStyle(color: Colors.red),
+                  style: const TextStyle(color: AppColors.danger),
                 ),
               ),
             ),

--- a/front/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
+++ b/front/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
@@ -107,7 +107,7 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
                         child: Text(
                           e.toString(),
                           textAlign: TextAlign.center,
-                          style: const TextStyle(color: Colors.red),
+                          style: const TextStyle(color: AppColors.danger),
                         ),
                       ),
                     ),
@@ -144,7 +144,7 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
       case 'pending':
         return AppColors.info;
       case 'rejected':
-        return Colors.red;
+        return AppColors.danger;
       default:
         return AppColors.textMutedDark;
     }

--- a/front/mobile/lib/features/training/screens/training_screen.dart
+++ b/front/mobile/lib/features/training/screens/training_screen.dart
@@ -126,7 +126,7 @@ class TrainingScreen extends ConsumerWidget {
               height: 400,
               child: Center(
                 child:
-                    Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                    Text(e.toString(), style: const TextStyle(color: AppColors.danger)),
               ),
             ),
           ),

--- a/front/mobile/lib/features/user_auth/screens/user_home_screen.dart
+++ b/front/mobile/lib/features/user_auth/screens/user_home_screen.dart
@@ -157,7 +157,7 @@ class UserHomeScreen extends ConsumerWidget {
               child: _QuickActionCard(
                 icon: Icons.door_sliding_outlined,
                 label: 'Placard',
-                color: const Color(0xFF8B6914),
+                color: AppColors.cabinet,
                 onTap: () {
                   HapticFeedback.lightImpact();
                   context.push('/cabinet');

--- a/front/mobile/lib/features/user_auth/screens/user_login_screen.dart
+++ b/front/mobile/lib/features/user_auth/screens/user_login_screen.dart
@@ -292,7 +292,7 @@ class _UserLoginScreenState extends ConsumerState<UserLoginScreen> {
               icon: const Icon(Icons.group_outlined),
               label: const Text('Acces Demo'),
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF059669),
+                backgroundColor: AppColors.rhDark,
                 foregroundColor: Colors.white,
               ),
             ),

--- a/front/mobile/lib/features/vehicle_position/screens/vehicle_map_screen.dart
+++ b/front/mobile/lib/features/vehicle_position/screens/vehicle_map_screen.dart
@@ -148,7 +148,7 @@ class VehicleMapScreen extends ConsumerWidget {
               height: 400,
               child: Center(
                 child:
-                    Text(e.toString(), style: const TextStyle(color: Colors.red)),
+                    Text(e.toString(), style: const TextStyle(color: AppColors.danger)),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary

Global design and architecture coherence pass on the Flutter mobile app. Three categories of improvements:

### 1. Color System Coherence (15 screens)
- **Eliminated all hardcoded `Color(0xFF...)` values** from feature screens
- `Color(0xFF8B6914)` → `AppColors.cabinet` (cabinet_screen, user_home_screen)
- `Color(0xFF059669)` → `AppColors.rhDark` (login_screen, user_login_screen)
- `Colors.red` → `AppColors.danger` across 15 screens (error states, delete buttons, status indicators)
- `Colors.grey` → `AppColors.borderLight`/`AppColors.textMuted`
- `Colors.blue` → `AppColors.info`
- Added new cabinet domain to `AppColors`: `cabinet`, `cabinetLight`, `cabinetDark`
- Updated `forDomain()` and `forDomainLight()` helpers with `cabinet`/`documents` cases

### 2. API Cold-Start Resilience
- Added `requestWithRetry<T>()` method to `ApiClient` — matches web's `fetchWithRetry()` pattern
- Progressive backoff: 3s → 6s → 10s between retries
- Login: 3 retries, 60s timeout (vs 2 retries, 20s for other requests)
- Handles 502/503/504 (Render cold-start), connection timeouts, network errors
- `RetryCallback` typedef for UI feedback during retry
- Wired `auth_repository.login()` to use `requestWithRetry(isLoginRequest: true)`

### 3. ErrorState Widget
- New `ErrorState` widget (matches `EmptyState` pattern)
- Consistent error display with danger icon, message, and optional retry button
- Uses `AppColors.danger` and `AppColors.rh` from the design system

## Review & Testing Checklist for Human
- [ ] Run `flutter analyze` — all changes use existing AppColors tokens, no new hardcoded values
- [ ] Verify cabinet screen renders correctly (gold colors should look identical — same hex values)
- [ ] Test login with demo account — retry mechanism should trigger on cold-start (502/503/504)
- [ ] Verify error states across feature screens use AppColors.danger (red) consistently

### Notes
- No Flutter SDK on build machine — relies on CI `flutter analyze` for validation
- The `Colors.white` usage on buttons with explicit backgrounds was kept as-is (semantically correct for contrast)
- All screen-level imports were verified for no duplicates


Link to Devin session: https://app.devin.ai/sessions/b0f38569e0aa4cd5bef3eb00ff3232ea
Requested by: @kitokoh