### PR TITLE
fix(mobile): harden auth and settings repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.204)
+Derniere mise a jour : 2026-06-01 (v4.16.205)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -52,6 +52,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.202, `extractDataList()` accepte aussi les listes `data.items` et `extractDataMap()` accepte les objets `data.item`. Ne pas reintroduire de parsing local different dans `leopardo_platform_admin` : les plans, entreprises, demandes client et metriques doivent passer par ces helpers partages.
 - Depuis v4.16.203, les repositories cabinet employee/manager passent par `requestWithRetry` et les helpers `extractDataList()` / `extractDataMap()`. Garder un timeout upload distinct plus long pour `MultipartFile`, mais ne pas revenir a des appels `apiClient.dio.*` directs pour dossiers, documents, partages ou statistiques du placard numerique.
 - Depuis v4.16.204, le mobile manager ne doit plus caster directement les listes modules/organigramme depuis `response.data['data']`. Les repositories `modules`, `organigramme` et le digest d'accueil doivent rester sur `requestWithRetry` + helpers payload pour eviter les ecrans vides ou spinners quand Laravel renvoie un payload pagine/enveloppe.
+- Depuis v4.16.205, les flux auth/settings employee/manager utilisent `requestWithRetry` avec timeouts courts et `extractDataMap()`. Conserver `/auth/me` avec timeout court et `maxRetriesOverride: 0` pour ne jamais bloquer le demarrage mobile, et garder un timeout upload separe pour l'enrolement biometrie.
 - Le Plan 20 readiness lancement vit dans `docs/PLAN_ACTION/20_PLAN_READINESS_LANCEMENT_PRODUCTION.md`. Le cockpit API `GET /api/v1/launch-readiness` est la source de verite pour le score go-live tenant ; toute extension dashboard/support doit garder ce contrat tenant-scope et RBAC P/RH.
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.205] - 2026-06-01
+
+### Fixed
+
+- Mobile employee/manager : durcissement des repositories auth et settings avec `requestWithRetry`, timeouts courts pour `/auth/me`, parsing tolerant `extractDataMap()` et uploads biometrie avec timeout dedie. Les flux login Google, register, logout, profil, langue, mot de passe, QR employe et biometrie ne reposent plus sur des appels Dio directs fragiles.
+- Mobile employee : les donnees Compte critiques (parcours professionnel, stats placard numerique, QR profil et scan QR entreprise) utilisent maintenant le client retry-aware pour reduire les ecrans bloques quand Render ou l'API repond lentement.
+
 ## [4.16.204] - 2026-06-01
 
 ### Fixed

--- a/front/mobile_apps/leopardo_employee/lib/features/auth/data/auth_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/auth/data/auth_repository.dart
@@ -1,6 +1,6 @@
-import 'package:dio/dio.dart' as dio_options;
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/models/employee.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
@@ -15,6 +15,9 @@ class AuthRepository {
   final AppPreferences preferences;
 
   AuthRepository(this.apiClient, this.storage, this.preferences);
+
+  static const _actionTimeout = Duration(seconds: 12);
+  static const _authCheckTimeout = Duration(seconds: 10);
 
   Future<Map<String, dynamic>> login(String email, String password) async {
     final response = await apiClient.requestWithRetry(
@@ -33,10 +36,14 @@ class AuthRepository {
     // Hydrate depuis /auth/me pour recuperer manager_role + capabilities
     // (la reponse /auth/login ne les expose pas).
     try {
-      final meResponse = await apiClient.dio.get('/auth/me');
-      final meData = meResponse.data['data'];
-      if (meData is Map) {
-        final employee = Employee.fromJson(meData.cast<String, dynamic>());
+      final meResponse = await apiClient.requestWithRetry(
+        '/auth/me',
+        timeoutOverride: _authCheckTimeout,
+        maxRetriesOverride: 0,
+      );
+      final meData = extractDataMap(meResponse.data);
+      if (meData.isNotEmpty) {
+        final employee = Employee.fromJson(meData);
         await _persistEmployeeContext(employee);
         return {'employee': employee};
       }
@@ -66,9 +73,13 @@ class AuthRepository {
     // Note: Le backend doit être capable de vérifier ce token.
     // Pour simplifier l'intégration Socialite existante, on peut passer par une route
     // qui accepte le token.
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/auth/google/token',
+      method: 'POST',
       data: {'token': idToken, 'device_name': 'Mobile App'},
+      isLoginRequest: true,
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
     final data = response.data as Map<String, dynamic>;
@@ -89,8 +100,9 @@ class AuthRepository {
     required String email,
     required String password,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/auth/register',
+      method: 'POST',
       data: {
         'first_name': firstName,
         'last_name': lastName,
@@ -99,6 +111,9 @@ class AuthRepository {
         'password_confirmation': password,
         'device_name': 'Mobile App',
       },
+      isLoginRequest: true,
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
     final data = response.data as Map<String, dynamic>;
@@ -115,7 +130,12 @@ class AuthRepository {
 
   Future<void> logout() async {
     try {
-      await apiClient.dio.post('/auth/logout');
+      await apiClient.requestWithRetry(
+        '/auth/logout',
+        method: 'POST',
+        maxRetriesOverride: 0,
+        timeoutOverride: _actionTimeout,
+      );
     } catch (_) {
       // Ignore errors if token is already invalid
     } finally {
@@ -132,14 +152,12 @@ class AuthRepository {
       // Timeout court (10 s) pour ne pas bloquer le splash plus longtemps que nécessaire.
       // En cas de cold-start Render ou de réseau lent, l’utilisateur voit /welcome
       // plutôt que rester coincé sur l’écran de chargement.
-      final response = await apiClient.dio.get(
+      final response = await apiClient.requestWithRetry(
         '/auth/me',
-        options: dio_options.Options(
-          sendTimeout: const Duration(seconds: 10),
-          receiveTimeout: const Duration(seconds: 10),
-        ),
+        timeoutOverride: _authCheckTimeout,
+        maxRetriesOverride: 0,
       );
-      final data = response.data['data'];
+      final data = extractDataMap(response.data);
       final employee = Employee.fromJson(data);
       await _persistEmployeeContext(employee);
       return {'employee': employee};
@@ -158,8 +176,9 @@ class AuthRepository {
     String? recoveryEmail,
     String? personalPhone,
   }) async {
-    final response = await apiClient.dio.patch(
+    final response = await apiClient.requestWithRetry(
       '/auth/profile',
+      method: 'PATCH',
       data: {
         'first_name': firstName.trim(),
         'last_name': lastName.trim(),
@@ -168,11 +187,11 @@ class AuthRepository {
         'recovery_email': recoveryEmail?.trim(),
         'personal_phone': personalPhone?.trim(),
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
-    final employee = Employee.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    final employee = Employee.fromJson(extractDataMap(response.data));
     await _persistEmployeeContext(employee);
     return employee;
   }
@@ -182,25 +201,29 @@ class AuthRepository {
     required String newPassword,
     required String confirmation,
   }) async {
-    await apiClient.dio.post(
+    await apiClient.requestWithRetry(
       '/auth/change-password',
+      method: 'POST',
       data: {
         'current_password': currentPassword,
         'new_password': newPassword,
         'new_password_confirmation': confirmation,
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
   }
 
   Future<Employee> updatePreferredLanguage(String language) async {
-    final response = await apiClient.dio.patch(
+    final response = await apiClient.requestWithRetry(
       '/auth/language',
+      method: 'PATCH',
       data: {'language': language.trim().toLowerCase()},
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
-    final employee = Employee.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    final employee = Employee.fromJson(extractDataMap(response.data));
     await _persistEmployeeContext(employee);
     return employee;
   }

--- a/front/mobile_apps/leopardo_employee/lib/features/settings/data/settings_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/settings/data/settings_repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/models/employee.dart';
 import 'package:leopardo_core/models/notification_preferences.dart';
@@ -13,6 +14,10 @@ class SettingsRepository {
   final ApiClient _apiClient;
   final AppPreferences _preferences;
 
+  static const _actionTimeout = Duration(seconds: 12);
+  static const _readTimeout = Duration(seconds: 10);
+  static const _uploadTimeout = Duration(seconds: 30);
+
   Future<Employee> updateProfile({
     required String firstName,
     required String lastName,
@@ -21,8 +26,9 @@ class SettingsRepository {
     String? recoveryEmail,
     String? personalPhone,
   }) async {
-    final response = await _apiClient.dio.patch(
+    final response = await _apiClient.requestWithRetry(
       '/auth/profile',
+      method: 'PATCH',
       data: {
         'first_name': firstName.trim(),
         'last_name': lastName.trim(),
@@ -31,44 +37,50 @@ class SettingsRepository {
         'recovery_email': recoveryEmail?.trim(),
         'personal_phone': personalPhone?.trim(),
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
-    return Employee.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    return Employee.fromJson(extractDataMap(response.data));
   }
 
   Future<EmployeeCareer> loadCareer() async {
-    final response = await _apiClient.dio.get('/me/career');
-    return EmployeeCareer.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
+    final response = await _apiClient.requestWithRetry(
+      '/me/career',
+      timeoutOverride: _readTimeout,
     );
+    return EmployeeCareer.fromJson(extractDataMap(response.data));
   }
 
   Future<CabinetStats> loadCabinetStats() async {
-    final response = await _apiClient.dio.get('/cabinet/stats');
-    return CabinetStats.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
+    final response = await _apiClient.requestWithRetry(
+      '/cabinet/stats',
+      timeoutOverride: _readTimeout,
     );
+    return CabinetStats.fromJson(extractDataMap(response.data));
   }
 
   Future<EmployeeQrPayload> loadEmployeeQrPayload() async {
-    final response = await _apiClient.dio.get('/me/qr-profile');
-    return EmployeeQrPayload.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
+    final response = await _apiClient.requestWithRetry(
+      '/me/qr-profile',
+      timeoutOverride: _readTimeout,
     );
+    return EmployeeQrPayload.fromJson(extractDataMap(response.data));
   }
 
   Future<String> submitCompanyQr(String token, {String? message}) async {
-    final response = await _apiClient.dio.post(
+    final response = await _apiClient.requestWithRetry(
       '/me/company-qr/scan',
+      method: 'POST',
       data: {
         'qr_token': token.trim(),
         if (message != null && message.trim().isNotEmpty)
           'message': message.trim(),
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
-    final data = (response.data['data'] as Map).cast<String, dynamic>();
+    final data = extractDataMap(response.data);
     return (response.data['message'] ?? data['status'] ?? 'Demande envoyee')
         .toString();
   }
@@ -78,13 +90,16 @@ class SettingsRepository {
     required String newPassword,
     required String confirmation,
   }) async {
-    await _apiClient.dio.post(
+    await _apiClient.requestWithRetry(
       '/auth/change-password',
+      method: 'POST',
       data: {
         'current_password': currentPassword,
         'new_password': newPassword,
         'new_password_confirmation': confirmation,
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
   }
 
@@ -137,13 +152,16 @@ class SettingsRepository {
   }
 
   Future<BiometricEnrollment?> loadBiometricEnrollment() async {
-    final response = await _apiClient.dio.get('/auth/biometric-enrollment');
-    final data = response.data['data'];
-    if (data == null) {
+    final response = await _apiClient.requestWithRetry(
+      '/auth/biometric-enrollment',
+      timeoutOverride: _readTimeout,
+    );
+    final data = extractDataMap(response.data);
+    if (data.isEmpty) {
       return null;
     }
 
-    return BiometricEnrollment.fromJson((data as Map).cast<String, dynamic>());
+    return BiometricEnrollment.fromJson(data);
   }
 
   Future<BiometricEnrollment> submitBiometricEnrollment({
@@ -170,13 +188,14 @@ class SettingsRepository {
         ),
     });
 
-    final response = await _apiClient.dio.post(
+    final response = await _apiClient.requestWithRetry(
       '/auth/biometric-enrollment',
+      method: 'POST',
       data: formData,
+      maxRetriesOverride: 0,
+      timeoutOverride: _uploadTimeout,
     );
-    return BiometricEnrollment.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    return BiometricEnrollment.fromJson(extractDataMap(response.data));
   }
 }
 
@@ -291,10 +310,7 @@ class CabinetStats {
 }
 
 class EmployeeQrPayload {
-  const EmployeeQrPayload({
-    required this.token,
-    required this.expiresAt,
-  });
+  const EmployeeQrPayload({required this.token, required this.expiresAt});
 
   final String token;
   final String? expiresAt;

--- a/front/mobile_apps/leopardo_manager/lib/features/auth/data/auth_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/auth/data/auth_repository.dart
@@ -1,6 +1,6 @@
-import 'package:dio/dio.dart' as dio_options;
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/models/employee.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
@@ -15,6 +15,9 @@ class AuthRepository {
   final AppPreferences preferences;
 
   AuthRepository(this.apiClient, this.storage, this.preferences);
+
+  static const _actionTimeout = Duration(seconds: 12);
+  static const _authCheckTimeout = Duration(seconds: 10);
 
   Future<Map<String, dynamic>> login(String email, String password) async {
     final response = await apiClient.requestWithRetry(
@@ -33,10 +36,14 @@ class AuthRepository {
     // Hydrate depuis /auth/me pour recuperer manager_role + capabilities
     // (la reponse /auth/login ne les expose pas).
     try {
-      final meResponse = await apiClient.dio.get('/auth/me');
-      final meData = meResponse.data['data'];
-      if (meData is Map) {
-        final employee = Employee.fromJson(meData.cast<String, dynamic>());
+      final meResponse = await apiClient.requestWithRetry(
+        '/auth/me',
+        timeoutOverride: _authCheckTimeout,
+        maxRetriesOverride: 0,
+      );
+      final meData = extractDataMap(meResponse.data);
+      if (meData.isNotEmpty) {
+        final employee = Employee.fromJson(meData);
         await _persistEmployeeContext(employee);
         return {'employee': employee};
       }
@@ -66,9 +73,13 @@ class AuthRepository {
     // Note: Le backend doit être capable de vérifier ce token.
     // Pour simplifier l'intégration Socialite existante, on peut passer par une route
     // qui accepte le token.
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/auth/google/token',
+      method: 'POST',
       data: {'token': idToken, 'device_name': 'Mobile App'},
+      isLoginRequest: true,
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
     final data = response.data as Map<String, dynamic>;
@@ -89,8 +100,9 @@ class AuthRepository {
     required String email,
     required String password,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/auth/register',
+      method: 'POST',
       data: {
         'first_name': firstName,
         'last_name': lastName,
@@ -99,6 +111,9 @@ class AuthRepository {
         'password_confirmation': password,
         'device_name': 'Mobile App',
       },
+      isLoginRequest: true,
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
     final data = response.data as Map<String, dynamic>;
@@ -115,7 +130,12 @@ class AuthRepository {
 
   Future<void> logout() async {
     try {
-      await apiClient.dio.post('/auth/logout');
+      await apiClient.requestWithRetry(
+        '/auth/logout',
+        method: 'POST',
+        maxRetriesOverride: 0,
+        timeoutOverride: _actionTimeout,
+      );
     } catch (_) {
       // Ignore errors if token is already invalid
     } finally {
@@ -129,14 +149,12 @@ class AuthRepository {
     if (token == null) return null;
 
     try {
-      final response = await apiClient.dio.get(
+      final response = await apiClient.requestWithRetry(
         '/auth/me',
-        options: dio_options.Options(
-          sendTimeout: const Duration(seconds: 10),
-          receiveTimeout: const Duration(seconds: 10),
-        ),
+        timeoutOverride: _authCheckTimeout,
+        maxRetriesOverride: 0,
       );
-      final data = response.data['data'];
+      final data = extractDataMap(response.data);
       final employee = Employee.fromJson(data);
       await _persistEmployeeContext(employee);
       return {'employee': employee};
@@ -152,18 +170,19 @@ class AuthRepository {
     required String lastName,
     required String email,
   }) async {
-    final response = await apiClient.dio.patch(
+    final response = await apiClient.requestWithRetry(
       '/auth/profile',
+      method: 'PATCH',
       data: {
         'first_name': firstName.trim(),
         'last_name': lastName.trim(),
         'email': email.trim(),
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
-    final employee = Employee.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    final employee = Employee.fromJson(extractDataMap(response.data));
     await _persistEmployeeContext(employee);
     return employee;
   }
@@ -173,25 +192,29 @@ class AuthRepository {
     required String newPassword,
     required String confirmation,
   }) async {
-    await apiClient.dio.post(
+    await apiClient.requestWithRetry(
       '/auth/change-password',
+      method: 'POST',
       data: {
         'current_password': currentPassword,
         'new_password': newPassword,
         'new_password_confirmation': confirmation,
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
   }
 
   Future<Employee> updatePreferredLanguage(String language) async {
-    final response = await apiClient.dio.patch(
+    final response = await apiClient.requestWithRetry(
       '/auth/language',
+      method: 'PATCH',
       data: {'language': language.trim().toLowerCase()},
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
-    final employee = Employee.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    final employee = Employee.fromJson(extractDataMap(response.data));
     await _persistEmployeeContext(employee);
     return employee;
   }

--- a/front/mobile_apps/leopardo_manager/lib/features/settings/data/settings_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/settings/data/settings_repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/models/employee.dart';
 import 'package:leopardo_core/models/notification_preferences.dart';
@@ -13,23 +14,28 @@ class SettingsRepository {
   final ApiClient _apiClient;
   final AppPreferences _preferences;
 
+  static const _actionTimeout = Duration(seconds: 12);
+  static const _readTimeout = Duration(seconds: 10);
+  static const _uploadTimeout = Duration(seconds: 30);
+
   Future<Employee> updateProfile({
     required String firstName,
     required String lastName,
     required String email,
   }) async {
-    final response = await _apiClient.dio.patch(
+    final response = await _apiClient.requestWithRetry(
       '/auth/profile',
+      method: 'PATCH',
       data: {
         'first_name': firstName.trim(),
         'last_name': lastName.trim(),
         'email': email.trim(),
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
 
-    return Employee.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    return Employee.fromJson(extractDataMap(response.data));
   }
 
   Future<void> changePassword({
@@ -37,13 +43,16 @@ class SettingsRepository {
     required String newPassword,
     required String confirmation,
   }) async {
-    await _apiClient.dio.post(
+    await _apiClient.requestWithRetry(
       '/auth/change-password',
+      method: 'POST',
       data: {
         'current_password': currentPassword,
         'new_password': newPassword,
         'new_password_confirmation': confirmation,
       },
+      maxRetriesOverride: 0,
+      timeoutOverride: _actionTimeout,
     );
   }
 
@@ -96,13 +105,16 @@ class SettingsRepository {
   }
 
   Future<BiometricEnrollment?> loadBiometricEnrollment() async {
-    final response = await _apiClient.dio.get('/auth/biometric-enrollment');
-    final data = response.data['data'];
-    if (data == null) {
+    final response = await _apiClient.requestWithRetry(
+      '/auth/biometric-enrollment',
+      timeoutOverride: _readTimeout,
+    );
+    final data = extractDataMap(response.data);
+    if (data.isEmpty) {
       return null;
     }
 
-    return BiometricEnrollment.fromJson((data as Map).cast<String, dynamic>());
+    return BiometricEnrollment.fromJson(data);
   }
 
   Future<BiometricEnrollment> submitBiometricEnrollment({
@@ -129,13 +141,14 @@ class SettingsRepository {
         ),
     });
 
-    final response = await _apiClient.dio.post(
+    final response = await _apiClient.requestWithRetry(
       '/auth/biometric-enrollment',
+      method: 'POST',
       data: formData,
+      maxRetriesOverride: 0,
+      timeoutOverride: _uploadTimeout,
     );
-    return BiometricEnrollment.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    return BiometricEnrollment.fromJson(extractDataMap(response.data));
   }
 }
 


### PR DESCRIPTION
## Summary
- move employee and manager auth flows to requestWithRetry with short /auth/me timeouts
- harden profile, language, password, QR, career and biometric settings calls
- document the auth/settings retry contract in changelog and AGENTS

## Validation
- dart format targeted auth/settings files
- git diff --check
- dev-hub/tools/validate-mobile-workflow-contracts.ps1
- dev-hub/tools/validate-mobile-plan28.ps1
- dev-hub/tools/validate-mobile-plan29.ps1