### PR TITLE
test: guard mobile startup first frame

### DIFF
--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -112,6 +112,11 @@ jobs:
         working-directory: ${{ matrix.project.path }}
         run: flutter analyze
 
+      - name: Run core widget tests
+        if: matrix.project.name == 'leopardo_core'
+        working-directory: ${{ matrix.project.path }}
+        run: flutter test
+
   flutter-build-debug:
     name: Build Debug ${{ matrix.project.name }}
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-05-31 (v4.16.197)
+Derniere mise a jour : 2026-06-01 (v4.16.198)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -47,6 +47,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.195, `StartupGate` ne doit plus bloquer le premier vrai ecran : il lance le bootstrap en arriere-plan et rend l'app immediatement. Les routers employee/manager demarrent sur `/welcome`, le platform admin sur `/platform/login`, et `checkAuth` ne doit jamais forcer un retour vers un splash. `SecureStorage`, `AppPreferences` et `TranslationCatalogCache` doivent rester tolerants si Hive `offlineCache` n'est pas encore ouvert.
 - Depuis v4.16.196, les apps Android employee/manager/platform admin ne doivent plus afficher de logo dans le splash natif. Garder `launch_background` en fond simple et le splash Android 12+ avec `splash_transparent`; les logos appartiennent au premier ecran Flutter, pas au launch screen natif. Les builds Firebase doivent garder des noms prefixes par app (`employee-*`, `manager-*`, `platform-admin-*`) pour eviter la confusion entre releases `main` et `manual`.
 - Depuis v4.16.197, `StartupGate` demarre le bootstrap apres le premier frame Flutter et garde un ecran de garde lisible tant que le bootstrap critique n'est pas termine. Ne pas remettre Hive, intl, Firebase, Google Sign-In ou un appel reseau avant le premier rendu : en cas de lenteur native, le testeur doit voir un etat Leopardo explicite, jamais une page noire.
+- Depuis v4.16.198, les tests widget `front/mobile_apps/leopardo_core/test/core/widgets/startup_gate_test.dart` sont le garde anti-regression pour le demarrage mobile et sont executes par `mobile-apps-ci.yml` sur `leopardo_core`. Toute refonte startup doit conserver l'affichage immediat du garde et le mode degrade actionnable apres timeout.
 - Le Plan 20 readiness lancement vit dans `docs/PLAN_ACTION/20_PLAN_READINESS_LANCEMENT_PRODUCTION.md`. Le cockpit API `GET /api/v1/launch-readiness` est la source de verite pour le score go-live tenant ; toute extension dashboard/support doit garder ce contrat tenant-scope et RBAC P/RH.
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.198] - 2026-06-01
+
+### Added
+
+- Mobile core : ajout de tests widget `StartupGate` couvrant l'affichage immediat du garde de demarrage et le mode degrade apres timeout, afin de bloquer les regressions page noire/logo infini avant distribution testeurs.
+- CI mobile : `Mobile Apps CI - Flutter` execute maintenant `flutter test` pour `leopardo_core`, ce qui rend le garde startup obligatoire sur chaque PR mobile.
+
 ## [4.16.197] - 2026-05-31
 
 ### Fixed

--- a/front/mobile_apps/leopardo_core/test/core/widgets/startup_gate_test.dart
+++ b/front/mobile_apps/leopardo_core/test/core/widgets/startup_gate_test.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leopardo_core/core/widgets/startup_gate.dart';
+
+void main() {
+  testWidgets('renders a visible startup guard before async bootstrap finishes', (
+    tester,
+  ) async {
+    final completer = Completer<void>();
+
+    await tester.pumpWidget(
+      StartupGate(
+        appName: 'Leopardo Test',
+        initializer: () => completer.future,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Text('Real app screen'),
+        ),
+      ),
+    );
+
+    expect(find.text('Leopardo Test'), findsOneWidget);
+    expect(find.text('Ouverture de votre espace...'), findsOneWidget);
+    expect(find.text('Real app screen'), findsOneWidget);
+
+    completer.complete();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Ouverture de votre espace...'), findsNothing);
+    expect(find.text('Real app screen'), findsOneWidget);
+  });
+
+  testWidgets('keeps a usable degraded state when critical bootstrap times out', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      StartupGate(
+        appName: 'Leopardo Test',
+        criticalTimeout: const Duration(milliseconds: 10),
+        initializer: () => Completer<void>().future,
+        child: const MaterialApp(home: Text('Real app screen')),
+      ),
+    );
+
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(find.text('Leopardo Test'), findsOneWidget);
+    expect(find.text('Demarrage en mode securise'), findsOneWidget);
+    expect(find.text('Continuer'), findsOneWidget);
+
+    await tester.tap(find.text('Continuer'));
+    await tester.pump();
+
+    expect(find.text('Demarrage en mode securise'), findsNothing);
+    expect(find.text('Real app screen'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget tests for StartupGate visible first frame and degraded timeout mode
- run flutter test for leopardo_core in Mobile Apps CI
- document the regression guard in CHANGELOG and AGENTS

## Validation
- validate-mobile-plan28.ps1
- validate-mobile-plan29.ps1
- workflow YAML parse
- git diff --check