### PR TITLE
fix: align mobile absence balances with self-service API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.229)
+Derniere mise a jour : 2026-06-01 (v4.16.230)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -95,6 +95,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.227, l'audit ops production est garde par `dev-hub/tools/validate-production-ops-readiness.ps1`. Avant lancement, verifier `DEPLOYMENT_GUIDE.md`, Render deploy/rollback hooks, Redis/queues, scheduler, Firebase App Distribution, FCM backend et backup/restore. `FIREBASE_READBACK_REQUIRED=true` ne doit etre active qu'apres rotation et test du service account.
 - Depuis v4.16.228, le Plan 68 est cloture et la suite canonique est `docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md`. Commencer par le lot 69.1 : recette mobile release sur vrais appareils/Firebase pour employee, manager et platform admin avant d'elargir marketing.
 - Depuis v4.16.229, la distribution Firebase staging Plan 69.1 run `26750677529` a reussi pour employee, manager et platform admin depuis `main` SHA `2fc2ca97058365ed468430c2c3323df0690d607e`. Le go final mobile reste conditionne au test sur appareils physiques documente dans `docs/validation/MOBILE_RELEASE_DEVICE_QA_2026_06_01.md`.
+- Depuis v4.16.230, les apps employee/manager doivent lire les soldes conges personnels via `GET /api/v1/me/leave-balances`, jamais via `/leave-balances` qui reste manager-only. Les demos Render doivent aussi avoir des lignes `leave_balances` backfillees par `DemoCompanyOnceSeeder`; si le formulaire absence indique "aucun type disponible", verifier d'abord ce seed/backfill avant de toucher aux permissions.
 - Apres un lot qui touche auth/web/admin/mobile, attendre les checks GitHub Actions du PR et verifier aussi les workflows `main` post-merge quand ils partent en cascade (deploy, staging E2E, OWASP, mobile) avant d'annoncer la preuve finale.
 - Le workflow manuel `Deploy - Leopardo RH` doit rester utilisable sur `main` sans dependance au lookup `workflow_run`; c'est le bouton ops pour relancer Render et reexecuter l'entrypoint (migrations/seeders) apres une correction de donnees demo.
 - Le smoke k6 `dev-hub/load/k6/api-core-smoke.js` doit rester read-only et suivre les endpoints reels du dashboard client (`auth/me`, `dashboard/summary`, `dashboard/recent-activity`, `dashboard/kpi`) avant d'ajouter des scenarios plus agressifs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.230] - 2026-06-01
+
+### Fixed
+
+- Mobile employee/manager : les formulaires d'absence lisent maintenant les soldes self-service via `/me/leave-balances` au lieu de la route manager `/leave-balances`.
+- Demo Render : `DemoCompanySeeder` et `DemoCompanyOnceSeeder` creent/backfill les `leave_balances` des entreprises demo pour que les demandes d'absence testeur puissent recuperer un `absence_type_id`.
+
+### Added
+
+- Plan 69.2 : ajout du rapport `EMPLOYEE_TERRAIN_API_SMOKE_2026_06_01.md` couvrant login, lectures employee, pointage multiple, avance et blocage absence corrige.
+
 ## [4.16.229] - 2026-06-01
 
 ### Added

--- a/api/database/seeders/DemoCompanyOnceSeeder.php
+++ b/api/database/seeders/DemoCompanyOnceSeeder.php
@@ -37,6 +37,7 @@ class DemoCompanyOnceSeeder extends Seeder
             ->exists();
 
         if ($alreadyRan && $existingDemoSlugs->count() === count(self::DEMO_SLUGS)) {
+            $this->backfillDemoLeaveBalances();
             $this->command?->info('DemoCompanyOnceSeeder skipped (already executed).');
 
             return;
@@ -48,6 +49,7 @@ class DemoCompanyOnceSeeder extends Seeder
         }
 
         if ($existingDemoSlugs->count() === count(self::DEMO_SLUGS)) {
+            $this->backfillDemoLeaveBalances();
             DB::table('seed_locks')->updateOrInsert(
                 ['lock_key' => self::LOCK_KEY],
                 [
@@ -72,6 +74,7 @@ class DemoCompanyOnceSeeder extends Seeder
         try {
             app()->instance('leopardo.demo_seed_once', true);
             $this->call(DemoCompanySeeder::class);
+            $this->backfillDemoLeaveBalances();
 
             DB::statement('SET search_path TO public');
             DB::table('seed_locks')
@@ -88,5 +91,99 @@ class DemoCompanyOnceSeeder extends Seeder
 
             throw $throwable;
         }
+    }
+
+    private function backfillDemoLeaveBalances(): void
+    {
+        if (
+            ! $this->sharedTableExists('employees')
+            || ! $this->sharedTableExists('absence_types')
+            || ! $this->sharedTableExists('leave_balances')
+        ) {
+            return;
+        }
+
+        $companies = DB::table('companies')
+            ->whereIn('slug', self::DEMO_SLUGS)
+            ->get(['id', 'slug']);
+
+        if ($companies->isEmpty()) {
+            return;
+        }
+
+        $year = (int) now()->format('Y');
+        $created = 0;
+
+        foreach ($companies as $company) {
+            $annualTypeId = DB::table($this->sharedTable('absence_types'))
+                ->where('company_id', $company->id)
+                ->where(function ($query): void {
+                    $query->where('code', 'like', 'CA_%')
+                        ->orWhere('name', 'like', 'Conge annuel%');
+                })
+                ->orderBy('id')
+                ->value('id');
+
+            if (! $annualTypeId) {
+                continue;
+            }
+
+            $employeeIds = DB::table($this->sharedTable('employees'))
+                ->where('company_id', $company->id)
+                ->where('status', 'active')
+                ->pluck('id')
+                ->map(fn ($id): int => (int) $id)
+                ->values();
+
+            foreach ($employeeIds as $index => $employeeId) {
+                $exists = DB::table($this->sharedTable('leave_balances'))
+                    ->where('company_id', $company->id)
+                    ->where('employee_id', $employeeId)
+                    ->where('absence_type_id', $annualTypeId)
+                    ->where('year', $year)
+                    ->exists();
+
+                if ($exists) {
+                    continue;
+                }
+
+                DB::table($this->sharedTable('leave_balances'))->insert([
+                    'company_id' => $company->id,
+                    'employee_id' => $employeeId,
+                    'absence_type_id' => $annualTypeId,
+                    'balance' => max(8, 18 - ($index % 5)),
+                    'used' => $index % 3,
+                    'pending' => 0,
+                    'year' => $year,
+                    'updated_at' => now(),
+                ]);
+
+                $created++;
+            }
+        }
+
+        if ($created > 0) {
+            $this->command?->info("DemoCompanyOnceSeeder backfilled {$created} demo leave balances.");
+        }
+    }
+
+    private function sharedTableExists(string $table): bool
+    {
+        $result = DB::selectOne(
+            'select exists (
+                select 1
+                from information_schema.tables
+                where table_schema = ?
+                  and table_name = ?
+            ) as exists',
+            ['shared_tenants', $table]
+        );
+
+        return (bool) ($result->exists ?? false);
+    }
+
+    private function sharedTable(string $table): string
+    {
+        return 'shared_tenants.'.$table;
     }
 }

--- a/api/database/seeders/DemoCompanySeeder.php
+++ b/api/database/seeders/DemoCompanySeeder.php
@@ -200,6 +200,7 @@ class DemoCompanySeeder extends Seeder
             $this->seedAttendanceLogs($companyId, $activeEmployeeIds);
             $absenceTypeIds = $this->createAbsenceTypes($companyId);
             $this->seedAbsences($companyId, $employeeIds, $absenceTypeIds, $managerIds['rh']);
+            $this->seedLeaveBalances($companyId, $activeEmployeeIds, $absenceTypeIds);
             $this->seedLeaveBalanceLogs($companyId, $employeeIds);
             $this->seedSalaryAdvance($companyId, $employeeIds[0] ?? null, $managerIds['rh'], $config['currency']);
             $this->seedPayrolls($companyId, $managerIds['principal'], $activeEmployeeIds, $config['currency']);
@@ -604,6 +605,37 @@ SQL);
                     'created_at' => now()->subMonth(),
                 ],
             ]);
+        }
+    }
+
+    private function seedLeaveBalances(string $companyId, array $employeeIds, array $absenceTypeIds): void
+    {
+        if (! $this->sharedTableExists('leave_balances')) {
+            return;
+        }
+
+        $annualTypeId = $absenceTypeIds['annual'] ?? null;
+        if (! $annualTypeId) {
+            return;
+        }
+
+        $year = (int) now()->format('Y');
+
+        foreach ($employeeIds as $index => $employeeId) {
+            DB::table($this->sharedTable('leave_balances'))->updateOrInsert(
+                [
+                    'company_id' => $companyId,
+                    'employee_id' => $employeeId,
+                    'absence_type_id' => $annualTypeId,
+                    'year' => $year,
+                ],
+                [
+                    'balance' => max(8, 18 - ($index % 5)),
+                    'used' => $index % 3,
+                    'pending' => 0,
+                    'updated_at' => now(),
+                ]
+            );
         }
     }
 

--- a/dev-hub/tools/mobile-workflow-contracts.json
+++ b/dev-hub/tools/mobile-workflow-contracts.json
@@ -51,7 +51,7 @@
         {
           "name": "absences",
           "routes": ["/absences"],
-          "endpoints": ["/absences", "/leave-balances"],
+          "endpoints": ["/absences", "/me/leave-balances"],
           "screenFiles": [
             "lib/features/absences/screens/absence_list_screen.dart"
           ],

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -52,6 +52,10 @@ Valider le parcours quotidien employe : login, pointage simple, pointages multip
 
 Rapport parcours employee + corrections ciblees si endpoint ou UI bloque.
 
+### Statut
+
+**Go partiel, correction livree.** Le smoke Render confirme le login employee, les lectures critiques, le pointage multiple (`normal` puis `overtime`) et la creation/annulation d'une avance. Le parcours absence a revele une rupture contrat mobile/API : les apps lisaient `/leave-balances` au lieu de `/me/leave-balances`, et les demos existantes n'avaient pas de `leave_balances`. Correction appliquee dans les apps employee/manager, le contrat mobile et les seeders demo. Rapport : `docs/validation/EMPLOYEE_TERRAIN_API_SMOKE_2026_06_01.md`.
+
 ## Lot 69.3 - Parcours manager/RH et isolation donnees
 
 ### Objectif

--- a/docs/validation/EMPLOYEE_TERRAIN_API_SMOKE_2026_06_01.md
+++ b/docs/validation/EMPLOYEE_TERRAIN_API_SMOKE_2026_06_01.md
@@ -1,0 +1,110 @@
+# Rapport Plan 69.2 - Smoke API employe terrain
+
+Date : 2026-06-01  
+Backend : `https://gestionemployerbackend.onrender.com/api/v1`  
+Compte : `karim.aouad@techcorp-algerie.dz`  
+Reference main testee avant correction : `a4a0e1f2`
+
+## Verdict
+
+**Go partiel.** Le parcours pointage multiple et avance fonctionne sur Render. Le parcours absence a revele une rupture de contrat mobile/API : les apps mobiles lisaient `/leave-balances`, route reservee manager, alors que le contrat self-service canonique est `/me/leave-balances`.
+
+Correction livree dans ce lot :
+
+- `leopardo_employee` lit maintenant `/me/leave-balances`.
+- `leopardo_manager` lit aussi `/me/leave-balances` pour son formulaire de demande personnelle.
+- Le contrat mobile reference `/me/leave-balances`.
+- Le seed demo cree/backfill des `leave_balances` pour les entreprises demo existantes afin que les testeurs puissent demander une absence sans intervention RH manuelle.
+
+## Resultats Render
+
+### Authentification
+
+- `GET /demo-users` : OK, expose les comptes QA attendus.
+- `POST /auth/login` employee : OK.
+- `GET /auth/me` employee : OK.
+
+Un `500` transitoire a ete observe une fois au login, puis cinq tentatives consecutives ont reussi. A surveiller comme signal Render/cold-start, pas encore comme regression reproductible.
+
+### Lectures employee
+
+Endpoints lus avec token employee :
+
+- `GET /attendance/today` : OK.
+- `GET /tasks/today` : OK.
+- `GET /me/monthly-summary` : OK.
+- `GET /absences` : OK.
+- `GET /salary-advances` : OK.
+- `GET /notifications?unread=true` : OK.
+- `GET /me/career` : OK.
+- `GET /cabinet/stats` : OK.
+
+### Pointage multiple
+
+Avant pointage, `attendance/today` retournait :
+
+- `checked_in=false`
+- `sessions=[]`
+- `summary.sessions_count=0`
+- `timezone=Africa/Algiers`
+
+Actions executees :
+
+1. `POST /attendance/check-in` avec `work_type=normal` : OK, log `365`, session `1`.
+2. `POST /attendance/check-out` : OK, session `1` fermee.
+3. `POST /attendance/check-in` avec `work_type=overtime` : OK, log `366`, session `2`.
+4. `POST /attendance/check-out` : OK, session `2` fermee.
+
+Etat final :
+
+- `sessions_count=2`
+- `is_working=false`
+- `work_types=normal,overtime`
+- `session_numbers=1,2`
+
+Le compte demo n'est pas laisse en session ouverte.
+
+### Avances
+
+Actions executees :
+
+1. `POST /salary-advances` montant `1000`, `repayment_months=1` : OK, demande `5`.
+2. `DELETE /salary-advances/5` : OK, demande rejetee/annulee.
+
+La reponse contient le contexte attendu : employe, entreprise, montant, motif, statut et champs de double validation.
+
+### Absences
+
+Constat avant correction :
+
+- `POST /absences` sans `absence_type_id` retourne correctement `422 VALIDATION_ERROR`.
+- `GET /leave-balances` retourne `403` pour un employe, car la route est manager-only.
+- `GET /me/leave-balances` retourne OK mais vide sur la demo actuelle de Render.
+
+Conclusion :
+
+- Le backend avait le bon contrat self-service, mais les apps mobiles utilisaient l'ancienne route manager.
+- Le seed demo ne remplissait pas `leave_balances`, seulement `leave_balance_logs`, ce qui rendait impossible une demande d'absence complete pour les testeurs demo.
+
+## Corrections appliquees
+
+- `front/mobile_apps/leopardo_employee/lib/features/absences/data/absence_repository.dart`
+- `front/mobile_apps/leopardo_manager/lib/features/absences/data/absence_repository.dart`
+- `dev-hub/tools/mobile-workflow-contracts.json`
+- `api/database/seeders/DemoCompanySeeder.php`
+- `api/database/seeders/DemoCompanyOnceSeeder.php`
+
+## Validations locales rapides
+
+- `php -l api/database/seeders/DemoCompanySeeder.php` : OK.
+- `php -l api/database/seeders/DemoCompanyOnceSeeder.php` : OK.
+- `dev-hub/tools/validate-mobile-workflow-contracts.ps1` : OK.
+
+## Prochaine preuve attendue
+
+Apres merge/deploiement Render :
+
+1. verifier `GET /me/leave-balances` sur Karim retourne au moins un type annuel ;
+2. creer une absence employee via `POST /absences` avec ce type ;
+3. annuler la demande via `DELETE /absences/{id}` ;
+4. confirmer cote mobile que le formulaire absence ne reste plus bloque sur "aucun type disponible".

--- a/front/mobile_apps/leopardo_employee/lib/features/absences/data/absence_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/absences/data/absence_repository.dart
@@ -22,7 +22,7 @@ class AbsenceRepository {
 
   Future<List<Map<String, dynamic>>> getLeaveBalances() async {
     final response = await apiClient.requestWithRetry(
-      '/leave-balances',
+      '/me/leave-balances',
       maxRetriesOverride: 0,
       timeoutOverride: _readTimeout,
     );

--- a/front/mobile_apps/leopardo_manager/lib/features/absences/data/absence_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/absences/data/absence_repository.dart
@@ -24,7 +24,7 @@ class AbsenceRepository {
 
   Future<List<Map<String, dynamic>>> getLeaveBalances() async {
     final response = await apiClient.requestWithRetry(
-      '/leave-balances',
+      '/me/leave-balances',
       maxRetriesOverride: 1,
       timeoutOverride: _readTimeout,
     );


### PR DESCRIPTION
## Summary
- align employee/manager mobile absence forms with the self-service `/me/leave-balances` contract
- backfill demo `leave_balances` during demo once seeding so Render testers can request absences
- document Plan 69.2 employee terrain smoke results and update AGENTS/CHANGELOG

## Validation
- php -l api/database/seeders/DemoCompanySeeder.php
- php -l api/database/seeders/DemoCompanyOnceSeeder.php
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/validate-mobile-workflow-contracts.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/release-readiness.ps1 -Strict
- git diff --check