### PR TITLE
docs: finalize plan 69 manager smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.233] - 2026-06-01
+
+### Added
+
+- Plan 69.3 : rapport manager/RH mis a jour apres deploiement Render #680 avec preuve finale `GET /employees`, isolation tenant, creation/suppression tache et creation/archivage collaborateur temporaire.
+
 ## [4.16.232] - 2026-06-01
 
 ### Fixed

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -76,7 +76,7 @@ Rapport manager/RH + preuve isolation.
 
 ### Statut
 
-**No-go partiel avant correction.** Le smoke Render confirme `auth/me`, `dashboard/manager-digest`, `schedules`, `tasks/today`, `absences`, `salary-advances` et `attendance/corrections`. `GET /employees?per_page=50` retourne `500`, ce qui bloque l'ecran Equipe et les workflows qui dependent du select collaborateur. Correction appliquee dans `EmployeeController@index` pour charger les champs serialises par `EmployeeResource`. Rapport : `docs/validation/MANAGER_RH_API_SMOKE_2026_06_01.md`.
+**Go apres corrections #679/#680.** Le smoke Render confirme `auth/me`, `dashboard/manager-digest`, `schedules`, `tasks/today`, `absences`, `salary-advances`, `attendance/corrections` et `GET /employees?per_page=50`. La liste equipe retourne 13 collaborateurs, tous scopes au meme `company_id` TechCorp. Creation/suppression d'une tache terrain et creation/archivage d'un collaborateur temporaire valides avec le contrat mobile (`salary_type=fixed`, invitation active). Rapport : `docs/validation/MANAGER_RH_API_SMOKE_2026_06_01.md`.
 
 ## Lot 69.4 - Super-admin plateforme
 

--- a/docs/validation/MANAGER_RH_API_SMOKE_2026_06_01.md
+++ b/docs/validation/MANAGER_RH_API_SMOKE_2026_06_01.md
@@ -3,17 +3,19 @@
 Date : 2026-06-01  
 Backend : `https://gestionemployerbackend.onrender.com/api/v1`  
 Compte : `ahmed.benali@techcorp-algerie.dz`  
-Reference main testee avant correction : `efd4c150`
+Reference main testee avant correction : `efd4c150`  
+Reference main validee apres corrections : `8ba81073`
 
 ## Verdict
 
-**No-go partiel avant correction.** Les endpoints manager critiques repondent sauf la liste equipe `GET /employees?per_page=50`, qui retourne `500` sur Render. Cette route alimente l'ecran Equipe manager/RH : tant qu'elle casse, le manager peut voir le dashboard mais ne peut pas exploiter correctement son equipe.
+**Go apres corrections #679/#680.** Les endpoints manager critiques repondent, la liste equipe `GET /employees?per_page=50` ne retourne plus de `500` sur Render, et les actions manager de base sont executees avec le contrat mobile.
 
 Correction livree dans ce lot :
 
 - `EmployeeController@index` selectionne maintenant les champs serialises par `EmployeeResource` seulement quand ils existent dans le schema courant.
 - `EmployeeResource` tolere les attributs optionnels absents sur les modeles partiellement charges.
-- Objectif : eviter les erreurs de ressource sur modeles Eloquent partiellement charges ou schemas Render partiellement migres, tout en gardant la pagination et l'isolation tenant existantes.
+- `EmployeeController@index` filtre aussi les colonnes relationnelles `company` / `schedule`, la recherche et le tri attendance via `Schema::hasColumn`.
+- Objectif atteint : eviter les erreurs de ressource sur modeles Eloquent partiellement charges ou schemas Render partiellement migres, tout en gardant la pagination et l'isolation tenant existantes.
 
 ## Resultats Render avant correction
 
@@ -55,10 +57,11 @@ Le test local `php artisan test --filter=EmployeesRbacTest` n'a pas pu etre expl
 
 ## Prochaine preuve attendue
 
-Apres merge/deploiement Render :
+## Preuve finale Render apres corrections
 
-1. retester `GET /employees?per_page=50` avec le manager TechCorp ;
-2. confirmer que tous les `company_id` retournes correspondent au tenant du manager ;
-3. creer puis supprimer une tache assignee a Karim ;
-4. creer puis archiver un collaborateur temporaire sans invitation ;
-5. documenter le verdict final Plan 69.3.
+1. `GET /employees?per_page=50` avec le manager TechCorp : OK.
+2. Isolation liste equipe : OK, 13 collaborateurs retournes, un seul `company_id` (`9fffe35e-6777-42c1-b1db-faaee04d0ef7`).
+3. Creation puis suppression d'une tache assignee a Karim : OK, tache temporaire `10`.
+4. Creation puis archivage d'un collaborateur temporaire avec le contrat mobile (`send_invitation=true`, `salary_type=fixed`) : OK, collaborateur temporaire `31`.
+
+Verdict Plan 69.3 : **Go** pour les parcours manager/RH de base sur Render.


### PR DESCRIPTION
## Summary
- Mark Plan 69.3 manager/RH as Go after Render smoke
- Record employee list isolation, task create/delete, and employee create/archive proof
- Add changelog entry

## Validation
- Render smoke: /employees 200, one TechCorp company_id
- Render smoke: task create/delete OK
- Render smoke: employee create/archive OK
