### PR TITLE
feat(mobile): modernize HR workflow screens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,3 +502,5 @@ Procedure recommandee :
 - Le module mobile Avances doit proposer une vraie demande employee-side via `POST /salary-advances` avec `amount`, `reason` et `repayment_months`, puis rafraichir la liste locale.
 - Depuis v4.16.138, l'ecran pointage doit utiliser `attendanceHistoryMonthKey(_now)` pour `historyProvider` ; ne jamais repasser `_now` complet comme cle provider, sinon l'historique se recharge chaque seconde avec l'horloge live.
 - Les actions pointage doivent rester protegees contre doubles taps et timeout provider : un succes API ou une erreur reseau ne doit jamais laisser `isPunching=true` indefiniment.
+- Depuis v4.16.139, les ecrans RH mobiles a fort impact demo (`Absences`, `Avances`, `Equipe`) doivent utiliser les composants de `front/mobile/lib/core/widgets/mobile_surface.dart` pour les listes, chargements et erreurs. Eviter de revenir a des `ListTile`/`AppBar` Material bruts sur ces parcours marketing-ready.
+- Depuis v4.16.139, la demande d'absence mobile doit resoudre un vrai `absence_type_id` via `leaveBalancesProvider` avant `POST /absences`; ne pas hardcoder de type d'absence cote Flutter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.139] - 2026-05-25
+
+### Changed
+
+- Mobile : lot 25.2 demarre la coherence visuelle premium avec composants partages `MobileEmptyLoading`, `MobileErrorPanel`, `MobileListCard` et `MobileMetricTile`.
+- Mobile : accueil allege pour reduire la surcharge, avec trois actions rapides prioritaires et quatre modules actifs visibles.
+- Mobile : ecrans Absences, Avances et Equipe modernises sur les surfaces sombres communes, avec etats de chargement, erreur et retry lisibles.
+- Mobile : demande d absence rendue actionnable depuis l ecran Absences via les soldes/types existants puis `POST /absences`.
+- Mobile : ecran Equipe manager/RH modernise sans perdre les champs metier critiques : date d embauche, role, type de paie, salaire/taux horaire et invitation.
+
 ## [4.16.138] - 2026-05-25
 
 ### Added

--- a/docs/PLAN_ACTION/25_PLAN_MODERNISATION_MOBILE_MARKETING_READY.md
+++ b/docs/PLAN_ACTION/25_PLAN_MODERNISATION_MOBILE_MARKETING_READY.md
@@ -30,6 +30,15 @@ Rendre l'application mobile Leopardo RH moderne, lisible, fiable et demonstrable
 - Revoir les contrastes, les tailles tactiles, les espacements, les etats vides et erreurs.
 - Limiter la surcharge visuelle sur l'accueil : 3 actions prioritaires, modules secondaires plus discrets.
 
+Etat v4.16.139 :
+
+- Livré : composants `MobileEmptyLoading`, `MobileErrorPanel`, `MobileListCard` et `MobileMetricTile`.
+- Livré : accueil allege a trois actions prioritaires et quatre modules actifs pour une premiere page moins surchargee.
+- Livré : ecrans Absences, Avances et Equipe alignes sur les surfaces mobiles sombres, avec erreurs/retry lisibles.
+- Livré : demande d absence mobile branchee sur les soldes/types existants puis `POST /absences`.
+- Livré : demande d avance mobile conservee sur `POST /salary-advances`, avec UI coherente.
+- Livré : equipe manager/RH modernisee, ajout employe garde date d embauche, role, salaire et invitation API.
+
 ## Lot 25.3 - Workflows employe reelement livrables
 
 - Absence : demande, historique, statut, annulation si autorisee.

--- a/front/mobile/lib/core/widgets/mobile_surface.dart
+++ b/front/mobile/lib/core/widgets/mobile_surface.dart
@@ -246,3 +246,194 @@ class MobilePrimaryAction extends StatelessWidget {
     );
   }
 }
+
+class MobileEmptyLoading extends StatelessWidget {
+  const MobileEmptyLoading({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 12),
+          Text(
+            label,
+            style: AppTypography.bodySmall.copyWith(
+              color: MobileSurface.secondary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class MobileErrorPanel extends StatelessWidget {
+  const MobileErrorPanel({super.key, required this.message, this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return MobilePanel(
+      color: AppColors.danger.withValues(alpha: 0.08),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const MobileIconBubble(
+            icon: Icons.wifi_off_rounded,
+            color: AppColors.danger,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Connexion indisponible',
+            style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            message,
+            style: AppTypography.bodySmall.copyWith(
+              color: MobileSurface.secondary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(height: 14),
+            OutlinedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('Reessayer'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class MobileListCard extends StatelessWidget {
+  const MobileListCard({
+    super.key,
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    this.trailing,
+    this.onTap,
+    this.footer,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+  final Widget? footer;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = MobilePanel(
+      padding: const EdgeInsets.all(14),
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              MobileIconBubble(icon: icon, color: iconColor),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: MobileSurface.text,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle,
+                      style: AppTypography.caption.copyWith(
+                        color: MobileSurface.secondary,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              if (trailing != null) ...[const SizedBox(width: 10), trailing!],
+            ],
+          ),
+          if (footer != null) ...[const SizedBox(height: 12), footer!],
+        ],
+      ),
+    );
+
+    if (onTap == null) return content;
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: onTap,
+      child: content,
+    );
+  }
+}
+
+class MobileMetricTile extends StatelessWidget {
+  const MobileMetricTile({
+    super.key,
+    required this.value,
+    required this.label,
+    required this.color,
+  });
+
+  final String value;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 12),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: color.withValues(alpha: 0.20), width: 0.7),
+        ),
+        child: Column(
+          children: [
+            Text(
+              value,
+              style: AppTypography.subtitle.copyWith(color: color),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const SizedBox(height: 3),
+            Text(
+              label,
+              style: AppTypography.caption.copyWith(
+                color: MobileSurface.secondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/front/mobile/lib/features/absences/screens/absence_list_screen.dart
+++ b/front/mobile/lib/features/absences/screens/absence_list_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:leopardo_rh/core/providers/core_providers.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
@@ -17,98 +19,116 @@ class AbsenceListScreen extends ConsumerWidget {
       backgroundColor: MobileSurface.background,
       appBar: MobileTopBar(
         title: 'Mes Absences',
-        subtitle: 'Demandes et decisions RH',
+        subtitle: 'Demandes, soldes et decisions RH',
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _showAbsenceRequestSheet(context),
+        icon: const Icon(Icons.event_available_outlined),
+        label: const Text('Demander'),
+      ),
       body: RefreshIndicator(
         color: AppColors.rh,
         backgroundColor: MobileSurface.background,
         onRefresh: () async => ref.refresh(absencesProvider.future),
         child: absencesAsync.when(
-          data:
-              (absences) =>
-                  absences.isEmpty
-                      ? ListView(
-                        physics: const AlwaysScrollableScrollPhysics(),
-                        children: const [
-                          SizedBox(height: 80),
-                          EmptyState(
-                            icon: Icons.calendar_today,
-                            title: 'Aucune absence',
-                            description:
-                                'Vous n\'avez pas encore fait de demande d\'absence.',
-                          ),
-                        ],
-                      )
-                      : ListView.builder(
-                        padding: const EdgeInsets.all(20),
-                        itemCount: absences.length,
-                        itemBuilder: (context, index) {
-                          final absence = absences[index];
-                          final color = _getStatusColor(absence.status);
-                          return MobilePanel(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            child: Row(
-                              children: [
-                                MobileIconBubble(
-                                  icon: Icons.event_available_outlined,
-                                  color: color,
-                                ),
-                                const SizedBox(width: 12),
-                                Expanded(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        absence.absenceTypeName ?? 'Absence',
-                                        style: AppTypography.bodySmall.copyWith(
-                                          color: MobileSurface.text,
-                                          fontWeight: FontWeight.w700,
-                                        ),
-                                      ),
-                                      const SizedBox(height: 4),
-                                      Text(
-                                        '${absence.startDate.day}/${absence.startDate.month} - ${absence.endDate.day}/${absence.endDate.month}',
-                                        style: AppTypography.caption.copyWith(
-                                          color: MobileSurface.secondary,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                                MobileStatusPill(
-                                  label: absence.status,
-                                  color: color,
-                                ),
-                              ],
+          data: (absences) {
+            if (absences.isEmpty) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.fromLTRB(24, 80, 24, 160),
+                children: const [
+                  EmptyState(
+                    icon: Icons.calendar_today,
+                    title: 'Aucune absence',
+                    description:
+                        'Demandez une absence depuis le bouton principal, puis suivez la decision RH ici.',
+                  ),
+                ],
+              );
+            }
+
+            return ListView.builder(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 110),
+              itemCount: absences.length,
+              itemBuilder: (context, index) {
+                final absence = absences[index];
+                final color = _getStatusColor(absence.status);
+                final dateLabel =
+                    '${_formatDate(absence.startDate)} - ${_formatDate(absence.endDate)}';
+
+                return MobileListCard(
+                  icon: Icons.event_available_outlined,
+                  iconColor: color,
+                  title: absence.absenceTypeName ?? 'Absence',
+                  subtitle:
+                      '$dateLabel - ${absence.daysCount.toStringAsFixed(1)} j',
+                  trailing: MobileStatusPill(
+                    label: _statusLabel(absence.status),
+                    color: color,
+                  ),
+                  footer:
+                      absence.reason == null || absence.reason!.trim().isEmpty
+                          ? null
+                          : Text(
+                            absence.reason!,
+                            style: AppTypography.caption.copyWith(
+                              color: MobileSurface.secondary,
                             ),
-                          );
-                        },
-                      ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                );
+              },
+            );
+          },
           loading:
-              () => const Center(
-                child: CircularProgressIndicator(
-                  semanticsLabel: 'Chargement des absences...',
-                ),
-              ),
+              () => const MobileEmptyLoading(label: 'Chargement des absences'),
           error:
-              (e, _) => Center(
-                child: Text(
-                  e.toString(),
-                  style: const TextStyle(color: AppColors.danger),
-                ),
+              (e, _) => ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.all(20),
+                children: [
+                  MobileErrorPanel(
+                    message: e.toString(),
+                    onRetry: () => ref.invalidate(absencesProvider),
+                  ),
+                ],
               ),
         ),
       ),
     );
   }
 
-  Color _getStatusColor(String status) {
+  void _showAbsenceRequestSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: MobileSurface.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (_) => const _AbsenceRequestSheet(),
+    );
+  }
+
+  static String _formatDate(DateTime date) {
+    return DateFormat('d MMM', 'fr_FR').format(date);
+  }
+
+  static String _statusLabel(String status) => switch (status) {
+    'approved' => 'approuvee',
+    'pending' => 'en attente',
+    'rejected' => 'rejetee',
+    'cancelled' => 'annulee',
+    _ => status,
+  };
+
+  static Color _getStatusColor(String status) {
     switch (status) {
       case 'approved':
         return AppColors.rh;
@@ -117,7 +137,301 @@ class AbsenceListScreen extends ConsumerWidget {
       case 'rejected':
         return AppColors.danger;
       default:
-        return AppColors.textMutedDark;
+        return MobileSurface.disabled;
     }
+  }
+}
+
+class _AbsenceRequestSheet extends ConsumerStatefulWidget {
+  const _AbsenceRequestSheet();
+
+  @override
+  ConsumerState<_AbsenceRequestSheet> createState() =>
+      _AbsenceRequestSheetState();
+}
+
+class _AbsenceRequestSheetState extends ConsumerState<_AbsenceRequestSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _reasonController = TextEditingController();
+  DateTime _startDate = DateTime.now().add(const Duration(days: 1));
+  DateTime _endDate = DateTime.now().add(const Duration(days: 1));
+  _AbsenceTypeOption? _selectedType;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+    final balances = ref.watch(leaveBalancesProvider);
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(22, 18, 22, bottom + 24),
+      child: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Container(
+                  width: 38,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: MobileSurface.border,
+                    borderRadius: BorderRadius.circular(99),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                'Nouvelle absence',
+                style: AppTypography.subtitle.copyWith(
+                  color: MobileSurface.text,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Choisissez le type de solde et la periode a transmettre au RH.',
+                style: AppTypography.bodySmall.copyWith(
+                  color: MobileSurface.secondary,
+                ),
+              ),
+              const SizedBox(height: 18),
+              balances.when(
+                data: (rawBalances) {
+                  final options =
+                      rawBalances
+                          .map(_AbsenceTypeOption.fromBalance)
+                          .where((option) => option != null)
+                          .cast<_AbsenceTypeOption>()
+                          .toList();
+                  _selectedType ??= options.isNotEmpty ? options.first : null;
+
+                  if (options.isEmpty) {
+                    return MobileErrorPanel(
+                      message:
+                          'Aucun type d absence disponible pour ce compte. Contactez le RH pour configurer les soldes.',
+                      onRetry: () => ref.invalidate(leaveBalancesProvider),
+                    );
+                  }
+
+                  return DropdownButtonFormField<_AbsenceTypeOption>(
+                    initialValue:
+                        options.contains(_selectedType)
+                            ? _selectedType
+                            : options.first,
+                    dropdownColor: MobileSurface.surface,
+                    decoration: const InputDecoration(labelText: 'Type'),
+                    items:
+                        options
+                            .map(
+                              (option) => DropdownMenuItem(
+                                value: option,
+                                child: Text(option.label),
+                              ),
+                            )
+                            .toList(),
+                    validator:
+                        (value) =>
+                            value == null ? 'Type d absence requis' : null,
+                    onChanged: (value) => setState(() => _selectedType = value),
+                  );
+                },
+                loading:
+                    () => const MobileEmptyLoading(
+                      label: 'Chargement des soldes',
+                    ),
+                error:
+                    (error, _) => MobileErrorPanel(
+                      message: error.toString(),
+                      onRetry: () => ref.invalidate(leaveBalancesProvider),
+                    ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: _DateTile(
+                      label: 'Debut',
+                      value: _startDate,
+                      onTap: () => _pickDate(isStart: true),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: _DateTile(
+                      label: 'Fin',
+                      value: _endDate,
+                      onTap: () => _pickDate(isStart: false),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _reasonController,
+                maxLines: 3,
+                maxLength: 180,
+                style: const TextStyle(color: MobileSurface.text),
+                decoration: const InputDecoration(
+                  labelText: 'Motif',
+                  hintText: 'Ex: rendez-vous medical, conge familial...',
+                ),
+                validator:
+                    (value) =>
+                        value == null || value.trim().length < 4
+                            ? 'Motif obligatoire'
+                            : null,
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: _submitting ? null : _submit,
+                child:
+                    _submitting
+                        ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                        : const Text('Soumettre au RH'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickDate({required bool isStart}) async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: isStart ? _startDate : _endDate,
+      firstDate: DateTime(now.year, now.month, now.day),
+      lastDate: DateTime(now.year + 2),
+    );
+    if (picked == null) return;
+
+    setState(() {
+      if (isStart) {
+        _startDate = picked;
+        if (_endDate.isBefore(_startDate)) _endDate = _startDate;
+      } else {
+        _endDate = picked.isBefore(_startDate) ? _startDate : picked;
+      }
+    });
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final selectedType = _selectedType;
+    if (selectedType == null) return;
+
+    setState(() => _submitting = true);
+    try {
+      await ref
+          .read(absenceRepositoryProvider)
+          .requestAbsence(
+            absenceTypeId: selectedType.id,
+            startDate: _startDate,
+            endDate: _endDate,
+            reason: _reasonController.text,
+          );
+      ref.invalidate(absencesProvider);
+      ref.invalidate(leaveBalancesProvider);
+      await ref.refresh(absencesProvider.future).then((_) {});
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Demande d absence transmise au RH.')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Echec : $error')));
+    }
+  }
+}
+
+class _DateTile extends StatelessWidget {
+  const _DateTile({
+    required this.label,
+    required this.value,
+    required this.onTap,
+  });
+
+  final String label;
+  final DateTime value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: MobileSurface.cardDecoration(
+          color: MobileSurface.chip,
+          radius: 12,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label,
+              style: AppTypography.caption.copyWith(
+                color: MobileSurface.disabled,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              DateFormat('d MMM yyyy', 'fr_FR').format(value),
+              style: AppTypography.bodySmall.copyWith(
+                color: MobileSurface.text,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AbsenceTypeOption {
+  const _AbsenceTypeOption({required this.id, required this.label});
+
+  final int id;
+  final String label;
+
+  static _AbsenceTypeOption? fromBalance(Map<String, dynamic> balance) {
+    final rawType = balance['absence_type'] ?? balance['absenceType'];
+    if (rawType is! Map) return null;
+    final type = rawType.cast<String, dynamic>();
+    final id = int.tryParse(type['id']?.toString() ?? '');
+    if (id == null) return null;
+
+    final name = type['name']?.toString();
+    final remaining =
+        balance['remaining_days'] ??
+        balance['remaining'] ??
+        balance['balance'] ??
+        balance['available_days'];
+    final suffix =
+        remaining == null ? '' : ' - ${remaining.toString()} j disponibles';
+
+    return _AbsenceTypeOption(
+      id: id,
+      label: '${name == null || name.isEmpty ? 'Absence' : name}$suffix',
+    );
   }
 }

--- a/front/mobile/lib/features/home/screens/home_screen.dart
+++ b/front/mobile/lib/features/home/screens/home_screen.dart
@@ -6,7 +6,6 @@ import 'package:intl/intl.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/theme/mobile_experience_icons.dart';
-import 'package:leopardo_rh/core/widgets/alert_banner.dart';
 import 'package:leopardo_rh/core/widgets/leopardo_badge.dart';
 import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
@@ -26,8 +25,8 @@ class HomeScreen extends ConsumerWidget {
           quickActions: <MobileQuickAction>[],
         );
     final stage = experience.stage;
-    final quickActions = experience.quickActions.take(4).toList();
-    final activeModules = experience.activeModules.take(6).toList();
+    final quickActions = experience.quickActions.take(3).toList();
+    final activeModules = experience.activeModules.take(4).toList();
     final firstName =
         employee?.firstName.isNotEmpty == true
             ? employee!.firstName
@@ -61,15 +60,13 @@ class HomeScreen extends ConsumerWidget {
                       stage: stage,
                       canManageTeam: canManageTeam,
                     ),
-                    const SizedBox(height: 14),
-                    _AlertStack(stage: stage, canManageTeam: canManageTeam),
-                    const SizedBox(height: 20),
+                    const SizedBox(height: 18),
                     _SectionTitle(
                       title: 'Actions rapides',
                       subtitle:
                           stage == 'new'
-                              ? 'Les premiers gestes utiles, sans surcharge.'
-                              : 'Les raccourcis du jour, prets a l emploi.',
+                              ? 'Les premiers gestes vraiment utiles.'
+                              : 'Vos trois gestes RH du jour.',
                     ),
                     const SizedBox(height: 12),
                     _QuickActionsGrid(actions: quickActions),
@@ -208,27 +205,6 @@ class _HeroHeader extends StatelessWidget {
     if (hour < 12) return 'Bonjour';
     if (hour < 18) return 'Bon apres-midi';
     return 'Bonsoir';
-  }
-}
-
-class _AlertStack extends StatelessWidget {
-  const _AlertStack({required this.stage, required this.canManageTeam});
-
-  final String stage;
-  final bool canManageTeam;
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertBanner(
-      message:
-          canManageTeam
-              ? 'Pointage, validations et equipe restent accessibles en deux gestes.'
-              : stage == 'new'
-              ? 'Commencez par pointer, puis explorez vos documents et absences.'
-              : 'Votre journee RH tient ici: pointage, absences et documents.',
-      level: canManageTeam ? AlertLevel.success : AlertLevel.info,
-      icon: canManageTeam ? Icons.groups_2_outlined : Icons.phone_iphone,
-    );
   }
 }
 

--- a/front/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
+++ b/front/mobile/lib/features/salary_advances/screens/salary_advance_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:leopardo_rh/core/providers/core_providers.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
 import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/salary_advances/providers/salary_advance_provider.dart';
 
 class SalaryAdvanceListScreen extends ConsumerWidget {
@@ -15,16 +16,12 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
     final advancesAsync = ref.watch(salaryAdvancesProvider);
 
     return Scaffold(
-      backgroundColor: AppColors.bgDark,
-      appBar: AppBar(
-        backgroundColor: AppColors.bgDark,
-        elevation: 0,
-        title: Text(
-          'Mes avances',
-          style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
-        ),
+      backgroundColor: MobileSurface.background,
+      appBar: MobileTopBar(
+        title: 'Avances',
+        subtitle: 'Demandes, statuts et remboursement',
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => context.pop(),
         ),
@@ -35,136 +32,74 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
         label: const Text('Demander'),
       ),
       body: RefreshIndicator(
+        color: AppColors.rh,
+        backgroundColor: MobileSurface.background,
         onRefresh: () async {
           await ref.refresh(salaryAdvancesProvider.future).then((_) {});
         },
         child: advancesAsync.when(
-          data:
-              (advances) =>
-                  advances.isEmpty
-                      ? ListView(
-                        physics: const AlwaysScrollableScrollPhysics(),
-                        padding: const EdgeInsets.fromLTRB(24, 80, 24, 160),
-                        children: const [
-                          EmptyState(
-                            icon: Icons.payments,
-                            title: 'Aucune avance',
-                            description:
-                                'Demandez une avance en quelques secondes, puis suivez la decision RH ici.',
-                          ),
-                        ],
-                      )
-                      : ListView.builder(
-                        physics: const AlwaysScrollableScrollPhysics(),
-                        padding: const EdgeInsets.fromLTRB(20, 20, 20, 110),
-                        itemCount: advances.length,
-                        itemBuilder: (context, index) {
-                          final advance = advances[index];
-                          final amount =
-                              '${(advance.amount ?? 0).toStringAsFixed(0)} DZD';
-                          final reason =
-                              advance.reason?.trim().isNotEmpty == true
-                                  ? advance.reason!
-                                  : 'Aucun motif';
-                          final months = advance.repaymentMonths;
+          data: (advances) {
+            if (advances.isEmpty) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.fromLTRB(24, 80, 24, 160),
+                children: const [
+                  EmptyState(
+                    icon: Icons.payments,
+                    title: 'Aucune avance',
+                    description:
+                        'Demandez une avance en quelques secondes, puis suivez la decision RH ici.',
+                  ),
+                ],
+              );
+            }
 
-                          return Semantics(
-                            label:
-                                'Avance de $amount, motif : $reason, statut ${_getStatusLabel(advance.status)}.',
-                            container: true,
-                            child: ExcludeSemantics(
-                              child: Container(
-                                margin: const EdgeInsets.only(bottom: 12),
-                                padding: const EdgeInsets.all(16),
-                                decoration: BoxDecoration(
-                                  color: AppColors.cardDark,
-                                  borderRadius: BorderRadius.circular(16),
-                                  border: Border.all(
-                                    color: AppColors.borderDark,
-                                  ),
-                                ),
-                                child: Row(
-                                  children: [
-                                    Container(
-                                      width: 42,
-                                      height: 42,
-                                      decoration: BoxDecoration(
-                                        color: _getStatusColor(
-                                          advance.status,
-                                        ).withValues(alpha: 0.14),
-                                        shape: BoxShape.circle,
-                                      ),
-                                      child: Icon(
-                                        Icons.payments_outlined,
-                                        color: _getStatusColor(advance.status),
-                                      ),
-                                    ),
-                                    const SizedBox(width: 14),
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            amount,
-                                            style: AppTypography.subtitle
-                                                .copyWith(
-                                                  color: AppColors.textDark,
-                                                ),
-                                          ),
-                                          const SizedBox(height: 4),
-                                          Text(
-                                            months == null
-                                                ? reason
-                                                : '$reason · $months mois',
-                                            maxLines: 2,
-                                            overflow: TextOverflow.ellipsis,
-                                            style: AppTypography.bodySmall
-                                                .copyWith(
-                                                  color:
-                                                      AppColors.textMutedDark,
-                                                ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                    const SizedBox(width: 10),
-                                    Text(
-                                      _getStatusLabel(advance.status),
-                                      style: TextStyle(
-                                        color: _getStatusColor(advance.status),
-                                        fontWeight: FontWeight.w600,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          );
-                        },
+            return ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 110),
+              itemCount: advances.length,
+              itemBuilder: (context, index) {
+                final advance = advances[index];
+                final color = _getStatusColor(advance.status);
+                final amount =
+                    '${(advance.amount ?? 0).toStringAsFixed(0)} DZD';
+                final reason =
+                    advance.reason?.trim().isNotEmpty == true
+                        ? advance.reason!
+                        : 'Aucun motif';
+                final months = advance.repaymentMonths;
+
+                return Semantics(
+                  label:
+                      'Avance de $amount, motif : $reason, statut ${_getStatusLabel(advance.status)}.',
+                  container: true,
+                  child: ExcludeSemantics(
+                    child: MobileListCard(
+                      icon: Icons.payments_outlined,
+                      iconColor: color,
+                      title: amount,
+                      subtitle:
+                          months == null ? reason : '$reason - $months mois',
+                      trailing: MobileStatusPill(
+                        label: _getStatusLabel(advance.status),
+                        color: color,
                       ),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
           loading:
-              () => const Center(
-                child: CircularProgressIndicator(
-                  semanticsLabel: 'Chargement des avances...',
-                ),
-              ),
+              () => const MobileEmptyLoading(label: 'Chargement des avances'),
           error:
               (e, _) => ListView(
                 physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.all(20),
                 children: [
-                  SizedBox(
-                    height: MediaQuery.of(context).size.height * 0.4,
-                    child: Center(
-                      child: Padding(
-                        padding: const EdgeInsets.all(24),
-                        child: Text(
-                          e.toString(),
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(color: AppColors.danger),
-                        ),
-                      ),
-                    ),
+                  MobileErrorPanel(
+                    message: e.toString(),
+                    onRetry: () => ref.invalidate(salaryAdvancesProvider),
                   ),
                 ],
               ),
@@ -177,7 +112,7 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      backgroundColor: AppColors.cardDark,
+      backgroundColor: MobileSurface.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
@@ -212,7 +147,7 @@ class SalaryAdvanceListScreen extends ConsumerWidget {
       case 'rejected':
         return AppColors.danger;
       default:
-        return AppColors.textMutedDark;
+        return MobileSurface.disabled;
     }
   }
 }
@@ -257,7 +192,7 @@ class _SalaryAdvanceRequestSheetState
                 width: 38,
                 height: 4,
                 decoration: BoxDecoration(
-                  color: AppColors.borderDark,
+                  color: MobileSurface.border,
                   borderRadius: BorderRadius.circular(99),
                 ),
               ),
@@ -265,13 +200,13 @@ class _SalaryAdvanceRequestSheetState
             const SizedBox(height: 18),
             Text(
               'Demande d avance',
-              style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
+              style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
             ),
             const SizedBox(height: 4),
             Text(
               'La demande sera transmise au RH pour validation.',
               style: AppTypography.bodySmall.copyWith(
-                color: AppColors.textMutedDark,
+                color: MobileSurface.secondary,
               ),
             ),
             const SizedBox(height: 18),
@@ -280,7 +215,7 @@ class _SalaryAdvanceRequestSheetState
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
               ),
-              style: const TextStyle(color: AppColors.textDark),
+              style: const TextStyle(color: MobileSurface.text),
               decoration: const InputDecoration(
                 labelText: 'Montant demande',
                 suffixText: 'DZD',
@@ -297,7 +232,7 @@ class _SalaryAdvanceRequestSheetState
             DropdownButtonFormField<int>(
               initialValue: _repaymentMonths,
               decoration: const InputDecoration(labelText: 'Remboursement'),
-              dropdownColor: AppColors.cardDark,
+              dropdownColor: MobileSurface.surface,
               items:
                   List.generate(12, (index) => index + 1)
                       .map(
@@ -315,7 +250,7 @@ class _SalaryAdvanceRequestSheetState
               controller: _reasonCtrl,
               maxLines: 3,
               maxLength: 180,
-              style: const TextStyle(color: AppColors.textDark),
+              style: const TextStyle(color: MobileSurface.text),
               decoration: const InputDecoration(
                 labelText: 'Motif',
                 hintText: 'Ex: besoin familial urgent',

--- a/front/mobile/lib/features/team/screens/team_screen.dart
+++ b/front/mobile/lib/features/team/screens/team_screen.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_rh/core/theme/app_colors.dart';
+import 'package:leopardo_rh/core/theme/app_typography.dart';
 import 'package:leopardo_rh/core/widgets/empty_state.dart';
-import 'package:leopardo_rh/core/widgets/leopardo_badge.dart';
+import 'package:leopardo_rh/core/widgets/mobile_surface.dart';
 import 'package:leopardo_rh/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_rh/features/team/data/employee_repository.dart';
 import 'package:leopardo_rh/features/team/providers/team_provider.dart';
@@ -39,10 +40,12 @@ class _TeamScreenState extends ConsumerState<TeamScreen>
     final employee = ref.watch(authProvider).employee;
     if (employee == null || !employee.canManageTeam) {
       return Scaffold(
-        appBar: AppBar(
-          title: const Text('Equipe'),
+        backgroundColor: MobileSurface.background,
+        appBar: MobileTopBar(
+          title: 'Equipe',
+          subtitle: 'Acces manager/RH requis',
           leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
+            icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
             tooltip: 'Retour',
             onPressed: () => context.pop(),
           ),
@@ -60,21 +63,39 @@ class _TeamScreenState extends ConsumerState<TeamScreen>
     }
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Equipe'),
+      backgroundColor: MobileSurface.background,
+      appBar: MobileTopBar(
+        title: 'Equipe',
+        subtitle: 'Collaborateurs et invitations',
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: MobileSurface.secondary),
           tooltip: 'Retour',
           onPressed: () => context.pop(),
         ),
-        bottom: TabBar(
-          controller: _tabController,
-          tabs: const [Tab(text: 'Employes'), Tab(text: 'Invitations')],
-        ),
       ),
-      body: TabBarView(
-        controller: _tabController,
-        children: const [_EmployeesTab(), _InvitationsTab()],
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+            child: Container(
+              padding: const EdgeInsets.all(4),
+              decoration: MobileSurface.cardDecoration(
+                color: MobileSurface.chip,
+                radius: 14,
+              ),
+              child: TabBar(
+                controller: _tabController,
+                tabs: const [Tab(text: 'Employes'), Tab(text: 'Invitations')],
+              ),
+            ),
+          ),
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: const [_EmployeesTab(), _InvitationsTab()],
+            ),
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => _openCreateEmployeeSheet(context),
@@ -88,6 +109,10 @@ class _TeamScreenState extends ConsumerState<TeamScreen>
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      backgroundColor: MobileSurface.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
       builder: (_) => const _CreateEmployeeForm(),
     );
   }
@@ -105,8 +130,18 @@ class _EmployeesTab extends ConsumerWidget {
         await ref.refresh(teamListProvider.future).then((_) {});
       },
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (err, _) => Center(child: Text('Erreur : $err')),
+        loading:
+            () => const MobileEmptyLoading(label: 'Chargement de l equipe'),
+        error:
+            (err, _) => ListView(
+              padding: const EdgeInsets.all(20),
+              children: [
+                MobileErrorPanel(
+                  message: err.toString(),
+                  onRetry: () => ref.invalidate(teamListProvider),
+                ),
+              ],
+            ),
         data: (employees) {
           if (employees.isEmpty) {
             return ListView(
@@ -121,25 +156,25 @@ class _EmployeesTab extends ConsumerWidget {
               ],
             );
           }
-          return ListView.separated(
+          return ListView.builder(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 110),
             itemCount: employees.length,
-            separatorBuilder: (_, __) => const Divider(height: 1),
             itemBuilder: (_, index) {
               final e = employees[index];
-              return ListTile(
-                leading: CircleAvatar(child: Text(_initials(e))),
-                title: Text(e.fullName),
-                subtitle: Text(
-                  [
-                    e.email,
-                    'Role : ${_roleLabel(e)}',
-                    if (_employmentLine(e) != null) _employmentLine(e)!,
-                  ].join('\n'),
-                ),
-                isThreeLine: true,
-                trailing: LeopardoBadge.forStatus(
-                  e.status,
-                  _statusLabel(e.status),
+              final subtitle = [
+                e.email,
+                _roleLabel(e),
+                if (_employmentLine(e) != null) _employmentLine(e)!,
+              ].join(' - ');
+
+              return MobileListCard(
+                icon: Icons.person_outline_rounded,
+                iconColor: _statusColor(e.status),
+                title: '${_initials(e)}  ${e.fullName}',
+                subtitle: subtitle,
+                trailing: MobileStatusPill(
+                  label: _statusLabel(e.status),
+                  color: _statusColor(e.status),
                 ),
                 onTap: () => _showActions(context, ref, e),
               );
@@ -190,9 +225,20 @@ class _EmployeesTab extends ConsumerWidget {
     _ => status,
   };
 
+  Color _statusColor(String status) => switch (status) {
+    'active' => AppColors.rh,
+    'suspended' => AppColors.warning,
+    'blocked' || 'archived' => AppColors.danger,
+    _ => MobileSurface.disabled,
+  };
+
   void _showActions(BuildContext context, WidgetRef ref, Employee employee) {
     showModalBottomSheet(
       context: context,
+      backgroundColor: MobileSurface.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
       builder:
           (_) => Padding(
             padding: const EdgeInsets.all(16),
@@ -201,11 +247,13 @@ class _EmployeesTab extends ConsumerWidget {
               children: [
                 Text(
                   employee.fullName,
-                  style: Theme.of(context).textTheme.titleLarge,
+                  style: AppTypography.subtitle.copyWith(
+                    color: MobileSurface.text,
+                  ),
                 ),
                 Text(
                   employee.email,
-                  style: const TextStyle(color: AppColors.textMuted),
+                  style: const TextStyle(color: MobileSurface.secondary),
                 ),
                 const SizedBox(height: 16),
                 if (employee.status != 'archived')
@@ -279,8 +327,18 @@ class _InvitationsTab extends ConsumerWidget {
         await ref.refresh(invitationsListProvider.future).then((_) {});
       },
       child: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (err, _) => Center(child: Text('Erreur : $err')),
+        loading:
+            () => const MobileEmptyLoading(label: 'Chargement des invitations'),
+        error:
+            (err, _) => ListView(
+              padding: const EdgeInsets.all(20),
+              children: [
+                MobileErrorPanel(
+                  message: err.toString(),
+                  onRetry: () => ref.invalidate(invitationsListProvider),
+                ),
+              ],
+            ),
         data: (invitations) {
           if (invitations.isEmpty) {
             return ListView(
@@ -295,28 +353,33 @@ class _InvitationsTab extends ConsumerWidget {
               ],
             );
           }
-          return ListView.separated(
+          return ListView.builder(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 110),
             itemCount: invitations.length,
-            separatorBuilder: (_, __) => const Divider(height: 1),
             itemBuilder: (_, index) {
               final inv = invitations[index];
-              return ListTile(
-                leading: const Icon(Icons.mail_outline, color: AppColors.ia),
-                title: Text(inv.email),
-                subtitle: Row(
-                  children: [
-                    LeopardoBadge.forStatus(
-                      inv.status,
-                      _invitationLabel(inv.status),
-                    ),
-                  ],
+              final color = _invitationColor(inv.status);
+              return MobileListCard(
+                icon: Icons.mail_outline_rounded,
+                iconColor: color,
+                title: inv.email,
+                subtitle:
+                    inv.sentAt == null
+                        ? 'Invitation ${_invitationLabel(inv.status)}'
+                        : 'Dernier envoi ${inv.sentAt!.day.toString().padLeft(2, '0')}/${inv.sentAt!.month.toString().padLeft(2, '0')}',
+                trailing: MobileStatusPill(
+                  label: _invitationLabel(inv.status),
+                  color: color,
                 ),
-                trailing:
+                footer:
                     inv.status == 'pending'
-                        ? IconButton(
-                          icon: const Icon(Icons.send),
-                          tooltip: 'Renvoyer',
-                          onPressed: () async => _resend(context, ref, inv),
+                        ? Align(
+                          alignment: Alignment.centerLeft,
+                          child: TextButton.icon(
+                            onPressed: () async => _resend(context, ref, inv),
+                            icon: const Icon(Icons.send_rounded, size: 16),
+                            label: const Text('Renvoyer'),
+                          ),
                         )
                         : null,
               );
@@ -334,6 +397,13 @@ class _InvitationsTab extends ConsumerWidget {
     'expired' => 'Expiree',
     'revoked' => 'Revoquee',
     _ => status,
+  };
+
+  Color _invitationColor(String status) => switch (status) {
+    'accepted' => AppColors.rh,
+    'sent' || 'pending' => AppColors.info,
+    'expired' || 'revoked' => AppColors.danger,
+    _ => MobileSurface.disabled,
   };
 
   Future<void> _resend(
@@ -420,13 +490,34 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              Center(
+                child: Container(
+                  width: 38,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: MobileSurface.border,
+                    borderRadius: BorderRadius.circular(99),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
               Text(
                 'Nouvel employe',
-                style: Theme.of(context).textTheme.titleLarge,
+                style: AppTypography.subtitle.copyWith(
+                  color: MobileSurface.text,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Invitation, role, date d embauche et base salariale sont envoyes a l API.',
+                style: AppTypography.bodySmall.copyWith(
+                  color: MobileSurface.secondary,
+                ),
               ),
               const SizedBox(height: 16),
               TextFormField(
                 controller: _firstName,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(labelText: 'Prenom'),
                 validator:
                     (v) =>
@@ -435,6 +526,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _lastName,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(labelText: 'Nom'),
                 validator:
                     (v) =>
@@ -443,6 +535,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _email,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(
                   labelText: 'Email professionnel',
                 ),
@@ -456,6 +549,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _phone,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(
                   labelText: 'Telephone (optionnel)',
                 ),
@@ -464,6 +558,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _matricule,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(
                   labelText: 'Matricule (optionnel)',
                 ),
@@ -471,6 +566,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _hireDate,
+                style: const TextStyle(color: MobileSurface.text),
                 readOnly: true,
                 decoration: const InputDecoration(
                   labelText: 'Date d embauche',
@@ -484,6 +580,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
                 initialValue: _role,
+                dropdownColor: MobileSurface.surface,
                 decoration: const InputDecoration(labelText: 'Role'),
                 items: const [
                   DropdownMenuItem(value: 'employee', child: Text('Employe')),
@@ -499,6 +596,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
                 const SizedBox(height: 8),
                 DropdownButtonFormField<String>(
                   initialValue: _managerRole,
+                  dropdownColor: MobileSurface.surface,
                   decoration: const InputDecoration(
                     labelText: 'Type de manager',
                   ),
@@ -525,6 +623,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
                 initialValue: _salaryType,
+                dropdownColor: MobileSurface.surface,
                 decoration: const InputDecoration(labelText: 'Type de paie'),
                 items: const [
                   DropdownMenuItem(
@@ -540,6 +639,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               if (_salaryType == 'hourly')
                 TextFormField(
                   controller: _hourlyRate,
+                  style: const TextStyle(color: MobileSurface.text),
                   decoration: const InputDecoration(
                     labelText: 'Taux horaire',
                     suffixText: 'DZD/h',
@@ -552,6 +652,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               else
                 TextFormField(
                   controller: _salaryBase,
+                  style: const TextStyle(color: MobileSurface.text),
                   decoration: InputDecoration(
                     labelText:
                         _salaryType == 'daily'
@@ -567,6 +668,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _jobTitle,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(
                   labelText: 'Poste (optionnel)',
                 ),
@@ -574,6 +676,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _department,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(
                   labelText: 'Departement (optionnel)',
                 ),
@@ -581,6 +684,7 @@ class _CreateEmployeeFormState extends ConsumerState<_CreateEmployeeForm> {
               const SizedBox(height: 8),
               TextFormField(
                 controller: _workLocation,
+                style: const TextStyle(color: MobileSurface.text),
                 decoration: const InputDecoration(
                   labelText: 'Lieu de travail (optionnel)',
                 ),

--- a/front/mobile/test/widgets/mobile_surface_test.dart
+++ b/front/mobile/test/widgets/mobile_surface_test.dart
@@ -28,6 +28,18 @@ void main() {
                     color: AppColors.rh,
                     icon: Icons.check_circle,
                   ),
+                  MobileEmptyLoading(label: 'Chargement test'),
+                  MobileErrorPanel(message: 'Serveur indisponible'),
+                  MobileListCard(
+                    icon: Icons.payments_outlined,
+                    iconColor: AppColors.finance,
+                    title: '12000 DZD',
+                    subtitle: 'Avance en attente',
+                    trailing: MobileStatusPill(
+                      label: 'En attente',
+                      color: AppColors.info,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -40,6 +52,10 @@ void main() {
       expect(find.text('CETTE SEMAINE'), findsOneWidget);
       expect(find.byIcon(Icons.fingerprint), findsOneWidget);
       expect(find.text('Present'), findsOneWidget);
+      expect(find.text('Chargement test'), findsOneWidget);
+      expect(find.text('Connexion indisponible'), findsOneWidget);
+      expect(find.text('12000 DZD'), findsOneWidget);
+      expect(find.text('En attente'), findsOneWidget);
       expect(MobileSurface.muted.computeLuminance(), greaterThan(0.30));
       expect(MobileSurface.disabled.computeLuminance(), greaterThan(0.20));
     },


### PR DESCRIPTION
## Summary
- add shared mobile loading/error/list components for marketing-ready HR screens
- modernize Absences, Advances, and Team mobile workflows on MobileSurface
- make absence requests action real by resolving absence types from leave balances before POST /absences
- lighten the mobile home screen to three priority actions and four modules

## Validation
- dart format targeted mobile files
- git diff --check
- local flutter analyze blocked by local Dart 3.7.2 vs flutter_lints ^6.0.0; CI Flutter is the source of truth