### PR TITLE
feat(plan31-iter1): normalize API responses with Resources

### DIFF
--- a/api/app/Http/Controllers/Api/V1/ApprovalController.php
+++ b/api/app/Http/Controllers/Api/V1/ApprovalController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\ApprovalRequestResource;
+use App\Http\Resources\Api\V1\ApprovalWorkflowResource;
 use App\Models\ApprovalDecision;
 use App\Models\ApprovalRequest;
 use App\Models\ApprovalWorkflow;
@@ -30,7 +31,7 @@ class ApprovalController extends Controller
             ->orderBy('name')
             ->get();
 
-        return response()->json(['data' => $workflows]);
+        return ApprovalWorkflowResource::collection($workflows)->response();
     }
 
     public function storeWorkflow(Request $request): JsonResponse
@@ -57,7 +58,9 @@ class ApprovalController extends Controller
             'company_id' => $actor->company_id,
         ]);
 
-        return response()->json(['data' => $workflow], 201);
+        return (new ApprovalWorkflowResource($workflow))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function updateWorkflow(Request $request, ApprovalWorkflow $approvalWorkflow): JsonResponse
@@ -81,7 +84,7 @@ class ApprovalController extends Controller
 
         $approvalWorkflow->update($validated);
 
-        return response()->json(['data' => $approvalWorkflow->fresh()]);
+        return (new ApprovalWorkflowResource($approvalWorkflow->fresh()))->response();
     }
 
     public function destroyWorkflow(Request $request, ApprovalWorkflow $approvalWorkflow): JsonResponse
@@ -112,7 +115,7 @@ class ApprovalController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 15));
 
-        return response()->json($requests);
+        return ApprovalRequestResource::collection($requests)->response();
     }
 
     public function approve(Request $request, ApprovalRequest $approvalRequest): ApprovalRequestResource

--- a/api/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/api/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\AuditLogResource;
 use App\Models\AuditLog;
 use App\Models\Employee;
 use Illuminate\Http\JsonResponse;
@@ -49,9 +50,9 @@ class AuditLogController extends Controller
             $query->where('created_at', '<=', $request->input('to'));
         }
 
-        return response()->json(
+        return AuditLogResource::collection(
             $query->orderByDesc('created_at')->paginate($request->integer('per_page', 25))
-        );
+        )->response();
     }
 
     public function show(Request $request, AuditLog $auditLog): JsonResponse
@@ -65,7 +66,7 @@ class AuditLogController extends Controller
             abort(404);
         }
 
-        return response()->json(['data' => $auditLog->load('user:id,first_name,last_name')]);
+        return (new AuditLogResource($auditLog->load('user:id,first_name,last_name')))->response();
     }
 
     public function exportCsv(Request $request): StreamedResponse

--- a/api/app/Http/Controllers/Api/V1/BankExportController.php
+++ b/api/app/Http/Controllers/Api/V1/BankExportController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\BankExportResource;
 use App\Models\BankExport;
 use App\Models\Employee;
 use App\Models\PayrollRun;
@@ -60,7 +61,9 @@ class BankExportController extends Controller
             'generated_at' => now(),
         ]);
 
-        return response()->json(['data' => $export], 201);
+        return (new BankExportResource($export))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, BankExport $bankExport): JsonResponse
@@ -76,7 +79,7 @@ class BankExportController extends Controller
 
         $bankExport->load('payrollRun:id,period_start,period_end,status');
 
-        return response()->json(['data' => $bankExport]);
+        return (new BankExportResource($bankExport))->response();
     }
 
     public function download(Request $request, BankExport $bankExport): StreamedResponse|JsonResponse

--- a/api/app/Http/Controllers/Api/V1/BillingController.php
+++ b/api/app/Http/Controllers/Api/V1/BillingController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\InvoiceResource;
+use App\Http\Resources\Api\V1\SubscriptionResource;
 use App\Models\Company;
 use App\Models\Employee;
 use App\Models\Invoice;
@@ -26,7 +28,7 @@ class BillingController extends Controller
             return response()->json(['data' => null, 'message' => 'No active subscription.'], 404);
         }
 
-        return response()->json(['data' => $subscription]);
+        return (new SubscriptionResource($subscription))->response();
     }
 
     public function upgrade(Request $request): JsonResponse
@@ -64,7 +66,7 @@ class BillingController extends Controller
             ]);
         }
 
-        return response()->json(['data' => $subscription->fresh()]);
+        return (new SubscriptionResource($subscription->fresh()))->response();
     }
 
     public function cancel(Request $request): JsonResponse
@@ -89,7 +91,7 @@ class BillingController extends Controller
             'cancel_reason' => $validated['reason'] ?? null,
         ]);
 
-        return response()->json(['data' => $subscription->fresh()]);
+        return (new SubscriptionResource($subscription->fresh()))->response();
     }
 
     public function renew(Request $request): JsonResponse
@@ -112,7 +114,7 @@ class BillingController extends Controller
             'current_period_end' => now()->addMonth(),
         ]);
 
-        return response()->json(['data' => $subscription->fresh()]);
+        return (new SubscriptionResource($subscription->fresh()))->response();
     }
 
     public function invoices(Request $request): JsonResponse
@@ -124,15 +126,7 @@ class BillingController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $invoices->items(),
-            'meta' => [
-                'current_page' => $invoices->currentPage(),
-                'last_page' => $invoices->lastPage(),
-                'per_page' => $invoices->perPage(),
-                'total' => $invoices->total(),
-            ],
-        ]);
+        return InvoiceResource::collection($invoices)->response();
     }
 
     public function showInvoice(Request $request, int $id): JsonResponse
@@ -143,7 +137,7 @@ class BillingController extends Controller
             ->with('payments')
             ->findOrFail($id);
 
-        return response()->json(['data' => $invoice]);
+        return (new InvoiceResource($invoice))->response();
     }
 
     public function invoicePdf(Request $request, int $id): Response

--- a/api/app/Http/Controllers/Api/V1/CabinetDocumentController.php
+++ b/api/app/Http/Controllers/Api/V1/CabinetDocumentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Cabinet\MoveDocumentRequest;
 use App\Http\Requests\Api\V1\Cabinet\StoreDocumentRequest;
 use App\Http\Requests\Api\V1\Cabinet\UpdateDocumentRequest;
+use App\Http\Resources\Api\V1\CabinetDocumentResource;
 use App\Models\CabinetDocument;
 use App\Models\Employee;
 use App\Services\CabinetService;
@@ -56,15 +57,7 @@ class CabinetDocumentController extends Controller
         $perPage = $request->integer('per_page', 20);
         $paginated = $query->orderByDesc('created_at')->paginate($perPage);
 
-        return response()->json([
-            'data' => $paginated->map(fn (CabinetDocument $d) => $this->serialize($d)),
-            'meta' => [
-                'current_page' => $paginated->currentPage(),
-                'last_page' => $paginated->lastPage(),
-                'per_page' => $paginated->perPage(),
-                'total' => $paginated->total(),
-            ],
-        ]);
+        return CabinetDocumentResource::collection($paginated)->response();
     }
 
     public function store(StoreDocumentRequest $request): JsonResponse
@@ -75,18 +68,16 @@ class CabinetDocumentController extends Controller
 
         $document = $this->cabinetService->uploadDocument($actor, $file, $request->validated());
 
-        return response()->json([
-            'data' => $this->serialize($document),
-        ], 201);
+        return (new CabinetDocumentResource($document))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, CabinetDocument $cabinetDocument): JsonResponse
     {
         $this->authorizeOwnership($request, $cabinetDocument);
 
-        return response()->json([
-            'data' => $this->serialize($cabinetDocument),
-        ]);
+        return (new CabinetDocumentResource($cabinetDocument))->response();
     }
 
     public function update(UpdateDocumentRequest $request, CabinetDocument $cabinetDocument): JsonResponse
@@ -95,9 +86,7 @@ class CabinetDocumentController extends Controller
 
         $document = $this->cabinetService->updateDocument($cabinetDocument, $request->validated());
 
-        return response()->json([
-            'data' => $this->serialize($document),
-        ]);
+        return (new CabinetDocumentResource($document))->response();
     }
 
     public function destroy(Request $request, CabinetDocument $cabinetDocument): JsonResponse
@@ -131,9 +120,7 @@ class CabinetDocumentController extends Controller
 
         $document = $this->cabinetService->moveDocument($cabinetDocument, $folderId);
 
-        return response()->json([
-            'data' => $this->serialize($document),
-        ]);
+        return (new CabinetDocumentResource($document))->response();
     }
 
     private function employee(Request $request): Employee
@@ -158,21 +145,4 @@ class CabinetDocumentController extends Controller
         }
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    private function serialize(CabinetDocument $doc): array
-    {
-        return [
-            'id' => $doc->id,
-            'folder_id' => $doc->folder_id,
-            'name' => $doc->name,
-            'original_name' => $doc->original_name,
-            'mime_type' => $doc->mime_type,
-            'size' => $doc->size,
-            'notes' => $doc->notes,
-            'created_at' => $doc->created_at?->toIso8601String(),
-            'updated_at' => $doc->updated_at?->toIso8601String(),
-        ];
-    }
 }

--- a/api/app/Http/Controllers/Api/V1/ContractController.php
+++ b/api/app/Http/Controllers/Api/V1/ContractController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\ContractAmendmentResource;
+use App\Http\Resources\Api\V1\ContractResource;
 use App\Models\Contract;
 use App\Models\ContractAmendment;
 use App\Models\Employee;
@@ -35,7 +37,8 @@ class ContractController extends Controller
 
         $perPage = $request->integer('per_page', 15);
 
-        return response()->json($query->orderByDesc('start_date')->paginate($perPage));
+        return ContractResource::collection($query->orderByDesc('start_date')->paginate($perPage))
+            ->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -82,7 +85,9 @@ class ContractController extends Controller
             'status' => 'draft',
         ]);
 
-        return response()->json(['data' => $contract->load(['employee:id,first_name,last_name', 'department:id,name'])], 201);
+        return (new ContractResource($contract->load(['employee:id,first_name,last_name', 'department:id,name'])))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, Contract $contract): JsonResponse
@@ -96,7 +101,8 @@ class ContractController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $contract->load(['employee:id,first_name,last_name', 'department:id,name', 'position:id,name', 'amendments'])]);
+        return (new ContractResource($contract->load(['employee:id,first_name,last_name', 'department:id,name', 'position:id,name', 'amendments'])))
+            ->response();
     }
 
     public function update(Request $request, Contract $contract): JsonResponse
@@ -140,7 +146,8 @@ class ContractController extends Controller
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
 
-        return response()->json(['data' => $contractFresh->load(['employee:id,first_name,last_name', 'department:id,name'])]);
+        return (new ContractResource($contractFresh->load(['employee:id,first_name,last_name', 'department:id,name'])))
+            ->response();
     }
 
     public function amendments(Request $request, Contract $contract): JsonResponse
@@ -154,7 +161,8 @@ class ContractController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $contract->amendments()->orderByDesc('effective_date')->get()]);
+        return ContractAmendmentResource::collection($contract->amendments()->orderByDesc('effective_date')->get())
+            ->response();
     }
 
     public function storeAmendment(Request $request, Contract $contract): JsonResponse
@@ -182,7 +190,9 @@ class ContractController extends Controller
             ...$validated,
         ]);
 
-        return response()->json(['data' => $amendment], 201);
+        return (new ContractAmendmentResource($amendment))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function expiring(Request $request): JsonResponse
@@ -199,7 +209,7 @@ class ContractController extends Controller
             ->with('employee:id,first_name,last_name')
             ->get();
 
-        return response()->json(['data' => $contracts]);
+        return ContractResource::collection($contracts)->response();
     }
 
     public function activate(Request $request, Contract $contract): JsonResponse
@@ -221,7 +231,7 @@ class ContractController extends Controller
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
 
-        return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
+        return (new ContractResource($contractFresh->load('employee:id,first_name,last_name')))->response();
     }
 
     public function suspend(Request $request, Contract $contract): JsonResponse
@@ -243,7 +253,7 @@ class ContractController extends Controller
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
 
-        return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
+        return (new ContractResource($contractFresh->load('employee:id,first_name,last_name')))->response();
     }
 
     public function terminate(Request $request, Contract $contract): JsonResponse
@@ -273,7 +283,7 @@ class ContractController extends Controller
         /** @var Contract $contractFresh */
         $contractFresh = $contract->fresh();
 
-        return response()->json(['data' => $contractFresh->load('employee:id,first_name,last_name')]);
+        return (new ContractResource($contractFresh->load('employee:id,first_name,last_name')))->response();
     }
 
     public function renew(Request $request, Contract $contract): JsonResponse
@@ -321,7 +331,9 @@ class ContractController extends Controller
             return $newContract;
         });
 
-        return response()->json(['data' => $newContract->load('employee:id,first_name,last_name')], 201);
+        return (new ContractResource($newContract->load('employee:id,first_name,last_name')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function myContracts(Request $request): JsonResponse
@@ -336,7 +348,7 @@ class ContractController extends Controller
             ->orderByDesc('start_date')
             ->get();
 
-        return response()->json(['data' => $contracts]);
+        return ContractResource::collection($contracts)->response();
     }
 
     public function generatePdf(Request $request, Contract $contract): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/EmployeeLoanController.php
+++ b/api/app/Http/Controllers/Api/V1/EmployeeLoanController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\LoanResource;
 use App\Models\Employee;
 use App\Models\EmployeeLoan;
 use App\Models\LoanRepayment;
@@ -34,7 +35,8 @@ class EmployeeLoanController extends Controller
             $query->where('status', $request->input('status'));
         }
 
-        return response()->json($query->orderByDesc('created_at')->paginate($request->integer('per_page', 15)));
+        return LoanResource::collection($query->orderByDesc('created_at')->paginate($request->integer('per_page', 15)))
+            ->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -96,7 +98,9 @@ class EmployeeLoanController extends Controller
             return $loan;
         });
 
-        return response()->json(['data' => $loan->load('repayments')], 201);
+        return (new LoanResource($loan->load('repayments')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, EmployeeLoan $employeeLoan): JsonResponse
@@ -110,7 +114,7 @@ class EmployeeLoanController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $employeeLoan->load(['employee:id,first_name,last_name', 'repayments'])]);
+        return (new LoanResource($employeeLoan->load(['employee:id,first_name,last_name', 'repayments'])))->response();
     }
 
     public function approve(Request $request, EmployeeLoan $employeeLoan): JsonResponse
@@ -132,7 +136,7 @@ class EmployeeLoanController extends Controller
             'approved_by' => $actor->id,
         ]);
 
-        return response()->json(['data' => $employeeLoan->fresh()]);
+        return (new LoanResource($employeeLoan->fresh()))->response();
     }
 
     public function disburse(Request $request, EmployeeLoan $employeeLoan): JsonResponse
@@ -154,6 +158,6 @@ class EmployeeLoanController extends Controller
             'disbursed_at' => now(),
         ]);
 
-        return response()->json(['data' => $employeeLoan->fresh()]);
+        return (new LoanResource($employeeLoan->fresh()))->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/EvaluationController.php
+++ b/api/app/Http/Controllers/Api/V1/EvaluationController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Evaluation\EvaluationIndexRequest;
 use App\Http\Requests\Api\V1\Evaluation\StoreEvaluationRequest;
 use App\Http\Requests\Api\V1\Evaluation\UpdateEvaluationRequest;
+use App\Http\Resources\Api\V1\EvaluationResource;
 use App\Models\Employee;
 use App\Models\Evaluation;
 use Illuminate\Http\JsonResponse;
@@ -69,12 +70,9 @@ class EvaluationController extends Controller
         }
 
         $perPage = $request->integer('per_page', 15);
-        $paginated = $query->orderByDesc('created_at')->paginate($perPage);
 
-        return response()->json([
-            'data' => $paginated->map(fn ($e) => $this->serialize($e)),
-            'meta' => ['current_page' => $paginated->currentPage(), 'last_page' => $paginated->lastPage(), 'per_page' => $paginated->perPage(), 'total' => $paginated->total()],
-        ]);
+        return EvaluationResource::collection($query->orderByDesc('created_at')->paginate($perPage))
+            ->response();
     }
 
     public function store(StoreEvaluationRequest $request): JsonResponse
@@ -100,14 +98,16 @@ class EvaluationController extends Controller
             'status' => 'draft',
         ]);
 
-        return response()->json(['data' => $this->serialize($evaluation->load('employee', 'evaluator'))], 201);
+        return (new EvaluationResource($evaluation->load('employee', 'evaluator')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, Evaluation $evaluation): JsonResponse
     {
         $this->authorize('view', $evaluation);
 
-        return response()->json(['data' => $this->serialize($evaluation->load('employee', 'evaluator'))]);
+        return (new EvaluationResource($evaluation->load('employee', 'evaluator')))->response();
     }
 
     public function update(UpdateEvaluationRequest $request, Evaluation $evaluation): JsonResponse
@@ -125,7 +125,7 @@ class EvaluationController extends Controller
         /** @var Evaluation $fresh */
         $fresh = $evaluation->fresh();
 
-        return response()->json(['data' => $this->serialize($fresh->load('employee', 'evaluator'))]);
+        return (new EvaluationResource($fresh->load('employee', 'evaluator')))->response();
     }
 
     public function submit(Request $request, Evaluation $evaluation): JsonResponse
@@ -141,7 +141,7 @@ class EvaluationController extends Controller
         /** @var Evaluation $fresh */
         $fresh = $evaluation->fresh();
 
-        return response()->json(['data' => $this->serialize($fresh->load('employee', 'evaluator'))]);
+        return (new EvaluationResource($fresh->load('employee', 'evaluator')))->response();
     }
 
     public function acknowledge(Request $request, Evaluation $evaluation): JsonResponse
@@ -157,7 +157,7 @@ class EvaluationController extends Controller
         /** @var Evaluation $fresh */
         $fresh = $evaluation->fresh();
 
-        return response()->json(['data' => $this->serialize($fresh->load('employee', 'evaluator'))]);
+        return (new EvaluationResource($fresh->load('employee', 'evaluator')))->response();
     }
 
     public function destroy(Request $request, Evaluation $evaluation): JsonResponse
@@ -173,24 +173,4 @@ class EvaluationController extends Controller
         return response()->json(['message' => 'Evaluation deleted successfully']);
     }
 
-    private function serialize(Evaluation $e): array
-    {
-        return [
-            'id' => $e->id,
-            'employee_id' => $e->employee_id,
-            'employee' => $e->relationLoaded('employee') && $e->employee ? ['id' => $e->employee->id, 'first_name' => $e->employee->first_name, 'last_name' => $e->employee->last_name, 'email' => $e->employee->email] : null,
-            'evaluator_id' => $e->evaluator_id,
-            'evaluator' => $e->relationLoaded('evaluator') && $e->evaluator ? ['id' => $e->evaluator->id, 'first_name' => $e->evaluator->first_name, 'last_name' => $e->evaluator->last_name] : null,
-            'period' => $e->period,
-            'score' => $e->score,
-            'criteria' => $e->criteria,
-            'strengths' => $e->strengths,
-            'improvements' => $e->improvements,
-            'overall_comment' => $e->overall_comment,
-            'status' => $e->status,
-            'acknowledged_at' => $e->acknowledged_at?->toIso8601String(),
-            'created_at' => $e->created_at?->toIso8601String(),
-            'updated_at' => $e->updated_at?->toIso8601String(),
-        ];
-    }
 }

--- a/api/app/Http/Controllers/Api/V1/ExpenseClaimController.php
+++ b/api/app/Http/Controllers/Api/V1/ExpenseClaimController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\ExpenseClaimResource;
 use App\Models\Employee;
 use App\Models\ExpenseClaim;
 use App\Models\ExpenseItem;
@@ -31,7 +32,8 @@ class ExpenseClaimController extends Controller
             $query->where('status', $request->input('status'));
         }
 
-        return response()->json($query->orderByDesc('created_at')->paginate($request->integer('per_page', 15)));
+        return ExpenseClaimResource::collection($query->orderByDesc('created_at')->paginate($request->integer('per_page', 15)))
+            ->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -69,7 +71,9 @@ class ExpenseClaimController extends Controller
 
         $claim->update(['total_amount' => $total]);
 
-        return response()->json(['data' => $claim->load('items')], 201);
+        return (new ExpenseClaimResource($claim->load('items')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, ExpenseClaim $expenseClaim): JsonResponse
@@ -83,7 +87,7 @@ class ExpenseClaimController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $expenseClaim->load(['employee:id,first_name,last_name', 'items'])]);
+        return (new ExpenseClaimResource($expenseClaim->load(['employee:id,first_name,last_name', 'items'])))->response();
     }
 
     public function submit(Request $request, ExpenseClaim $expenseClaim): JsonResponse
@@ -105,7 +109,7 @@ class ExpenseClaimController extends Controller
             'submitted_at' => now(),
         ]);
 
-        return response()->json(['data' => $expenseClaim->fresh()]);
+        return (new ExpenseClaimResource($expenseClaim->fresh()))->response();
     }
 
     public function approve(Request $request, ExpenseClaim $expenseClaim): JsonResponse
@@ -128,7 +132,7 @@ class ExpenseClaimController extends Controller
             'approved_at' => now(),
         ]);
 
-        return response()->json(['data' => $expenseClaim->fresh()]);
+        return (new ExpenseClaimResource($expenseClaim->fresh()))->response();
     }
 
     public function reject(Request $request, ExpenseClaim $expenseClaim): JsonResponse
@@ -147,6 +151,6 @@ class ExpenseClaimController extends Controller
 
         $expenseClaim->update(['status' => 'rejected']);
 
-        return response()->json(['data' => $expenseClaim->fresh()]);
+        return (new ExpenseClaimResource($expenseClaim->fresh()))->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/JobPostingActionController.php
+++ b/api/app/Http/Controllers/Api/V1/JobPostingActionController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\ApplicantResource;
+use App\Http\Resources\Api\V1\InterviewResource;
+use App\Http\Resources\Api\V1\JobPostingResource;
 use App\Models\Applicant;
 use App\Models\Employee;
 use App\Models\Interview;
@@ -31,7 +34,7 @@ class JobPostingActionController extends Controller
             'published_at' => now(),
         ]);
 
-        return response()->json(['data' => $job->fresh()]);
+        return (new JobPostingResource($job->fresh()))->response();
     }
 
     public function close(Request $request, int $id): JsonResponse
@@ -50,7 +53,7 @@ class JobPostingActionController extends Controller
 
         $job->update(['status' => 'closed']);
 
-        return response()->json(['data' => $job->fresh()]);
+        return (new JobPostingResource($job->fresh()))->response();
     }
 
     public function destroy(Request $request, int $id): JsonResponse
@@ -84,7 +87,7 @@ class JobPostingActionController extends Controller
             ->with(['jobPosting:id,title', 'interviews'])
             ->findOrFail($id);
 
-        return response()->json(['data' => $applicant]);
+        return (new ApplicantResource($applicant))->response();
     }
 
     public function updateApplicantStatus(Request $request, int $id): JsonResponse
@@ -102,7 +105,7 @@ class JobPostingActionController extends Controller
         $applicant = Applicant::where('company_id', $user->company_id)->findOrFail($id);
         $applicant->update($validated);
 
-        return response()->json(['data' => $applicant->fresh()]);
+        return (new ApplicantResource($applicant->fresh()))->response();
     }
 
     public function destroyApplicant(Request $request, int $id): JsonResponse
@@ -133,7 +136,7 @@ class JobPostingActionController extends Controller
 
         $interview->update(array_merge($validated, ['status' => 'completed']));
 
-        return response()->json(['data' => $interview->fresh()]);
+        return (new InterviewResource($interview->fresh()))->response();
     }
 
     public function destroyInterview(Request $request, int $id): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/LeavePolicyController.php
+++ b/api/app/Http/Controllers/Api/V1/LeavePolicyController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\LeaveAccrualResource;
+use App\Http\Resources\Api\V1\LeaveBalanceResource;
+use App\Http\Resources\Api\V1\LeavePolicyResource;
 use App\Models\AbsenceType;
 use App\Models\Employee;
 use App\Models\LeaveAccrual;
@@ -28,7 +31,7 @@ class LeavePolicyController extends Controller
             ->orderBy('name')
             ->get();
 
-        return response()->json(['data' => $policies]);
+        return LeavePolicyResource::collection($policies)->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -71,7 +74,9 @@ class LeavePolicyController extends Controller
             'company_id' => $actor->company_id,
         ]);
 
-        return response()->json(['data' => $policy->load('absenceType:id,name,code')], 201);
+        return (new LeavePolicyResource($policy->load('absenceType:id,name,code')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, LeavePolicy $leavePolicy): JsonResponse
@@ -82,7 +87,7 @@ class LeavePolicyController extends Controller
             abort(404);
         }
 
-        return response()->json(['data' => $leavePolicy->load('absenceType:id,name,code')]);
+        return (new LeavePolicyResource($leavePolicy->load('absenceType:id,name,code')))->response();
     }
 
     public function update(Request $request, LeavePolicy $leavePolicy): JsonResponse
@@ -117,7 +122,7 @@ class LeavePolicyController extends Controller
         /** @var LeavePolicy $leavePolicyFresh */
         $leavePolicyFresh = $leavePolicy->fresh();
 
-        return response()->json(['data' => $leavePolicyFresh->load('absenceType:id,name,code')]);
+        return (new LeavePolicyResource($leavePolicyFresh->load('absenceType:id,name,code')))->response();
     }
 
     public function balances(Request $request): JsonResponse
@@ -137,7 +142,7 @@ class LeavePolicyController extends Controller
             $query->where('employee_id', $request->integer('employee_id'));
         }
 
-        return response()->json(['data' => $query->get()]);
+        return LeaveBalanceResource::collection($query->get())->response();
     }
 
     public function destroy(Request $request, LeavePolicy $leavePolicy): JsonResponse
@@ -169,7 +174,7 @@ class LeavePolicyController extends Controller
             ->forYear($year)
             ->get();
 
-        return response()->json(['data' => $balances]);
+        return LeaveBalanceResource::collection($balances)->response();
     }
 
     public function accruals(Request $request): JsonResponse
@@ -190,7 +195,7 @@ class LeavePolicyController extends Controller
 
         $perPage = $request->integer('per_page', 25);
 
-        return response()->json($query->paginate($perPage));
+        return LeaveAccrualResource::collection($query->paginate($perPage))->response();
     }
 
     public function storeAccrual(Request $request): JsonResponse
@@ -249,6 +254,8 @@ class LeavePolicyController extends Controller
 
         $balance->increment('balance', (float) $validated['amount']);
 
-        return response()->json(['data' => $accrual->load(['employee:id,first_name,last_name', 'leavePolicy:id,name'])], 201);
+        return (new LeaveAccrualResource($accrual->load(['employee:id,first_name,last_name', 'leavePolicy:id,name'])))
+            ->response()
+            ->setStatusCode(201);
     }
 }

--- a/api/app/Http/Controllers/Api/V1/NotificationPreferenceController.php
+++ b/api/app/Http/Controllers/Api/V1/NotificationPreferenceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\NotificationPreferenceResource;
 use App\Models\CommunicationEvent;
 use App\Models\Employee;
 use App\Models\NotificationPreference;
@@ -16,7 +17,7 @@ class NotificationPreferenceController extends Controller
         /** @var Employee $employee */
         $employee = $request->user();
 
-        return response()->json(['data' => $this->preferencesFor($employee)]);
+        return (new NotificationPreferenceResource($this->preferencesFor($employee)))->response();
     }
 
     public function update(Request $request): JsonResponse
@@ -62,7 +63,7 @@ class NotificationPreferenceController extends Controller
             'occurred_at' => now(),
         ]);
 
-        return response()->json(['data' => $preferences->fresh()]);
+        return (new NotificationPreferenceResource($preferences->fresh()))->response();
     }
 
     private function preferencesFor(Employee $employee): NotificationPreference

--- a/api/app/Http/Controllers/Api/V1/OnboardingStepController.php
+++ b/api/app/Http/Controllers/Api/V1/OnboardingStepController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\OnboardingStepResource;
 use App\Models\Employee;
 use App\Models\OnboardingStep;
 use Illuminate\Database\Eloquent\Collection;
@@ -24,7 +25,7 @@ class OnboardingStepController extends Controller
             $steps = $this->seedDefaultSteps($user->company_id);
         }
 
-        return response()->json(['data' => $steps]);
+        return OnboardingStepResource::collection($steps)->response();
     }
 
     public function progress(Request $request): JsonResponse
@@ -65,7 +66,7 @@ class OnboardingStepController extends Controller
             'completed_by' => $user->id,
         ]);
 
-        return response()->json(['data' => $step->fresh()]);
+        return (new OnboardingStepResource($step->fresh()))->response();
     }
 
     public function skip(Request $request, string $stepKey): JsonResponse
@@ -83,7 +84,7 @@ class OnboardingStepController extends Controller
 
         $step->update(['status' => 'skipped']);
 
-        return response()->json(['data' => $step->fresh()]);
+        return (new OnboardingStepResource($step->fresh()))->response();
     }
 
     /**

--- a/api/app/Http/Controllers/Api/V1/PaySlipController.php
+++ b/api/app/Http/Controllers/Api/V1/PaySlipController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\PaySlipResource;
 use App\Models\Employee;
 use App\Models\PayrollRun;
 use App\Models\PaySlip;
@@ -64,15 +65,7 @@ class PaySlipController extends Controller
             ->orderByDesc('id')
             ->paginate($perPage);
 
-        return response()->json([
-            'data' => $slips->items(),
-            'meta' => [
-                'current_page' => $slips->currentPage(),
-                'last_page' => $slips->lastPage(),
-                'per_page' => $slips->perPage(),
-                'total' => $slips->total(),
-            ],
-        ]);
+        return PaySlipResource::collection($slips)->response();
     }
 
     public function indexForRun(Request $request, PayrollRun $payrollRun): JsonResponse
@@ -90,15 +83,7 @@ class PaySlipController extends Controller
             ->with(['employee:id,first_name,last_name,email', 'lines'])
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $slips->items(),
-            'meta' => [
-                'current_page' => $slips->currentPage(),
-                'last_page' => $slips->lastPage(),
-                'per_page' => $slips->perPage(),
-                'total' => $slips->total(),
-            ],
-        ]);
+        return PaySlipResource::collection($slips)->response();
     }
 
     public function show(Request $request, PaySlip $paySlip): JsonResponse
@@ -114,7 +99,7 @@ class PaySlipController extends Controller
 
         $paySlip->load(['employee:id,first_name,last_name,email', 'lines', 'payrollRun']);
 
-        return response()->json(['data' => $paySlip]);
+        return (new PaySlipResource($paySlip))->response();
     }
 
     public function myPaySlips(Request $request): JsonResponse
@@ -144,15 +129,7 @@ class PaySlipController extends Controller
             ->orderByDesc('id')
             ->paginate((int) ($validated['per_page'] ?? 12));
 
-        return response()->json([
-            'data' => $slips->items(),
-            'meta' => [
-                'current_page' => $slips->currentPage(),
-                'last_page' => $slips->lastPage(),
-                'per_page' => $slips->perPage(),
-                'total' => $slips->total(),
-            ],
-        ]);
+        return PaySlipResource::collection($slips)->response();
     }
 
     public function myPaySlipDetail(Request $request, PaySlip $paySlip): JsonResponse
@@ -169,7 +146,7 @@ class PaySlipController extends Controller
 
         $paySlip->load('lines');
 
-        return response()->json(['data' => $paySlip]);
+        return (new PaySlipResource($paySlip))->response();
     }
 
     public function downloadPdf(Request $request, PaySlip $paySlip, PaySlipPdfGenerator $generator): Response

--- a/api/app/Http/Controllers/Api/V1/PayrollController.php
+++ b/api/app/Http/Controllers/Api/V1/PayrollController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Payroll\PayrollIndexRequest;
 use App\Http\Requests\Api\V1\Payroll\StorePayrollRequest;
 use App\Http\Requests\Api\V1\Payroll\UpdatePayrollRequest;
+use App\Http\Resources\Api\V1\PayrollResource;
 use App\Models\Employee;
 use App\Models\Payroll;
 use App\Services\PayrollService;
@@ -63,10 +64,7 @@ class PayrollController extends Controller
         $perPage = $request->integer('per_page', 15);
         $paginated = $query->orderByDesc('period_year')->orderByDesc('period_month')->paginate($perPage);
 
-        return response()->json([
-            'data' => $paginated->map(fn ($p) => $this->serialize($p)),
-            'meta' => ['current_page' => $paginated->currentPage(), 'last_page' => $paginated->lastPage(), 'per_page' => $paginated->perPage(), 'total' => $paginated->total()],
-        ]);
+        return PayrollResource::collection($paginated)->response();
     }
 
     public function store(StorePayrollRequest $request): JsonResponse
@@ -79,7 +77,9 @@ class PayrollController extends Controller
 
         $payroll = $this->payrollService->create($actor, $request->validated());
 
-        return response()->json(['data' => $this->serialize($payroll->load('employee'))], 201);
+        return (new PayrollResource($payroll->load('employee')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, Payroll $payroll): JsonResponse
@@ -93,7 +93,7 @@ class PayrollController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $this->serialize($payroll->load('employee'))]);
+        return (new PayrollResource($payroll->load('employee')))->response();
     }
 
     public function update(UpdatePayrollRequest $request, Payroll $payroll): JsonResponse
@@ -109,7 +109,7 @@ class PayrollController extends Controller
 
         $payroll = $this->payrollService->update($payroll, $request->validated());
 
-        return response()->json(['data' => $this->serialize($payroll->load('employee'))]);
+        return (new PayrollResource($payroll->load('employee')))->response();
     }
 
     public function validatePayroll(Request $request, Payroll $payroll): JsonResponse
@@ -125,7 +125,7 @@ class PayrollController extends Controller
 
         $payroll = $this->payrollService->validate($payroll, $actor);
 
-        return response()->json(['data' => $this->serialize($payroll->load('employee'))]);
+        return (new PayrollResource($payroll->load('employee')))->response();
     }
 
     public function destroy(Request $request, Payroll $payroll): JsonResponse
@@ -144,19 +144,4 @@ class PayrollController extends Controller
         return response()->json(['message' => 'Payroll deleted successfully']);
     }
 
-    private function serialize(Payroll $p): array
-    {
-        return [
-            'id' => $p->id, 'employee_id' => $p->employee_id,
-            'employee' => $p->relationLoaded('employee') ? ['id' => $p->employee->id, 'first_name' => $p->employee->first_name, 'last_name' => $p->employee->last_name, 'email' => $p->employee->email] : null,
-            'period_month' => $p->period_month, 'period_year' => $p->period_year,
-            'gross_salary' => $p->gross_salary, 'overtime_amount' => $p->overtime_amount,
-            'bonuses' => $p->bonuses, 'deductions' => $p->deductions, 'cotisations' => $p->cotisations,
-            'ir_amount' => $p->ir_amount, 'advance_deduction' => $p->advance_deduction,
-            'absence_deduction' => $p->absence_deduction, 'penalty_deduction' => $p->penalty_deduction,
-            'net_salary' => $p->net_salary, 'pdf_path' => $p->pdf_path, 'status' => $p->status,
-            'validated_by' => $p->validated_by, 'validated_at' => $p->validated_at?->toIso8601String(),
-            'created_at' => $p->created_at?->toIso8601String(), 'updated_at' => $p->updated_at?->toIso8601String(),
-        ];
-    }
 }

--- a/api/app/Http/Controllers/Api/V1/PayrollRunController.php
+++ b/api/app/Http/Controllers/Api/V1/PayrollRunController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\PayrollRunResource;
 use App\Jobs\WarmPaySlipPdfPathsForPayrollRunJob;
 use App\Models\Employee;
 use App\Models\PayrollRun;
@@ -35,15 +36,7 @@ class PayrollRunController extends Controller
 
         $runs = $query->orderByDesc('period_start')->paginate($request->integer('per_page', 15));
 
-        return response()->json([
-            'data' => $runs->items(),
-            'meta' => [
-                'current_page' => $runs->currentPage(),
-                'last_page' => $runs->lastPage(),
-                'per_page' => $runs->perPage(),
-                'total' => $runs->total(),
-            ],
-        ]);
+        return PayrollRunResource::collection($runs)->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -70,7 +63,9 @@ class PayrollRunController extends Controller
             'notes' => $validated['notes'] ?? null,
         ]);
 
-        return response()->json(['data' => $run], 201);
+        return (new PayrollRunResource($run))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, PayrollRun $payrollRun): JsonResponse
@@ -86,7 +81,7 @@ class PayrollRunController extends Controller
 
         $payrollRun->loadCount('paySlips');
 
-        return response()->json(['data' => $payrollRun]);
+        return (new PayrollRunResource($payrollRun))->response();
     }
 
     public function calculate(Request $request, PayrollRun $payrollRun): JsonResponse
@@ -107,7 +102,7 @@ class PayrollRunController extends Controller
         $payrollRun->update(['status' => 'calculating']);
         $run = $this->calculator->calculateRun($payrollRun);
 
-        return response()->json(['data' => $run->loadCount('paySlips')]);
+        return (new PayrollRunResource($run->loadCount('paySlips')))->response();
     }
 
     public function validateRun(Request $request, PayrollRun $payrollRun): JsonResponse
@@ -139,7 +134,7 @@ class PayrollRunController extends Controller
             WarmPaySlipPdfPathsForPayrollRunJob::dispatch($payrollRun->id);
         }
 
-        return response()->json(['data' => $payrollRun->refresh()->loadCount('paySlips')]);
+        return (new PayrollRunResource($payrollRun->refresh()->loadCount('paySlips')))->response();
     }
 
     public function cancel(Request $request, PayrollRun $payrollRun): JsonResponse
@@ -159,7 +154,7 @@ class PayrollRunController extends Controller
 
         $payrollRun->update(['status' => 'cancelled']);
 
-        return response()->json(['data' => $payrollRun->refresh()]);
+        return (new PayrollRunResource($payrollRun->refresh()))->response();
     }
 
     public function summary(Request $request, PayrollRun $payrollRun): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/ProjectController.php
+++ b/api/app/Http/Controllers/Api/V1/ProjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\ProjectResource;
 use App\Models\Employee;
 use App\Models\Project;
 use Illuminate\Http\JsonResponse;
@@ -25,12 +26,9 @@ class ProjectController extends Controller
         }
 
         $perPage = $request->integer('per_page', 15);
-        $paginated = $query->orderByDesc('created_at')->paginate($perPage);
 
-        return response()->json([
-            'data' => $paginated->map(fn ($p) => $this->serialize($p)),
-            'meta' => ['current_page' => $paginated->currentPage(), 'last_page' => $paginated->lastPage(), 'per_page' => $paginated->perPage(), 'total' => $paginated->total()],
-        ]);
+        return ProjectResource::collection($query->orderByDesc('created_at')->paginate($perPage))
+            ->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -44,7 +42,9 @@ class ProjectController extends Controller
         $data = $request->validate(['name' => ['required', 'string', 'max:150'], 'description' => ['nullable', 'string'], 'start_date' => ['nullable', 'date_format:Y-m-d'], 'end_date' => ['nullable', 'date_format:Y-m-d', 'gte:start_date'], 'members' => ['nullable', 'array'], 'members.*' => ['integer', 'min:1'], 'status' => ['nullable', 'in:active,completed,archived']]);
         $project = Project::create(['company_id' => $actor->company_id, 'created_by' => $actor->id, 'members' => $data['members'] ?? [], 'status' => $data['status'] ?? 'active', ...$data]);
 
-        return response()->json(['data' => $this->serialize($project)], 201);
+        return (new ProjectResource($project))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, Project $project): JsonResponse
@@ -58,7 +58,7 @@ class ProjectController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $this->serialize($project)]);
+        return (new ProjectResource($project))->response();
     }
 
     public function update(Request $request, Project $project): JsonResponse
@@ -75,7 +75,7 @@ class ProjectController extends Controller
         $data = $request->validate(['name' => ['sometimes', 'string', 'max:150'], 'description' => ['nullable', 'string'], 'start_date' => ['nullable', 'date_format:Y-m-d'], 'end_date' => ['nullable', 'date_format:Y-m-d'], 'members' => ['nullable', 'array'], 'members.*' => ['integer', 'min:1'], 'status' => ['nullable', 'in:active,completed,archived']]);
         $project->update($data);
 
-        return response()->json(['data' => $this->serialize($project->fresh())]);
+        return (new ProjectResource($project->fresh()))->response();
     }
 
     public function destroy(Request $request, Project $project): JsonResponse
@@ -94,8 +94,4 @@ class ProjectController extends Controller
         return response()->json(['message' => 'Project deleted successfully']);
     }
 
-    private function serialize(Project $p): array
-    {
-        return ['id' => $p->id, 'name' => $p->name, 'description' => $p->description, 'start_date' => $p->start_date?->toDateString(), 'end_date' => $p->end_date?->toDateString(), 'members' => $p->members, 'status' => $p->status, 'created_by' => $p->created_by, 'created_at' => $p->created_at?->toIso8601String()];
-    }
 }

--- a/api/app/Http/Controllers/Api/V1/RecruitmentController.php
+++ b/api/app/Http/Controllers/Api/V1/RecruitmentController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\ApplicantResource;
+use App\Http\Resources\Api\V1\InterviewResource;
+use App\Http\Resources\Api\V1\JobPostingResource;
 use App\Models\Applicant;
 use App\Models\Employee;
 use App\Models\Interview;
@@ -33,7 +36,8 @@ class RecruitmentController extends Controller
             $query->where('status', $request->input('status'));
         }
 
-        return response()->json($query->orderByDesc('created_at')->paginate($request->integer('per_page', 15)));
+        return JobPostingResource::collection($query->orderByDesc('created_at')->paginate($request->integer('per_page', 15)))
+            ->response();
     }
 
     public function storeJob(Request $request): JsonResponse
@@ -74,7 +78,9 @@ class RecruitmentController extends Controller
             'status' => 'draft',
         ]);
 
-        return response()->json(['data' => $job], 201);
+        return (new JobPostingResource($job))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function showJob(Request $request, JobPosting $jobPosting): JsonResponse
@@ -85,7 +91,7 @@ class RecruitmentController extends Controller
             abort(404);
         }
 
-        return response()->json(['data' => $jobPosting->load(['department:id,name', 'applicants'])]);
+        return (new JobPostingResource($jobPosting->load(['department:id,name', 'applicants'])))->response();
     }
 
     public function updateJob(Request $request, JobPosting $jobPosting): JsonResponse
@@ -128,7 +134,7 @@ class RecruitmentController extends Controller
 
         $jobPosting->update($validated);
 
-        return response()->json(['data' => $jobPosting->fresh()]);
+        return (new JobPostingResource($jobPosting->fresh()))->response();
     }
 
     // ── Applicants ──────────────────────────────────────────────────────────
@@ -150,7 +156,8 @@ class RecruitmentController extends Controller
             $query->where('status', $request->input('status'));
         }
 
-        return response()->json($query->orderByDesc('applied_at')->paginate($request->integer('per_page', 15)));
+        return ApplicantResource::collection($query->orderByDesc('applied_at')->paginate($request->integer('per_page', 15)))
+            ->response();
     }
 
     public function storeApplicant(Request $request, JobPosting $jobPosting): JsonResponse
@@ -180,7 +187,9 @@ class RecruitmentController extends Controller
             'job_posting_id' => $jobPosting->id,
         ]);
 
-        return response()->json(['data' => $applicant], 201);
+        return (new ApplicantResource($applicant))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function updateApplicant(Request $request, Applicant $applicant): JsonResponse
@@ -202,7 +211,7 @@ class RecruitmentController extends Controller
 
         $applicant->update($validated);
 
-        return response()->json(['data' => $applicant->fresh()]);
+        return (new ApplicantResource($applicant->fresh()))->response();
     }
 
     // ── Interviews ──────────────────────────────────────────────────────────
@@ -235,7 +244,9 @@ class RecruitmentController extends Controller
             'applicant_id' => $applicant->id,
         ]);
 
-        return response()->json(['data' => $interview], 201);
+        return (new InterviewResource($interview))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function updateInterview(Request $request, Interview $interview): JsonResponse
@@ -257,6 +268,6 @@ class RecruitmentController extends Controller
 
         $interview->update($validated);
 
-        return response()->json(['data' => $interview->fresh()]);
+        return (new InterviewResource($interview->fresh()))->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/SalaryAdvanceController.php
+++ b/api/app/Http/Controllers/Api/V1/SalaryAdvanceController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\SalaryAdvance\DecideSalaryAdvanceRequest;
 use App\Http\Requests\Api\V1\SalaryAdvance\SalaryAdvanceIndexRequest;
 use App\Http\Requests\Api\V1\SalaryAdvance\StoreSalaryAdvanceRequest;
+use App\Http\Resources\Api\V1\SalaryAdvanceResource;
 use App\Models\Employee;
 use App\Models\SalaryAdvance;
 use App\Services\SalaryAdvanceService;
@@ -33,19 +34,18 @@ class SalaryAdvanceController extends Controller
         }
 
         $perPage = $request->integer('per_page', 15);
-        $paginated = $query->orderByDesc('created_at')->paginate($perPage);
 
-        return response()->json([
-            'data' => $paginated->map(fn ($a) => $this->serialize($a)),
-            'meta' => ['current_page' => $paginated->currentPage(), 'last_page' => $paginated->lastPage(), 'per_page' => $paginated->perPage(), 'total' => $paginated->total()],
-        ]);
+        return SalaryAdvanceResource::collection($query->orderByDesc('created_at')->paginate($perPage))
+            ->response();
     }
 
     public function store(StoreSalaryAdvanceRequest $request): JsonResponse
     {
         $advance = $this->salaryAdvanceService->create($request->user(), $request->validated());
 
-        return response()->json(['data' => $this->serialize($advance)], 201);
+        return (new SalaryAdvanceResource($advance))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, SalaryAdvance $salaryAdvance): JsonResponse
@@ -59,7 +59,7 @@ class SalaryAdvanceController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $this->serialize($salaryAdvance)]);
+        return (new SalaryAdvanceResource($salaryAdvance))->response();
     }
 
     public function approve(DecideSalaryAdvanceRequest $request, SalaryAdvance $salaryAdvance): JsonResponse
@@ -75,7 +75,7 @@ class SalaryAdvanceController extends Controller
 
         $advance = $this->salaryAdvanceService->approve($salaryAdvance, $actor, $request->validated());
 
-        return response()->json(['data' => $this->serialize($advance)]);
+        return (new SalaryAdvanceResource($advance))->response();
     }
 
     public function reject(DecideSalaryAdvanceRequest $request, SalaryAdvance $salaryAdvance): JsonResponse
@@ -91,7 +91,7 @@ class SalaryAdvanceController extends Controller
 
         $advance = $this->salaryAdvanceService->reject($salaryAdvance, $actor, $request->validated('decision_comment'));
 
-        return response()->json(['data' => $this->serialize($advance)]);
+        return (new SalaryAdvanceResource($advance))->response();
     }
 
     public function destroy(Request $request, SalaryAdvance $salaryAdvance): JsonResponse
@@ -107,11 +107,5 @@ class SalaryAdvanceController extends Controller
 
         $advance = $this->salaryAdvanceService->cancel($salaryAdvance);
 
-        return response()->json(['data' => $this->serialize($advance)]);
-    }
-
-    private function serialize(SalaryAdvance $a): array
-    {
-        return ['id' => $a->id, 'employee_id' => $a->employee_id, 'amount' => $a->amount, 'reason' => $a->reason, 'status' => $a->status, 'approved_by' => $a->approved_by, 'decision_comment' => $a->decision_comment, 'repayment_months' => $a->repayment_months, 'monthly_deduction' => $a->monthly_deduction, 'amount_remaining' => $a->amount_remaining, 'repayment_plan' => $a->repayment_plan, 'created_at' => $a->created_at?->toIso8601String(), 'updated_at' => $a->updated_at?->toIso8601String()];
-    }
+        return (new SalaryAdvanceResource($advance))->response();
 }

--- a/api/app/Http/Controllers/Api/V1/SalaryAdvanceController.php
+++ b/api/app/Http/Controllers/Api/V1/SalaryAdvanceController.php
@@ -108,4 +108,5 @@ class SalaryAdvanceController extends Controller
         $advance = $this->salaryAdvanceService->cancel($salaryAdvance);
 
         return (new SalaryAdvanceResource($advance))->response();
+    }
 }

--- a/api/app/Http/Controllers/Api/V1/SalaryComponentController.php
+++ b/api/app/Http/Controllers/Api/V1/SalaryComponentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SalaryComponentResource;
 use App\Models\Employee;
 use App\Models\SalaryComponent;
 use Illuminate\Http\JsonResponse;
@@ -32,9 +33,7 @@ class SalaryComponentController extends Controller
             $query->active();
         }
 
-        return response()->json([
-            'data' => $query->orderBy('order')->get(),
-        ]);
+        return SalaryComponentResource::collection($query->orderBy('order')->get())->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -75,7 +74,9 @@ class SalaryComponentController extends Controller
             'active' => true,
         ]);
 
-        return response()->json(['data' => $component], 201);
+        return (new SalaryComponentResource($component))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, SalaryComponent $salaryComponent): JsonResponse
@@ -89,7 +90,7 @@ class SalaryComponentController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $salaryComponent]);
+        return (new SalaryComponentResource($salaryComponent))->response();
     }
 
     public function update(Request $request, SalaryComponent $salaryComponent): JsonResponse
@@ -119,7 +120,7 @@ class SalaryComponentController extends Controller
 
         $salaryComponent->update($validated);
 
-        return response()->json(['data' => $salaryComponent->refresh()]);
+        return (new SalaryComponentResource($salaryComponent->refresh()))->response();
     }
 
     public function destroy(Request $request, SalaryComponent $salaryComponent): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/SalaryStructureController.php
+++ b/api/app/Http/Controllers/Api/V1/SalaryStructureController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SalaryStructureResource;
 use App\Models\Employee;
 use App\Models\SalaryStructure;
 use Illuminate\Http\JsonResponse;
@@ -29,9 +30,7 @@ class SalaryStructureController extends Controller
             $query->active();
         }
 
-        return response()->json([
-            'data' => $query->orderBy('name')->get(),
-        ]);
+        return SalaryStructureResource::collection($query->orderBy('name')->get())->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -60,7 +59,9 @@ class SalaryStructureController extends Controller
             'active' => true,
         ]);
 
-        return response()->json(['data' => $structure], 201);
+        return (new SalaryStructureResource($structure))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, SalaryStructure $salaryStructure): JsonResponse
@@ -76,7 +77,7 @@ class SalaryStructureController extends Controller
 
         $salaryStructure->load('components');
 
-        return response()->json(['data' => $salaryStructure]);
+        return (new SalaryStructureResource($salaryStructure))->response();
     }
 
     public function update(Request $request, SalaryStructure $salaryStructure): JsonResponse
@@ -101,7 +102,7 @@ class SalaryStructureController extends Controller
 
         $salaryStructure->update($validated);
 
-        return response()->json(['data' => $salaryStructure->refresh()]);
+        return (new SalaryStructureResource($salaryStructure->refresh()))->response();
     }
 
     public function destroy(Request $request, SalaryStructure $salaryStructure): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/SelfServiceController.php
+++ b/api/app/Http/Controllers/Api/V1/SelfServiceController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\LoanResource;
+use App\Http\Resources\Api\V1\TrainingEnrollmentResource;
 use App\Models\Employee;
 use App\Models\EmployeeLoan;
 use App\Models\LoanRepayment;
@@ -23,15 +25,7 @@ class SelfServiceController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $enrollments->items(),
-            'meta' => [
-                'current_page' => $enrollments->currentPage(),
-                'last_page' => $enrollments->lastPage(),
-                'per_page' => $enrollments->perPage(),
-                'total' => $enrollments->total(),
-            ],
-        ]);
+        return TrainingEnrollmentResource::collection($enrollments)->response();
     }
 
     public function selfEnroll(Request $request, int $sessionId): JsonResponse
@@ -54,7 +48,9 @@ class SelfServiceController extends Controller
             'status' => 'enrolled',
         ]);
 
-        return response()->json(['data' => $enrollment], 201);
+        return (new TrainingEnrollmentResource($enrollment))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function myLoans(Request $request): JsonResponse
@@ -68,15 +64,7 @@ class SelfServiceController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $loans->items(),
-            'meta' => [
-                'current_page' => $loans->currentPage(),
-                'last_page' => $loans->lastPage(),
-                'per_page' => $loans->perPage(),
-                'total' => $loans->total(),
-            ],
-        ]);
+        return LoanResource::collection($loans)->response();
     }
 
     public function myLoanRepayments(Request $request, int $loanId): JsonResponse
@@ -93,6 +81,6 @@ class SelfServiceController extends Controller
             ->orderBy('due_date')
             ->get();
 
-        return response()->json(['data' => $repayments]);
+        return response()->json(['data' => $repayments]); // LoanRepayment — no dedicated Resource yet
     }
 }

--- a/api/app/Http/Controllers/Api/V1/SocialContributionController.php
+++ b/api/app/Http/Controllers/Api/V1/SocialContributionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SocialContributionResource;
 use App\Models\Employee;
 use App\Models\SocialContribution;
 use Illuminate\Http\JsonResponse;
@@ -28,9 +29,7 @@ class SocialContributionController extends Controller
             $query->where('type', $request->input('type'));
         }
 
-        return response()->json([
-            'data' => $query->orderBy('country_code')->orderBy('type')->orderBy('name')->get(),
-        ]);
+        return SocialContributionResource::collection($query->orderBy('country_code')->orderBy('type')->orderBy('name')->get())->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -64,7 +63,9 @@ class SocialContributionController extends Controller
             'effective_to' => $validated['effective_to'] ?? null,
         ]);
 
-        return response()->json(['data' => $contribution], 201);
+        return (new SocialContributionResource($contribution))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function update(Request $request, SocialContribution $socialContribution): JsonResponse
@@ -86,7 +87,7 @@ class SocialContributionController extends Controller
 
         $socialContribution->update($validated);
 
-        return response()->json(['data' => $socialContribution->refresh()]);
+        return (new SocialContributionResource($socialContribution->refresh()))->response();
     }
 
     public function destroy(Request $request, SocialContribution $socialContribution): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/TaskController.php
+++ b/api/app/Http/Controllers/Api/V1/TaskController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\TaskCommentResource;
+use App\Http\Resources\Api\V1\TaskResource;
 use App\Models\Employee;
 use App\Models\Task;
 use App\Models\TaskComment;
@@ -36,12 +38,9 @@ class TaskController extends Controller
         }
 
         $perPage = $request->integer('per_page', 15);
-        $paginated = $query->orderBy('due_date')->orderByDesc('created_at')->paginate($perPage);
 
-        return response()->json([
-            'data' => $paginated->map(fn ($t) => $this->serialize($t)),
-            'meta' => ['current_page' => $paginated->currentPage(), 'last_page' => $paginated->lastPage(), 'per_page' => $paginated->perPage(), 'total' => $paginated->total()],
-        ]);
+        return TaskResource::collection($query->orderBy('due_date')->orderByDesc('created_at')->paginate($perPage))
+            ->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -52,7 +51,9 @@ class TaskController extends Controller
 
         $task = Task::create(['company_id' => $actor->company_id, 'created_by' => $actor->id, 'assigned_to' => $data['assigned_to'] ?? [], 'status' => 'todo', 'priority' => $data['priority'] ?? 'normal', 'visibility' => $data['visibility'] ?? 'visible', ...$data]);
 
-        return response()->json(['data' => $this->serialize($task)], 201);
+        return (new TaskResource($task))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, Task $task): JsonResponse
@@ -66,7 +67,7 @@ class TaskController extends Controller
             abort(403);
         }
 
-        return response()->json(['data' => $this->serialize($task->load('comments.author'))]);
+        return (new TaskResource($task->load('comments.author')))->response();
     }
 
     public function update(Request $request, Task $task): JsonResponse
@@ -85,7 +86,7 @@ class TaskController extends Controller
         $data = $request->validate(['title' => ['sometimes', 'string', 'max:200'], 'description' => ['nullable', 'string'], 'assigned_to' => ['sometimes', 'array'], 'assigned_to.*' => ['integer', 'min:1'], 'project_id' => ['nullable', 'integer', 'min:1'], 'due_date' => ['sometimes', 'date'], 'priority' => ['sometimes', 'in:low,normal,high,urgent'], 'status' => ['sometimes', 'in:todo,inprogress,review,done,rejected,cancelled'], 'category' => ['nullable', 'string', 'max:100'], 'visibility' => ['sometimes', 'in:private,visible'], 'checklist' => ['nullable', 'array']]);
         $task->update($data);
 
-        return response()->json(['data' => $this->serialize($task->fresh())]);
+        return (new TaskResource($task->fresh()))->response();
     }
 
     public function destroy(Request $request, Task $task): JsonResponse
@@ -115,17 +116,9 @@ class TaskController extends Controller
         $data = $request->validate(['content' => ['required', 'string', 'max:5000']]);
         $comment = TaskComment::create(['company_id' => $actor->company_id, 'task_id' => $task->id, 'author_id' => $actor->id, 'content' => $data['content']]);
 
-        return response()->json(['data' => ['id' => $comment->id, 'task_id' => $comment->task_id, 'author_id' => $comment->author_id, 'content' => $comment->content, 'created_at' => $comment->created_at?->toIso8601String()]], 201);
+        return (new TaskCommentResource($comment))
+            ->response()
+            ->setStatusCode(201);
     }
 
-    private function serialize(Task $task): array
-    {
-        $data = ['id' => $task->id, 'title' => $task->title, 'description' => $task->description, 'created_by' => $task->created_by, 'assigned_to' => $task->assigned_to, 'project_id' => $task->project_id, 'due_date' => $task->due_date?->toIso8601String(), 'priority' => $task->priority, 'status' => $task->status, 'category' => $task->category, 'visibility' => $task->visibility, 'checklist' => $task->checklist, 'created_at' => $task->created_at?->toIso8601String(), 'updated_at' => $task->updated_at?->toIso8601String()];
-
-        if ($task->relationLoaded('comments')) {
-            $data['comments'] = $task->comments->map(fn ($c) => ['id' => $c->id, 'author_id' => $c->author_id, 'author' => $c->relationLoaded('author') ? ['id' => $c->author->id, 'first_name' => $c->author->first_name, 'last_name' => $c->author->last_name] : null, 'content' => $c->content, 'created_at' => $c->created_at?->toIso8601String()]);
-        }
-
-        return $data;
-    }
 }

--- a/api/app/Http/Controllers/Api/V1/TaxSlabController.php
+++ b/api/app/Http/Controllers/Api/V1/TaxSlabController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\TaxSlabResource;
 use App\Models\Employee;
 use App\Models\TaxSlab;
 use Illuminate\Http\JsonResponse;
@@ -24,9 +25,7 @@ class TaxSlabController extends Controller
             $query->forCountry($request->input('country_code'));
         }
 
-        return response()->json([
-            'data' => $query->orderBy('country_code')->orderBy('min_amount')->get(),
-        ]);
+        return TaxSlabResource::collection($query->orderBy('country_code')->orderBy('min_amount')->get())->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -60,7 +59,9 @@ class TaxSlabController extends Controller
             'effective_to' => $validated['effective_to'] ?? null,
         ]);
 
-        return response()->json(['data' => $slab], 201);
+        return (new TaxSlabResource($slab))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function update(Request $request, TaxSlab $taxSlab): JsonResponse
@@ -83,7 +84,7 @@ class TaxSlabController extends Controller
 
         $taxSlab->update($validated);
 
-        return response()->json(['data' => $taxSlab->refresh()]);
+        return (new TaxSlabResource($taxSlab->refresh()))->response();
     }
 
     public function destroy(Request $request, TaxSlab $taxSlab): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/TrainingController.php
+++ b/api/app/Http/Controllers/Api/V1/TrainingController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\TrainingCourseResource;
+use App\Http\Resources\Api\V1\TrainingEnrollmentResource;
+use App\Http\Resources\Api\V1\TrainingSessionResource;
 use App\Models\Employee;
 use App\Models\TrainingCourse;
 use App\Models\TrainingEnrollment;
@@ -27,7 +30,8 @@ class TrainingController extends Controller
             $query->where('category', $request->input('category'));
         }
 
-        return response()->json($query->orderBy('title')->paginate($request->integer('per_page', 15)));
+        return TrainingCourseResource::collection($query->orderBy('title')->paginate($request->integer('per_page', 15)))
+            ->response();
     }
 
     public function storeCourse(Request $request): JsonResponse
@@ -55,7 +59,9 @@ class TrainingController extends Controller
             'company_id' => $actor->company_id,
         ]);
 
-        return response()->json(['data' => $course], 201);
+        return (new TrainingCourseResource($course))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function showCourse(Request $request, TrainingCourse $trainingCourse): JsonResponse
@@ -66,7 +72,7 @@ class TrainingController extends Controller
             abort(404);
         }
 
-        return response()->json(['data' => $trainingCourse->load('sessions')]);
+        return (new TrainingCourseResource($trainingCourse->load('sessions')))->response();
     }
 
     public function updateCourse(Request $request, TrainingCourse $trainingCourse): JsonResponse
@@ -94,7 +100,7 @@ class TrainingController extends Controller
 
         $trainingCourse->update($validated);
 
-        return response()->json(['data' => $trainingCourse->fresh()]);
+        return (new TrainingCourseResource($trainingCourse->fresh()))->response();
     }
 
     // ── Sessions ────────────────────────────────────────────────────────────
@@ -107,7 +113,8 @@ class TrainingController extends Controller
             abort(404);
         }
 
-        return response()->json(['data' => $trainingCourse->sessions()->with('trainer:id,first_name,last_name')->orderByDesc('start_date')->get()]);
+        return TrainingSessionResource::collection($trainingCourse->sessions()->with('trainer:id,first_name,last_name')->orderByDesc('start_date')->get())
+            ->response();
     }
 
     public function storeSession(Request $request, TrainingCourse $trainingCourse): JsonResponse
@@ -140,7 +147,9 @@ class TrainingController extends Controller
             'training_course_id' => $trainingCourse->id,
         ]);
 
-        return response()->json(['data' => $session], 201);
+        return (new TrainingSessionResource($session))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function updateSession(Request $request, TrainingSession $trainingSession): JsonResponse
@@ -170,7 +179,7 @@ class TrainingController extends Controller
 
         $trainingSession->update($validated);
 
-        return response()->json(['data' => $trainingSession->fresh()]);
+        return (new TrainingSessionResource($trainingSession->fresh()))->response();
     }
 
     // ── Enrollments ─────────────────────────────────────────────────────────
@@ -202,7 +211,9 @@ class TrainingController extends Controller
             'status' => 'enrolled',
         ]);
 
-        return response()->json(['data' => $enrollment->load('employee:id,first_name,last_name')], 201);
+        return (new TrainingEnrollmentResource($enrollment->load('employee:id,first_name,last_name')))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function updateEnrollment(Request $request, TrainingEnrollment $trainingEnrollment): JsonResponse
@@ -228,6 +239,6 @@ class TrainingController extends Controller
 
         $trainingEnrollment->update($validated);
 
-        return response()->json(['data' => $trainingEnrollment->fresh()]);
+        return (new TrainingEnrollmentResource($trainingEnrollment->fresh()))->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/VehicleAlertController.php
+++ b/api/app/Http/Controllers/Api/V1/VehicleAlertController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\VehicleAlertResource;
 use App\Models\Employee;
 use App\Models\VehicleAlert;
 use Illuminate\Http\JsonResponse;
@@ -29,15 +30,7 @@ class VehicleAlertController extends Controller
         $alerts = $query->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $alerts->items(),
-            'meta' => [
-                'current_page' => $alerts->currentPage(),
-                'last_page' => $alerts->lastPage(),
-                'per_page' => $alerts->perPage(),
-                'total' => $alerts->total(),
-            ],
-        ]);
+        return VehicleAlertResource::collection($alerts)->response();
     }
 
     public function acknowledge(Request $request, int $id): JsonResponse
@@ -51,6 +44,6 @@ class VehicleAlertController extends Controller
             'acknowledged_by' => $user->id,
         ]);
 
-        return response()->json(['data' => $alert->fresh()]);
+        return (new VehicleAlertResource($alert->fresh()))->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/VehicleController.php
+++ b/api/app/Http/Controllers/Api/V1/VehicleController.php
@@ -3,6 +3,11 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\VehicleAlertResource;
+use App\Http\Resources\Api\V1\VehicleAssignmentResource;
+use App\Http\Resources\Api\V1\VehicleMaintenanceResource;
+use App\Http\Resources\Api\V1\VehicleResource;
+use App\Http\Resources\Api\V1\VehicleTripResource;
 use App\Models\Employee;
 use App\Models\Vehicle;
 use App\Services\Tracking\TraccarService;
@@ -27,15 +32,7 @@ class VehicleController extends Controller
         $vehicles = $query->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $vehicles->items(),
-            'meta' => [
-                'current_page' => $vehicles->currentPage(),
-                'last_page' => $vehicles->lastPage(),
-                'per_page' => $vehicles->perPage(),
-                'total' => $vehicles->total(),
-            ],
-        ]);
+        return VehicleResource::collection($vehicles)->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -63,7 +60,9 @@ class VehicleController extends Controller
 
         $vehicle = Vehicle::create($validated);
 
-        return response()->json(['data' => $vehicle], 201);
+        return (new VehicleResource($vehicle))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, int $id): JsonResponse
@@ -72,7 +71,7 @@ class VehicleController extends Controller
         $user = $request->user();
         $vehicle = Vehicle::where('company_id', $user->company_id)->findOrFail($id);
 
-        return response()->json(['data' => $vehicle]);
+        return (new VehicleResource($vehicle))->response();
     }
 
     public function update(Request $request, int $id): JsonResponse
@@ -100,7 +99,7 @@ class VehicleController extends Controller
 
         $vehicle->update($validated);
 
-        return response()->json(['data' => $vehicle->fresh()]);
+        return (new VehicleResource($vehicle->fresh()))->response();
     }
 
     public function destroy(Request $request, int $id): JsonResponse
@@ -138,15 +137,7 @@ class VehicleController extends Controller
             ->orderByDesc('start_time')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $trips->items(),
-            'meta' => [
-                'current_page' => $trips->currentPage(),
-                'last_page' => $trips->lastPage(),
-                'per_page' => $trips->perPage(),
-                'total' => $trips->total(),
-            ],
-        ]);
+        return VehicleTripResource::collection($trips)->response();
     }
 
     public function vehicleAlerts(Request $request, int $id): JsonResponse
@@ -159,15 +150,7 @@ class VehicleController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $alerts->items(),
-            'meta' => [
-                'current_page' => $alerts->currentPage(),
-                'last_page' => $alerts->lastPage(),
-                'per_page' => $alerts->perPage(),
-                'total' => $alerts->total(),
-            ],
-        ]);
+        return VehicleAlertResource::collection($alerts)->response();
     }
 
     public function maintenance(Request $request, int $id): JsonResponse
@@ -180,15 +163,7 @@ class VehicleController extends Controller
             ->orderByDesc('service_date')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $records->items(),
-            'meta' => [
-                'current_page' => $records->currentPage(),
-                'last_page' => $records->lastPage(),
-                'per_page' => $records->perPage(),
-                'total' => $records->total(),
-            ],
-        ]);
+        return VehicleMaintenanceResource::collection($records)->response();
     }
 
     public function assign(Request $request, int $id): JsonResponse
@@ -248,6 +223,6 @@ class VehicleController extends Controller
             ->orderByDesc('start_date')
             ->get();
 
-        return response()->json(['data' => $assignments]);
+        return VehicleAssignmentResource::collection($assignments)->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/VehicleMaintenanceController.php
+++ b/api/app/Http/Controllers/Api/V1/VehicleMaintenanceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\VehicleMaintenanceResource;
 use App\Models\Employee;
 use App\Models\VehicleMaintenance;
 use Illuminate\Http\JsonResponse;
@@ -26,15 +27,7 @@ class VehicleMaintenanceController extends Controller
         $records = $query->orderByDesc('service_date')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $records->items(),
-            'meta' => [
-                'current_page' => $records->currentPage(),
-                'last_page' => $records->lastPage(),
-                'per_page' => $records->perPage(),
-                'total' => $records->total(),
-            ],
-        ]);
+        return VehicleMaintenanceResource::collection($records)->response();
     }
 
     public function store(Request $request): JsonResponse
@@ -58,7 +51,9 @@ class VehicleMaintenanceController extends Controller
 
         $record = VehicleMaintenance::create($validated);
 
-        return response()->json(['data' => $record], 201);
+        return (new VehicleMaintenanceResource($record))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function update(Request $request, int $id): JsonResponse
@@ -81,7 +76,7 @@ class VehicleMaintenanceController extends Controller
 
         $record->update($validated);
 
-        return response()->json(['data' => $record->fresh()]);
+        return (new VehicleMaintenanceResource($record->fresh()))->response();
     }
 
     public function destroy(Request $request, int $id): JsonResponse

--- a/api/app/Http/Controllers/Api/V1/VehicleTripController.php
+++ b/api/app/Http/Controllers/Api/V1/VehicleTripController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\VehicleTripResource;
 use App\Models\Employee;
 use App\Models\VehicleTrip;
 use Illuminate\Http\JsonResponse;
@@ -32,15 +33,7 @@ class VehicleTripController extends Controller
         $trips = $query->orderByDesc('start_time')
             ->paginate($request->integer('per_page', 20));
 
-        return response()->json([
-            'data' => $trips->items(),
-            'meta' => [
-                'current_page' => $trips->currentPage(),
-                'last_page' => $trips->lastPage(),
-                'per_page' => $trips->perPage(),
-                'total' => $trips->total(),
-            ],
-        ]);
+        return VehicleTripResource::collection($trips)->response();
     }
 
     public function show(Request $request, int $id): JsonResponse
@@ -49,6 +42,6 @@ class VehicleTripController extends Controller
         $user = $request->user();
         $trip = VehicleTrip::where('company_id', $user->company_id)->findOrFail($id);
 
-        return response()->json(['data' => $trip]);
+        return (new VehicleTripResource($trip))->response();
     }
 }

--- a/api/app/Http/Controllers/Api/V1/WebhookController.php
+++ b/api/app/Http/Controllers/Api/V1/WebhookController.php
@@ -62,15 +62,9 @@ class WebhookController extends Controller
             'active' => true,
         ]);
 
-        return response()->json([
-            'data' => [
-                'id' => $webhook->id,
-                'url' => $webhook->url,
-                'events' => $webhook->events,
-                'secret' => $webhook->secret,
-                'active' => $webhook->active,
-            ],
-        ], 201);
+        return (new WebhookEndpointResource($webhook))
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function show(Request $request, WebhookEndpoint $webhookEndpoint): JsonResponse
@@ -84,20 +78,9 @@ class WebhookController extends Controller
             abort(404);
         }
 
-        return response()->json([
-            'data' => [
-                'id' => $webhookEndpoint->id,
-                'url' => $webhookEndpoint->url,
-                'events' => $webhookEndpoint->events,
-                'active' => $webhookEndpoint->active,
-                'failure_count' => $webhookEndpoint->failure_count,
-                'last_triggered_at' => $webhookEndpoint->last_triggered_at?->toIso8601String(),
-                'recent_deliveries' => $webhookEndpoint->deliveries()
-                    ->orderByDesc('delivered_at')
-                    ->limit(20)
-                    ->get(['id', 'event', 'response_code', 'duration_ms', 'delivered_at']),
-            ],
-        ]);
+        return (new WebhookEndpointResource(
+            $webhookEndpoint->load(['deliveries' => fn ($q) => $q->orderByDesc('delivered_at')->limit(20)])
+        ))->response();
     }
 
     public function update(UpdateWebhookEndpointRequest $request, WebhookEndpoint $webhookEndpoint): WebhookEndpointResource

--- a/api/app/Http/Resources/Api/V1/ApprovalWorkflowResource.php
+++ b/api/app/Http/Resources/Api/V1/ApprovalWorkflowResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\ApprovalWorkflow;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin ApprovalWorkflow
+ */
+class ApprovalWorkflowResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'model_type' => $this->model_type,
+            'levels' => $this->levels,
+            'auto_approve_below' => $this->auto_approve_below,
+            'escalation_hours' => $this->escalation_hours,
+            'active' => $this->active,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/BankExportResource.php
+++ b/api/app/Http/Resources/Api/V1/BankExportResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\BankExport;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin BankExport
+ */
+class BankExportResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'payroll_run_id' => $this->payroll_run_id,
+            'format' => $this->format,
+            'file_path' => $this->file_path,
+            'total_amount' => $this->total_amount,
+            'transfer_count' => $this->transfer_count,
+            'status' => $this->status,
+            'generated_at' => $this->generated_at?->toIso8601String(),
+            'sent_at' => $this->sent_at?->toIso8601String(),
+            'payroll_run' => $this->whenLoaded('payrollRun'),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/CabinetDocumentResource.php
+++ b/api/app/Http/Resources/Api/V1/CabinetDocumentResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\CabinetDocument;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CabinetDocument
+ */
+class CabinetDocumentResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'folder_id' => $this->folder_id,
+            'name' => $this->name,
+            'original_name' => $this->original_name,
+            'mime_type' => $this->mime_type,
+            'size' => $this->size,
+            'notes' => $this->notes,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/CabinetFolderResource.php
+++ b/api/app/Http/Resources/Api/V1/CabinetFolderResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\CabinetFolder;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CabinetFolder
+ */
+class CabinetFolderResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'parent_id' => $this->parent_id,
+            'name' => $this->name,
+            'children' => CabinetFolderResource::collection($this->whenLoaded('children')),
+            'documents' => CabinetDocumentResource::collection($this->whenLoaded('documents')),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/CabinetShareResource.php
+++ b/api/app/Http/Resources/Api/V1/CabinetShareResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\CabinetShare;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CabinetShare
+ */
+class CabinetShareResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'document_id' => $this->document_id,
+            'shared_with_id' => $this->shared_with_id,
+            'permission' => $this->permission,
+            'expires_at' => $this->expires_at?->toIso8601String(),
+            'document' => new CabinetDocumentResource($this->whenLoaded('document')),
+            'shared_with' => $this->whenLoaded('sharedWith'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/ContractAmendmentResource.php
+++ b/api/app/Http/Resources/Api/V1/ContractAmendmentResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\ContractAmendment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin ContractAmendment
+ */
+class ContractAmendmentResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'contract_id' => $this->contract_id,
+            'amendment_type' => $this->amendment_type,
+            'changes' => $this->changes,
+            'effective_date' => $this->effective_date?->toDateString(),
+            'reason' => $this->reason,
+            'approved_by' => $this->approved_by,
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/EvaluationResource.php
+++ b/api/app/Http/Resources/Api/V1/EvaluationResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Evaluation;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Evaluation
+ */
+class EvaluationResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'employee_id' => $this->employee_id,
+            'evaluator_id' => $this->evaluator_id,
+            'period' => $this->period,
+            'score' => $this->score,
+            'criteria' => $this->criteria,
+            'strengths' => $this->strengths,
+            'improvements' => $this->improvements,
+            'overall_comment' => $this->overall_comment,
+            'status' => $this->status,
+            'acknowledged_at' => $this->acknowledged_at?->toIso8601String(),
+            'employee' => $this->whenLoaded('employee'),
+            'evaluator' => $this->whenLoaded('evaluator'),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/InterviewResource.php
+++ b/api/app/Http/Resources/Api/V1/InterviewResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Interview;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Interview
+ */
+class InterviewResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'applicant_id' => $this->applicant_id,
+            'interviewer_id' => $this->interviewer_id,
+            'type' => $this->type,
+            'scheduled_at' => $this->scheduled_at?->toIso8601String(),
+            'duration_minutes' => $this->duration_minutes,
+            'status' => $this->status,
+            'feedback' => $this->feedback,
+            'rating' => $this->rating,
+            'interviewer' => $this->whenLoaded('interviewer'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/LeaveAccrualResource.php
+++ b/api/app/Http/Resources/Api/V1/LeaveAccrualResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\LeaveAccrual;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin LeaveAccrual
+ */
+class LeaveAccrualResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'employee_id' => $this->employee_id,
+            'leave_policy_id' => $this->leave_policy_id,
+            'amount' => $this->amount,
+            'type' => $this->type,
+            'description' => $this->description,
+            'effective_date' => $this->effective_date?->toDateString(),
+            'created_by' => $this->created_by,
+            'employee' => $this->whenLoaded('employee'),
+            'leave_policy' => $this->whenLoaded('leavePolicy'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/LeaveBalanceResource.php
+++ b/api/app/Http/Resources/Api/V1/LeaveBalanceResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\LeaveBalance;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin LeaveBalance
+ */
+class LeaveBalanceResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'employee_id' => $this->employee_id,
+            'absence_type_id' => $this->absence_type_id,
+            'balance' => $this->balance,
+            'used' => $this->used,
+            'pending' => $this->pending,
+            'year' => $this->year,
+            'employee' => $this->whenLoaded('employee'),
+            'absence_type' => $this->whenLoaded('absenceType'),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/NotificationPreferenceResource.php
+++ b/api/app/Http/Resources/Api/V1/NotificationPreferenceResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin NotificationPreference
+ */
+class NotificationPreferenceResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'employee_id' => $this->employee_id,
+            'app_enabled' => $this->app_enabled,
+            'email_enabled' => $this->email_enabled,
+            'push_enabled' => $this->push_enabled,
+            'sms_enabled' => $this->sms_enabled,
+            'whatsapp_enabled' => $this->whatsapp_enabled,
+            'locale' => $this->locale,
+            'timezone' => $this->timezone,
+            'categories' => $this->categories,
+            'quiet_hours' => $this->quiet_hours,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/ProjectResource.php
+++ b/api/app/Http/Resources/Api/V1/ProjectResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Project;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Project
+ */
+class ProjectResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'start_date' => $this->start_date?->toDateString(),
+            'end_date' => $this->end_date?->toDateString(),
+            'members' => $this->members,
+            'status' => $this->status,
+            'created_by' => $this->created_by,
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/SalaryAdvanceResource.php
+++ b/api/app/Http/Resources/Api/V1/SalaryAdvanceResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\SalaryAdvance;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin SalaryAdvance
+ */
+class SalaryAdvanceResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'employee_id' => $this->employee_id,
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+            'reason' => $this->reason,
+            'status' => $this->status,
+            'requested_at' => $this->requested_at?->toIso8601String(),
+            'approved_at' => $this->approved_at?->toIso8601String(),
+            'approved_by' => $this->approved_by,
+            'employee' => $this->whenLoaded('employee'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/SalaryComponentResource.php
+++ b/api/app/Http/Resources/Api/V1/SalaryComponentResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\SalaryComponent;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin SalaryComponent
+ */
+class SalaryComponentResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'code' => $this->code,
+            'type' => $this->type,
+            'amount' => $this->amount,
+            'percentage' => $this->percentage,
+            'is_taxable' => $this->is_taxable,
+            'is_active' => $this->is_active,
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/SalaryStructureResource.php
+++ b/api/app/Http/Resources/Api/V1/SalaryStructureResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\SalaryStructure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin SalaryStructure
+ */
+class SalaryStructureResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'base_salary' => $this->base_salary,
+            'currency' => $this->currency,
+            'is_active' => $this->is_active,
+            'components' => SalaryComponentResource::collection($this->whenLoaded('components')),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/SocialContributionResource.php
+++ b/api/app/Http/Resources/Api/V1/SocialContributionResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\SocialContribution;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin SocialContribution
+ */
+class SocialContributionResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'code' => $this->code,
+            'country_code' => $this->country_code,
+            'employee_rate' => $this->employee_rate,
+            'employer_rate' => $this->employer_rate,
+            'cap' => $this->cap,
+            'is_active' => $this->is_active,
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/TaskCommentResource.php
+++ b/api/app/Http/Resources/Api/V1/TaskCommentResource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\TaskComment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin TaskComment
+ */
+class TaskCommentResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'task_id' => $this->task_id,
+            'author_id' => $this->author_id,
+            'content' => $this->content,
+            'author' => $this->whenLoaded('author'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/TaskResource.php
+++ b/api/app/Http/Resources/Api/V1/TaskResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Task;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Task
+ */
+class TaskResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'created_by' => $this->created_by,
+            'assigned_to' => $this->assigned_to,
+            'project_id' => $this->project_id,
+            'due_date' => $this->due_date?->toIso8601String(),
+            'priority' => $this->priority,
+            'status' => $this->status,
+            'category' => $this->category,
+            'visibility' => $this->visibility,
+            'checklist' => $this->checklist,
+            'comments' => TaskCommentResource::collection($this->whenLoaded('comments')),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/TaxSlabResource.php
+++ b/api/app/Http/Resources/Api/V1/TaxSlabResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\TaxSlab;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin TaxSlab
+ */
+class TaxSlabResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'country_code' => $this->country_code,
+            'min_amount' => $this->min_amount,
+            'max_amount' => $this->max_amount,
+            'rate' => $this->rate,
+            'effective_from' => $this->effective_from?->toDateString(),
+            'effective_to' => $this->effective_to?->toDateString(),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/TrainingEnrollmentResource.php
+++ b/api/app/Http/Resources/Api/V1/TrainingEnrollmentResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\TrainingEnrollment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin TrainingEnrollment
+ */
+class TrainingEnrollmentResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'training_session_id' => $this->training_session_id,
+            'employee_id' => $this->employee_id,
+            'status' => $this->status,
+            'score' => $this->score,
+            'feedback' => $this->feedback,
+            'completed_at' => $this->completed_at?->toIso8601String(),
+            'employee' => $this->whenLoaded('employee'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/TrainingSessionResource.php
+++ b/api/app/Http/Resources/Api/V1/TrainingSessionResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\TrainingSession;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin TrainingSession
+ */
+class TrainingSessionResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'training_course_id' => $this->training_course_id,
+            'trainer_id' => $this->trainer_id,
+            'external_trainer' => $this->external_trainer,
+            'start_date' => $this->start_date?->toDateString(),
+            'end_date' => $this->end_date?->toDateString(),
+            'location' => $this->location,
+            'status' => $this->status,
+            'notes' => $this->notes,
+            'trainer' => $this->whenLoaded('trainer'),
+            'enrollments' => TrainingEnrollmentResource::collection($this->whenLoaded('enrollments')),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/VehicleAlertResource.php
+++ b/api/app/Http/Resources/Api/V1/VehicleAlertResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\VehicleAlert;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VehicleAlert
+ */
+class VehicleAlertResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'vehicle_id' => $this->vehicle_id,
+            'type' => $this->type,
+            'message' => $this->message,
+            'severity' => $this->severity,
+            'resolved_at' => $this->resolved_at?->toIso8601String(),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/VehicleAssignmentResource.php
+++ b/api/app/Http/Resources/Api/V1/VehicleAssignmentResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\VehicleAssignment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VehicleAssignment
+ */
+class VehicleAssignmentResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'vehicle_id' => $this->vehicle_id,
+            'employee_id' => $this->employee_id,
+            'start_date' => $this->start_date?->toDateString(),
+            'end_date' => $this->end_date?->toDateString(),
+            'reason' => $this->reason,
+            'employee' => $this->whenLoaded('employee'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/VehicleMaintenanceResource.php
+++ b/api/app/Http/Resources/Api/V1/VehicleMaintenanceResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\VehicleMaintenance;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VehicleMaintenance
+ */
+class VehicleMaintenanceResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'vehicle_id' => $this->vehicle_id,
+            'type' => $this->type,
+            'description' => $this->description,
+            'service_date' => $this->service_date?->toDateString(),
+            'cost' => $this->cost,
+            'currency' => $this->currency,
+            'provider' => $this->provider,
+            'next_service_date' => $this->next_service_date?->toDateString(),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Http/Resources/Api/V1/VehicleTripResource.php
+++ b/api/app/Http/Resources/Api/V1/VehicleTripResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\VehicleTrip;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VehicleTrip
+ */
+class VehicleTripResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'vehicle_id' => $this->vehicle_id,
+            'driver_id' => $this->driver_id,
+            'start_time' => $this->start_time?->toIso8601String(),
+            'end_time' => $this->end_time?->toIso8601String(),
+            'start_location' => $this->start_location,
+            'end_location' => $this->end_location,
+            'distance_km' => $this->distance_km,
+            'purpose' => $this->purpose,
+            'driver' => $this->whenLoaded('driver'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}


### PR DESCRIPTION
## 📝 Description

**Plan 31 — Iteration 1: API Response Normalization**

Replaces raw `response()->json(['data' => $model])` and manual `serialize()` methods across 31 controllers with dedicated Laravel API Resource classes, establishing a consistent response contract for the API.

### What changed

**25 new Resource classes** created in `app/Http/Resources/Api/V1/`:
`ApprovalWorkflowResource`, `AuditLogResource` (pre-existing, not new — correction: was pre-existing), `BankExportResource`, `CabinetDocumentResource`, `CabinetFolderResource`, `CabinetShareResource`, `ContractAmendmentResource`, `EvaluationResource`, `ExpenseClaimResource`, `InterviewResource`, `LeaveAccrualResource`, `LeaveBalanceResource`, `LoanResource`, `NotificationPreferenceResource`, `OnboardingStepResource`, `PayrollResource`, `PayrollRunResource`, `ProjectResource`, `SalaryAdvanceResource`, `SalaryComponentResource`, `SalaryStructureResource`, `SocialContributionResource`, `TaskCommentResource`, `TaskResource`, `TaxSlabResource`, `TrainingEnrollmentResource`, `TrainingSessionResource`, `VehicleAlertResource`, `VehicleAssignmentResource`, `VehicleMaintenanceResource`, `VehicleTripResource`, `VehicleResource`

**31 controllers refactored** to use Resources instead of raw JSON:
`ApprovalController`, `AuditLogController`, `BankExportController`, `BillingController`, `CabinetDocumentController`, `ContractController`, `EmployeeLoanController`, `EvaluationController`, `ExpenseClaimController`, `JobPostingActionController`, `LeavePolicyController`, `NotificationPreferenceController`, `OnboardingStepController`, `PayrollController`, `PayrollRunController`, `PaySlipController`, `ProjectController`, `RecruitmentController`, `SalaryAdvanceController`, `SalaryComponentController`, `SalaryStructureController`, `SelfServiceController`, `SocialContributionController`, `TaskController`, `TaxSlabController`, `TrainingController`, `VehicleAlertController`, `VehicleController`, `VehicleMaintenanceController`, `VehicleTripController`, `WebhookController`

**Private `serialize()` methods removed** from: `PayrollController`, `EvaluationController`, `ProjectController`, `TaskController`, `CabinetDocumentController`, `SalaryAdvanceController`

**Intentionally unchanged**: Controllers returning computed/aggregated data (`DashboardController`, `HrReportController`, `AdvancedReportController`, `FleetController`, `OrgChartController`, `PlanningController`, `AIWorkflowController`, `ExportController`, `FeatureFlagController`) retain `response()->json(['data' => ...])` since they don't return Eloquent model instances.

## 🚩 Important Review Points

1. **⚠️ Pagination envelope change**: Laravel Resource collections automatically produce `{"data": [...], "links": {...}, "meta": {...}}` — the old manual pagination used a slightly different `meta` shape (`current_page`, `last_page`, `per_page`, `total`). **Frontend/mobile clients consuming paginated endpoints must be checked for compatibility.**

2. **⚠️ Field exposure**: Each new Resource explicitly lists fields in `toArray()`. Fields previously returned by Eloquent's default serialization that are NOT in the Resource's `toArray()` will now be **omitted**. Verify nothing critical is dropped — especially for controllers that had custom `serialize()` methods (e.g., `PayrollController`, `CabinetDocumentController`).

3. **Pre-existing Resources used but not modified**: `SubscriptionResource`, `InvoiceResource`, `ContractResource`, `PayrollResource`, `WebhookEndpointResource`, `ApprovalRequestResource`, `JobPostingResource`, `ApplicantResource` — verify these exist and expose the expected fields.

4. **WebhookController `show()`**: Refactored from inline field mapping (including `recent_deliveries` query) to `$webhookEndpoint->load(['deliveries' => ...])` — verify `WebhookEndpointResource` handles the `deliveries` relationship.

5. **SelfServiceController `myLoanRepayments()`**: Still returns raw JSON with a comment noting no `LoanRepaymentResource` exists yet.

## 🧪 How Has This Been Tested?

- [ ] Unit Tests
- [ ] Feature/Integration Tests
- [ ] E2E / Manual Verification

> **Not yet tested.** This is a structural refactor — no tests were added or modified. Recommend running existing feature tests to catch any response format regressions.

## 🚩 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Link to Devin session: https://app.devin.ai/sessions/7a62287ce5754a679c29ff9e7fe682e9