### PR TITLE
fix: force visible first frame for mobile apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-05-31 (v4.16.196)
+Derniere mise a jour : 2026-05-31 (v4.16.197)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -46,6 +46,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.188, les trois apps mobiles ne doivent plus bloquer `runApp()` sur Hive, Google Sign-In ou intl. Le bootstrap passe par `StartupGate`; Hive `offlineCache` doit tenter une recuperation par suppression/reouverture en cas de corruption, et Google Sign-In reste non bloquant. Ne pas remettre d'`await` natif fragile avant le premier frame, sinon les testeurs peuvent revoir une page grise.
 - Depuis v4.16.195, `StartupGate` ne doit plus bloquer le premier vrai ecran : il lance le bootstrap en arriere-plan et rend l'app immediatement. Les routers employee/manager demarrent sur `/welcome`, le platform admin sur `/platform/login`, et `checkAuth` ne doit jamais forcer un retour vers un splash. `SecureStorage`, `AppPreferences` et `TranslationCatalogCache` doivent rester tolerants si Hive `offlineCache` n'est pas encore ouvert.
 - Depuis v4.16.196, les apps Android employee/manager/platform admin ne doivent plus afficher de logo dans le splash natif. Garder `launch_background` en fond simple et le splash Android 12+ avec `splash_transparent`; les logos appartiennent au premier ecran Flutter, pas au launch screen natif. Les builds Firebase doivent garder des noms prefixes par app (`employee-*`, `manager-*`, `platform-admin-*`) pour eviter la confusion entre releases `main` et `manual`.
+- Depuis v4.16.197, `StartupGate` demarre le bootstrap apres le premier frame Flutter et garde un ecran de garde lisible tant que le bootstrap critique n'est pas termine. Ne pas remettre Hive, intl, Firebase, Google Sign-In ou un appel reseau avant le premier rendu : en cas de lenteur native, le testeur doit voir un etat Leopardo explicite, jamais une page noire.
 - Le Plan 20 readiness lancement vit dans `docs/PLAN_ACTION/20_PLAN_READINESS_LANCEMENT_PRODUCTION.md`. Le cockpit API `GET /api/v1/launch-readiness` est la source de verite pour le score go-live tenant ; toute extension dashboard/support doit garder ce contrat tenant-scope et RBAC P/RH.
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.197] - 2026-05-31
+
+### Fixed
+
+- Mobile employee/manager/platform admin : `StartupGate` attend maintenant le premier frame Flutter avant de lancer les initialisations Hive/intl/Firebase/Google, et affiche un garde-fou visuel lisible au lieu d'une page noire si une initialisation bloque ou expire.
+- Mobile bootstrap : les initialisations critiques Hive et locales sont isolees par etape ; un echec de cache local ou de formatage de date est journalise et ne bloque plus l'ouverture de l'espace utilisateur.
+
 ## [4.16.196] - 2026-05-31
 
 ### Fixed

--- a/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
@@ -29,13 +29,49 @@ class StartupGate extends StatefulWidget {
 }
 
 class _StartupGateState extends State<StartupGate> {
+  bool _showStartupGuard = true;
+  String? _startupWarning;
+
   @override
   void initState() {
     super.initState();
-    unawaited(_runStartup());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_runStartup());
+    });
   }
 
   Future<void> _runStartup() async {
+    final critical = widget.criticalInitializer ?? widget.initializer;
+    try {
+      await critical().timeout(widget.criticalTimeout);
+    } on TimeoutException catch (error, stackTrace) {
+      debugPrint('${widget.appName} critical startup timed out: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      if (mounted) {
+        setState(() {
+          _startupWarning = 'Demarrage en mode securise';
+        });
+      }
+      return;
+    } catch (error, stackTrace) {
+      debugPrint('${widget.appName} critical startup failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      if (mounted) {
+        setState(() {
+          _startupWarning = 'Initialisation partielle';
+        });
+      }
+      return;
+    }
+
+    if (mounted) {
+      setState(() {
+        _showStartupGuard = false;
+        _startupWarning = null;
+      });
+    }
+
     if (widget.optionalInitializer != null) {
       unawaited(
         widget.optionalInitializer!().timeout(widget.optionalTimeout).catchError(
@@ -48,18 +84,89 @@ class _StartupGateState extends State<StartupGate> {
         ),
       );
     }
-
-    final critical = widget.criticalInitializer ?? widget.initializer;
-    try {
-      await critical().timeout(widget.criticalTimeout);
-    } on TimeoutException catch (error, stackTrace) {
-      debugPrint('${widget.appName} critical startup timed out: $error');
-      debugPrintStack(stackTrace: stackTrace);
-    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return widget.child;
+    return Stack(
+      textDirection: TextDirection.ltr,
+      children: [
+        widget.child,
+        if (_showStartupGuard)
+          Positioned.fill(
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Material(
+                color: const Color(0xFF0B1120),
+                child: SafeArea(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(28),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 58,
+                            height: 58,
+                            decoration: const BoxDecoration(
+                              color: Color(0xFF10B981),
+                              shape: BoxShape.circle,
+                            ),
+                            alignment: Alignment.center,
+                            child: const Text(
+                              'L',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 28,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 18),
+                          Text(
+                            widget.appName,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              color: Color(0xFFE2EAF6),
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            _startupWarning ?? 'Ouverture de votre espace...',
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              color: Color(0xFF8EA9C8),
+                              fontSize: 13,
+                              height: 1.35,
+                            ),
+                          ),
+                          if (_startupWarning != null) ...[
+                            const SizedBox(height: 18),
+                            OutlinedButton(
+                              onPressed:
+                                  () => setState(() {
+                                    _showStartupGuard = false;
+                                  }),
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: const Color(0xFFE2EAF6),
+                                side: const BorderSide(
+                                  color: Color(0xFF1A2B44),
+                                ),
+                              ),
+                              child: const Text('Continuer'),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
   }
 }

--- a/front/mobile_apps/leopardo_employee/lib/main.dart
+++ b/front/mobile_apps/leopardo_employee/lib/main.dart
@@ -31,8 +31,8 @@ void main() {
 
 /// Ops critiques : JAMAIS soumises à un timeout.
 Future<void> _bootstrapCritical() async {
-  await _openOfflineCache();
-  await _initializeLocales();
+  await _runStartupStep('Hive offline cache', _openOfflineCache);
+  await _runStartupStep('Locale formatting', _initializeLocales);
 }
 
 /// Conservé pour compatibilité (non utilisé quand criticalInitializer est fourni).
@@ -80,6 +80,15 @@ Future<void> _initializeLocales() async {
   await initializeDateFormatting('en', null);
   await initializeDateFormatting('en_US', null);
   await initializeDateFormatting('en_GB', null);
+}
+
+Future<void> _runStartupStep(String label, Future<void> Function() step) async {
+  try {
+    await step();
+  } catch (error, stackTrace) {
+    debugPrint('Startup step skipped ($label): $error');
+    debugPrintStack(stackTrace: stackTrace);
+  }
 }
 
 class _StartupRuntimeError extends StatelessWidget {

--- a/front/mobile_apps/leopardo_manager/lib/main.dart
+++ b/front/mobile_apps/leopardo_manager/lib/main.dart
@@ -29,8 +29,8 @@ void main() {
 
 /// Ops critiques : JAMAIS soumises à un timeout.
 Future<void> _bootstrapCritical() async {
-  await _openOfflineCache();
-  await _initializeLocales();
+  await _runStartupStep('Hive offline cache', _openOfflineCache);
+  await _runStartupStep('Locale formatting', _initializeLocales);
 }
 
 /// Conservé pour compatibilité.
@@ -78,6 +78,15 @@ Future<void> _initializeLocales() async {
   await initializeDateFormatting('en', null);
   await initializeDateFormatting('en_US', null);
   await initializeDateFormatting('en_GB', null);
+}
+
+Future<void> _runStartupStep(String label, Future<void> Function() step) async {
+  try {
+    await step();
+  } catch (error, stackTrace) {
+    debugPrint('Startup step skipped ($label): $error');
+    debugPrintStack(stackTrace: stackTrace);
+  }
 }
 
 class _StartupRuntimeError extends StatelessWidget {

--- a/front/mobile_apps/leopardo_platform_admin/lib/main.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/main.dart
@@ -37,8 +37,8 @@ Future<void> _bootstrap() async {
 }
 
 Future<void> _bootstrapCritical() async {
-  await _openOfflineCache();
-  await _initializeLocales();
+  await _runStartupStep('Hive offline cache', _openOfflineCache);
+  await _runStartupStep('Locale formatting', _initializeLocales);
 }
 
 Future<void> _initFirebase() async {
@@ -68,6 +68,15 @@ Future<void> _initializeLocales() async {
   await initializeDateFormatting('ar', null);
   await initializeDateFormatting('tr_TR', null);
   await initializeDateFormatting('en_US', null);
+}
+
+Future<void> _runStartupStep(String label, Future<void> Function() step) async {
+  try {
+    await step();
+  } catch (error, stackTrace) {
+    debugPrint('Startup step skipped ($label): $error');
+    debugPrintStack(stackTrace: stackTrace);
+  }
 }
 
 class _StartupRuntimeError extends StatelessWidget {


### PR DESCRIPTION
## Summary
- start mobile bootstrap only after the first Flutter frame instead of during StartupGate initState
- show a visible Leopardo startup guard while critical bootstrap is running or degraded, so testers never see a blank black screen
- isolate Hive and locale bootstrap steps for employee, manager and platform admin so local cache/date failures cannot block app opening

## Validation
- validate-mobile-plan28.ps1
- validate-mobile-plan29.ps1
- validate-mobile-workflow-contracts.ps1
- startup static check
- git diff --check

Note: full Flutter analyze/build is intentionally left to GitHub Actions because the local Windows Flutter/Dart SDK is behind the repo constraint.