### PR TITLE
fix(mobile): harden remaining api repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.205)
+Derniere mise a jour : 2026-06-01 (v4.16.206)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -43,6 +43,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.185, les notifications mobiles doivent rester compatibles avec `GET /api/v1/notifications?unread=true` et l'ancien alias `unread_only=true`. Les clients employee/manager doivent utiliser `ApiClient.requestWithRetry` avec timeout court, parser les collections paginees Laravel (`data`) et garder `DELETE /api/v1/notifications/{notification}` scoppé a l'utilisateur authentifie.
 - Depuis v4.16.186, les preferences notifications employee/manager sont pilotables depuis les ecrans Compte via `/api/v1/notification-preferences`. Toute evolution UI doit garder le modele partage `leopardo_core/lib/models/notification_preferences.dart`, la sauvegarde retry-aware et les heures calmes compatibles avec `CommunicationService`.
 - Depuis v4.16.187, les listes notifications employee/manager doivent rester actionnables : tap = marquer lu, swipe/menu = supprimer via `DELETE /api/v1/notifications/{notification}`, puis refresh provider. Ne pas supprimer l'action de suppression sans retirer aussi le contrat frontend/API.
+- Depuis v4.16.206, les apps employee/manager ne doivent plus ajouter d'appels API mobiles via `apiClient.dio.*` sauf cas volontairement bas niveau comme `dio.download` pour un fichier. Utiliser `requestWithRetry`, timeouts explicites et `extractDataMap`/`extractDataList` afin de conserver la protection Render cold-start et les payloads Laravel pagines.
 - Depuis v4.16.188, les trois apps mobiles ne doivent plus bloquer `runApp()` sur Hive, Google Sign-In ou intl. Le bootstrap passe par `StartupGate`; Hive `offlineCache` doit tenter une recuperation par suppression/reouverture en cas de corruption, et Google Sign-In reste non bloquant. Ne pas remettre d'`await` natif fragile avant le premier frame, sinon les testeurs peuvent revoir une page grise.
 - Depuis v4.16.195, `StartupGate` ne doit plus bloquer le premier vrai ecran : il lance le bootstrap en arriere-plan et rend l'app immediatement. Les routers employee/manager demarrent sur `/welcome`, le platform admin sur `/platform/login`, et `checkAuth` ne doit jamais forcer un retour vers un splash. `SecureStorage`, `AppPreferences` et `TranslationCatalogCache` doivent rester tolerants si Hive `offlineCache` n'est pas encore ouvert.
 - Depuis v4.16.196, les apps Android employee/manager/platform admin ne doivent plus afficher de logo dans le splash natif. Garder `launch_background` en fond simple et le splash Android 12+ avec `splash_transparent`; les logos appartiennent au premier ecran Flutter, pas au launch screen natif. Les builds Firebase doivent garder des noms prefixes par app (`employee-*`, `manager-*`, `platform-admin-*`) pour eviter la confusion entre releases `main` et `manual`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.206] - 2026-06-01
+
+### Fixed
+
+- Mobile employee/manager : durcissement des derniers repositories API hors telechargements payroll. Les flux `user_auth`, IA chat/voice et demande entreprise utilisent maintenant `requestWithRetry`, des timeouts explicites et le parsing tolerant `extractDataMap`/`extractDataList`.
+- Mobile employee/manager : les appels `/user/*`, `/ai/*` et `/company-requests` ne contournent plus les protections cold-start Render, ce qui reduit les risques de spinner infini ou de payload mal caste sur les ecrans secondaires.
+
 ## [4.16.205] - 2026-06-01
 
 ### Fixed

--- a/front/mobile_apps/leopardo_employee/lib/features/ai_chat/data/ai_chat_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/ai_chat/data/ai_chat_repository.dart
@@ -1,4 +1,5 @@
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 
 class AiChatRepository {
   final ApiClient apiClient;
@@ -6,14 +7,16 @@ class AiChatRepository {
   AiChatRepository(this.apiClient);
 
   Future<String> sendMessage(String message, {int? conversationId}) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/ai/chat',
+      method: 'POST',
+      timeoutOverride: const Duration(seconds: 30),
       data: {
         'message': message,
         if (conversationId != null) 'conversation_id': conversationId,
       },
     );
-    final data = response.data;
+    final data = extractDataMap(response.data);
     return data['response'] as String? ??
         data['message'] as String? ??
         data['content'] as String? ??

--- a/front/mobile_apps/leopardo_employee/lib/features/ai_voice/data/ai_voice_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/ai_voice/data/ai_voice_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 
 class AiVoiceRepository {
   final ApiClient apiClient;
@@ -11,19 +12,23 @@ class AiVoiceRepository {
     final formData = FormData.fromMap({
       'audio': MultipartFile.fromBytes(audioBytes, filename: filename),
     });
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/ai/voice/transcribe',
+      method: 'POST',
+      timeoutOverride: const Duration(seconds: 45),
       data: formData,
     );
-    return response.data['text'] as String? ?? '';
+    return extractDataMap(response.data)['text'] as String? ?? '';
   }
 
   Future<Uint8List> synthesize(String text) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry<List<int>>(
       '/ai/voice/synthesize',
+      method: 'POST',
       data: {'text': text},
+      timeoutOverride: const Duration(seconds: 45),
       options: Options(responseType: ResponseType.bytes),
     );
-    return Uint8List.fromList(response.data);
+    return Uint8List.fromList(response.data ?? const <int>[]);
   }
 }

--- a/front/mobile_apps/leopardo_employee/lib/features/personal_space/screens/company_request_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/personal_space/screens/company_request_screen.dart
@@ -44,8 +44,10 @@ class _CompanyRequestScreenState extends ConsumerState<CompanyRequestScreen> {
 
     try {
       final apiClient = ref.read(apiClientProvider);
-      await apiClient.dio.post(
+      await apiClient.requestWithRetry(
         '/company-requests',
+        method: 'POST',
+        timeoutOverride: const Duration(seconds: 15),
         data: {
           'company_name': _companyNameController.text.trim(),
           'sector': _sectorController.text.trim(),

--- a/front/mobile_apps/leopardo_employee/lib/features/user_auth/data/user_auth_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/user_auth/data/user_auth_repository.dart
@@ -1,4 +1,5 @@
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
 import 'package:leopardo_core/models/app_user.dart';
 
@@ -15,8 +16,10 @@ class UserAuthRepository {
     required String password,
     String? phone,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/register',
+      method: 'POST',
+      isLoginRequest: true,
       data: {
         'first_name': firstName,
         'last_name': lastName,
@@ -26,11 +29,11 @@ class UserAuthRepository {
       },
     );
 
-    final data = response.data as Map<String, dynamic>;
+    final data = _authPayload(response.data);
     final token = data['token'] as String;
     await storage.saveToken(token);
 
-    final user = AppUser.fromJson(data['data'] as Map<String, dynamic>);
+    final user = AppUser.fromJson(_userPayload(data));
     return {'user': user};
   }
 
@@ -38,16 +41,18 @@ class UserAuthRepository {
     required String email,
     required String password,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/login',
+      method: 'POST',
+      isLoginRequest: true,
       data: {'email': email, 'password': password, 'device_name': 'Mobile App'},
     );
 
-    final data = response.data as Map<String, dynamic>;
+    final data = _authPayload(response.data);
     final token = data['token'] as String;
     await storage.saveToken(token);
 
-    final user = AppUser.fromJson(data['data'] as Map<String, dynamic>);
+    final user = AppUser.fromJson(_userPayload(data));
     return {'user': user};
   }
 
@@ -58,8 +63,10 @@ class UserAuthRepository {
     required String lastName,
     String? avatarUrl,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/google-signin',
+      method: 'POST',
+      isLoginRequest: true,
       data: {
         'google_id': googleId,
         'email': email,
@@ -69,11 +76,11 @@ class UserAuthRepository {
       },
     );
 
-    final data = response.data as Map<String, dynamic>;
+    final data = _authPayload(response.data);
     final token = data['token'] as String;
     await storage.saveToken(token);
 
-    final user = AppUser.fromJson(data['data'] as Map<String, dynamic>);
+    final user = AppUser.fromJson(_userPayload(data));
     return {'user': user, 'is_new': data['is_new'] ?? false};
   }
 
@@ -82,8 +89,12 @@ class UserAuthRepository {
     if (token == null) return null;
 
     try {
-      final response = await apiClient.dio.get('/user/me');
-      final data = response.data['data'] as Map<String, dynamic>;
+      final response = await apiClient.requestWithRetry(
+        '/user/me',
+        timeoutOverride: const Duration(seconds: 8),
+        maxRetriesOverride: 0,
+      );
+      final data = _userPayload(extractDataMap(response.data));
       return AppUser.fromJson(data);
     } catch (_) {
       return null;
@@ -92,7 +103,12 @@ class UserAuthRepository {
 
   Future<void> logout() async {
     try {
-      await apiClient.dio.post('/user/logout');
+      await apiClient.requestWithRetry(
+        '/user/logout',
+        method: 'POST',
+        timeoutOverride: const Duration(seconds: 8),
+        maxRetriesOverride: 0,
+      );
     } catch (_) {
       // Ignore
     } finally {
@@ -101,9 +117,13 @@ class UserAuthRepository {
   }
 
   Future<List<Map<String, dynamic>>> getCompanyRequests() async {
-    final response = await apiClient.dio.get('/user/company-requests');
-    final data = response.data['data'] as List<dynamic>;
-    return data.cast<Map<String, dynamic>>();
+    final response = await apiClient.requestWithRetry(
+      '/user/company-requests',
+      timeoutOverride: const Duration(seconds: 12),
+    );
+    return extractDataList(
+      response.data,
+    ).whereType<Map>().map((item) => item.cast<String, dynamic>()).toList();
   }
 
   Future<Map<String, dynamic>> submitCompanyRequest({
@@ -115,8 +135,10 @@ class UserAuthRepository {
     String? phone,
     String? description,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/company-requests',
+      method: 'POST',
+      timeoutOverride: const Duration(seconds: 15),
       data: {
         'company_name': companyName,
         'email': email,
@@ -127,7 +149,7 @@ class UserAuthRepository {
         if (description != null) 'description': description,
       },
     );
-    return response.data['data'] as Map<String, dynamic>;
+    return extractDataMap(response.data);
   }
 
   Future<AppUser> updateProfile({
@@ -136,8 +158,10 @@ class UserAuthRepository {
     String? phone,
     String? preferredLanguage,
   }) async {
-    final response = await apiClient.dio.patch(
+    final response = await apiClient.requestWithRetry(
       '/user/profile',
+      method: 'PATCH',
+      timeoutOverride: const Duration(seconds: 12),
       data: {
         if (firstName != null) 'first_name': firstName,
         if (lastName != null) 'last_name': lastName,
@@ -146,8 +170,42 @@ class UserAuthRepository {
       },
     );
 
-    return AppUser.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    return AppUser.fromJson(_userPayload(extractDataMap(response.data)));
+  }
+
+  Map<String, dynamic> _authPayload(dynamic payload) {
+    if (payload is! Map) {
+      return const <String, dynamic>{};
+    }
+
+    final root = payload.cast<String, dynamic>();
+    final rootToken = root['token'];
+    if (rootToken is String && rootToken.isNotEmpty) {
+      return root;
+    }
+
+    final data = root['data'];
+    if (data is Map) {
+      final dataMap = data.cast<String, dynamic>();
+      final dataToken = dataMap['token'];
+      if (dataToken is String && dataToken.isNotEmpty) {
+        return dataMap;
+      }
+    }
+
+    final nested = root['auth'];
+    if (nested is Map) {
+      return nested.cast<String, dynamic>();
+    }
+
+    return extractDataMap(payload);
+  }
+
+  Map<String, dynamic> _userPayload(Map<String, dynamic> payload) {
+    final user = payload['user'] ?? payload['employee'] ?? payload['data'];
+    if (user is Map) {
+      return user.cast<String, dynamic>();
+    }
+    return payload;
   }
 }

--- a/front/mobile_apps/leopardo_manager/lib/features/ai_chat/data/ai_chat_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/ai_chat/data/ai_chat_repository.dart
@@ -1,4 +1,5 @@
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 
 class AiChatRepository {
   final ApiClient apiClient;
@@ -6,14 +7,16 @@ class AiChatRepository {
   AiChatRepository(this.apiClient);
 
   Future<String> sendMessage(String message, {int? conversationId}) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/ai/chat',
+      method: 'POST',
+      timeoutOverride: const Duration(seconds: 30),
       data: {
         'message': message,
         if (conversationId != null) 'conversation_id': conversationId,
       },
     );
-    final data = response.data;
+    final data = extractDataMap(response.data);
     return data['response'] as String? ??
         data['message'] as String? ??
         data['content'] as String? ??

--- a/front/mobile_apps/leopardo_manager/lib/features/ai_voice/data/ai_voice_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/ai_voice/data/ai_voice_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 
 class AiVoiceRepository {
   final ApiClient apiClient;
@@ -11,19 +12,23 @@ class AiVoiceRepository {
     final formData = FormData.fromMap({
       'audio': MultipartFile.fromBytes(audioBytes, filename: filename),
     });
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/ai/voice/transcribe',
+      method: 'POST',
+      timeoutOverride: const Duration(seconds: 45),
       data: formData,
     );
-    return response.data['text'] as String? ?? '';
+    return extractDataMap(response.data)['text'] as String? ?? '';
   }
 
   Future<Uint8List> synthesize(String text) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry<List<int>>(
       '/ai/voice/synthesize',
+      method: 'POST',
       data: {'text': text},
+      timeoutOverride: const Duration(seconds: 45),
       options: Options(responseType: ResponseType.bytes),
     );
-    return Uint8List.fromList(response.data);
+    return Uint8List.fromList(response.data ?? const <int>[]);
   }
 }

--- a/front/mobile_apps/leopardo_manager/lib/features/personal_space/screens/company_request_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/personal_space/screens/company_request_screen.dart
@@ -44,8 +44,10 @@ class _CompanyRequestScreenState extends ConsumerState<CompanyRequestScreen> {
 
     try {
       final apiClient = ref.read(apiClientProvider);
-      await apiClient.dio.post(
+      await apiClient.requestWithRetry(
         '/company-requests',
+        method: 'POST',
+        timeoutOverride: const Duration(seconds: 15),
         data: {
           'company_name': _companyNameController.text.trim(),
           'sector': _sectorController.text.trim(),

--- a/front/mobile_apps/leopardo_manager/lib/features/user_auth/data/user_auth_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/user_auth/data/user_auth_repository.dart
@@ -1,4 +1,5 @@
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
 import 'package:leopardo_core/models/app_user.dart';
 
@@ -15,8 +16,10 @@ class UserAuthRepository {
     required String password,
     String? phone,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/register',
+      method: 'POST',
+      isLoginRequest: true,
       data: {
         'first_name': firstName,
         'last_name': lastName,
@@ -26,11 +29,11 @@ class UserAuthRepository {
       },
     );
 
-    final data = response.data as Map<String, dynamic>;
+    final data = _authPayload(response.data);
     final token = data['token'] as String;
     await storage.saveToken(token);
 
-    final user = AppUser.fromJson(data['data'] as Map<String, dynamic>);
+    final user = AppUser.fromJson(_userPayload(data));
     return {'user': user};
   }
 
@@ -38,16 +41,18 @@ class UserAuthRepository {
     required String email,
     required String password,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/login',
+      method: 'POST',
+      isLoginRequest: true,
       data: {'email': email, 'password': password, 'device_name': 'Mobile App'},
     );
 
-    final data = response.data as Map<String, dynamic>;
+    final data = _authPayload(response.data);
     final token = data['token'] as String;
     await storage.saveToken(token);
 
-    final user = AppUser.fromJson(data['data'] as Map<String, dynamic>);
+    final user = AppUser.fromJson(_userPayload(data));
     return {'user': user};
   }
 
@@ -58,8 +63,10 @@ class UserAuthRepository {
     required String lastName,
     String? avatarUrl,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/google-signin',
+      method: 'POST',
+      isLoginRequest: true,
       data: {
         'google_id': googleId,
         'email': email,
@@ -69,11 +76,11 @@ class UserAuthRepository {
       },
     );
 
-    final data = response.data as Map<String, dynamic>;
+    final data = _authPayload(response.data);
     final token = data['token'] as String;
     await storage.saveToken(token);
 
-    final user = AppUser.fromJson(data['data'] as Map<String, dynamic>);
+    final user = AppUser.fromJson(_userPayload(data));
     return {'user': user, 'is_new': data['is_new'] ?? false};
   }
 
@@ -82,8 +89,12 @@ class UserAuthRepository {
     if (token == null) return null;
 
     try {
-      final response = await apiClient.dio.get('/user/me');
-      final data = response.data['data'] as Map<String, dynamic>;
+      final response = await apiClient.requestWithRetry(
+        '/user/me',
+        timeoutOverride: const Duration(seconds: 8),
+        maxRetriesOverride: 0,
+      );
+      final data = _userPayload(extractDataMap(response.data));
       return AppUser.fromJson(data);
     } catch (_) {
       return null;
@@ -92,7 +103,12 @@ class UserAuthRepository {
 
   Future<void> logout() async {
     try {
-      await apiClient.dio.post('/user/logout');
+      await apiClient.requestWithRetry(
+        '/user/logout',
+        method: 'POST',
+        timeoutOverride: const Duration(seconds: 8),
+        maxRetriesOverride: 0,
+      );
     } catch (_) {
       // Ignore
     } finally {
@@ -101,9 +117,13 @@ class UserAuthRepository {
   }
 
   Future<List<Map<String, dynamic>>> getCompanyRequests() async {
-    final response = await apiClient.dio.get('/user/company-requests');
-    final data = response.data['data'] as List<dynamic>;
-    return data.cast<Map<String, dynamic>>();
+    final response = await apiClient.requestWithRetry(
+      '/user/company-requests',
+      timeoutOverride: const Duration(seconds: 12),
+    );
+    return extractDataList(
+      response.data,
+    ).whereType<Map>().map((item) => item.cast<String, dynamic>()).toList();
   }
 
   Future<Map<String, dynamic>> submitCompanyRequest({
@@ -115,8 +135,10 @@ class UserAuthRepository {
     String? phone,
     String? description,
   }) async {
-    final response = await apiClient.dio.post(
+    final response = await apiClient.requestWithRetry(
       '/user/company-requests',
+      method: 'POST',
+      timeoutOverride: const Duration(seconds: 15),
       data: {
         'company_name': companyName,
         'email': email,
@@ -127,7 +149,7 @@ class UserAuthRepository {
         if (description != null) 'description': description,
       },
     );
-    return response.data['data'] as Map<String, dynamic>;
+    return extractDataMap(response.data);
   }
 
   Future<AppUser> updateProfile({
@@ -136,8 +158,10 @@ class UserAuthRepository {
     String? phone,
     String? preferredLanguage,
   }) async {
-    final response = await apiClient.dio.patch(
+    final response = await apiClient.requestWithRetry(
       '/user/profile',
+      method: 'PATCH',
+      timeoutOverride: const Duration(seconds: 12),
       data: {
         if (firstName != null) 'first_name': firstName,
         if (lastName != null) 'last_name': lastName,
@@ -146,8 +170,42 @@ class UserAuthRepository {
       },
     );
 
-    return AppUser.fromJson(
-      (response.data['data'] as Map).cast<String, dynamic>(),
-    );
+    return AppUser.fromJson(_userPayload(extractDataMap(response.data)));
+  }
+
+  Map<String, dynamic> _authPayload(dynamic payload) {
+    if (payload is! Map) {
+      return const <String, dynamic>{};
+    }
+
+    final root = payload.cast<String, dynamic>();
+    final rootToken = root['token'];
+    if (rootToken is String && rootToken.isNotEmpty) {
+      return root;
+    }
+
+    final data = root['data'];
+    if (data is Map) {
+      final dataMap = data.cast<String, dynamic>();
+      final dataToken = dataMap['token'];
+      if (dataToken is String && dataToken.isNotEmpty) {
+        return dataMap;
+      }
+    }
+
+    final nested = root['auth'];
+    if (nested is Map) {
+      return nested.cast<String, dynamic>();
+    }
+
+    return extractDataMap(payload);
+  }
+
+  Map<String, dynamic> _userPayload(Map<String, dynamic> payload) {
+    final user = payload['user'] ?? payload['employee'] ?? payload['data'];
+    if (user is Map) {
+      return user.cast<String, dynamic>();
+    }
+    return payload;
   }
 }


### PR DESCRIPTION
## Summary
- move remaining employee/manager user_auth repositories to requestWithRetry with tolerant auth payload parsing
- harden AI chat/voice and company request submission with explicit timeouts
- document the no-direct-Dio mobile rule for future agents

## Validation
- dart format targeted files
- git diff --check
- dev-hub/tools/validate-mobile-workflow-contracts.ps1
- dev-hub/tools/validate-mobile-plan28.ps1
- dev-hub/tools/validate-mobile-plan29.ps1

Note: local flutter analyze is blocked by the Windows Flutter SDK using Dart 3.7.2 while the apps require SDK 3.8+ via flutter_lints >=6; GitHub Actions remains the build source of truth.