### PR TITLE
fix(mobile): stop attendance history reload loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,3 +500,5 @@ Procedure recommandee :
 - Les actions check-in/check-out/correction doivent rester bornees et afficher un SnackBar succes/echec clair ; ne pas relancer de retry long cote mobile qui donne l'impression que le bouton tourne sans fin.
 - La creation mobile d'employe doit conserver les champs RH minimum : `contract_start`, `salary_type`, `salary_base` ou `hourly_rate`, `matricule` et `extra_data.department/job_title/work_location`. Le backend `StoreEmployeeRequest`, `EmployeeController@index` et `EmployeeResource` doivent rester alignes avec ce contrat.
 - Le module mobile Avances doit proposer une vraie demande employee-side via `POST /salary-advances` avec `amount`, `reason` et `repayment_months`, puis rafraichir la liste locale.
+- Depuis v4.16.138, l'ecran pointage doit utiliser `attendanceHistoryMonthKey(_now)` pour `historyProvider` ; ne jamais repasser `_now` complet comme cle provider, sinon l'historique se recharge chaque seconde avec l'horloge live.
+- Les actions pointage doivent rester protegees contre doubles taps et timeout provider : un succes API ou une erreur reseau ne doit jamais laisser `isPunching=true` indefiniment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.138] - 2026-05-25
+
+### Added
+
+- Documentation : Plan 25 de modernisation mobile marketing-ready, couvrant pointage fiable, design system mobile, workflows employe/manager/RH et readiness lancement.
+- Mobile : helper teste `attendanceHistoryMonthKey()` pour garantir que l'historique pointage reste cle par mois et non par tick d'horloge.
+
+### Fixed
+
+- Mobile : l'historique pointage n'est plus reobserve avec un `DateTime` qui change chaque seconde, ce qui evitait des rechargements API continus pendant l'horloge live.
+- Mobile : pointage protege contre les doubles taps et garde timeout provider pour que l'etat `isPunching` retombe toujours, meme si l'API ou le reseau ne repond plus.
+
 ## [4.16.137] - 2026-05-25
 
 ### Changed

--- a/docs/PLAN_ACTION/25_PLAN_MODERNISATION_MOBILE_MARKETING_READY.md
+++ b/docs/PLAN_ACTION/25_PLAN_MODERNISATION_MOBILE_MARKETING_READY.md
@@ -1,0 +1,60 @@
+# Plan 25 - Modernisation mobile marketing-ready
+
+Date : 2026-05-25
+Statut : en execution iterative
+
+## Objectif
+
+Rendre l'application mobile Leopardo RH moderne, lisible, fiable et demonstrable devant des prospects. Le mobile doit etre agreable au quotidien pour les employes, managers et RH, tout en consommant les vraies API Render sans etats bloquants ni boutons decoratifs.
+
+## Diagnostic actuel
+
+- Pointage : le bouton peut donner une impression de chargement infini si des etats secondaires restent actifs ou si l'historique est recharge trop souvent.
+- Navigation : les modules existent, mais l'experience doit mieux separer les actions quotidiennes, les demandes RH et les espaces manager/RH.
+- Design : la base sombre est coherente, mais il faut renforcer la lisibilite, les etats vides utiles, les feedbacks courts et les surfaces communes.
+- API : les routes principales existent ; le mobile doit normaliser les payloads, borner les delais et afficher des messages clairs quand Render ou le reseau ralentit.
+- Marketing : les ecrans demo doivent raconter immediatement la valeur produit : pointer, demander une absence, demander une avance, consulter son equipe, lire ses notifications.
+
+## Lot 25.1 - Pointage fiable et non bloquant
+
+- Stabiliser la cle de chargement historique pour ne pas relancer `GET /attendance` a chaque tick de l'horloge.
+- Empecher les doubles taps pendant un pointage.
+- Ajouter un garde timeout cote provider pour que `isPunching` retombe toujours.
+- Conserver un feedback immediat : haptique, SnackBar de confirmation, carte du jour mise a jour.
+- Garder les chargements historiques non bloquants pour que le pointage reste utilisable.
+
+## Lot 25.2 - Design system mobile premium
+
+- Centraliser les surfaces : fond, cartes, boutons, chips, messages, sections.
+- Harmoniser les ecrans critiques : Accueil, Pointage, Absences, Avances, Equipe, Compte.
+- Revoir les contrastes, les tailles tactiles, les espacements, les etats vides et erreurs.
+- Limiter la surcharge visuelle sur l'accueil : 3 actions prioritaires, modules secondaires plus discrets.
+
+## Lot 25.3 - Workflows employe reelement livrables
+
+- Absence : demande, historique, statut, annulation si autorisee.
+- Avance : demande, statut, plan de remboursement, message RH clair.
+- Pointage : arrivee, depart, correction employee-side et modification RH/manager.
+- Documents/paie : consultation mobile lisible, erreurs API explicites.
+
+## Lot 25.4 - Workflows manager/RH mobile
+
+- Equipe : liste, ajout, archive, invitations, refresh garanti.
+- Presence equipe : resume du jour, retards, absences, corrections.
+- Validation : absences, avances et autres demandes avec decision claire.
+- Filtrage par role/capabilities afin qu'un utilisateur ne voie que ses ressources.
+
+## Lot 25.5 - Qualite marketing et lancement
+
+- Captures ou parcours demo mobiles stables pour landing page, videos et commerciaux.
+- E2E/smoke mobile couvrant login demo, pointage, demande absence, demande avance, equipe manager.
+- Guide QA mobile avec comptes demo, URL API, scenarios et resultats attendus.
+- Observabilite UX : evenements de succes/echec sur pointage, demande RH et navigation modules.
+
+## Definition of done
+
+- Aucun bouton critique ne tourne indefiniment.
+- Chaque action visible appelle une vraie API ou affiche clairement pourquoi elle est indisponible.
+- Les ecrans principaux sont lisibles en petit mobile, grands telephones et RTL.
+- Les tests Flutter Analyze/Test/APK restent verts en CI.
+- Les contrats API/OpenAPI/docs sont alignes a chaque nouvelle route ou payload mobile.

--- a/front/mobile/lib/features/attendance/providers/attendance_provider.dart
+++ b/front/mobile/lib/features/attendance/providers/attendance_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:leopardo_rh/features/attendance/data/attendance_repository.dart';
@@ -53,6 +55,7 @@ class AttendanceState {
 class AttendanceNotifier extends StateNotifier<AttendanceState> {
   final AttendanceRepository _repository;
   final Ref _ref;
+  static const _punchGuardTimeout = Duration(seconds: 12);
 
   AttendanceNotifier(this._repository, this._ref) : super(AttendanceState()) {
     loadTodayData();
@@ -106,13 +109,14 @@ class AttendanceNotifier extends StateNotifier<AttendanceState> {
   }
 
   Future<bool> checkIn() async {
+    if (state.isPunching) return false;
     state = state.copyWith(
       isPunching: true,
       clearError: true,
       clearNotice: true,
     );
     try {
-      final log = await _repository.checkIn();
+      final log = await _repository.checkIn().timeout(_punchGuardTimeout);
       state = state.copyWith(
         todayLog: log,
         isPunching: false,
@@ -122,6 +126,7 @@ class AttendanceNotifier extends StateNotifier<AttendanceState> {
       return true;
     } catch (e) {
       if (e is ApiException && e.statusCode == 401) {
+        state = state.copyWith(isPunching: false);
         await _ref.read(authProvider.notifier).logout();
         return false;
       }
@@ -131,13 +136,14 @@ class AttendanceNotifier extends StateNotifier<AttendanceState> {
   }
 
   Future<bool> checkOut() async {
+    if (state.isPunching) return false;
     state = state.copyWith(
       isPunching: true,
       clearError: true,
       clearNotice: true,
     );
     try {
-      final log = await _repository.checkOut();
+      final log = await _repository.checkOut().timeout(_punchGuardTimeout);
       state = state.copyWith(
         todayLog: log,
         isPunching: false,
@@ -147,6 +153,7 @@ class AttendanceNotifier extends StateNotifier<AttendanceState> {
       return true;
     } catch (e) {
       if (e is ApiException && e.statusCode == 401) {
+        state = state.copyWith(isPunching: false);
         await _ref.read(authProvider.notifier).logout();
         return false;
       }
@@ -182,6 +189,7 @@ class AttendanceNotifier extends StateNotifier<AttendanceState> {
       return true;
     } catch (e) {
       if (e is ApiException && e.statusCode == 401) {
+        state = state.copyWith(isPunching: false);
         await _ref.read(authProvider.notifier).logout();
         return false;
       }
@@ -210,6 +218,7 @@ class AttendanceNotifier extends StateNotifier<AttendanceState> {
       return true;
     } catch (e) {
       if (e is ApiException && e.statusCode == 401) {
+        state = state.copyWith(isPunching: false);
         await _ref.read(authProvider.notifier).logout();
         return false;
       }

--- a/front/mobile/lib/features/attendance/screens/attendance_screen.dart
+++ b/front/mobile/lib/features/attendance/screens/attendance_screen.dart
@@ -11,6 +11,10 @@ import 'package:leopardo_rh/features/attendance/providers/attendance_provider.da
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_rh/models/attendance_log.dart';
 
+DateTime attendanceHistoryMonthKey(DateTime value) {
+  return DateTime(value.year, value.month);
+}
+
 class AttendanceScreen extends ConsumerStatefulWidget {
   const AttendanceScreen({super.key});
 
@@ -70,7 +74,8 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   Widget build(BuildContext context) {
     final authState = ref.watch(authProvider);
     final attState = ref.watch(attendanceProvider);
-    final weekAsync = ref.watch(historyProvider(_now));
+    final historyMonth = attendanceHistoryMonthKey(_now);
+    final weekAsync = ref.watch(historyProvider(historyMonth));
     final weekLogs = weekAsync.maybeWhen(
       data: (value) => value,
       orElse: () => const <AttendanceLog>[],
@@ -90,7 +95,7 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
           color: AppColors.rh,
           backgroundColor: _card,
           onRefresh: () async {
-            ref.invalidate(historyProvider(_now));
+            ref.invalidate(historyProvider(historyMonth));
             await ref.read(attendanceProvider.notifier).loadTodayData();
           },
           child: ListView(
@@ -139,6 +144,7 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }
 
   Future<void> _handlePunch(bool isCheckedIn) async {
+    if (ref.read(attendanceProvider).isPunching) return;
     HapticFeedback.mediumImpact();
     ScaffoldMessenger.of(context).clearSnackBars();
     final messenger = ScaffoldMessenger.of(context);
@@ -185,7 +191,9 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
         ),
       );
     }
-    if (success) ref.invalidate(historyProvider(_now));
+    if (success) {
+      ref.invalidate(historyProvider(attendanceHistoryMonthKey(_now)));
+    }
   }
 
   Widget _buildHeader({

--- a/front/mobile/test/features/attendance/attendance_screen_test.dart
+++ b/front/mobile/test/features/attendance/attendance_screen_test.dart
@@ -1,7 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leopardo_rh/features/attendance/data/attendance_repository.dart';
+import 'package:leopardo_rh/features/attendance/screens/attendance_screen.dart';
 
 void main() {
+  test('uses stable month key for attendance history refreshes', () {
+    final firstTick = attendanceHistoryMonthKey(DateTime(2026, 5, 25, 8, 0, 1));
+    final nextTick = attendanceHistoryMonthKey(DateTime(2026, 5, 25, 8, 0, 2));
+
+    expect(firstTick, DateTime(2026, 5));
+    expect(nextTick, firstTick);
+  });
+
   test('decodes normalized today payload for a single employee', () {
     final decoded = AttendanceRepository.decodeTodayResponse({
       'data': {


### PR DESCRIPTION
## Summary
- Fix the attendance screen history provider key so the live clock no longer re-triggers history API loading every second.
- Add double-tap protection and a provider timeout guard so isPunching cannot remain true indefinitely.
- Add Plan 25 for mobile modernization marketing readiness and document the new attendance guardrail.

## Validation
- dart format on modified Flutter files
- git diff --check

## Local limitation
- lutter analyze and lutter test are blocked locally by Dart SDK 3.7.2 while lutter_lints ^6.0.0 requires Dart ^3.8.0; CI uses the correct Flutter SDK.