### PR TITLE
fix: separate critical and optional startup initializers — résout le logo infini

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-05-22
+Derniere mise a jour : 2026-05-31
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -44,6 +44,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.186, les preferences notifications employee/manager sont pilotables depuis les ecrans Compte via `/api/v1/notification-preferences`. Toute evolution UI doit garder le modele partage `leopardo_core/lib/models/notification_preferences.dart`, la sauvegarde retry-aware et les heures calmes compatibles avec `CommunicationService`.
 - Depuis v4.16.187, les listes notifications employee/manager doivent rester actionnables : tap = marquer lu, swipe/menu = supprimer via `DELETE /api/v1/notifications/{notification}`, puis refresh provider. Ne pas supprimer l'action de suppression sans retirer aussi le contrat frontend/API.
 - Depuis v4.16.188, les trois apps mobiles ne doivent plus bloquer `runApp()` sur Hive, Google Sign-In ou intl. Le bootstrap passe par `StartupGate`; Hive `offlineCache` doit tenter une recuperation par suppression/reouverture en cas de corruption, et Google Sign-In reste non bloquant. Ne pas remettre d'`await` natif fragile avant le premier frame, sinon les testeurs peuvent revoir une page grise.
+- Depuis v4.16.191, `StartupGate` distingue `criticalInitializer` (Hive, locales — sans timeout) et `optionalInitializer` (Google Sign-In — timeout 8s silencié). NE JAMAIS soumettre Hive ou `initializeDateFormatting` au timeout du `StartupGate` : sur cold start Render ou device lent, ces ops depassent facilement 8s et la future se termine avant que Hive soit pret, ce qui bloque l'app sur le logo indefiniment.
 - Le Plan 20 readiness lancement vit dans `docs/PLAN_ACTION/20_PLAN_READINESS_LANCEMENT_PRODUCTION.md`. Le cockpit API `GET /api/v1/launch-readiness` est la source de verite pour le score go-live tenant ; toute extension dashboard/support doit garder ce contrat tenant-scope et RBAC P/RH.
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.191] - 2026-05-31
+
+### Fixed
+
+- Mobile employee/manager/platform admin : correction du blocage logo infini introduit par le timeout global de 8s dans `StartupGate`. Les ops critiques (`_openOfflineCache`, `_initializeLocales`) sont désormais exécutées sans timeout via `criticalInitializer` ; seul Google Sign-In (optionnel) est soumis à `optionalTimeout`. L'app ne peut plus rester bloquée sur l'écran de chargement à cause d'un timeout silencieux sur Hive ou les locales.
+
 ## [4.16.190] - 2026-05-29
 
 ### Changed

--- a/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
@@ -12,14 +12,23 @@ class StartupGate extends StatefulWidget {
     required this.initializer,
     required this.child,
     required this.appName,
-    this.timeout = const Duration(seconds: 8),
+    /// [criticalInitializer] : ops sans timeout (Hive, locales).
+    /// Conservé pour compatibilité : si [criticalInitializer] est null,
+    /// [initializer] est utilisé sans timeout.
+    this.criticalInitializer,
+    /// [optionalInitializer] : ops optionnelles (Google Sign-In, etc.).
+    /// Lancées en parallèle, silenciées après [optionalTimeout].
+    this.optionalInitializer,
+    this.optionalTimeout = const Duration(seconds: 8),
     super.key,
   });
 
   final StartupInitializer initializer;
+  final StartupInitializer? criticalInitializer;
+  final StartupInitializer? optionalInitializer;
   final Widget child;
   final String appName;
-  final Duration timeout;
+  final Duration optionalTimeout;
 
   @override
   State<StartupGate> createState() => _StartupGateState();
@@ -41,14 +50,25 @@ class _StartupGateState extends State<StartupGate> {
   }
 
   Future<void> _runStartup() async {
-    try {
-      await widget.initializer().timeout(widget.timeout);
-    } on TimeoutException catch (error, stackTrace) {
-      debugPrint(
-        '${widget.appName} startup continued after timeout: ${error.message}',
+    // Lance les ops optionnelles en parallèle sans bloquer le chemin critique.
+    if (widget.optionalInitializer != null) {
+      unawaited(
+        widget.optionalInitializer!().timeout(widget.optionalTimeout).catchError(
+          (Object error, StackTrace stackTrace) {
+            debugPrint(
+              '${widget.appName} optional startup timed out or failed: $error',
+            );
+            debugPrintStack(stackTrace: stackTrace);
+          },
+        ),
       );
-      debugPrintStack(stackTrace: stackTrace);
     }
+
+    // Exécute les ops critiques SANS timeout.
+    // Si [criticalInitializer] est fourni, on l'utilise ; sinon fallback
+    // sur [initializer] (comportement compatible avec l'ancienne API).
+    final critical = widget.criticalInitializer ?? widget.initializer;
+    await critical();
   }
 
   @override

--- a/front/mobile_apps/leopardo_employee/lib/main.dart
+++ b/front/mobile_apps/leopardo_employee/lib/main.dart
@@ -19,12 +19,23 @@ void main() {
   runApp(
     StartupGate(
       appName: 'Leopardo Employee',
+      // initializer est requis par l'API mais n'est plus exécuté directement
+      // quand criticalInitializer et optionalInitializer sont fournis.
       initializer: _bootstrap,
+      criticalInitializer: _bootstrapCritical,
+      optionalInitializer: _safeGoogleSignInInitialize,
       child: const ProviderScope(child: LeopardoApp()),
     ),
   );
 }
 
+/// Ops critiques : JAMAIS soumises à un timeout.
+Future<void> _bootstrapCritical() async {
+  await _openOfflineCache();
+  await _initializeLocales();
+}
+
+/// Conservé pour compatibilité (non utilisé quand criticalInitializer est fourni).
 Future<void> _bootstrap() async {
   unawaited(_safeGoogleSignInInitialize());
   await _openOfflineCache();

--- a/front/mobile_apps/leopardo_manager/lib/main.dart
+++ b/front/mobile_apps/leopardo_manager/lib/main.dart
@@ -20,11 +20,20 @@ void main() {
     StartupGate(
       appName: 'Leopardo Manager',
       initializer: _bootstrap,
+      criticalInitializer: _bootstrapCritical,
+      optionalInitializer: _safeGoogleSignInInitialize,
       child: const ProviderScope(child: LeopardoApp()),
     ),
   );
 }
 
+/// Ops critiques : JAMAIS soumises à un timeout.
+Future<void> _bootstrapCritical() async {
+  await _openOfflineCache();
+  await _initializeLocales();
+}
+
+/// Conservé pour compatibilité.
 Future<void> _bootstrap() async {
   unawaited(_safeGoogleSignInInitialize());
   await _openOfflineCache();

--- a/front/mobile_apps/leopardo_platform_admin/lib/main.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/main.dart
@@ -18,6 +18,8 @@ Future<void> main() async {
     StartupGate(
       appName: 'Leopardo Platform Admin',
       initializer: _bootstrap,
+      criticalInitializer: _bootstrap,
+      // Pas d'optionalInitializer pour platform admin (pas de Google Sign-In).
       child: const ProviderScope(child: PlatformAdminApp()),
     ),
   );


### PR DESCRIPTION
## Problème

Depuis le commit #627, les 3 apps mobiles restent bloquées sur l'écran logo (logo infini).

### Cause racine

Dans `StartupGate._runStartup()`, le timeout global de **8 secondes** couvrait **toutes** les ops du `_bootstrap()` — y compris `_openOfflineCache()` (Hive) et `_initializeLocales()`. Sur un cold start Render ou un device lent :

1. Les locales + Hive dépassent 8s
2. → `TimeoutException` silencieusement attrapé
3. → `Future` se termine sans erreur
4. → `FutureBuilder` passe à `ConnectionState.done`
5. → L'app s'affiche **mais Hive n'est pas initialisé**
6. → Crash des providers Riverpod → retour au logo en boucle

### Fix

`StartupGate` expose deux nouveaux paramètres optionnels :
- `criticalInitializer` — Hive + locales, exécuté **sans timeout**
- `optionalInitializer` — Google Sign-In, lancé en parallèle avec `optionalTimeout` (8s)

L'ancienne API (`initializer` seul) reste 100% compatible (fallback).

### Fichiers modifiés
- `front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart`
- `front/mobile_apps/leopardo_employee/lib/main.dart`
- `front/mobile_apps/leopardo_manager/lib/main.dart`
- `front/mobile_apps/leopardo_platform_admin/lib/main.dart`
- `CHANGELOG.md` (v4.16.191)
- `AGENTS.md` (leçon ajoutée)

### Test attendu
- ✅ L'app démarre sur l'écran login (pas de logo infini)
- ✅ Hive `offlineCache` est ouvert avant le premier frame de l'app
- ✅ Google Sign-In timeout n'empêche plus le démarrage