### PR TITLE
feat: complete platform admin company create flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.217)
+Derniere mise a jour : 2026-06-01 (v4.16.218)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -103,6 +103,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.171, `dev-hub/tools/mobile-workflow-contracts.json` couvre aussi `leopardo_platform_admin`. Toute nouvelle action mobile super-admin doit declarer sa route `/platform/*`, son endpoint `/platform/*` et ses tokens d'ecran dans ce contrat, en plus de garder le Plan 29 vert.
 - Depuis v4.16.184, le Plan 56 durcit l'app mobile `leopardo_platform_admin` : pas d'hydratation `/platform/auth/me` sans token local, gestion explicite du `202 TWO_FA_REQUIRED`, bouton compte demo super-admin et validation email/code pays sur la creation client.
 - Depuis v4.16.172, la fiche client mobile platform admin vit sur `/platform/companies/:companyId` et consomme `/platform/companies/{company}/health`, `/subscription` et `/features`. `PlatformCompany.id` doit rester une string pour supporter les UUID de `public.companies`; ne pas le recaster en int.
+- Depuis v4.16.218, `leopardo_platform_admin` doit garder `PlatformRepository.createCompany()` avec retour `PlatformCompany` et redirection vers `/platform/companies/{companyId}` apres creation. Ne pas revenir a un `void` silencieux : le super-admin doit voir la fiche du client cree sans attendre un refresh manuel.
 - Depuis v4.16.173, cette fiche client est actionnable : edition abonnement via `GET /platform/plans` + `PATCH /platform/companies/{company}/subscription`, et edition modules via `PATCH /platform/companies/{company}/features`. Le module `rh` reste verrouille actif cote UI comme cote API.
 - Depuis v4.16.174, `shared/i18n/sync/sync-mobile.js` ecrit les catalogues ARB a la fois dans `front/mobile/lib/l10n` et `front/mobile_apps/leopardo_core/lib/l10n`. Ne pas laisser Jules traduire seulement l'ancien mobile : les apps employee/manager/platform admin lisent le core.
 - Depuis v4.16.153, `mobile-distribute.yml` se declenche aussi sur `main` quand `front/mobile_apps/**` change et distribue les trois apps Android `employee`, `manager` et `platform_admin`. Garder `FIREBASE_EMPLOYEE_ANDROID_APP_ID`, `FIREBASE_MANAGER_ANDROID_APP_ID`, `FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID` et les fichiers `google-services.json` synchronises ; `deploy-main.yml` peut sauter une app non prete, mais le workflow mobile manuel doit echouer si l'app demandee n'est pas correctement configuree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.218] - 2026-06-01
+
+### Changed
+
+- Plan 67.2 : l'app mobile platform admin recupere maintenant le client cree par `POST /platform/companies` et redirige directement vers sa fiche.
+- `PlatformCompany.fromProvisioningResponse()` couvre le payload `data.company` et conserve les UUID comme strings pour le routing mobile.
+- Ajout du rapport `PLATFORM_ADMIN_E2E_REPORT_2026_06_01.md` et d'un test modele platform admin pour le mapping creation client.
+
 ## [4.16.217] - 2026-06-01
 
 ### Added

--- a/docs/PLAN_ACTION/67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md
+++ b/docs/PLAN_ACTION/67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md
@@ -63,6 +63,10 @@ Le super-admin mobile est separe, mais le parcours complet doit etre prouve : lo
 
 Un super-admin peut se connecter et creer un client sans acces tenant parasite.
 
+### Statut
+
+**Livre en cours de validation CI.** `PlatformRepository.createCompany()` retourne maintenant le client cree, l'app ouvre sa fiche directement et `docs/validation/PLATFORM_ADMIN_E2E_REPORT_2026_06_01.md` documente le parcours.
+
 ## Lot 67.3 - GPS natif, geofence UX et notification douce
 
 ### Probleme

--- a/docs/validation/PLATFORM_ADMIN_E2E_REPORT_2026_06_01.md
+++ b/docs/validation/PLATFORM_ADMIN_E2E_REPORT_2026_06_01.md
@@ -1,0 +1,71 @@
+# Platform admin E2E report - 2026-06-01
+
+## Perimetre
+
+Ce rapport couvre le Lot 67.2 : verifier que l'app mobile super-admin peut effectuer le parcours minimal de lancement.
+
+Parcours vise :
+
+1. Login super-admin.
+2. Hydratation session.
+3. Creation entreprise.
+4. Redirection vers la fiche client creee.
+5. Consultation health/subscription/features.
+
+## Etat backend
+
+Le backend couvre deja :
+
+- `POST /api/v1/platform/auth/login`
+- `GET /api/v1/platform/auth/me`
+- `POST /api/v1/platform/auth/logout`
+- `POST /api/v1/platform/companies`
+- `GET /api/v1/platform/companies/{company}/health`
+- `GET/PATCH /api/v1/platform/companies/{company}/subscription`
+- `GET/PATCH /api/v1/platform/companies/{company}/features`
+
+Tests existants :
+
+- `PlatformAuthTest`
+- `PlatformCompanyProvisioningTest`
+- `PlatformCompanyHealthApiTest`
+- `PlatformCompanySubscriptionApiTest`
+- `PlatformCompanyFeatureApiTest`
+- `FrontendApiContractTest`
+
+## Changement mobile livre
+
+Avant ce lot, `PlatformRepository.createCompany()` retournait `void`. L'app pouvait creer le client, mais elle ne conservait pas l'identifiant retourne par l'API.
+
+Maintenant :
+
+- `createCompany()` retourne `PlatformCompany`.
+- `CompanyCreateScreen` invalide la liste clients puis redirige vers `/platform/companies/{companyId}`.
+- `PlatformCompany.fromProvisioningResponse()` mappe le payload `data.company`.
+- Les UUID restent des strings pour le routing mobile.
+
+## Garde ajoute
+
+Test modele :
+
+- `front/mobile_apps/leopardo_platform_admin/test/models/platform_company_model_test.dart`
+
+Il couvre :
+
+- mapping du payload de creation plateforme ;
+- conservation des IDs UUID comme strings.
+
+## Validation locale effectuee
+
+Commandes :
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\dev-hub\tools\validate-mobile-workflow-contracts.ps1
+powershell -ExecutionPolicy Bypass -File .\dev-hub\tools\validate-mobile-plan29.ps1
+```
+
+Les tests Flutter complets restent executes par GitHub Actions pour eviter les lenteurs locales.
+
+## Risque restant
+
+La preuve device super-admin complete depend encore de credentials/staging reels et sera reprise dans le Lot 67.6 release readiness.

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/companies/company_create_screen.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/companies/company_create_screen.dart
@@ -63,7 +63,7 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _submitting = true);
     try {
-      await ref
+      final company = await ref
           .read(platformRepositoryProvider)
           .createCompany(
             name: _name.text.trim(),
@@ -79,7 +79,12 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Entreprise creee')));
-      context.pop();
+      if (company.id.isNotEmpty) {
+        final route = '/platform/companies/${Uri.encodeComponent(company.id)}';
+        context.go(route);
+      } else {
+        context.go('/platform/companies');
+      }
     } catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_models.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_models.dart
@@ -39,17 +39,43 @@ class PlatformCompany {
   final String createdAt;
 
   factory PlatformCompany.fromJson(Map<String, dynamic> json) {
-    final planValue = json['plan'];
+    final data = (json['company'] as Map?)?.cast<String, dynamic>() ?? json;
+    final planValue = data['plan'];
+    final planName = data['plan_name'];
+
     return PlatformCompany(
-      id: json['id']?.toString() ?? '',
-      name: json['name']?.toString() ?? json['company_name']?.toString() ?? '-',
-      status: json['status']?.toString() ?? 'unknown',
-      country: json['country']?.toString() ?? '--',
+      id: data['id']?.toString() ?? '',
+      name: data['name']?.toString() ?? data['company_name']?.toString() ?? '-',
+      status: data['status']?.toString() ?? 'unknown',
+      country: data['country']?.toString() ?? '--',
       plan:
           planValue is Map
               ? planValue['name']?.toString() ?? 'Plan'
-              : planValue?.toString() ?? 'Plan',
-      createdAt: json['created_at']?.toString() ?? '',
+              : planName?.toString() ?? planValue?.toString() ?? 'Plan',
+      createdAt: data['created_at']?.toString() ?? '',
+    );
+  }
+
+  factory PlatformCompany.fromProvisioningResponse(Map<String, dynamic> json) {
+    final data = (json['data'] as Map?)?.cast<String, dynamic>() ?? json;
+    final company = (data['company'] as Map?)?.cast<String, dynamic>() ?? data;
+    final planValue = company['plan'];
+
+    return PlatformCompany(
+      id: company['id']?.toString() ?? '',
+      name:
+          company['name']?.toString() ??
+          company['company_name']?.toString() ??
+          '-',
+      status: company['status']?.toString() ?? 'unknown',
+      country: company['country']?.toString() ?? '--',
+      plan:
+          planValue is Map
+              ? planValue['name']?.toString() ?? 'Plan'
+              : company['plan_name']?.toString() ??
+                  company['plan']?.toString() ??
+                  'Plan',
+      createdAt: company['created_at']?.toString() ?? '',
     );
   }
 }

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_repository.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_repository.dart
@@ -181,7 +181,7 @@ class PlatformRepository {
     return PlatformCompanyFeatures.fromJson(response.data ?? {});
   }
 
-  Future<void> createCompany({
+  Future<PlatformCompany> createCompany({
     required String name,
     required String email,
     required String country,
@@ -191,7 +191,7 @@ class PlatformRepository {
     required String managerEmail,
     int? planId,
   }) async {
-    await _apiClient.requestWithRetry<Map<String, dynamic>>(
+    final response = await _apiClient.requestWithRetry<Map<String, dynamic>>(
       '/platform/companies',
       method: 'POST',
       timeoutOverride: _actionTimeout,
@@ -207,6 +207,8 @@ class PlatformRepository {
         if (planId != null) 'plan_id': planId,
       },
     );
+
+    return PlatformCompany.fromProvisioningResponse(response.data ?? {});
   }
 
   Future<List<PlatformCompanyRequest>> companyRequests() async {

--- a/front/mobile_apps/leopardo_platform_admin/test/models/platform_company_model_test.dart
+++ b/front/mobile_apps/leopardo_platform_admin/test/models/platform_company_model_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leopardo_platform_admin/src/features/platform/platform_models.dart';
+
+void main() {
+  test('maps platform company from provisioning response', () {
+    final company = PlatformCompany.fromProvisioningResponse({
+      'data': {
+        'company': {
+          'id': '9b2f5b8e-tenant',
+          'name': 'Client Terrain',
+          'status': 'active',
+          'country': 'DZ',
+          'plan_id': 7,
+          'plan_name': 'Business',
+          'created_at': '2026-06-01T07:00:00Z',
+        },
+        'manager': {'email': 'manager@client.test'},
+      },
+    });
+
+    expect(company.id, '9b2f5b8e-tenant');
+    expect(company.name, 'Client Terrain');
+    expect(company.status, 'active');
+    expect(company.country, 'DZ');
+    expect(company.plan, 'Business');
+    expect(company.createdAt, '2026-06-01T07:00:00Z');
+  });
+
+  test('keeps uuid ids as strings for company detail routing', () {
+    final company = PlatformCompany.fromJson({
+      'id': 'company-uuid-123',
+      'name': 'Leopardo Client',
+      'country': 'TR',
+      'plan': {'name': 'Scale'},
+    });
+
+    expect(company.id, 'company-uuid-123');
+    expect(company.plan, 'Scale');
+  });
+}


### PR DESCRIPTION
## Summary
- make platform admin mobile company creation return the created PlatformCompany
- redirect the super-admin directly to the new company detail page after creation
- add model coverage and a Plan 67.2 validation report

## Validation
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\validate-mobile-workflow-contracts.ps1
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\validate-mobile-plan29.ps1
- powershell -ExecutionPolicy Bypass -File .\\dev-hub\\tools\\validate-mobile-runtime-smoke.ps1
- git diff --check