### PR TITLE
docs: start post 67 audit hygiene plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.223)
+Derniere mise a jour : 2026-06-01 (v4.16.224)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -89,6 +89,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le controle generalise de release vit dans `docs/validation/RELEASE_READINESS_GATE.md` avec le script `dev-hub/tools/release-readiness.ps1`; produire ou mettre a jour un rapport `docs/validation/RELEASE_READINESS_REPORT_*.md` avant de declarer un score production-ready.
 - Depuis v4.16.223, `release-readiness.ps1 -Strict` doit passer a `23/23` et couvrir aussi `front/mobile_apps/leopardo_core`, `leopardo_employee`, `leopardo_manager`, `leopardo_platform_admin`, les gardes Plan 67, `mobile-distribute.yml`, `front/web`, `front/zkteco-kiosk` et le cadrage open core/marketplace. Ne plus declarer une readiness mobile uniquement sur l'ancien `front/mobile`.
 - Depuis v4.16.223, l'ouverture open core/marketplace est cadree par `docs/architecture/adr/0004-open-core-marketplace-boundaries.md` et `docs/GUIDES/GUIDE_OPEN_CORE_MARKETPLACE.md`. Ne pas publier de depot/package public sans secret scan, license scan, nettoyage demo data, validation juridique et scopes/webhooks documentes. Les plugins partenaires doivent passer par API publique et webhooks signes, jamais par import direct du backend Laravel ou des apps mobiles.
+- Depuis v4.16.224, l'audit post-Plan 67 vit dans `docs/PLAN_ACTION/68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md`. Utiliser `dev-hub/tools/repository-hygiene-report.ps1` pour verifier l'hygiene depot avant de supprimer des branches. Ne pas supprimer la branche locale historique `codex/plan57-api-docs-ecosystem` sans audit explicite de son contenu/stash.
 - Apres un lot qui touche auth/web/admin/mobile, attendre les checks GitHub Actions du PR et verifier aussi les workflows `main` post-merge quand ils partent en cascade (deploy, staging E2E, OWASP, mobile) avant d'annoncer la preuve finale.
 - Le workflow manuel `Deploy - Leopardo RH` doit rester utilisable sur `main` sans dependance au lookup `workflow_run`; c'est le bouton ops pour relancer Render et reexecuter l'entrypoint (migrations/seeders) apres une correction de donnees demo.
 - Le smoke k6 `dev-hub/load/k6/api-core-smoke.js` doit rester read-only et suivre les endpoints reels du dashboard client (`auth/me`, `dashboard/summary`, `dashboard/recent-activity`, `dashboard/kpi`) avant d'ajouter des scenarios plus agressifs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.224] - 2026-06-01
+
+### Added
+
+- Ajout du Plan 68 `68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md` pour organiser l'audit post-Plan 67 avant le prochain cycle produit.
+- Ajout du garde `repository-hygiene-report.ps1` et du rapport `REPOSITORY_HYGIENE_REPORT_2026_06_01.md` pour verifier branches distantes/locales et alignement `origin/main`.
+
+### Changed
+
+- Sommaire des plans : ajout du Plan 68 comme suite canonique apres cloture du Plan 67.
+
 ## [4.16.223] - 2026-06-01
 
 ### Added

--- a/dev-hub/tools/repository-hygiene-report.ps1
+++ b/dev-hub/tools/repository-hygiene-report.ps1
@@ -1,0 +1,78 @@
+param(
+    [string]$Root = ".",
+    [switch]$SkipFetch
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Git([string[]]$Arguments) {
+    $output = & git @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed: $output"
+    }
+
+    return @($output)
+}
+
+Push-Location $Root
+try {
+    if (-not $SkipFetch) {
+        Invoke-Git @("fetch", "--prune", "origin") | Out-Null
+    }
+
+    $current = (Invoke-Git @("branch", "--show-current") | Select-Object -First 1).Trim()
+    $head = (Invoke-Git @("rev-parse", "--short", "HEAD") | Select-Object -First 1).Trim()
+    $originMain = (Invoke-Git @("rev-parse", "--short", "origin/main") | Select-Object -First 1).Trim()
+
+    $remoteMerged = Invoke-Git @("branch", "-r", "--merged", "origin/main") |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -and $_ -notin @("origin/main", "origin/HEAD") -and $_ -notlike "origin/HEAD ->*" } |
+        Sort-Object
+
+    $remoteUnmerged = Invoke-Git @("branch", "-r", "--no-merged", "origin/main") |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -and $_ -notin @("origin/main", "origin/HEAD") -and $_ -notlike "origin/HEAD ->*" } |
+        Sort-Object
+
+    $localMerged = Invoke-Git @("branch", "--merged", "main") |
+        ForEach-Object { $_.Trim().TrimStart("*").Trim() } |
+        Where-Object { $_ -and $_ -ne "main" -and $_ -ne $current } |
+        Sort-Object
+
+    $localUnmerged = Invoke-Git @("branch", "--no-merged", "main") |
+        ForEach-Object { $_.Trim().TrimStart("*").Trim() } |
+        Where-Object { $_ -and $_ -ne $current } |
+        Sort-Object
+
+    $status = Invoke-Git @("status", "--short", "--branch")
+
+    Write-Host "# Repository hygiene report"
+    Write-Host ""
+    Write-Host ("Current branch: {0}" -f $current)
+    Write-Host ("HEAD: {0}" -f $head)
+    Write-Host ("origin/main: {0}" -f $originMain)
+    Write-Host ""
+    Write-Host "## Status"
+    $status | ForEach-Object { Write-Host $_ }
+    Write-Host ""
+    Write-Host ("Remote merged branches: {0}" -f @($remoteMerged).Count)
+    $remoteMerged | ForEach-Object { Write-Host ("- {0}" -f $_) }
+    Write-Host ""
+    Write-Host ("Remote unmerged branches: {0}" -f @($remoteUnmerged).Count)
+    $remoteUnmerged | ForEach-Object { Write-Host ("- {0}" -f $_) }
+    Write-Host ""
+    Write-Host ("Local merged branches: {0}" -f @($localMerged).Count)
+    $localMerged | ForEach-Object { Write-Host ("- {0}" -f $_) }
+    Write-Host ""
+    Write-Host ("Local unmerged branches: {0}" -f @($localUnmerged).Count)
+    $localUnmerged | ForEach-Object { Write-Host ("- {0}" -f $_) }
+
+    if (@($remoteMerged).Count -gt 0 -or @($remoteUnmerged).Count -gt 0) {
+        exit 2
+    }
+
+    exit 0
+}
+finally {
+    Pop-Location
+}

--- a/docs/PLAN_ACTION/00_SOMMAIRE.md
+++ b/docs/PLAN_ACTION/00_SOMMAIRE.md
@@ -72,6 +72,7 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 8. **Plan 59** : aligner la vitrine, le pricing et le storytelling sur ce qui est reellement livre.
 9. **Plan 66** : maintenir la cartographie A-J a jour a chaque nouveau retour testeur ou changement de positionnement.
 10. **Plan 67** : executer les derniers lots de preuve produit avant marketing : runtime mobile, platform admin, GPS, branding applique, notifications et release readiness.
+11. **Plan 68** : auditer le projet apres cloture Plan 67 : hygiene depot, contrats API/fronts, qualite code pragmatique, operations et prochain plan produit.
 
 Chaque plan doit sortir avec son changement code/documentation, ses tests ou preuves CI, une entree `CHANGELOG.md` et, si une lecon durable apparait, une entree `AGENTS.md`.
 

--- a/docs/PLAN_ACTION/68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md
+++ b/docs/PLAN_ACTION/68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md
@@ -1,0 +1,82 @@
+# Plan 68 - Audit post-67 qualite code et lancement
+
+## Objectif
+
+Cloturer proprement le cycle des plans 01-67 et repartir sur un audit operationnel verifiable avant lancement marche.
+
+Le Plan 68 ne remplace pas les plans historiques. Il sert a verifier que le depot, les contrats API, les apps mobiles, la vitrine, le kiosk, les workflows CI/CD et les preuves de readiness restent coherents apres les merges successifs.
+
+## Lot 68.1 - Hygiene depot et branches
+
+### Probleme
+
+Le projet a recu beaucoup de branches et de contributions successives. Avant de lancer une nouvelle phase produit, le depot doit rester lisible : `origin/main` comme seule source de verite, branches mergées supprimees, branches locales historiques identifiees sans suppression aveugle.
+
+### Actions
+
+- Verifier `git fetch --prune origin`.
+- Lister les branches distantes mergees dans `origin/main`.
+- Lister les branches distantes non mergees.
+- Lister les branches locales mergees et non mergees.
+- Ajouter un garde reproductible pour refaire ce controle.
+- Documenter les branches restantes a traiter manuellement.
+
+### Statut
+
+**Livre.** Le script `dev-hub/tools/repository-hygiene-report.ps1` produit un rapport machine lisible. Le rapport `docs/validation/REPOSITORY_HYGIENE_REPORT_2026_06_01.md` confirme que le distant ne suit plus que `main`; la seule branche locale non mergee observee est `codex/plan57-api-docs-ecosystem`, a conserver tant que son contenu/stash n'est pas audite.
+
+## Lot 68.2 - Audit contrats API/fronts
+
+### Objectif
+
+Verifier que les surfaces mobiles employee, manager, platform admin, vitrine, kiosk et admin-dashboard consomment des routes documentees ou explicitement matricees.
+
+### Livrables attendus
+
+- Relancer les gardes `mobile-workflow-contracts`, OpenAPI et frontend/API matrix.
+- Produire un rapport des endpoints orphelins ou non documentes.
+- Corriger uniquement les divergences a fort risque.
+
+## Lot 68.3 - Audit code quality pragmatique
+
+### Objectif
+
+Identifier les zones de dette qui menacent le lancement sans lancer de refonte large.
+
+### Livrables attendus
+
+- Rapport top risques par surface : backend, mobile core, employee, manager, platform admin, web, kiosk.
+- Liste de quick wins exploitables par PR courtes.
+- Garde anti-regression si un risque peut etre automatise.
+
+## Lot 68.4 - Audit production ops
+
+### Objectif
+
+Verifier que les operations essentielles sont documentees et testables : deploy, rollback, backup, queues, Redis, notifications, Firebase distribution, staging smoke.
+
+### Livrables attendus
+
+- Rapport operations post-67.
+- Mise a jour runbooks si une procedure manque.
+- Liste des secrets/envs requis pour lancement.
+
+## Lot 68.5 - Nouveau plan produit
+
+### Objectif
+
+Produire le prochain plan d'action base sur l'audit, pas sur une accumulation brute de demandes.
+
+### Livrables attendus
+
+- Regrouper les demandes restantes par theme coherent.
+- Prioriser selon impact lancement, risque securite, impact business et effort.
+- Definir les lots de la prochaine execution.
+
+## Critere de cloture Plan 68
+
+- Depot distant propre.
+- Branche locale historique documentee ou traitee.
+- Readiness 23/23 toujours verte.
+- Contrats API/fronts verifies.
+- Nouveau plan produit redige a partir d'un audit concret.

--- a/docs/validation/REPOSITORY_HYGIENE_REPORT_2026_06_01.md
+++ b/docs/validation/REPOSITORY_HYGIENE_REPORT_2026_06_01.md
@@ -1,0 +1,32 @@
+# Repository hygiene report - 2026-06-01
+
+## Resultat
+
+Le depot distant est propre apres merge du Plan 67.7 :
+
+- `origin/main` est la seule branche distante suivie.
+- Aucune branche distante mergee ou non mergee n'est restee a nettoyer.
+- Le local est aligne sur `origin/main` au moment du controle.
+
+## Branche locale restante
+
+Une branche locale non mergee existe encore :
+
+- `codex/plan57-api-docs-ecosystem`
+
+Decision : ne pas la supprimer automatiquement. Elle est associee a un ancien travail/stash potentiel et doit etre auditee separement avant suppression ou recuperation.
+
+## Commandes de preuve
+
+```powershell
+git fetch --prune origin
+git branch -r --merged origin/main
+git branch -r --no-merged origin/main
+git branch --merged main
+git branch --no-merged main
+powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/repository-hygiene-report.ps1 -SkipFetch
+```
+
+## Statut
+
+Lot 68.1 livre. Le prochain controle peut etre relance avec `dev-hub/tools/repository-hygiene-report.ps1`.


### PR DESCRIPTION
## Summary
- Add Plan 68 for the post-Plan-67 quality and launch audit cycle.
- Add a repository hygiene guard that reports remote/local merged and unmerged branches.
- Document the current repository hygiene state and the remaining local historical branch to audit manually.

## Validation
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/repository-hygiene-report.ps1 -SkipFetch
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/release-readiness.ps1 -Strict
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD
- git diff --check