### PR TITLE
docs: define plan 69 launch execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.227)
+Derniere mise a jour : 2026-06-01 (v4.16.228)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -93,6 +93,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.225, la gouvernance contrats front/API est verifiee par `dev-hub/tools/validate-frontend-api-contract-governance.ps1`. Toute nouvelle route critique consommee par mobile, admin, web ou kiosk doit rester alignee entre `docs/validation/FRONTEND_API_CONTRACT_MATRIX.md`, `api/tests/Feature/FrontendApiContractTest.php`, `api/openapi.yaml` et, si mobile, `dev-hub/tools/mobile-workflow-contracts.json`.
 - Depuis v4.16.226, `dev-hub/tools/validate-code-quality-governance.ps1` bloque le retour des chemins OpenAPI obsoletes dans les docs canoniques et verifie les artefacts qualite post-67. Les docs publiques doivent pointer vers `/docs` et `/docs/openapi.yaml`, pas vers l'ancien `/openapi/v1.yaml`.
 - Depuis v4.16.227, l'audit ops production est garde par `dev-hub/tools/validate-production-ops-readiness.ps1`. Avant lancement, verifier `DEPLOYMENT_GUIDE.md`, Render deploy/rollback hooks, Redis/queues, scheduler, Firebase App Distribution, FCM backend et backup/restore. `FIREBASE_READBACK_REQUIRED=true` ne doit etre active qu'apres rotation et test du service account.
+- Depuis v4.16.228, le Plan 68 est cloture et la suite canonique est `docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md`. Commencer par le lot 69.1 : recette mobile release sur vrais appareils/Firebase pour employee, manager et platform admin avant d'elargir marketing.
 - Apres un lot qui touche auth/web/admin/mobile, attendre les checks GitHub Actions du PR et verifier aussi les workflows `main` post-merge quand ils partent en cascade (deploy, staging E2E, OWASP, mobile) avant d'annoncer la preuve finale.
 - Le workflow manuel `Deploy - Leopardo RH` doit rester utilisable sur `main` sans dependance au lookup `workflow_run`; c'est le bouton ops pour relancer Render et reexecuter l'entrypoint (migrations/seeders) apres une correction de donnees demo.
 - Le smoke k6 `dev-hub/load/k6/api-core-smoke.js` doit rester read-only et suivre les endpoints reels du dashboard client (`auth/me`, `dashboard/summary`, `dashboard/recent-activity`, `dashboard/kpi`) avant d'ajouter des scenarios plus agressifs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.228] - 2026-06-01
+
+### Added
+
+- Ajout du Plan 69 `69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md` comme prochain cycle d'execution post-audit.
+- Ajout du rapport `NEXT_PRODUCT_PLAN_2026_06_01.md` pour cloturer le Plan 68 et prioriser les lots lancement.
+
+### Changed
+
+- Plan 68 : lot 68.5 et statut final marques livres, avec suite canonique vers Plan 69.
+- Sommaire des plans : ajout du Plan 69.
+
 ## [4.16.227] - 2026-06-01
 
 ### Added

--- a/docs/PLAN_ACTION/00_SOMMAIRE.md
+++ b/docs/PLAN_ACTION/00_SOMMAIRE.md
@@ -73,6 +73,7 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 9. **Plan 66** : maintenir la cartographie A-J a jour a chaque nouveau retour testeur ou changement de positionnement.
 10. **Plan 67** : executer les derniers lots de preuve produit avant marketing : runtime mobile, platform admin, GPS, branding applique, notifications et release readiness.
 11. **Plan 68** : auditer le projet apres cloture Plan 67 : hygiene depot, contrats API/fronts, qualite code pragmatique, operations et prochain plan produit.
+12. **Plan 69** : executer la recette lancement Mobile-First Company OS : apps mobiles reelles, parcours employee/manager/platform admin, paie asynchrone et observabilite.
 
 Chaque plan doit sortir avec son changement code/documentation, ses tests ou preuves CI, une entree `CHANGELOG.md` et, si une lecon durable apparait, une entree `AGENTS.md`.
 

--- a/docs/PLAN_ACTION/68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md
+++ b/docs/PLAN_ACTION/68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md
@@ -85,6 +85,10 @@ Produire le prochain plan d'action base sur l'audit, pas sur une accumulation br
 - Prioriser selon impact lancement, risque securite, impact business et effort.
 - Definir les lots de la prochaine execution.
 
+### Statut
+
+**Livre.** Le prochain cycle est formalise dans `docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md`. Le rapport `docs/validation/NEXT_PRODUCT_PLAN_2026_06_01.md` explique l'ordre d'execution et cloture le Plan 68.
+
 ## Critere de cloture Plan 68
 
 - Depot distant propre.
@@ -92,3 +96,7 @@ Produire le prochain plan d'action base sur l'audit, pas sur une accumulation br
 - Readiness 23/23 toujours verte.
 - Contrats API/fronts verifies.
 - Nouveau plan produit redige a partir d'un audit concret.
+
+## Statut final
+
+**Cloture le 2026-06-01.** Les lots 68.1 a 68.5 sont livres. La suite canonique est le Plan 69.

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -1,0 +1,133 @@
+# Plan 69 - Execution lancement Mobile-First Company OS
+
+## Objectif
+
+Transformer les preuves et audits des Plans 67-68 en execution produit orientee lancement. Le Plan 69 cible ce qui doit etre verifie ou renforce avant exposition marketing plus large : vrais appareils mobiles, parcours metier critiques, isolation donnees, super-admin, paie/finance et observabilite.
+
+## Principe d'execution
+
+- Travailler par PR courtes, mergees apres checks verts.
+- Ne pas relancer de refonte large sans bug ou risque concret.
+- Prioriser les preuves exploitables par testeurs et clients.
+- Garder `front/mobile_apps/` comme source canonique mobile.
+- Garder `api/openapi.yaml`, `FrontendApiContractTest` et `FRONTEND_API_CONTRACT_MATRIX.md` alignes.
+
+## Lot 69.1 - Recette mobile release sur vrais appareils
+
+### Objectif
+
+Prouver que les trois apps `employee`, `manager` et `platform_admin` s'ouvrent, affichent un premier ecran utile, se connectent et sortent correctement sur APK Firebase issus de `main`.
+
+### Actions
+
+- Declencher `mobile-distribute.yml` pour les trois apps.
+- Verifier noms APK prefixes par app.
+- Tester login demo employee, manager et super-admin.
+- Verifier que le splash ne bloque pas et que `StartupGate` affiche un etat explicite si bootstrap lent.
+- Documenter version, SHA, appareil, resultat.
+
+### Sortie attendue
+
+Rapport device QA par app avec verdict `Go`, `Go conditionnel` ou `No-go`.
+
+## Lot 69.2 - Parcours employe terrain
+
+### Objectif
+
+Valider le parcours quotidien employe : login, pointage simple, pointages multiples, pause/reprise, taches du jour, demandes absence/avance, notifications, compte durable.
+
+### Actions
+
+- Smoke API employee avec token demo.
+- Verifier `attendance/today` avec `sessions` et `summary`.
+- Verifier `tasks/today` et completion tache.
+- Verifier absence/avance avec contexte complet.
+- Verifier compte durable, career et placard numerique.
+
+### Sortie attendue
+
+Rapport parcours employee + corrections ciblees si endpoint ou UI bloque.
+
+## Lot 69.3 - Parcours manager/RH et isolation donnees
+
+### Objectif
+
+Valider que manager/RH voient uniquement leurs equipes, peuvent agir sur employes, horaires, taches, corrections, absences, avances et branding tenant.
+
+### Actions
+
+- Smoke API manager avec token demo.
+- Verifier liste equipe sans spinner infini.
+- Verifier create/update employe avec salaire, horaire et QR.
+- Verifier corrections pointage, absences, avances et taches.
+- Ajouter ou renforcer un test d'isolation si un risque tenant est detecte.
+
+### Sortie attendue
+
+Rapport manager/RH + preuve isolation.
+
+## Lot 69.4 - Super-admin plateforme
+
+### Objectif
+
+Valider l'app platform admin : login obligatoire, compte demo, creation entreprise, fiche entreprise, subscription/features, health et demandes clients.
+
+### Actions
+
+- Smoke API platform avec token super-admin.
+- Verifier creation entreprise payload minimal.
+- Verifier fiche client et actions modules/abonnement.
+- Verifier que l'app ne consomme pas les routes tenant `/device-tokens`.
+
+### Sortie attendue
+
+Rapport platform admin + corrections si creation ou navigation bloque.
+
+## Lot 69.5 - Paie, avances et documents asynchrones
+
+### Objectif
+
+Stabiliser le cycle financier mobile-first : avance double validation, solde employe, paiement masse, documents PDF et confirmation reception.
+
+### Actions
+
+- Verifier endpoints avances `manager-approve`, `mark-paid`, `confirm-received`.
+- Verifier `payment-batches` et documents paiement.
+- Verifier queues `documents,pdf,payroll,notifications`.
+- Ne pas bloquer l'UI sur generation PDF.
+
+### Sortie attendue
+
+Rapport paie/finance + tests backend cibles si un workflow manque.
+
+## Lot 69.6 - Observabilite lancement
+
+### Objectif
+
+Preparer une lecture simple du lancement : health API, queue health, erreurs 5xx, deploy SHA, Firebase releases, backups et incidents.
+
+### Actions
+
+- Consolider les signaux `launch-readiness`, `health`, queue et deploy.
+- Ajouter un rapport lancement par SHA.
+- Documenter seuils P1/P2 et action de rollback.
+
+### Sortie attendue
+
+Cockpit de lancement documentaire et procedures d'escalade simples.
+
+## Priorite
+
+1. Lot 69.1
+2. Lot 69.2
+3. Lot 69.3
+4. Lot 69.4
+5. Lot 69.5
+6. Lot 69.6
+
+## Critere de cloture
+
+- Les trois apps mobiles sont testees sur vrais appareils ou Firebase App Distribution.
+- Les parcours employee, manager/RH et platform admin ont un rapport de preuve.
+- Les gaps bloquants ont une PR corrective ou un no-go explicite.
+- Le depot reste propre, `main` distant aligne et release readiness verte.

--- a/docs/validation/NEXT_PRODUCT_PLAN_2026_06_01.md
+++ b/docs/validation/NEXT_PRODUCT_PLAN_2026_06_01.md
@@ -1,0 +1,37 @@
+# Next product plan - 2026-06-01
+
+## Decision
+
+Le prochain cycle d'execution est le Plan 69 : `docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md`.
+
+Ce plan est issu des preuves Plan 67 et de l'audit Plan 68. Il ne relance pas une refonte. Il concentre l'execution sur les parcours qui peuvent bloquer le lancement marketing :
+
+- ouverture et login des trois apps mobiles ;
+- parcours employe terrain ;
+- parcours manager/RH et isolation donnees ;
+- super-admin plateforme ;
+- paie/avances/documents asynchrones ;
+- observabilite lancement.
+
+## Pourquoi cet ordre
+
+1. Sans app mobile ouvrable sur vrais appareils, les autres preuves ne valent pas pour les testeurs.
+2. Le parcours employe est le coeur de valeur quotidien.
+3. Le manager/RH porte la confiance client et l'isolation tenant.
+4. Le super-admin conditionne l'onboarding de nouveaux clients.
+5. La paie/finance doit rester asynchrone et traçable avant volume.
+6. L'observabilite permet d'exploiter le lancement sans piloter a l'aveugle.
+
+## Statut Plan 68
+
+Les lots 68.1 a 68.5 sont livres au niveau attendu :
+
+- hygiene depot ;
+- gouvernance contrats API/fronts ;
+- qualite code pragmatique ;
+- operations production ;
+- prochain plan produit.
+
+## Prochain premier lot
+
+Demarrer par **Plan 69.1 - Recette mobile release sur vrais appareils**.


### PR DESCRIPTION
## Summary
- Close Plan 68 with the next audited execution cycle.
- Add Plan 69 for launch execution across mobile devices, employee, manager/RH, platform admin, payroll/finance and observability.
- Add the next product plan report and update AGENTS/CHANGELOG/sommaire.

## Validation
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/release-readiness.ps1 -Strict
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD
- git diff --check