### PR TITLE
fix: prevent mobile logo startup deadlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-05-31 (v4.16.192)
+Derniere mise a jour : 2026-05-31 (v4.16.194)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -44,7 +44,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.186, les preferences notifications employee/manager sont pilotables depuis les ecrans Compte via `/api/v1/notification-preferences`. Toute evolution UI doit garder le modele partage `leopardo_core/lib/models/notification_preferences.dart`, la sauvegarde retry-aware et les heures calmes compatibles avec `CommunicationService`.
 - Depuis v4.16.187, les listes notifications employee/manager doivent rester actionnables : tap = marquer lu, swipe/menu = supprimer via `DELETE /api/v1/notifications/{notification}`, puis refresh provider. Ne pas supprimer l'action de suppression sans retirer aussi le contrat frontend/API.
 - Depuis v4.16.188, les trois apps mobiles ne doivent plus bloquer `runApp()` sur Hive, Google Sign-In ou intl. Le bootstrap passe par `StartupGate`; Hive `offlineCache` doit tenter une recuperation par suppression/reouverture en cas de corruption, et Google Sign-In reste non bloquant. Ne pas remettre d'`await` natif fragile avant le premier frame, sinon les testeurs peuvent revoir une page grise.
-- Depuis v4.16.191, `StartupGate` distingue `criticalInitializer` (Hive, locales — sans timeout) et `optionalInitializer` (Google Sign-In — timeout 8s silencié). NE JAMAIS soumettre Hive ou `initializeDateFormatting` au timeout du `StartupGate` : sur cold start Render ou device lent, ces ops depassent facilement 8s et la future se termine avant que Hive soit pret, ce qui bloque l'app sur le logo indefiniment.
+- Depuis v4.16.194, `StartupGate` distingue `criticalInitializer` et `optionalInitializer`, mais le chemin critique a aussi un timeout court de securite : aucune app mobile ne doit rester sur un logo infini. Les initialisations natives non indispensables (Google Sign-In, Firebase Messaging) doivent rester dans `optionalInitializer`; l'hydratation auth doit toujours avoir un timeout et rediriger vers login/welcome si le backend ou le token ne repond pas.
 - Le Plan 20 readiness lancement vit dans `docs/PLAN_ACTION/20_PLAN_READINESS_LANCEMENT_PRODUCTION.md`. Le cockpit API `GET /api/v1/launch-readiness` est la source de verite pour le score go-live tenant ; toute extension dashboard/support doit garder ce contrat tenant-scope et RBAC P/RH.
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.194] - 2026-05-31
+
+### Fixed
+
+- Mobile employee/manager/platform admin : ajout d'une barriere anti-logo infini avec timeout court du bootstrap critique, Firebase platform admin sorti du chemin bloquant et timeout explicite de l'hydratation auth avant redirection vers l'ecran de connexion.
+
 ## [4.16.193] - 2026-05-31
 
 ### Added

--- a/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
@@ -12,13 +12,9 @@ class StartupGate extends StatefulWidget {
     required this.initializer,
     required this.child,
     required this.appName,
-    /// [criticalInitializer] : ops sans timeout (Hive, locales).
-    /// Conservé pour compatibilité : si [criticalInitializer] est null,
-    /// [initializer] est utilisé sans timeout.
     this.criticalInitializer,
-    /// [optionalInitializer] : ops optionnelles (Google Sign-In, etc.).
-    /// Lancées en parallèle, silenciées après [optionalTimeout].
     this.optionalInitializer,
+    this.criticalTimeout = const Duration(seconds: 6),
     this.optionalTimeout = const Duration(seconds: 8),
     super.key,
   });
@@ -28,6 +24,7 @@ class StartupGate extends StatefulWidget {
   final StartupInitializer? optionalInitializer;
   final Widget child;
   final String appName;
+  final Duration criticalTimeout;
   final Duration optionalTimeout;
 
   @override
@@ -50,7 +47,6 @@ class _StartupGateState extends State<StartupGate> {
   }
 
   Future<void> _runStartup() async {
-    // Lance les ops optionnelles en parallèle sans bloquer le chemin critique.
     if (widget.optionalInitializer != null) {
       unawaited(
         widget.optionalInitializer!().timeout(widget.optionalTimeout).catchError(
@@ -64,11 +60,13 @@ class _StartupGateState extends State<StartupGate> {
       );
     }
 
-    // Exécute les ops critiques SANS timeout.
-    // Si [criticalInitializer] est fourni, on l'utilise ; sinon fallback
-    // sur [initializer] (comportement compatible avec l'ancienne API).
     final critical = widget.criticalInitializer ?? widget.initializer;
-    await critical();
+    try {
+      await critical().timeout(widget.criticalTimeout);
+    } on TimeoutException catch (error, stackTrace) {
+      debugPrint('${widget.appName} critical startup timed out: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
   }
 
   @override
@@ -76,13 +74,11 @@ class _StartupGateState extends State<StartupGate> {
     return FutureBuilder<void>(
       future: _startupFuture,
       builder: (context, snapshot) {
-        // Afficher l'app dès que les initialisations critiques sont terminées.
         if (snapshot.connectionState == ConnectionState.done &&
             snapshot.error == null) {
           return widget.child;
         }
 
-        // En cas d'erreur critique, afficher un panneau de récupération.
         if (snapshot.hasError) {
           return MaterialApp(
             title: widget.appName,
@@ -111,18 +107,13 @@ class _StartupGateState extends State<StartupGate> {
           );
         }
 
-        // Pendant le chargement : écran minimal, fond seul, sans texte superflu.
-        // Sur un device normal le bootstrap dure < 300ms et cet écran est
-        // presque invisible.
         return MaterialApp(
           title: widget.appName,
           debugShowCheckedModeBanner: false,
           theme: AppTheme.lightTheme,
           darkTheme: AppTheme.darkTheme,
           themeMode: ThemeMode.dark,
-          home: const Scaffold(
-            backgroundColor: MobileSurface.background,
-          ),
+          home: const Scaffold(backgroundColor: MobileSurface.background),
         );
       },
     );

--- a/front/mobile_apps/leopardo_employee/lib/features/auth/providers/auth_provider.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/auth/providers/auth_provider.dart
@@ -28,6 +28,8 @@ class AuthState {
 }
 
 class AuthNotifier extends StateNotifier<AuthState> {
+  static const _startupAuthTimeout = Duration(seconds: 12);
+
   final AuthRepository _repository;
   final PushNotificationService _pushNotifications;
   final ApiClient _apiClient;
@@ -42,7 +44,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> checkAuth() async {
     state = state.copyWith(isLoading: true);
     try {
-      final data = await _repository.checkAuth();
+      final data = await _repository.checkAuth().timeout(_startupAuthTimeout);
       if (data != null) {
         state = state.copyWith(isLoading: false, employee: data['employee']);
       } else {

--- a/front/mobile_apps/leopardo_manager/lib/features/auth/providers/auth_provider.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/auth/providers/auth_provider.dart
@@ -28,6 +28,8 @@ class AuthState {
 }
 
 class AuthNotifier extends StateNotifier<AuthState> {
+  static const _startupAuthTimeout = Duration(seconds: 12);
+
   final AuthRepository _repository;
   final PushNotificationService _pushNotifications;
   final ApiClient _apiClient;
@@ -40,7 +42,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> checkAuth() async {
     state = state.copyWith(isLoading: true);
     try {
-      final data = await _repository.checkAuth();
+      final data = await _repository.checkAuth().timeout(_startupAuthTimeout);
       if (data != null) {
         state = state.copyWith(isLoading: false, employee: data['employee']);
       } else {

--- a/front/mobile_apps/leopardo_platform_admin/lib/main.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/main.dart
@@ -25,15 +25,18 @@ Future<void> main() async {
     StartupGate(
       appName: 'Leopardo Platform Admin',
       initializer: _bootstrap,
-      criticalInitializer: _bootstrap,
-      // Pas d'optionalInitializer pour platform admin (pas de Google Sign-In).
+      criticalInitializer: _bootstrapCritical,
+      optionalInitializer: _initFirebase,
       child: const ProviderScope(child: PlatformAdminApp()),
     ),
   );
 }
 
 Future<void> _bootstrap() async {
-  await _initFirebase();
+  await _bootstrapCritical();
+}
+
+Future<void> _bootstrapCritical() async {
   await _openOfflineCache();
   await _initializeLocales();
 }

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/auth/platform_auth_controller.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/auth/platform_auth_controller.dart
@@ -46,6 +46,8 @@ final platformAuthControllerProvider =
     );
 
 class PlatformAuthController extends Notifier<PlatformAuthState> {
+  static const _startupAuthTimeout = Duration(seconds: 12);
+
   @override
   PlatformAuthState build() {
     Future.microtask(_hydrate);
@@ -54,7 +56,10 @@ class PlatformAuthController extends Notifier<PlatformAuthState> {
 
   Future<void> _hydrate() async {
     try {
-      final user = await ref.read(platformRepositoryProvider).me();
+      final user = await ref
+          .read(platformRepositoryProvider)
+          .me()
+          .timeout(_startupAuthTimeout);
       state = state.copyWith(user: user, isBootstrapping: false);
     } catch (_) {
       state = state.copyWith(


### PR DESCRIPTION
## Summary
- prevent employee/manager/platform admin apps from staying forever on splash/logo
- add a short safety timeout around critical startup and auth hydration
- move platform admin Firebase initialization to optional startup
- document the mobile startup rule in AGENTS and CHANGELOG

## Validation
- dart format on modified Dart files
- git diff --check
- local flutter analyze is blocked by local Dart SDK 3.7.2 while mobile apps require flutter_lints >=6 / Dart ^3.8; CI mobile remains the source of truth