### PR TITLE
docs: consolidate final launch action plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.215)
+Derniere mise a jour : 2026-06-01 (v4.16.216)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -79,6 +79,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - La matrice frontend/API canonique vit dans `docs/validation/FRONTEND_API_CONTRACT_MATRIX.md`. Toute nouvelle dependance admin/mobile/kiosk a une route Laravel doit ajouter la ligne matrice et, au minimum, un garde dans `FrontendApiContractTest`.
 - Depuis v4.16.154, le Plan 30 API hardening vit dans `docs/PLAN_ACTION/30_PLAN_API_WORKFLOW_HARDENING.md`. `POST /api/v1/platform/companies` doit rester compatible avec le payload minimal de `leopardo_platform_admin` (name, email, country, city, manager names/email) en resolvant cote serveur `sector`, `plan_id`, `language`, `currency` et `timezone`. Ne pas rendre `sector` ou `plan_id` obligatoires sans adapter l'app mobile et les tests.
 - Depuis v4.16.189, les retours testeurs produit 31-44 sont formalises dans `docs/PLAN_ACTION/57_PLAN_API_DOCS_ECOSYSTEME_DEVELOPPEUR.md` a `65_PLAN_PAIEMENT_MASSE_SIGNATURE_NUMERIQUE.md`. Avant de coder ces chantiers, choisir le plan concerne, livrer ses lots dans l'ordre, mettre a jour `00_SOMMAIRE.md` si un nouveau plan est ajoute, puis pousser via PR pour garder la mission lisible.
+- Depuis v4.16.216, les plans 01-66 sont consideres comme historiques executes ou cartographies. Avant de rouvrir un ancien sujet, consulter `docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md`; les derniers lots de lancement doivent etre rattaches a `docs/PLAN_ACTION/67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md` sauf besoin clairement hors perimetre.
 - Les decisions d'architecture structurantes vivent dans `docs/architecture/adr/`, le diagramme C4 dans `docs/architecture/C4_ARCHITECTURE.md`, et le point d'entree operations dans `docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md`.
 - Le guide partenaire canonique est `docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md`; l'actualiser avec tout changement API/webhook/SSO expose aux integrateurs.
 - Le controle generalise de release vit dans `docs/validation/RELEASE_READINESS_GATE.md` avec le script `dev-hub/tools/release-readiness.ps1`; produire ou mettre a jour un rapport `docs/validation/RELEASE_READINESS_REPORT_*.md` avant de declarer un score production-ready.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.216] - 2026-06-01
+
+### Added
+
+- Plan 66.1 : ajout de la matrice anti-oubli `docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md`, couvrant les 44 points consolides avec statut, plan source, preuve et prochain lot.
+- Ajout du Plan 67 `67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md` pour reprendre les derniers lots launch-readiness : runtime mobile, super-admin E2E, GPS natif, theming tenant, notifications et rapport release.
+- Le sommaire des plans reference maintenant le Plan 67 comme suite canonique apres cloture/cartographie des plans 01-66.
+
 ## [4.16.215] - 2026-06-01
 
 ### Added

--- a/docs/PLAN_ACTION/00_SOMMAIRE.md
+++ b/docs/PLAN_ACTION/00_SOMMAIRE.md
@@ -58,6 +58,7 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 | 64 | `64_PLAN_CLOTURE_TIMEZONE_GPS.md` | Cloture automatique des journees, timezones correctes et geofence GPS douce |
 | 65 | `65_PLAN_PAIEMENT_MASSE_SIGNATURE_NUMERIQUE.md` | Paiements en masse, confirmations employees, audit et preparation signature numerique |
 | 66 | `66_PLAN_CONSOLIDATION_MOBILE_FIRST_COMPANY_OS.md` | Plan maitre A-J : cartographie des 44 idees consolidees, anti-oubli et ordre de livraison |
+| 67 | `67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md` | Audit final lancement : mobile runtime smoke, super-admin E2E, GPS natif, theming tenant, notifications et release readiness |
 
 ### Ordre d'execution recommande
 
@@ -70,6 +71,7 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 7. **Plan 58** : personnalisation premium tenant une fois le socle operationnel stable.
 8. **Plan 59** : aligner la vitrine, le pricing et le storytelling sur ce qui est reellement livre.
 9. **Plan 66** : maintenir la cartographie A-J a jour a chaque nouveau retour testeur ou changement de positionnement.
+10. **Plan 67** : executer les derniers lots de preuve produit avant marketing : runtime mobile, platform admin, GPS, branding applique, notifications et release readiness.
 
 Chaque plan doit sortir avec son changement code/documentation, ses tests ou preuves CI, une entree `CHANGELOG.md` et, si une lecon durable apparait, une entree `AGENTS.md`.
 

--- a/docs/PLAN_ACTION/66_PLAN_CONSOLIDATION_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/66_PLAN_CONSOLIDATION_MOBILE_FIRST_COMPANY_OS.md
@@ -38,7 +38,9 @@ Verifier que les 44 idees consolidees sont soit deja implementees, soit rattache
 - Marquer comme `implemente`, `partiel`, `a faire`, `hors lancement`.
 - Ne pas dupliquer les plans existants.
 
-**Statut : A faire** (necesssite un agent dedie pour passer en revue les 65 plans)
+**Statut : Implemente le 2026-06-01** via `docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md`.
+
+Decision : les plans 01-66 deviennent des plans historiques executes ou cartographies. Les gaps launch-readiness sont consolides dans le Plan 67.
 
 ### Lot 66.2 - Stabilite mobile immediate
 
@@ -55,7 +57,7 @@ Verifier que les 44 idees consolidees sont soit deja implementees, soit rattache
 - Finance : avances, solde, paiements, documents.
 - Infra : queues, workers, monitoring, k6.
 
-**Statut : A faire** — Necesssite des passes de validation par domaine.
+**Statut : Repris dans Plan 67** — Les passes de validation par domaine sont formalisees dans les lots 67.1 a 67.6.
 
 ### Lot 66.4 - Marketplace et open core
 
@@ -63,7 +65,7 @@ Verifier que les 44 idees consolidees sont soit deja implementees, soit rattache
 - Definir ce qui est open core et ce qui reste enterprise.
 - Ne rien ouvrir publiquement sans audit secrets, licences et donnees demo.
 
-**Statut : A faire** — Hors lancement immediat, a cadrer en lot futur.
+**Statut : Repris dans Plan 67.7** — Hors lancement immediat, a cadrer sans risque licence/secrets.
 
 ### Lot 66.5 - Positionnement final ✅ IMPLEMENTE
 
@@ -128,7 +130,7 @@ _Mis à jour le 2026-05-31 par KiloClaw — passe de revue des plans 55 à 66._
 | 63 | Architecture Heures de Pointe | ✅ IMPLÉMENTÉ | Redis/predis, queues documents/pdf/payroll/notifications/webhooks, cache digest/schedules, scheduler auto-close et runbook worker. |
 | 64 | Clôture Timezone GPS | ✅ IMPLÉMENTÉ | Timezone device, geofence doux, auto-close configurable et mobile repositories livres. UX GPS native reste lot mobile futur. |
 | 65 | Paiement Masse Signature Numérique | ✅ IMPLÉMENTÉ | Modèles `PaymentBatch`, `PaymentItem`, `PaymentConfirmation`, endpoints, confirmation idempotente et documents async. |
-| 66 | Consolidation Mobile-First Company OS | ✅ IMPLÉMENTÉ | Table de cartographie présente, Lot 66.5 exécuté (positionnement vitrine). Cette section mise à jour. |
+| 66 | Consolidation Mobile-First Company OS | ✅ IMPLÉMENTÉ | Matrice anti-oubli 44 points livree, Lot 66.5 execute (positionnement vitrine), suite consolidee dans Plan 67. |
 
 ### Fichiers créés ou modifiés par cette passe
 

--- a/docs/PLAN_ACTION/67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md
+++ b/docs/PLAN_ACTION/67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md
@@ -1,0 +1,164 @@
+# Plan 67 - Audit final qualite produit et lancement
+
+## Source
+
+Ce plan prend la suite des plans 01-66 apres la matrice anti-oubli du 2026-06-01.
+
+Il sert a passer d'une accumulation de plans a une discipline de lancement : preuve d'ouverture mobile, preuve API, preuve super-admin, preuve notifications et preuve release.
+
+## Objectif
+
+Amener Leopardo RH au niveau "pret lancement marche" avec des preuves simples, repetables et actionnables.
+
+Le produit vise le positionnement :
+
+> OS de gestion d'entreprise mobile-first.
+
+## Regles d'execution
+
+- Ne plus rouvrir les plans 01-66 sauf pour corriger une reference.
+- Tout nouveau lot doit pointer vers la matrice `docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md`.
+- Chaque lot doit livrer code, documentation et preuve CI ou rapport de verification.
+- Les checks GitHub Actions restent la source de verite pour les validations couteuses.
+- Les trois apps mobiles de lancement restent dans `front/mobile_apps/`.
+
+## Lot 67.1 - Mobile runtime smoke strict
+
+### Probleme
+
+Les testeurs ont deja vu des pages grises/noires ou un logo bloque. Meme si le code bootstrap a ete corrige, il faut une preuve de non-regression par app.
+
+### Actions
+
+- Ajouter ou completer un smoke de demarrage pour :
+  - `leopardo_employee`
+  - `leopardo_manager`
+  - `leopardo_platform_admin`
+- Verifier que chaque app affiche un ecran actionnable sans attendre Hive, Firebase, Google Sign-In, intl ou reseau.
+- Verifier les noms de build/release pour eviter la confusion `main` / `manual`.
+- Documenter la preuve dans un rapport release readiness.
+
+### Critere de sortie
+
+Les trois apps affichent un premier ecran Flutter lisible et le workflow mobile CI/Firebase reste vert.
+
+## Lot 67.2 - Super-admin platform admin end-to-end
+
+### Probleme
+
+Le super-admin mobile est separe, mais le parcours complet doit etre prouve : login, session, creation entreprise, fiche client, abonnement, modules.
+
+### Actions
+
+- Verifier auth platform admin : login demo, session locale, token, erreurs 401/403/202 2FA.
+- Verifier creation entreprise via `POST /api/v1/platform/companies`.
+- Verifier fiche client : health, subscription, features.
+- Ajouter tests backend ou contrats mobile manquants si une route n'est pas couverte.
+
+### Critere de sortie
+
+Un super-admin peut se connecter et creer un client sans acces tenant parasite.
+
+## Lot 67.3 - GPS natif, geofence UX et notification douce
+
+### Probleme
+
+Le backend sait calculer le geofence, mais la partie permission native et feedback manager/employee doit etre finalisee.
+
+### Actions
+
+- Ajouter l'acquisition GPS mobile de maniere non bloquante.
+- Envoyer latitude/longitude/accuracy avec le pointage quand disponible.
+- Afficher un message employe doux en cas de hors-zone.
+- Creer une notification manager si la politique entreprise le demande.
+
+### Critere de sortie
+
+Le pointage reste possible sans GPS, mais devient plus fiable quand la permission est accordee.
+
+## Lot 67.4 - Theming tenant applique
+
+### Probleme
+
+Le Plan 58 livre le contrat branding et l'ecran manager, mais les apps n'appliquent pas encore globalement le theme tenant.
+
+### Actions
+
+- Lire `GET /api/v1/company/branding` apres login.
+- Appliquer logo/couleurs en mode safe dans manager et employee.
+- Garder accessibilite : contraste minimal, fallback Leopardo si couleur invalide.
+- Ne pas appliquer de theme tenant sur platform admin global.
+
+### Critere de sortie
+
+Une entreprise cliente voit son identite visuelle dans son espace sans casser la lisibilite.
+
+## Lot 67.5 - Notifications production proof
+
+### Probleme
+
+Les tokens FCM, preferences et jobs existent, mais il faut une preuve simple de bout en bout.
+
+### Actions
+
+- Verifier enregistrement/suppression device token sur login/logout.
+- Verifier notification employee, manager et super-admin sur cas metier.
+- Documenter les secrets requis et le mode fallback audit-only.
+- Ajouter un rapport de test manuel si FCM ne peut pas etre teste localement.
+
+### Critere de sortie
+
+Les notifications ne sont plus seulement architecturales : chaque profil a au moins un scenario prouve.
+
+## Lot 67.6 - Release readiness par profil
+
+### Probleme
+
+Les modules sont nombreux. Le lancement exige une preuve lisible par profil et non une liste de commits.
+
+### Actions
+
+- Produire un rapport `docs/validation/RELEASE_READINESS_REPORT_YYYY_MM_DD.md`.
+- Couvrir :
+  - employee
+  - manager/RH
+  - platform admin
+  - API publique
+  - vitrine web
+  - kiosk
+- Lister risques restants, contournements et priorites post-lancement.
+
+### Critere de sortie
+
+Le depot peut etre audite rapidement avant marketing, avec un score par surface et des actions restantes.
+
+## Lot 67.7 - Marketplace/open core cadrage
+
+### Probleme
+
+Marketplace et open core sont strategiques, mais non bloquants pour lancer. Les traiter trop tot peut creer un risque legal/securite.
+
+### Actions
+
+- Definir ce qui peut devenir open source.
+- Definir ce qui reste enterprise.
+- Lister les secrets, donnees demo, licences et modules a isoler.
+- Cadrer plugins/webhooks/scopes API sans implementation prematuree.
+
+### Critere de sortie
+
+Decision strategique documentee, sans exposer de code sensible.
+
+## Ordre recommande
+
+1. Lot 67.1
+2. Lot 67.2
+3. Lot 67.3
+4. Lot 67.4
+5. Lot 67.5
+6. Lot 67.6
+7. Lot 67.7
+
+## Statut
+
+**Cree le 2026-06-01.** Execution a demarrer apres merge de cette planification.

--- a/docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md
+++ b/docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md
@@ -1,0 +1,91 @@
+# Matrice anti-oubli des plans produit - 2026-06-01
+
+## Objectif
+
+Cette matrice consolide les 44 points du document "Mobile-First Company OS" et les rattache aux plans d'action existants.
+
+Regle de lecture :
+
+- **Livre** : code, documentation et garde CI existent sur `main`.
+- **Partiel** : le socle existe, mais il reste un lot UX, mobile, ops ou preuve release.
+- **Planifie** : le besoin est documente, pas encore livre.
+- **Hors lancement** : utile strategiquement, mais non bloquant pour une premiere mise sur le marche.
+
+## Synthese executive
+
+| Domaine | Etat courant | Decision |
+|---|---|---|
+| API, docs, queues, tests de charge | Majoritairement livre | Continuer avec preuves staging et couverture OpenAPI incrementale |
+| Mobile employee/manager/platform admin | Fonctionnel et distribue via CI, mais garder smoke runtime strict | Plan 67 doit produire une preuve d'ouverture/login par app apres chaque lot mobile |
+| Pointage intelligent | Livre sur multi-sessions, timezone, geofence doux et auto-close | Reste permission GPS native + UX manager de notification hors zone |
+| Finance mobile-first | Plans 60-65 livres cote API/mobile/documents | Reste UX de paiement masse manager et signature numerique avancee |
+| Super-admin plateforme | Partiel | Plan 67 doit reprendre auth/session/2FA et creation entreprise en verification produit |
+| Tenant branding | API + mobile manager livres | Reste application theming globale sur employee/manager/web |
+| Marketplace/open core | Cadre absent | Hors lancement immediat, a cadrer sans risque licence/secrets |
+
+## Matrice des 44 points consolides
+
+| # | Point consolide | Plan(s) source | Statut | Preuve / livrable | Prochain lot |
+|---|---|---|---|---|---|
+| 1 | Nettoyage depot, branches, duplications | 15, 16, 30, 66 | Partiel | PRs recentes mergees, branches plan58/64/65 prunees localement | Audit branches mortes dans Plan 67 |
+| 2 | Nettoyage des 3 sous-apps mobiles | 26, 27, 28, 48 | Partiel | `front/mobile_apps/` canonique, legacy clarifie | Revue dependances/imports par app dans Plan 67 |
+| 3 | Dockerisation et infra standard | 01, 07, 20, 63 | Partiel | Worker queues documente, Redis/predis et scheduler livres | Docker compose/workers dev reste futur |
+| 4 | APIs professionnelles | 23, 30, 57 | Livre progressif | OpenAPI canonique, `/docs`, `/api-explorer`, contrat JSON et gates OpenAPI | Completer endpoints restants au fil des modules |
+| 5 | Architecture async et montee en charge | 19, 29, 63 | Livre socle | Queues documents/pdf/payroll/notifications/webhooks, `queue:health-check` | Mesures staging et alerting externe |
+| 6 | Tests de charge | 27, 63 | Partiel | k6 smoke read-only et workflow manuel existent | Ajouter scenarios authentifies progressifs quand tokens staging stables |
+| 7 | Monitoring et observabilite | 07, 20, 63 | Partiel | health, queue health, launch readiness, OWASP/ZAP | Dashboards externes et alertes production |
+| 8 | Branding mobile complet | 41 | Livre socle | Icons/splash natifs distincts employee/manager/platform admin | Verifier assets release a chaque store build |
+| 9 | UX mobile-first | 25, 27, 51 | Partiel | Pointage v3, StartupGate non bloquant, ecrans cles modernises | Smoke runtime + design audit Plan 67 |
+| 10 | Design system unifie | 25, 28, 41 | Partiel | `leopardo_core` partage theme/widgets | Tokeniser plus largement les surfaces mobile |
+| 11 | Personnalisation entreprise | 58 | Partiel avance | `GET/PATCH /company/branding`, upload logo, ecran manager | Appliquer theme tenant aux apps employee/manager/web |
+| 12 | Pointage intelligent | 31, 42, 51 | Livre | Premier pointage direct, choix avances progressifs, sessions multiples | Garder regression tests et UX details jour |
+| 13 | Pointages multiples | 42, 49 | Livre | `session_number`, `work_type`, details jour, totaux multi-sessions | Aucun lot bloquant |
+| 14 | Cloture automatique | 64 | Livre backend | `attendance:auto-close` configurable avec correction window | UX mobile reclamation native a relier si necessaire |
+| 15 | Gestion timezone | 64 | Livre | `device_timezone`, UTC + local company dans resources | Aucun lot bloquant |
+| 16 | Verification GPS | 64 | Partiel | Geofence doux backend/API, payload mobile optionnel | Permission native + message manager dans Plan 67 |
+| 17 | Kiosque et biometrie | 25, 32, 64 | Partiel | Biometric enrollment API et consentement existent | Kiosque verification terrain reste futur |
+| 18 | Gestion des taches | 31, 38, 50 | Livre socle | `/tasks`, `/tasks/today`, templates metier manager mobile | Enrichir templates par secteur apres retours clients |
+| 19 | Performance employe | 31, 38 | Partiel | `performance_score`, temps estime/complete, note de cloture | Score carriere portable a formaliser |
+| 20 | Workflow validation | 19, 52, 60 | Livre avance | Absences/avances/corrections enrichies, double validation avances | Workflows generiques multi-niveaux futur |
+| 21 | Notifications temps reel | 19, 26, 63 | Partiel avance | CommunicationService, FCM device tokens, preferences, queues | Verifier end-to-end FCM avec credentials production |
+| 22 | Profil employe persistant | 32 | Livre socle | `/auth/profile`, `/me/career`, emails personnels et telephone | UX carriere a enrichir |
+| 23 | Placard numerique | 32 | Partiel | Espace documentaire personnel scope employee | UX partage/public et quotas futur |
+| 24 | QR onboarding | 33, 54 | Livre socle | Jetons signes, QR visuel partage, scan employee/company | Tests terrain scanner reels |
+| 25 | Dashboard manager operationnel | 34, 40, 53 | Partiel avance | `manager-digest`, team, status, corrections, schedules | Vue temps reel approfondie |
+| 26 | Gestion RH mobile | 53 | Partiel | Roles/status planifies et modules manager | Nommer/revoquer RH a verifier end-to-end |
+| 27 | Parametres entreprise | 35, 36, 58 | Partiel avance | Schedules, horaires, branding | Pauses/jours feries/tolerances UX mobile |
+| 28 | Isolation multi-tenant stricte | 23, 30, 53, 64 | Livre par garde | Tests tenant sur paie, docs, attendance, manager digest | Continuer tests par nouveau endpoint |
+| 29 | Authentification superadmin | 29, 56 | Partiel | Platform admin mobile separe, session guards partiels | Plan 67 reprend auth/2FA/session demo |
+| 30 | Dashboard superadmin | 45, 46, 56 | Partiel | Fiche client, subscription, features, health | Stats globales et monitoring a valider |
+| 31 | Gestion entreprises | 29, 30, 45, 46 | Partiel avance | `POST /platform/companies` payload mobile minimal | Creation entreprise E2E platform admin a tester |
+| 32 | Avances securisees | 60 | Livre | approve -> mark-paid -> confirm-received, API/tests/mobile | Aucun lot bloquant |
+| 33 | Solde employe | 61 | Livre | `/me/balance`, `/payroll/mobile-summary`, blocs mobile | Aucun lot bloquant |
+| 34 | Cycles de paie | 61 | Livre socle | cycle courant, deductions avances, isolation tenant | Pays/regles supplementaires restent Plan 03 |
+| 35 | Pre-calcul paie | 63 | Partiel | queues payroll, scheduler/runbook | Batch nocturne par calendrier entreprise futur |
+| 36 | Paiement masse | 65 | Livre backend | payment batches/items/confirmations, mark-paid async docs | UX manager mobile paiement masse futur |
+| 37 | Bordereaux et PDFs | 62, 65 | Livre | `payment_documents`, `GeneratePaymentDocumentJob`, downloads mobile | Templates legaux pays a enrichir |
+| 38 | Signature numerique | 65 | Partiel | confirmation employee auditee, version document | Signature cryptographique avancee hors lancement |
+| 39 | Multilingue | 24, 47 | Partiel avance | Sync i18n core/mobile, plan Jules, 4 langues vitrine | Retirer hardcodes progressivement |
+| 40 | Documentation developpeur | 57 | Livre socle | `/docs`, `/api-explorer`, guide partenaire | API explorer premium/sandbox tokens futur |
+| 41 | Marketplace future | 66.4 | Planifie | Mentionnee dans plan 66 | Cadrage Plan 67 hors lancement |
+| 42 | Open core strategique | 66.4 | Planifie | Mentionne dans plan 66 | Audit licences/secrets avant decision |
+| 43 | Requalification produit | 59, 66.5 | Livre | Vitrine "Mobile-First Company OS" en 4 langues | Aligner decks commerciaux futurs |
+| 44 | Vision finale produit | 59, 66 | Livre comme direction | Plan maitre A-J et positionnement final | Continuer preuves produit par domaine |
+
+## Gaps launch-readiness a reprendre en premier
+
+1. **Plan 67.1 - Mobile runtime smoke strict** : verifier ouverture, login demo, navigation principale et absence de splash/logo infini sur les 3 apps.
+2. **Plan 67.2 - Super-admin platform admin** : login/session/2FA demo, creation entreprise et fiche client en parcours E2E.
+3. **Plan 67.3 - GPS native et notifications terrain** : permission mobile, payload GPS fiable, notification douce hors zone.
+4. **Plan 67.4 - Theming tenant applique** : utiliser `company/branding` pour personnaliser manager/employee sans casser l'accessibilite.
+5. **Plan 67.5 - Evidence release** : rapport release readiness par profil, avec liens CI, workflows Firebase et tests API.
+
+## Decision de cloture des plans 01-66
+
+Les plans 01-66 sont maintenant traites comme **plans historiques executes ou cartographies**.
+
+Tout nouveau travail doit :
+
+1. Verifier cette matrice avant de creer un nouveau plan.
+2. Ajouter le lot dans le Plan 67 si le besoin concerne la finalisation lancement.
+3. Creer un nouveau plan numerote seulement si le besoin sort clairement du perimetre Plan 67.


### PR DESCRIPTION
## Summary
- add the 2026-06-01 anti-forget coverage matrix for the 44 consolidated tester/product points
- add Plan 67 as the canonical final launch-readiness plan after plans 01-66
- update Plan 66, the plan index, CHANGELOG and AGENTS with the new execution rule

## Validation
- git diff --check