### PR TITLE
fix: remove native mobile splash logo and personalize builds

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -254,17 +254,20 @@ jobs:
         app:
           - name: employee
             project_path: front/mobile_apps/leopardo_employee
-            artifact_name: leopardo-employee-main
+            artifact_name: leopardo-employee-staging
+            version_prefix: employee
             firebase_secret: FIREBASE_EMPLOYEE_ANDROID_APP_ID
             android_package: com.leopardo.employee
           - name: manager
             project_path: front/mobile_apps/leopardo_manager
-            artifact_name: leopardo-manager-main
+            artifact_name: leopardo-manager-staging
+            version_prefix: manager
             firebase_secret: FIREBASE_MANAGER_ANDROID_APP_ID
             android_package: com.leopardo.manager
           - name: platform_admin
             project_path: front/mobile_apps/leopardo_platform_admin
-            artifact_name: leopardo-platform-admin-main
+            artifact_name: leopardo-platform-admin-staging
+            version_prefix: platform-admin
             firebase_secret: FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID
             android_package: com.leopardo.platformadmin
 
@@ -363,7 +366,7 @@ jobs:
           echo "API_BASE_URL=${DEFAULT_API_BASE_URL}" > .env.build
           flutter build apk --release \
             --dart-define-from-file=.env.build \
-            --build-name="main-${GITHUB_RUN_NUMBER}" \
+            --build-name="${{ matrix.app.version_prefix }}-main-${GITHUB_RUN_NUMBER}" \
             --build-number="${GITHUB_RUN_NUMBER}"
 
       - name: Upload mobile artifact
@@ -385,6 +388,7 @@ jobs:
           file: ${{ matrix.app.project_path }}/build/app/outputs/flutter-apk/app-release.apk
           releaseNotes: |
             Auto deploy from main - Leopardo ${{ matrix.app.name }}
+            Build: ${{ matrix.app.version_prefix }}-main-${{ github.run_number }}
             Commit: ${{ needs.prepare.outputs.sha }}
             Workflow: ${{ github.workflow }}
             Backend: https://gestionemployerbackend.onrender.com

--- a/.github/workflows/mobile-distribute.yml
+++ b/.github/workflows/mobile-distribute.yml
@@ -59,16 +59,19 @@ jobs:
           - name: employee
             project_path: front/mobile_apps/leopardo_employee
             artifact_name: leopardo-employee
+            version_prefix: employee
             firebase_secret: FIREBASE_EMPLOYEE_ANDROID_APP_ID
             android_package: com.leopardo.employee
           - name: manager
             project_path: front/mobile_apps/leopardo_manager
             artifact_name: leopardo-manager
+            version_prefix: manager
             firebase_secret: FIREBASE_MANAGER_ANDROID_APP_ID
             android_package: com.leopardo.manager
           - name: platform_admin
             project_path: front/mobile_apps/leopardo_platform_admin
             artifact_name: leopardo-platform-admin
+            version_prefix: platform-admin
             firebase_secret: FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID
             android_package: com.leopardo.platformadmin
 
@@ -110,19 +113,23 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME:-}"
           INPUT_ENV="${{ github.event.inputs.environment }}"
+          APP_VERSION_PREFIX="${{ matrix.app.version_prefix }}"
 
           if [[ "$TAG" == *"-prod" ]]; then
             TARGET="prod"
-            BUILD_NAME="${TAG%-prod}"
+            BUILD_NAME="${APP_VERSION_PREFIX}-${TAG%-prod}"
           elif [[ "$TAG" == *"-staging" ]]; then
             TARGET="staging"
-            BUILD_NAME="${TAG%-staging}"
+            BUILD_NAME="${APP_VERSION_PREFIX}-${TAG%-staging}"
           elif [[ "$INPUT_ENV" == "prod" ]]; then
             TARGET="prod"
-            BUILD_NAME="manual-$(date +%Y%m%d)"
+            BUILD_NAME="${APP_VERSION_PREFIX}-manual-$(date +%Y%m%d)"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "main" ]]; then
+            TARGET="staging"
+            BUILD_NAME="${APP_VERSION_PREFIX}-main-${GITHUB_RUN_NUMBER}"
           else
             TARGET="staging"
-            BUILD_NAME="manual-$(date +%Y%m%d)"
+            BUILD_NAME="${APP_VERSION_PREFIX}-manual-$(date +%Y%m%d)"
           fi
 
           echo "TARGET=$TARGET" >> "$GITHUB_ENV"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-05-31 (v4.16.195)
+Derniere mise a jour : 2026-05-31 (v4.16.196)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -45,6 +45,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.187, les listes notifications employee/manager doivent rester actionnables : tap = marquer lu, swipe/menu = supprimer via `DELETE /api/v1/notifications/{notification}`, puis refresh provider. Ne pas supprimer l'action de suppression sans retirer aussi le contrat frontend/API.
 - Depuis v4.16.188, les trois apps mobiles ne doivent plus bloquer `runApp()` sur Hive, Google Sign-In ou intl. Le bootstrap passe par `StartupGate`; Hive `offlineCache` doit tenter une recuperation par suppression/reouverture en cas de corruption, et Google Sign-In reste non bloquant. Ne pas remettre d'`await` natif fragile avant le premier frame, sinon les testeurs peuvent revoir une page grise.
 - Depuis v4.16.195, `StartupGate` ne doit plus bloquer le premier vrai ecran : il lance le bootstrap en arriere-plan et rend l'app immediatement. Les routers employee/manager demarrent sur `/welcome`, le platform admin sur `/platform/login`, et `checkAuth` ne doit jamais forcer un retour vers un splash. `SecureStorage`, `AppPreferences` et `TranslationCatalogCache` doivent rester tolerants si Hive `offlineCache` n'est pas encore ouvert.
+- Depuis v4.16.196, les apps Android employee/manager/platform admin ne doivent plus afficher de logo dans le splash natif. Garder `launch_background` en fond simple et le splash Android 12+ avec `splash_transparent`; les logos appartiennent au premier ecran Flutter, pas au launch screen natif. Les builds Firebase doivent garder des noms prefixes par app (`employee-*`, `manager-*`, `platform-admin-*`) pour eviter la confusion entre releases `main` et `manual`.
 - Le Plan 20 readiness lancement vit dans `docs/PLAN_ACTION/20_PLAN_READINESS_LANCEMENT_PRODUCTION.md`. Le cockpit API `GET /api/v1/launch-readiness` est la source de verite pour le score go-live tenant ; toute extension dashboard/support doit garder ce contrat tenant-scope et RBAC P/RH.
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.196] - 2026-05-31
+
+### Fixed
+
+- Mobile Android employee/manager/platform admin : suppression du logo du splash natif (`launch_background`) et neutralisation du splash Android 12+ avec une icone transparente. Si Flutter ne rend pas son premier frame, le testeur ne voit plus un faux etat "logo charge" qui masque le diagnostic.
+- Mobile distribution : les noms de build APK/AAB sont maintenant prefixes par app (`employee-*`, `manager-*`, `platform-admin-*`) au lieu de rester generiques (`main-*` / `manual-*`).
+
 ## [4.16.195] - 2026-05-31
 
 ### Fixed

--- a/dev-hub/tools/validate-mobile-plan29.ps1
+++ b/dev-hub/tools/validate-mobile-plan29.ps1
@@ -92,7 +92,7 @@ $mobileDistribute = Get-Content -LiteralPath (Join-Path $repoRoot ".github/workf
 
 Assert-Contains $deployMain "leopardo_platform_admin" "Deploy main mobile distribution"
 Assert-Contains $deployMain "FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID" "Deploy main mobile distribution"
-Assert-Contains $deployMain "leopardo-platform-admin-main" "Deploy main mobile distribution"
+Assert-Contains $deployMain "leopardo-platform-admin-staging" "Deploy main mobile distribution"
 
 Assert-Contains $mobileDistribute "branches:" "Mobile distribute auto trigger"
 Assert-Contains $mobileDistribute "front/mobile_apps/**" "Mobile distribute auto trigger"

--- a/docs/validation/MOBILE_FIREBASE_DISTRIBUTION.md
+++ b/docs/validation/MOBILE_FIREBASE_DISTRIBUTION.md
@@ -81,9 +81,9 @@ Le job echoue si le `buildVersion` du build courant n'apparait pas dans App Dist
 
 Derniere verification connue :
 
-- Employee Android : release `manual-20260526 (7)` envoyee dans `leopardo-rh` sous `android:com.leopardo.employee`.
-- Manager Android : release `manual-20260526 (7)` envoyee dans `leopardo-rh` sous `android:com.leopardo.manager`.
-- Platform Admin Android : release `manual-20260526 (7)` envoyee dans `leopardo-rh` sous `android:com.leopardo.platformadmin`.
+- Employee Android : les builds doivent utiliser un nom de version prefixe `employee-*` et etre envoyes dans `leopardo-rh` sous `android:com.leopardo.employee`.
+- Manager Android : les builds doivent utiliser un nom de version prefixe `manager-*` et etre envoyes dans `leopardo-rh` sous `android:com.leopardo.manager`.
+- Platform Admin Android : les builds doivent utiliser un nom de version prefixe `platform-admin-*` et etre envoyes dans `leopardo-rh` sous `android:com.leopardo.platformadmin`.
 
 Important : Firebase App Distribution affiche les releases par app. Dans la console, selectionner le projet `leopardo-rh`, puis App Distribution, puis l'app Android `com.leopardo.employee`, `com.leopardo.manager` ou `com.leopardo.platformadmin`. Les fichiers iOS sont installes dans le depot, mais la distribution iOS necessitera un workflow macOS signe produisant un `.ipa`.
 

--- a/front/mobile_apps/leopardo_employee/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/front/mobile_apps/leopardo_employee/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/leopardo_splash_background" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item>
 </layer-list>

--- a/front/mobile_apps/leopardo_employee/android/app/src/main/res/drawable/launch_background.xml
+++ b/front/mobile_apps/leopardo_employee/android/app/src/main/res/drawable/launch_background.xml
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/leopardo_splash_background" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item>
 </layer-list>

--- a/front/mobile_apps/leopardo_employee/android/app/src/main/res/drawable/splash_transparent.xml
+++ b/front/mobile_apps/leopardo_employee/android/app/src/main/res/drawable/splash_transparent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="1dp"
+    android:height="1dp"
+    android:viewportWidth="1"
+    android:viewportHeight="1">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,0h1v1h-1z" />
+</vector>

--- a/front/mobile_apps/leopardo_employee/android/app/src/main/res/values-v31/styles.xml
+++ b/front/mobile_apps/leopardo_employee/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowSplashScreenBackground">@color/leopardo_splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/splash_transparent</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+</resources>

--- a/front/mobile_apps/leopardo_manager/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/front/mobile_apps/leopardo_manager/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/leopardo_splash_background" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item>
 </layer-list>

--- a/front/mobile_apps/leopardo_manager/android/app/src/main/res/drawable/launch_background.xml
+++ b/front/mobile_apps/leopardo_manager/android/app/src/main/res/drawable/launch_background.xml
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/leopardo_splash_background" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item>
 </layer-list>

--- a/front/mobile_apps/leopardo_manager/android/app/src/main/res/drawable/splash_transparent.xml
+++ b/front/mobile_apps/leopardo_manager/android/app/src/main/res/drawable/splash_transparent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="1dp"
+    android:height="1dp"
+    android:viewportWidth="1"
+    android:viewportHeight="1">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,0h1v1h-1z" />
+</vector>

--- a/front/mobile_apps/leopardo_manager/android/app/src/main/res/values-v31/styles.xml
+++ b/front/mobile_apps/leopardo_manager/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowSplashScreenBackground">@color/leopardo_splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/splash_transparent</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+</resources>

--- a/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/leopardo_splash_background" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item>
 </layer-list>

--- a/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/drawable/launch_background.xml
+++ b/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/drawable/launch_background.xml
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/leopardo_splash_background" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item>
 </layer-list>

--- a/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/drawable/splash_transparent.xml
+++ b/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/drawable/splash_transparent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="1dp"
+    android:height="1dp"
+    android:viewportWidth="1"
+    android:viewportHeight="1">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,0h1v1h-1z" />
+</vector>

--- a/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/values-v31/styles.xml
+++ b/front/mobile_apps/leopardo_platform_admin/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowSplashScreenBackground">@color/leopardo_splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/splash_transparent</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- remove centered native launch logos from the three Android mobile apps so a frozen native splash is no longer mistaken for a loaded Flutter screen
- override Android 12+ splash animated icon with a transparent drawable for employee, manager and platform admin
- prefix Firebase/App Distribution build names by app: employee, manager and platform-admin

## Validation
- XML parse check for mobile Android resources
- validate-mobile-plan28.ps1
- validate-mobile-plan29.ps1
- validate-mobile-workflow-contracts.ps1
- git diff --check
- workflow YAML parse check