### PR TITLE
feat(mobile): polish dark mobile experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.119, l observabilite UX client est contractuelle : `trackClientEvent` emet `login_success`, `login_failed`, `dashboard_loaded`, `feature_blocked`, `demo_user_selected` et les tests Playwright les verifient. Ne pas brancher un outil tiers directement dans les composants ; ajouter d abord un endpoint/backend stable ou adapter `front/web/src/lib/client-analytics.ts`.
 - Depuis v4.16.120, les evenements UX authentifies se persistent via `POST /api/v1/client-events` dans `client_events`. Garder `login_failed` hors persistance tant que le tenant n est pas fiable, conserver la minimisation PII dans `ClientEventController`, et etendre `ClientEventControllerTest` pour tout nouvel evenement allowliste.
 - Le kiosque ZKTeco emet `leopardo:kiosk-status` et affiche la derniere synchronisation. Garder cet etat offline-first lisible lors des evolutions kiosk/bridge, car c est le signal terrain principal pour les clients.
+- Depuis v4.16.134, le mobile utilise un socle visuel sombre inspire du mockup pointage v3 via `front/mobile/lib/core/widgets/mobile_surface.dart`. Pour tout nouvel ecran mobile, privilegier `MobileTopBar`, `MobilePanel`, `MobileStatusPill`, `MobileIconBubble` et les couleurs `MobileSurface.*` afin de garder une experience 2026 coherente sans dupliquer des `BoxDecoration`.
 
 ## Pieges connus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.134] - 2026-05-24
+
+### Changed
+
+- Mobile : theme sombre par defaut aligne sur le design pointage v3 (`#0B1120`, cartes `#111B2E`, bordures fines, actions compactes).
+- Mobile : ajout d'un kit de surfaces partagees (`MobileSurface`, panels, top bars, pills, bulles icones) pour eviter les styles eparpilles entre les ecrans.
+- Mobile : ecrans Accueil, Modules RH, Notifications, Absences, Fiches de paie et Parametres polis dans un style plus epure, dense et coherent avec le mockup `leopardo_attendance_v3_final.html`.
+
 ## [4.16.133] - 2026-05-24
 
 ### Changed

--- a/front/mobile/lib/app.dart
+++ b/front/mobile/lib/app.dart
@@ -239,7 +239,7 @@ class LeopardoApp extends ConsumerWidget {
       title: 'Leopardo RH',
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.light,
+      themeMode: ThemeMode.dark,
       routerConfig: router,
       debugShowCheckedModeBanner: false,
       locale: locale,

--- a/front/mobile/lib/core/theme/app_theme.dart
+++ b/front/mobile/lib/core/theme/app_theme.dart
@@ -25,12 +25,18 @@ class AppTheme {
 
   static ThemeData _buildTheme(Brightness brightness) {
     final isDark = brightness == Brightness.dark;
-    final scaffold = isDark ? AppColors.bgDark : AppColors.bgLight;
-    final surface = isDark ? AppColors.cardDark : AppColors.cardLight;
-    final fieldFill = isDark ? AppColors.cardDark : AppColors.bgLight;
-    final border = isDark ? AppColors.borderDark : AppColors.borderLight;
-    final text = isDark ? AppColors.textDark : AppColors.textLight;
-    final muted = isDark ? AppColors.textMutedDark : AppColors.textMuted;
+    const mobileDarkBackground = Color(0xFF0B1120);
+    const mobileDarkSurface = Color(0xFF111B2E);
+    const mobileDarkField = Color(0xFF0C1525);
+    const mobileDarkBorder = Color(0xFF1A2B44);
+    const mobileDarkText = Color(0xFFE2EAF6);
+    const mobileDarkMuted = Color(0xFF7A9CC0);
+    final scaffold = isDark ? mobileDarkBackground : AppColors.bgLight;
+    final surface = isDark ? mobileDarkSurface : AppColors.cardLight;
+    final fieldFill = isDark ? mobileDarkField : AppColors.bgLight;
+    final border = isDark ? mobileDarkBorder : AppColors.borderLight;
+    final text = isDark ? mobileDarkText : AppColors.textLight;
+    final muted = isDark ? mobileDarkMuted : AppColors.textMuted;
     final scheme = ColorScheme.fromSeed(
       seedColor: AppColors.rh,
       brightness: brightness,
@@ -78,8 +84,8 @@ class AppTheme {
         elevation: 0,
         margin: EdgeInsets.zero,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(24),
-          side: BorderSide(color: border),
+          borderRadius: BorderRadius.circular(isDark ? 16 : 24),
+          side: BorderSide(color: border, width: isDark ? 0.7 : 1),
         ),
       ),
       dividerTheme: DividerThemeData(color: border, thickness: 1, space: 1),
@@ -103,10 +109,10 @@ class AppTheme {
           backgroundColor: AppColors.rh,
           foregroundColor: Colors.white,
           elevation: 0,
-          minimumSize: const Size.fromHeight(52),
+          minimumSize: Size.fromHeight(isDark ? 46 : 52),
           padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(18),
+            borderRadius: BorderRadius.circular(isDark ? 12 : 18),
           ),
           textStyle: AppTypography.subtitle,
         ),
@@ -115,9 +121,9 @@ class AppTheme {
         style: FilledButton.styleFrom(
           backgroundColor: AppColors.rh,
           foregroundColor: Colors.white,
-          minimumSize: const Size.fromHeight(52),
+          minimumSize: Size.fromHeight(isDark ? 46 : 52),
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(18),
+            borderRadius: BorderRadius.circular(isDark ? 12 : 18),
           ),
           textStyle: AppTypography.subtitle,
         ),
@@ -126,10 +132,10 @@ class AppTheme {
         style: OutlinedButton.styleFrom(
           foregroundColor: text,
           side: BorderSide(color: border),
-          minimumSize: const Size.fromHeight(52),
+          minimumSize: Size.fromHeight(isDark ? 46 : 52),
           padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(18),
+            borderRadius: BorderRadius.circular(isDark ? 12 : 18),
           ),
           textStyle: AppTypography.subtitle,
         ),

--- a/front/mobile/lib/core/widgets/mobile_surface.dart
+++ b/front/mobile/lib/core/widgets/mobile_surface.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+
+import 'package:leopardo_rh/core/theme/app_colors.dart';
+import 'package:leopardo_rh/core/theme/app_typography.dart';
+
+class MobileSurface {
+  MobileSurface._();
+
+  static const Color background = Color(0xFF0B1120);
+  static const Color surface = Color(0xFF111B2E);
+  static const Color chip = Color(0xFF0C1525);
+  static const Color border = Color(0xFF1A2B44);
+  static const Color text = Color(0xFFE2EAF6);
+  static const Color muted = Color(0xFF3D5470);
+  static const Color secondary = Color(0xFF7A9CC0);
+  static const Color disabled = Color(0xFF2A4560);
+
+  static BoxDecoration cardDecoration({
+    Color color = surface,
+    double radius = 16,
+    Color borderColor = border,
+  }) {
+    return BoxDecoration(
+      color: color,
+      borderRadius: BorderRadius.circular(radius),
+      border: Border.all(color: borderColor, width: 0.7),
+    );
+  }
+}
+
+class MobilePage extends StatelessWidget {
+  const MobilePage({
+    super.key,
+    required this.children,
+    this.padding = const EdgeInsets.fromLTRB(20, 16, 20, 28),
+    this.appBar,
+    this.bottom,
+  });
+
+  final List<Widget> children;
+  final EdgeInsetsGeometry padding;
+  final PreferredSizeWidget? appBar;
+  final Widget? bottom;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: MobileSurface.background,
+      appBar: appBar,
+      bottomNavigationBar: bottom,
+      body: SafeArea(child: ListView(padding: padding, children: children)),
+    );
+  }
+}
+
+class MobileTopBar extends StatelessWidget implements PreferredSizeWidget {
+  const MobileTopBar({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.actions = const [],
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget? leading;
+  final List<Widget> actions;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(72);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: MobileSurface.background,
+      elevation: 0,
+      leading: leading,
+      actions: actions,
+      titleSpacing: leading == null ? 20 : 0,
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            style: AppTypography.subtitle.copyWith(
+              color: MobileSurface.text,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              subtitle!,
+              style: AppTypography.caption.copyWith(color: MobileSurface.muted),
+            ),
+          ],
+        ],
+      ),
+      iconTheme: const IconThemeData(color: MobileSurface.secondary),
+    );
+  }
+}
+
+class MobilePanel extends StatelessWidget {
+  const MobilePanel({
+    super.key,
+    required this.child,
+    this.padding = const EdgeInsets.all(16),
+    this.margin,
+    this.color = MobileSurface.surface,
+    this.radius = 16,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry? margin;
+  final Color color;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: margin,
+      padding: padding,
+      decoration: MobileSurface.cardDecoration(color: color, radius: radius),
+      child: child,
+    );
+  }
+}
+
+class MobileSectionLabel extends StatelessWidget {
+  const MobileSectionLabel(this.label, {super.key});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 6, bottom: 8),
+      child: Text(
+        label.toUpperCase(),
+        style: AppTypography.caption.copyWith(
+          color: MobileSurface.disabled,
+          letterSpacing: 0.6,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class MobileIconBubble extends StatelessWidget {
+  const MobileIconBubble({
+    super.key,
+    required this.icon,
+    required this.color,
+    this.size = 40,
+  });
+
+  final IconData icon;
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color.withValues(alpha: 0.12),
+      ),
+      child: Icon(icon, color: color, size: size * 0.48),
+    );
+  }
+}
+
+class MobileStatusPill extends StatelessWidget {
+  const MobileStatusPill({
+    super.key,
+    required this.label,
+    required this.color,
+    this.icon,
+  });
+
+  final String label;
+  final Color color;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: 0.25), width: 0.7),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 13, color: color),
+            const SizedBox(width: 5),
+          ],
+          Text(
+            label,
+            style: AppTypography.caption.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class MobilePrimaryAction extends StatelessWidget {
+  const MobilePrimaryAction({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 18),
+      label: Text(label),
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.rh,
+        foregroundColor: Colors.white,
+        minimumSize: const Size.fromHeight(46),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+}

--- a/front/mobile/lib/features/absences/screens/absence_list_screen.dart
+++ b/front/mobile/lib/features/absences/screens/absence_list_screen.dart
@@ -16,7 +16,7 @@ class AbsenceListScreen extends ConsumerWidget {
     return Scaffold(
       backgroundColor: MobileSurface.background,
       appBar: MobileTopBar(
-        title: 'Mes absences',
+        title: 'Mes Absences',
         subtitle: 'Demandes et decisions RH',
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),

--- a/front/mobile/lib/features/absences/screens/absence_list_screen.dart
+++ b/front/mobile/lib/features/absences/screens/absence_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/absences/providers/absence_provider.dart';
 
 class AbsenceListScreen extends ConsumerWidget {
@@ -13,21 +14,19 @@ class AbsenceListScreen extends ConsumerWidget {
     final absencesAsync = ref.watch(absencesProvider);
 
     return Scaffold(
-      backgroundColor: AppColors.bgDark,
-      appBar: AppBar(
-        backgroundColor: AppColors.bgDark,
-        elevation: 0,
-        title: Text(
-          'Mes Absences',
-          style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
-        ),
+      backgroundColor: MobileSurface.background,
+      appBar: MobileTopBar(
+        title: 'Mes absences',
+        subtitle: 'Demandes et decisions RH',
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
       body: RefreshIndicator(
+        color: AppColors.rh,
+        backgroundColor: MobileSurface.background,
         onRefresh: () async => ref.refresh(absencesProvider.future),
         child: absencesAsync.when(
           data:
@@ -50,28 +49,43 @@ class AbsenceListScreen extends ConsumerWidget {
                         itemCount: absences.length,
                         itemBuilder: (context, index) {
                           final absence = absences[index];
-                          return Card(
-                            color: AppColors.cardDark,
-                            margin: const EdgeInsets.only(bottom: 12),
-                            child: ListTile(
-                              title: Text(
-                                absence.absenceTypeName ?? 'Absence',
-                                style: AppTypography.subtitle.copyWith(
-                                  color: AppColors.textDark,
+                          final color = _getStatusColor(absence.status);
+                          return MobilePanel(
+                            margin: const EdgeInsets.only(bottom: 8),
+                            child: Row(
+                              children: [
+                                MobileIconBubble(
+                                  icon: Icons.event_available_outlined,
+                                  color: color,
                                 ),
-                              ),
-                              subtitle: Text(
-                                '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
-                                style: AppTypography.bodySmall.copyWith(
-                                  color: AppColors.textMutedDark,
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        absence.absenceTypeName ?? 'Absence',
+                                        style: AppTypography.bodySmall.copyWith(
+                                          color: MobileSurface.text,
+                                          fontWeight: FontWeight.w700,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
+                                        style: AppTypography.caption.copyWith(
+                                          color: MobileSurface.secondary,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
                                 ),
-                              ),
-                              trailing: Text(
-                                absence.status,
-                                style: TextStyle(
-                                  color: _getStatusColor(absence.status),
+                                MobileStatusPill(
+                                  label: absence.status,
+                                  color: color,
                                 ),
-                              ),
+                              ],
                             ),
                           );
                         },

--- a/front/mobile/lib/features/home/screens/home_screen.dart
+++ b/front/mobile/lib/features/home/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/theme/mobile_experience_icons.dart';
 import 'package:leopardo_rh/core/widgets/alert_banner.dart';
 import 'package:leopardo_rh/core/widgets/leopardo_badge.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_rh/models/mobile_experience.dart';
 
@@ -36,7 +37,7 @@ class HomeScreen extends ConsumerWidget {
             ? employee!.firstName
             : employee?.email.split('@').first ?? '';
     final canManageTeam = employee?.canManageTeam == true;
-    final background = AppColors.backgroundFor(context);
+    const background = MobileSurface.background;
 
     return Scaffold(
       backgroundColor: background,
@@ -46,9 +47,9 @@ class HomeScreen extends ConsumerWidget {
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
             colors: [
-              AppColors.tint(context, AppColors.rh, lightAlpha: 0.08),
+              AppColors.rh.withValues(alpha: 0.08),
               background,
-              AppColors.tint(context, AppColors.ia, lightAlpha: 0.04),
+              AppColors.ia.withValues(alpha: 0.05),
             ],
           ),
         ),
@@ -57,14 +58,14 @@ class HomeScreen extends ConsumerWidget {
             children: [
               Expanded(
                 child: ListView(
-                  padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
                   children: [
                     _HeaderRow(
                       firstName: firstName,
                       stage: stage,
                       canManageTeam: canManageTeam,
                     ),
-                    const SizedBox(height: 18),
+                    const SizedBox(height: 14),
                     _LeoCard(
                       firstName: firstName,
                       stage: stage,
@@ -76,7 +77,7 @@ class HomeScreen extends ConsumerWidget {
                       canManageTeam: canManageTeam,
                       upcomingModules: upcomingModules,
                     ),
-                    const SizedBox(height: 24),
+                    const SizedBox(height: 20),
                     _SectionTitle(
                       title: 'Actions rapides',
                       subtitle:
@@ -86,7 +87,7 @@ class HomeScreen extends ConsumerWidget {
                     ),
                     const SizedBox(height: 12),
                     _QuickActionsGrid(actions: quickActions),
-                    const SizedBox(height: 24),
+                    const SizedBox(height: 20),
                     _SectionTitle(
                       title: 'Modules actifs',
                       subtitle:
@@ -95,7 +96,7 @@ class HomeScreen extends ConsumerWidget {
                     const SizedBox(height: 12),
                     _ModulesScroller(modules: activeModules),
                     if (upcomingModules.isNotEmpty) ...[
-                      const SizedBox(height: 24),
+                      const SizedBox(height: 20),
                       const _SectionTitle(
                         title: 'Bientot dans Leopardo',
                         subtitle:
@@ -105,7 +106,7 @@ class HomeScreen extends ConsumerWidget {
                       _UpcomingModules(modules: upcomingModules),
                     ],
                     if (canManageTeam) ...[
-                      const SizedBox(height: 24),
+                      const SizedBox(height: 20),
                       const _ManagerDigestCard(),
                     ],
                   ],
@@ -144,10 +145,16 @@ class _HeaderRow extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 12),
-        IconButton.filledTonal(
-          onPressed: () => context.push('/settings'),
-          icon: const Icon(Icons.tune),
-          tooltip: 'Parametres',
+        Container(
+          decoration: MobileSurface.cardDecoration(
+            color: MobileSurface.chip,
+            radius: 14,
+          ),
+          child: IconButton(
+            onPressed: () => context.push('/settings'),
+            icon: const Icon(Icons.tune, color: MobileSurface.secondary),
+            tooltip: 'Parametres',
+          ),
         ),
       ],
     );
@@ -167,8 +174,8 @@ class _HeroHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
+    const text = MobileSurface.text;
+    const muted = MobileSurface.muted;
     final dateLabel = DateFormat.EEEE(
       'fr_FR',
     ).add_d().add_MMMM().format(DateTime.now());
@@ -176,14 +183,14 @@ class _HeroHeader extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: AppColors.surfaceFor(context),
-        borderRadius: BorderRadius.circular(28),
-        border: Border.all(color: AppColors.borderFor(context)),
+        color: MobileSurface.surface,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: MobileSurface.border, width: 0.7),
         boxShadow: [
           BoxShadow(
-            color: AppColors.rh.withValues(alpha: 0.06),
-            blurRadius: 24,
-            offset: const Offset(0, 12),
+            color: AppColors.rh.withValues(alpha: 0.05),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
           ),
         ],
       ),
@@ -210,7 +217,7 @@ class _HeroHeader extends StatelessWidget {
             firstName.isEmpty
                 ? _greetingForHour(DateTime.now().hour)
                 : '${_greetingForHour(DateTime.now().hour)}, $firstName',
-            style: AppTypography.display.copyWith(color: text, fontSize: 30),
+            style: AppTypography.display.copyWith(color: text, fontSize: 28),
           ),
           const SizedBox(height: 6),
           Text(
@@ -242,8 +249,8 @@ class _LeoCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
+    const text = MobileSurface.text;
+    const muted = MobileSurface.secondary;
     final shortName = firstName.isEmpty ? 'vous' : firstName;
     final guidance =
         stage == 'new'
@@ -255,19 +262,11 @@ class _LeoCard extends StatelessWidget {
             : 'Aujourd hui, tout part du pointage, puis de la consultation de votre mois et de vos documents RH.';
 
     return Container(
-      padding: const EdgeInsets.all(22),
+      padding: const EdgeInsets.all(18),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(28),
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            AppColors.tint(context, AppColors.ia, lightAlpha: 0.15),
-            AppColors.surfaceFor(context),
-            AppColors.tint(context, AppColors.rh, lightAlpha: 0.06),
-          ],
-        ),
-        border: Border.all(color: AppColors.borderFor(context)),
+        borderRadius: BorderRadius.circular(18),
+        color: MobileSurface.surface,
+        border: Border.all(color: MobileSurface.border, width: 0.7),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -279,12 +278,7 @@ class _LeoCard extends StatelessWidget {
                 height: 46,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: AppColors.tint(
-                    context,
-                    AppColors.ia,
-                    lightAlpha: 0.18,
-                    darkAlpha: 0.24,
-                  ),
+                  color: AppColors.ia.withValues(alpha: 0.18),
                 ),
                 child: const Icon(Icons.auto_awesome, color: AppColors.ia),
               ),
@@ -384,14 +378,14 @@ class _SectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
+    const text = MobileSurface.text;
+    const muted = MobileSurface.secondary;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(title, style: AppTypography.title.copyWith(color: text)),
-        const SizedBox(height: 4),
+        Text(title, style: AppTypography.subtitle.copyWith(color: text)),
+        const SizedBox(height: 3),
         Text(subtitle, style: AppTypography.bodySmall.copyWith(color: muted)),
       ],
     );
@@ -442,14 +436,14 @@ class _QuickActionCard extends StatelessWidget {
     final muted = AppColors.textSecondaryFor(context);
 
     return InkWell(
-      borderRadius: BorderRadius.circular(24),
+      borderRadius: BorderRadius.circular(16),
       onTap: () => context.push(action.route),
       child: Ink(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: AppColors.surfaceFor(context),
-          borderRadius: BorderRadius.circular(24),
-          border: Border.all(color: AppColors.borderFor(context)),
+          color: MobileSurface.surface,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MobileSurface.border, width: 0.7),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -530,7 +524,7 @@ class _ModuleCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final color = AppColors.forDomain(module.domain);
     final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
+    const muted = MobileSurface.secondary;
 
     return InkWell(
       onTap: module.isActive ? () => context.push(module.route!) : null,
@@ -783,8 +777,10 @@ class _ChatInputBar extends StatelessWidget {
         10 + MediaQuery.of(context).padding.bottom,
       ),
       decoration: BoxDecoration(
-        color: AppColors.backgroundFor(context),
-        border: Border(top: BorderSide(color: AppColors.borderFor(context))),
+        color: MobileSurface.background,
+        border: const Border(
+          top: BorderSide(color: MobileSurface.border, width: 0.7),
+        ),
       ),
       child: Row(
         children: [
@@ -820,7 +816,7 @@ class _ChatInputBar extends StatelessWidget {
                           : 'Leo arrive bientot dans cette conversation...',
                   hintStyle: AppTypography.bodySmall.copyWith(color: muted),
                   filled: true,
-                  fillColor: AppColors.surfaceFor(context),
+                  fillColor: MobileSurface.chip,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(999),
                     borderSide: BorderSide.none,

--- a/front/mobile/lib/features/home/screens/modules_hub_screen.dart
+++ b/front/mobile/lib/features/home/screens/modules_hub_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/theme/mobile_experience_icons.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_rh/models/mobile_experience.dart';
 
@@ -18,16 +19,17 @@ class ModulesHubScreen extends ConsumerWidget {
     final activeModules = experience?.activeModules ?? const <MobileModule>[];
     final upcomingModules =
         experience?.upcomingModules ?? const <MobileModule>[];
-    final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
-    final background = AppColors.backgroundFor(context);
+    const text = MobileSurface.text;
+    const muted = MobileSurface.secondary;
+    const background = MobileSurface.background;
 
     return Scaffold(
       backgroundColor: background,
-      appBar: AppBar(
-        title: const Text('Modules RH'),
+      appBar: MobileTopBar(
+        title: 'Modules RH',
+        subtitle: 'Vos outils actifs',
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => context.pop(),
         ),
@@ -49,9 +51,9 @@ class ModulesHubScreen extends ConsumerWidget {
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
-                color: AppColors.surfaceFor(context),
-                borderRadius: BorderRadius.circular(28),
-                border: Border.all(color: AppColors.borderFor(context)),
+                color: MobileSurface.surface,
+                borderRadius: BorderRadius.circular(18),
+                border: Border.all(color: MobileSurface.border, width: 0.7),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -71,7 +73,7 @@ class ModulesHubScreen extends ConsumerWidget {
             const SizedBox(height: 24),
             Text(
               'Modules actifs',
-              style: AppTypography.title.copyWith(color: text),
+              style: AppTypography.subtitle.copyWith(color: text),
             ),
             const SizedBox(height: 6),
             Text(
@@ -135,20 +137,20 @@ class _ModuleCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = AppColors.forDomain(module.domain);
-    final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
+    const text = MobileSurface.text;
+    const muted = MobileSurface.secondary;
 
     return Material(
-      color: AppColors.surfaceFor(context),
-      borderRadius: BorderRadius.circular(24),
+      color: MobileSurface.surface,
+      borderRadius: BorderRadius.circular(16),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(16),
         child: Container(
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(24),
-            border: Border.all(color: AppColors.borderFor(context)),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: MobileSurface.border, width: 0.7),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -198,15 +200,15 @@ class _UpcomingRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = AppColors.forDomain(module.domain);
-    final text = AppColors.textPrimaryFor(context);
-    final muted = AppColors.textSecondaryFor(context);
+    const text = MobileSurface.text;
+    const muted = MobileSurface.secondary;
 
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.surfaceFor(context),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: AppColors.borderFor(context)),
+        color: MobileSurface.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: MobileSurface.border, width: 0.7),
       ),
       child: Row(
         children: [

--- a/front/mobile/lib/features/notifications/screens/notification_list_screen.dart
+++ b/front/mobile/lib/features/notifications/screens/notification_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:leopardo_rh/core/providers/core_providers.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/notifications/providers/notification_provider.dart';
 
 class NotificationListScreen extends ConsumerWidget {
@@ -14,42 +15,38 @@ class NotificationListScreen extends ConsumerWidget {
     final notificationsAsync = ref.watch(notificationsProvider);
 
     return Scaffold(
-      backgroundColor: AppColors.bgDark,
-      appBar: AppBar(
-        backgroundColor: AppColors.bgDark,
-        elevation: 0,
-        title: Text(
-          'Notifications',
-          style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
-        ),
+      backgroundColor: MobileSurface.background,
+      appBar: MobileTopBar(
+        title: 'Notifications',
+        subtitle: 'Alertes RH, paie et validations',
         actions: [
           IconButton(
             tooltip: 'Actualiser',
-            icon: const Icon(Icons.refresh, color: AppColors.textDark),
+            icon: const Icon(Icons.refresh, color: MobileSurface.secondary),
             onPressed: () => ref.invalidate(notificationsProvider),
           ),
           IconButton(
             tooltip: 'Tout marquer comme lu',
-            icon: const Icon(Icons.done_all, color: AppColors.textDark),
+            icon: const Icon(Icons.done_all, color: MobileSurface.secondary),
             onPressed: () async {
-              await ref
-                  .read(notificationRepositoryProvider)
-                  .markAllAsRead();
+              await ref.read(notificationRepositoryProvider).markAllAsRead();
               ref.invalidate(notificationsProvider);
             },
           ),
         ],
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
       body: notificationsAsync.when(
         data:
-            (notifications) =>
-                RefreshIndicator(
-                  onRefresh: () async => ref.refresh(notificationsProvider.future),
-                  child: notifications.isEmpty
+            (notifications) => RefreshIndicator(
+              onRefresh: () async => ref.refresh(notificationsProvider.future),
+              color: AppColors.rh,
+              backgroundColor: MobileSurface.background,
+              child:
+                  notifications.isEmpty
                       ? ListView(
                         padding: const EdgeInsets.all(20),
                         children: [
@@ -66,55 +63,22 @@ class NotificationListScreen extends ConsumerWidget {
                         itemCount: notifications.length,
                         itemBuilder: (context, index) {
                           final notification = notifications[index];
-                          return Card(
-                            color: AppColors.cardDark,
-                            margin: const EdgeInsets.only(bottom: 12),
-                            child: ListTile(
-                              onTap: () async {
-                                if (!notification.isRead) {
-                                  await ref
-                                      .read(notificationRepositoryProvider)
-                                      .markAsRead(notification.id);
-                                  ref.invalidate(notificationsProvider);
-                                }
-                              },
-                              leading: Icon(
-                                notification.isRead
-                                    ? Icons.notifications_none
-                                    : Icons.notifications_active,
-                                color:
-                                    notification.isRead
-                                        ? AppColors.textMutedDark
-                                        : AppColors.info,
-                              ),
-                              title: Text(
-                                notification.title,
-                                style: AppTypography.subtitle.copyWith(
-                                  color: AppColors.textDark,
-                                  fontWeight:
-                                      notification.isRead
-                                          ? FontWeight.normal
-                                          : FontWeight.bold,
-                                ),
-                              ),
-                              subtitle: Text(
-                                notification.body,
-                                style: AppTypography.bodySmall.copyWith(
-                                  color: AppColors.textMutedDark,
-                                ),
-                              ),
-                              trailing: notification.isRead
-                                  ? null
-                                  : const Icon(
-                                      Icons.circle,
-                                      size: 10,
-                                      color: AppColors.info,
-                                    ),
-                            ),
+                          return _NotificationTile(
+                            title: notification.title,
+                            body: notification.body,
+                            isRead: notification.isRead,
+                            onTap: () async {
+                              if (!notification.isRead) {
+                                await ref
+                                    .read(notificationRepositoryProvider)
+                                    .markAsRead(notification.id);
+                                ref.invalidate(notificationsProvider);
+                              }
+                            },
                           );
                         },
                       ),
-                ),
+            ),
         loading: () => const Center(child: CircularProgressIndicator()),
         error:
             (e, _) => Center(
@@ -123,6 +87,95 @@ class NotificationListScreen extends ConsumerWidget {
                 style: const TextStyle(color: AppColors.danger),
               ),
             ),
+      ),
+    );
+  }
+}
+
+class _NotificationTile extends StatelessWidget {
+  const _NotificationTile({
+    required this.title,
+    required this.body,
+    required this.isRead,
+    required this.onTap,
+  });
+
+  final String title;
+  final String body;
+  final bool isRead;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = isRead ? MobileSurface.disabled : AppColors.info;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: onTap,
+        child: Ink(
+          padding: const EdgeInsets.all(14),
+          decoration: MobileSurface.cardDecoration(
+            color:
+                isRead
+                    ? MobileSurface.surface
+                    : AppColors.info.withValues(alpha: 0.08),
+            radius: 14,
+          ),
+          child: Row(
+            children: [
+              MobileIconBubble(
+                icon:
+                    isRead
+                        ? Icons.notifications_none
+                        : Icons.notifications_active,
+                color: accent,
+                size: 38,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            title,
+                            style: AppTypography.bodySmall.copyWith(
+                              color: MobileSurface.text,
+                              fontWeight:
+                                  isRead ? FontWeight.w500 : FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        if (!isRead)
+                          Container(
+                            width: 7,
+                            height: 7,
+                            decoration: const BoxDecoration(
+                              color: AppColors.info,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 5),
+                    Text(
+                      body,
+                      style: AppTypography.caption.copyWith(
+                        color: MobileSurface.secondary,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/front/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
+++ b/front/mobile/lib/features/payrolls/screens/payroll_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/payrolls/providers/payroll_provider.dart';
 import 'package:leopardo_rh/core/providers/core_providers.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -58,125 +59,134 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
     final payrollsAsync = ref.watch(payrollsProvider);
 
     return Scaffold(
-      backgroundColor: AppColors.bgDark,
-      appBar: AppBar(
-        backgroundColor: AppColors.bgDark,
-        elevation: 0,
-        title: Text(
-          'Mes Fiches de Paie',
-          style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
-        ),
+      backgroundColor: MobileSurface.background,
+      appBar: MobileTopBar(
+        title: 'Fiches de paie',
+        subtitle: 'Bulletins valides et exports PDF',
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => context.pop(),
         ),
       ),
       body: RefreshIndicator(
+        color: AppColors.rh,
+        backgroundColor: MobileSurface.background,
         onRefresh: () async => await ref.refresh(payrollsProvider.future),
         child: payrollsAsync.when(
-          data: (payrolls) => payrolls.isEmpty
-              ? ListView(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  children: const [
-                    SizedBox(height: 80),
-                    EmptyState(
-                      icon: Icons.description,
-                      title: 'Aucune fiche de paie',
-                      description:
-                          'Vos fiches de paie apparaîtront ici dès qu\'elles seront validées.',
-                    ),
-                  ],
-                )
-              : ListView.builder(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  padding: const EdgeInsets.all(20),
-                  itemCount: payrolls.length,
-                  itemBuilder: (context, index) {
-                    final payroll = payrolls[index];
-                    final isDownloading = _downloadingId == payroll.id;
-                    return Card(
-                      color: AppColors.cardDark,
-                      margin: const EdgeInsets.only(bottom: 12),
-                      child: ListTile(
-                        title: Text(
-                          'Mois: ${payroll.month}/${payroll.year}',
-                          style: AppTypography.subtitle.copyWith(
-                            color: AppColors.textDark,
+          data:
+              (payrolls) =>
+                  payrolls.isEmpty
+                      ? ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: const [
+                          SizedBox(height: 80),
+                          EmptyState(
+                            icon: Icons.description,
+                            title: 'Aucune fiche de paie',
+                            description:
+                                'Vos fiches de paie apparaîtront ici dès qu\'elles seront validées.',
                           ),
-                        ),
-                        subtitle: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'Salaire Net: ${payroll.netSalary.toStringAsFixed(2)} DZD',
-                              style: AppTypography.bodySmall.copyWith(
-                                color: AppColors.textMutedDark,
-                              ),
-                            ),
-                            if (payroll.status == 'validated')
-                              Padding(
-                                padding: const EdgeInsets.only(top: 4),
-                                child: Row(
-                                  children: [
-                                    const Icon(Icons.check_circle,
-                                        size: 14, color: AppColors.success),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      'Validé',
-                                      style: AppTypography.bodySmall.copyWith(
-                                        color: AppColors.success,
+                        ],
+                      )
+                      : ListView.builder(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.all(20),
+                        itemCount: payrolls.length,
+                        itemBuilder: (context, index) {
+                          final payroll = payrolls[index];
+                          final isDownloading = _downloadingId == payroll.id;
+                          return MobilePanel(
+                            margin: const EdgeInsets.only(bottom: 8),
+                            child: Row(
+                              children: [
+                                const MobileIconBubble(
+                                  icon: Icons.receipt_long_outlined,
+                                  color: AppColors.rh,
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        'Mois ${payroll.month}/${payroll.year}',
+                                        style: AppTypography.bodySmall.copyWith(
+                                          color: MobileSurface.text,
+                                          fontWeight: FontWeight.w700,
+                                        ),
                                       ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        '${payroll.netSalary.toStringAsFixed(2)} DZD net',
+                                        style: AppTypography.caption.copyWith(
+                                          color: MobileSurface.secondary,
+                                        ),
+                                      ),
+                                      if (payroll.status == 'validated')
+                                        const Padding(
+                                          padding: EdgeInsets.only(top: 6),
+                                          child: MobileStatusPill(
+                                            label: 'Valide',
+                                            color: AppColors.success,
+                                            icon: Icons.check_circle,
+                                          ),
+                                        ),
+                                    ],
+                                  ),
+                                ),
+                                isDownloading
+                                    ? const SizedBox(
+                                      width: 24,
+                                      height: 24,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        semanticsLabel:
+                                            'Telechargement en cours...',
+                                      ),
+                                    )
+                                    : IconButton(
+                                      icon: const Icon(
+                                        Icons.picture_as_pdf,
+                                        color: AppColors.info,
+                                      ),
+                                      tooltip: 'Telecharger le bulletin PDF',
+                                      onPressed:
+                                          payroll.pdfPath != null
+                                              ? () => _downloadPdf(payroll.id)
+                                              : null,
                                     ),
-                                  ],
-                                ),
-                              ),
-                          ],
-                        ),
-                        trailing: isDownloading
-                            ? const SizedBox(
-                                width: 24,
-                                height: 24,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  semanticsLabel: 'Téléchargement en cours...',
-                                ),
-                              )
-                            : IconButton(
-                                icon: const Icon(Icons.picture_as_pdf,
-                                    color: AppColors.info),
-                                tooltip: 'Télécharger le bulletin PDF',
-                                onPressed: payroll.pdfPath != null
-                                    ? () => _downloadPdf(payroll.id)
-                                    : null,
-                              ),
+                              ],
+                            ),
+                          );
+                        },
                       ),
-                    );
-                  },
-                ),
-          loading: () => const SingleChildScrollView(
-            physics: AlwaysScrollableScrollPhysics(),
-            child: SizedBox(
-              height: 400,
-              child: Center(
-                child: CircularProgressIndicator(
-                  semanticsLabel: 'Chargement des fiches de paie...',
-                ),
-              ),
-            ),
-          ),
-          error: (e, _) => SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            child: SizedBox(
-              height: 400,
-              child: Center(
-                child: Text(
-                  e.toString(),
-                  style: const TextStyle(color: AppColors.danger),
+          loading:
+              () => const SingleChildScrollView(
+                physics: AlwaysScrollableScrollPhysics(),
+                child: SizedBox(
+                  height: 400,
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      semanticsLabel: 'Chargement des fiches de paie...',
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
+          error:
+              (e, _) => SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: SizedBox(
+                  height: 400,
+                  child: Center(
+                    child: Text(
+                      e.toString(),
+                      style: const TextStyle(color: AppColors.danger),
+                    ),
+                  ),
+                ),
+              ),
         ),
       ),
     );

--- a/front/mobile/lib/features/settings/screens/settings_screen.dart
+++ b/front/mobile/lib/features/settings/screens/settings_screen.dart
@@ -531,7 +531,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           const SizedBox(height: 8),
-          const Text(
+          Text(
             'Une fois soumises, vos donnees biometrie restent en attente. Toute premiere activation ou modification necessite une approbation manager/RH.',
             style: AppTypography.caption.copyWith(
               color: MobileSurface.secondary,

--- a/front/mobile/lib/features/settings/screens/settings_screen.dart
+++ b/front/mobile/lib/features/settings/screens/settings_screen.dart
@@ -7,6 +7,8 @@ import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:leopardo_rh/core/providers/core_providers.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
+import 'package:leopardo_rh/core/theme/app_typography.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_rh/features/settings/data/biometric_enrollment.dart';
 import 'package:leopardo_rh/features/settings/data/settings_repository.dart';
@@ -123,10 +125,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final isManager = employee?.isManager == true;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Parametres'),
+      backgroundColor: MobileSurface.background,
+      appBar: MobileTopBar(
+        title: 'Compte',
+        subtitle: 'Profil, langue et securite',
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => context.pop(),
         ),
@@ -153,23 +157,22 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget _buildIdentityCard(BuildContext context, String? role) {
     return Container(
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(16),
-      ),
+      decoration: MobileSurface.cardDecoration(),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             'Acces mobile',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
           ),
           const SizedBox(height: 8),
           Text(
             role == 'manager'
                 ? 'Profil RH / manager: acces au suivi de l equipe et a l historique.'
                 : 'Profil employe: acces au pointage, a l historique personnel et aux parametres de preparation biometrie.',
-            style: const TextStyle(color: AppColors.textMuted),
+            style: AppTypography.bodySmall.copyWith(
+              color: MobileSurface.secondary,
+            ),
           ),
         ],
       ),
@@ -179,18 +182,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget _buildProfileSection(BuildContext context, AuthState authState) {
     return Container(
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(16),
-      ),
+      decoration: MobileSurface.cardDecoration(),
       child: Form(
         key: _profileFormKey,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
+            Text(
               'Mon profil',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
             ),
             const SizedBox(height: 16),
             TextFormField(
@@ -250,21 +250,20 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget _buildLanguageSection(BuildContext context, AuthState authState) {
     return Container(
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(16),
-      ),
+      decoration: MobileSurface.cardDecoration(),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             'Langue',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
           ),
           const SizedBox(height: 8),
-          const Text(
+          Text(
             'Cette preference est synchronisee avec votre compte et pilote aussi le mode RTL.',
-            style: TextStyle(color: AppColors.textMuted),
+            style: AppTypography.bodySmall.copyWith(
+              color: MobileSurface.secondary,
+            ),
           ),
           const SizedBox(height: 16),
           DropdownButtonFormField<String>(
@@ -310,23 +309,22 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget _buildPasswordSection(BuildContext context, AuthState authState) {
     return Container(
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(16),
-      ),
+      decoration: MobileSurface.cardDecoration(),
       child: Form(
         key: _passwordFormKey,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
+            Text(
               'Securite',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
             ),
             const SizedBox(height: 8),
-            const Text(
+            Text(
               'Changez votre mot de passe avant les prochaines etapes de modernisation.',
-              style: TextStyle(color: AppColors.textMuted),
+              style: AppTypography.bodySmall.copyWith(
+                color: MobileSurface.secondary,
+              ),
             ),
             const SizedBox(height: 16),
             TextFormField(
@@ -391,27 +389,28 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final employee = ref.read(authProvider).employee;
     return Container(
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(16),
-      ),
+      decoration: MobileSurface.cardDecoration(),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             'Preparation biometrie',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
           ),
           const SizedBox(height: 8),
           Text(
             'Le visage peut etre capture depuis le mobile puis soumis a validation manager / RH. Pour l empreinte, Android/iOS permettent de verifier localement que vous utilisez bien un doigt enregistre, mais ne donnent pas acces au gabarit brut; l activation effective cote pointage restera donc approuvee puis exploitee par la borne entreprise.',
-            style: const TextStyle(color: AppColors.textMuted),
+            style: AppTypography.bodySmall.copyWith(
+              color: MobileSurface.secondary,
+            ),
           ),
           const SizedBox(height: 12),
           if (employee != null)
             Text(
               'Actif aujourd hui - visage: ${employee.biometricFaceEnabled ? "oui" : "non"} | empreinte: ${employee.biometricFingerprintEnabled ? "oui" : "non"}',
-              style: const TextStyle(color: AppColors.textMuted),
+              style: AppTypography.caption.copyWith(
+                color: MobileSurface.secondary,
+              ),
             ),
           if (_latestEnrollment != null) ...[
             const SizedBox(height: 8),
@@ -431,7 +430,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 padding: const EdgeInsets.only(top: 4),
                 child: Text(
                   'Retour manager/RH: ${_latestEnrollment!.managerNote}',
-                  style: const TextStyle(color: AppColors.textMuted),
+                  style: AppTypography.caption.copyWith(
+                    color: MobileSurface.secondary,
+                  ),
                 ),
               ),
           ],
@@ -532,7 +533,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           const SizedBox(height: 8),
           const Text(
             'Une fois soumises, vos donnees biometrie restent en attente. Toute premiere activation ou modification necessite une approbation manager/RH.',
-            style: TextStyle(color: AppColors.textMuted, fontSize: 12),
+            style: AppTypography.caption.copyWith(
+              color: MobileSurface.secondary,
+            ),
           ),
         ],
       ),

--- a/front/mobile/test/widgets/mobile_surface_test.dart
+++ b/front/mobile/test/widgets/mobile_surface_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leopardo_rh/core/theme/app_colors.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
+
+void main() {
+  testWidgets(
+    'MobileSurface widgets render the dark mobile design primitives',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            appBar: const MobileTopBar(
+              title: 'Compte',
+              subtitle: 'Profil et securite',
+            ),
+            body: const MobilePanel(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  MobileSectionLabel('Cette semaine'),
+                  MobileIconBubble(
+                    icon: Icons.fingerprint,
+                    color: AppColors.rh,
+                  ),
+                  MobileStatusPill(
+                    label: 'Present',
+                    color: AppColors.rh,
+                    icon: Icons.check_circle,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Compte'), findsOneWidget);
+      expect(find.text('Profil et securite'), findsOneWidget);
+      expect(find.text('CETTE SEMAINE'), findsOneWidget);
+      expect(find.byIcon(Icons.fingerprint), findsOneWidget);
+      expect(find.text('Present'), findsOneWidget);
+    },
+  );
+
+  testWidgets('MobilePrimaryAction exposes the requested tap callback', (
+    tester,
+  ) async {
+    var tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: MobilePrimaryAction(
+            icon: Icons.play_arrow,
+            label: 'Pointer',
+            onPressed: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Pointer'));
+    await tester.pump();
+
+    expect(tapped, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared MobileSurface widgets for the v3 mobile dark design language.
- Switch the mobile app to the refined dark theme inspired by the attendance v3 reference.
- Polish high-traffic screens: Home, Modules, Notifications, Absences, Payrolls, Settings.

## Validation
- dart format on changed mobile files
- git diff --check
- node shared/i18n/validators/validate.js

Note: local flutter analyze is blocked because this workstation has Dart 3.7.2 while flutter_lints 6.0.0 requires Dart ^3.8.0; GitHub Actions Flutter is the source of truth.