### PR TITLE
feat: splash screen natif + router auth-aware (#637 — v4.16.193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.193] - 2026-05-31
+
+### Added
+
+- Mobile employee / manager / platform admin : ajout d'un `SplashScreen` natif Flutter (logo Leopardo + glow émeraude + barre de progression) affiché pendant `checkAuth()`. L'app ne reste plus sur un écran vide pendant le cold start Render.
+
+### Changed
+
+- Mobile employee / manager / platform admin : le router démarre sur `/splash` (ou `/platform/splash`) et redirige automatiquement vers `/welcome` (non connecté) ou `/` (connecté) dès que le bootstrap auth est terminé. Plus de cas où `isLoading=true` laisse l'utilisateur sur un écran blanc/logo figé.
+
 ## [4.16.192] - 2026-05-31
 
 ### Changed

--- a/front/mobile_apps/leopardo_core/lib/core/widgets/splash_screen.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/widgets/splash_screen.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:leopardo_core/core/theme/app_colors.dart';
+import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/core/widgets/mobile_surface.dart';
+
+/// Écran de démarrage affiché pendant la vérification auth au démarrage.
+/// Disparaît automatiquement dès que [GoRouter] redirige (isLoading=false).
+///
+/// Design : fond sombre, logo centré avec glow, nom app, barre de progression
+/// fine en bas — sobre et rapide.
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({required this.appName, super.key});
+
+  final String appName;
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _fadeIn;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+    _fadeIn = CurvedAnimation(parent: _ctrl, curve: Curves.easeOut);
+    _ctrl.forward();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: MobileSurface.background,
+      body: FadeTransition(
+        opacity: _fadeIn,
+        child: SafeArea(
+          child: Stack(
+            children: [
+              // ── Logo + nom centré ────────────────────────────────────────
+              Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Logo avec glow émeraude
+                    Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        gradient: const LinearGradient(
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                          colors: [AppColors.rh, AppColors.rhDark],
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: AppColors.rh.withValues(alpha: 0.40),
+                            blurRadius: 32,
+                            spreadRadius: 4,
+                          ),
+                        ],
+                      ),
+                      child: const Center(
+                        child: Text(
+                          'L',
+                          style: TextStyle(
+                            fontFamily: AppTypography.fontFamily,
+                            fontWeight: FontWeight.w800,
+                            fontSize: 38,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    // Nom app
+                    Text(
+                      'Leopardo RH',
+                      style: const TextStyle(
+                        fontFamily: AppTypography.fontFamily,
+                        fontWeight: FontWeight.w700,
+                        fontSize: 22,
+                        color: MobileSurface.text,
+                        letterSpacing: 0.3,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      widget.appName,
+                      style: const TextStyle(
+                        color: MobileSurface.secondary,
+                        fontSize: 13,
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // ── Barre de progression fine en bas ─────────────────────────
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 32,
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 48),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(2),
+                        child: const LinearProgressIndicator(
+                          minHeight: 2,
+                          backgroundColor: MobileSurface.border,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            AppColors.rh,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/front/mobile_apps/leopardo_employee/lib/app.dart
+++ b/front/mobile_apps/leopardo_employee/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:leopardo_employee/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_employee/features/auth/screens/login_screen.dart';
 import 'package:leopardo_employee/features/auth/screens/register_screen.dart';
 import 'package:leopardo_employee/features/auth/screens/welcome_screen.dart';
+import 'package:leopardo_core/core/widgets/splash_screen.dart';
 import 'package:leopardo_employee/features/attendance/screens/attendance_screen.dart';
 import 'package:leopardo_employee/features/attendance/screens/history_screen.dart';
 import 'package:leopardo_employee/features/attendance/screens/monthly_summary_screen.dart';
@@ -45,15 +46,23 @@ final routerProvider = Provider<GoRouter>((ref) {
   ref.onDispose(authListenable.dispose);
 
   return GoRouter(
-    initialLocation: '/',
+    initialLocation: '/splash',
     refreshListenable: authListenable,
     redirect: (context, state) {
       final authState = authListenable.value;
       final isAuth = authState.employee != null;
-
-      if (authState.isLoading) return null;
-
       final location = state.matchedLocation;
+
+      // Pendant le chargement initial : rester sur le splash.
+      if (authState.isLoading) {
+        return location == '/splash' ? null : '/splash';
+      }
+
+      // Auth terminée : quitter le splash.
+      if (location == '/splash') {
+        return isAuth ? '/' : '/welcome';
+      }
+
       const publicRoutes = {
         '/welcome',
         '/login',
@@ -70,6 +79,12 @@ final routerProvider = Provider<GoRouter>((ref) {
       return null;
     },
     routes: [
+      GoRoute(
+        path: '/splash',
+        builder: (context, state) => const SplashScreen(
+          appName: 'Espace Employé',
+        ),
+      ),
       GoRoute(
         path: '/welcome',
         builder: (context, state) => const WelcomeScreen(),

--- a/front/mobile_apps/leopardo_manager/lib/app.dart
+++ b/front/mobile_apps/leopardo_manager/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:leopardo_manager/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_manager/features/auth/screens/login_screen.dart';
 import 'package:leopardo_manager/features/auth/screens/register_screen.dart';
 import 'package:leopardo_manager/features/auth/screens/welcome_screen.dart';
+import 'package:leopardo_core/core/widgets/splash_screen.dart';
 import 'package:leopardo_manager/features/attendance/screens/attendance_screen.dart';
 import 'package:leopardo_manager/features/attendance/screens/history_screen.dart';
 import 'package:leopardo_manager/features/attendance/screens/monthly_summary_screen.dart';
@@ -53,15 +54,21 @@ final routerProvider = Provider<GoRouter>((ref) {
   ref.onDispose(authListenable.dispose);
 
   return GoRouter(
-    initialLocation: '/',
+    initialLocation: '/splash',
     refreshListenable: authListenable,
     redirect: (context, state) {
       final authState = authListenable.value;
       final isAuth = authState.employee != null;
-
-      if (authState.isLoading) return null;
-
       final location = state.matchedLocation;
+
+      if (authState.isLoading) {
+        return location == '/splash' ? null : '/splash';
+      }
+
+      if (location == '/splash') {
+        return isAuth ? '/' : '/welcome';
+      }
+
       const publicRoutes = {
         '/welcome',
         '/login',
@@ -78,6 +85,12 @@ final routerProvider = Provider<GoRouter>((ref) {
       return null;
     },
     routes: [
+      GoRoute(
+        path: '/splash',
+        builder: (context, state) => const SplashScreen(
+          appName: 'Espace Manager',
+        ),
+      ),
       GoRoute(
         path: '/welcome',
         builder: (context, state) => const WelcomeScreen(),

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/platform_admin_app.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/platform_admin_app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_theme.dart';
+import 'package:leopardo_core/core/widgets/splash_screen.dart';
 import 'package:leopardo_core/l10n/l10n.dart';
 
 import 'features/auth/platform_auth_controller.dart';
@@ -25,19 +26,35 @@ final platformRouterProvider = Provider<GoRouter>((ref) {
   ref.onDispose(authListenable.dispose);
 
   return GoRouter(
-    initialLocation: '/platform',
+    initialLocation: '/platform/splash',
     refreshListenable: authListenable,
     redirect: (context, state) {
       final authState = authListenable.value;
       final location = state.matchedLocation;
+      final onSplash = location == '/platform/splash';
       final onLogin = location == '/platform/login';
 
-      if (authState.isBootstrapping) return null;
+      // Pendant le bootstrap : rester sur le splash.
+      if (authState.isBootstrapping) {
+        return onSplash ? null : '/platform/splash';
+      }
+
+      // Bootstrap terminé : quitter le splash.
+      if (onSplash) {
+        return authState.isAuthenticated ? '/platform' : '/platform/login';
+      }
+
       if (!authState.isAuthenticated && !onLogin) return '/platform/login';
       if (authState.isAuthenticated && onLogin) return '/platform';
       return null;
     },
     routes: [
+      GoRoute(
+        path: '/platform/splash',
+        builder: (context, state) => const SplashScreen(
+          appName: 'Administration',
+        ),
+      ),
       GoRoute(
         path: '/platform/login',
         builder: (context, state) => const PlatformLoginScreen(),


### PR DESCRIPTION
## Problème résolu

Depuis le début, l'app restait sur un **logo figé** au démarrage.
Cause : pendant `checkAuth()` (cold start Render = 10-30s), `isLoading=true` bloquait toute navigation. `initialLocation='/'` tombait dans un état indéfini → logo ou écran blanc.

## Fix

**`SplashScreen` partagé** (`leopardo_core`) :
- Logo Leopardo centré avec glow émeraude
- Barre de progression fine en bas
- Fade-in 600ms

**Router auth-aware** (3 apps) :
- `initialLocation: '/splash'`
- `isLoading=true` → reste sur `/splash`
- `isLoading=false` → redirect vers `/welcome` (non connecté) ou `/` (connecté)

## Fichiers
- `leopardo_core/core/widgets/splash_screen.dart` (nouveau)
- `leopardo_employee/lib/app.dart`
- `leopardo_manager/lib/app.dart`
- `leopardo_platform_admin/lib/src/platform_admin_app.dart`
- `CHANGELOG.md` (v4.16.193)