### PR TITLE
fix: resolve platform company details from public schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.234)
+Derniere mise a jour : 2026-06-01 (v4.16.235)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -117,6 +117,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.171, `dev-hub/tools/mobile-workflow-contracts.json` couvre aussi `leopardo_platform_admin`. Toute nouvelle action mobile super-admin doit declarer sa route `/platform/*`, son endpoint `/platform/*` et ses tokens d'ecran dans ce contrat, en plus de garder le Plan 29 vert.
 - Depuis v4.16.184, le Plan 56 durcit l'app mobile `leopardo_platform_admin` : pas d'hydratation `/platform/auth/me` sans token local, gestion explicite du `202 TWO_FA_REQUIRED`, bouton compte demo super-admin et validation email/code pays sur la creation client.
 - Depuis v4.16.172, la fiche client mobile platform admin vit sur `/platform/companies/:companyId` et consomme `/platform/companies/{company}/health`, `/subscription` et `/features`. `PlatformCompany.id` doit rester une string pour supporter les UUID de `public.companies`; ne pas le recaster en int.
+- Depuis v4.16.235, les endpoints detail platform admin (`/platform/companies/{company}/health`, `/subscription`, `/features`) doivent forcer `SET search_path TO public` avant de charger `Company`. Sans ce garde, une creation client ou une requete tenant precedente peut laisser PostgreSQL chercher l'UUID dans le mauvais schema et produire un faux `404`.
 - Depuis v4.16.218, `leopardo_platform_admin` doit garder `PlatformRepository.createCompany()` avec retour `PlatformCompany` et redirection vers `/platform/companies/{companyId}` apres creation. Ne pas revenir a un `void` silencieux : le super-admin doit voir la fiche du client cree sans attendre un refresh manuel.
 - Depuis v4.16.173, cette fiche client est actionnable : edition abonnement via `GET /platform/plans` + `PATCH /platform/companies/{company}/subscription`, et edition modules via `PATCH /platform/companies/{company}/features`. Le module `rh` reste verrouille actif cote UI comme cote API.
 - Depuis v4.16.174, `shared/i18n/sync/sync-mobile.js` ecrit les catalogues ARB a la fois dans `front/mobile/lib/l10n` et `front/mobile_apps/leopardo_core/lib/l10n`. Ne pas laisser Jules traduire seulement l'ancien mobile : les apps employee/manager/platform admin lisent le core.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.235] - 2026-06-01
+
+### Fixed
+
+- API platform admin : les endpoints detail entreprise (`/platform/companies/{id}/health`, `/subscription`, `/features`) forcent maintenant `search_path=public` avant de charger `Company`, pour eviter les `404` apres provisioning ou apres une requete tenant.
+
 ## [4.16.234] - 2026-06-01
 
 ### Fixed

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanyFeatureController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanyFeatureController.php
@@ -7,11 +7,14 @@ use App\Models\Company;
 use App\Services\FeatureFlag;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class PlatformCompanyFeatureController extends Controller
 {
     public function show(string $companyId): JsonResponse
     {
+        DB::statement('SET search_path TO public');
+
         $company = Company::query()->findOrFail($companyId);
 
         return new JsonResponse([
@@ -25,6 +28,8 @@ class PlatformCompanyFeatureController extends Controller
 
     public function update(Request $request, string $companyId): JsonResponse
     {
+        DB::statement('SET search_path TO public');
+
         $company = Company::query()->findOrFail($companyId);
 
         $validated = $request->validate([

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanyHealthController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanyHealthController.php
@@ -7,11 +7,14 @@ use App\Models\Company;
 use App\Services\PlatformCompanyHealthService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class PlatformCompanyHealthController extends Controller
 {
     public function index(Request $request, PlatformCompanyHealthService $healthService): JsonResponse
     {
+        DB::statement('SET search_path TO public');
+
         return new JsonResponse($healthService->portfolio(
             limit: $request->integer('limit', 50),
         ));
@@ -19,6 +22,8 @@ class PlatformCompanyHealthController extends Controller
 
     public function __invoke(string $companyId, PlatformCompanyHealthService $healthService): JsonResponse
     {
+        DB::statement('SET search_path TO public');
+
         $company = Company::query()->findOrFail($companyId);
 
         return new JsonResponse($healthService->build($company));

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanySubscriptionController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanySubscriptionController.php
@@ -13,6 +13,8 @@ class PlatformCompanySubscriptionController extends Controller
 {
     public function show(string $companyId): JsonResponse
     {
+        DB::statement('SET search_path TO public');
+
         $company = Company::query()->findOrFail($companyId);
 
         return new JsonResponse([
@@ -22,6 +24,8 @@ class PlatformCompanySubscriptionController extends Controller
 
     public function update(Request $request, string $companyId): JsonResponse
     {
+        DB::statement('SET search_path TO public');
+
         $company = Company::query()->findOrFail($companyId);
 
         $validated = $request->validate([

--- a/api/tests/Feature/PlatformCompanyHealthApiTest.php
+++ b/api/tests/Feature/PlatformCompanyHealthApiTest.php
@@ -184,6 +184,42 @@ class PlatformCompanyHealthApiTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_platform_company_detail_endpoints_resolve_public_company_after_tenant_search_path(): void
+    {
+        DB::table('plans')->insert([
+            'id' => 1,
+            'name' => 'Starter',
+            'price_monthly' => 29,
+            'price_yearly' => 290,
+            'trial_days' => 14,
+            'is_active' => true,
+        ]);
+
+        $company = Company::factory()->create([
+            'plan_id' => 1,
+            'timezone' => 'UTC',
+            'features' => ['rh' => true],
+        ]);
+
+        DB::statement('CREATE SCHEMA IF NOT EXISTS shared_tenants');
+        DB::statement('CREATE TABLE IF NOT EXISTS shared_tenants.companies (LIKE public.companies INCLUDING ALL)');
+        DB::statement('SET search_path TO shared_tenants,public');
+
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+        $this->getJson("/api/v1/platform/companies/{$company->id}/health")
+            ->assertOk()
+            ->assertJsonPath('data.company.id', $company->id);
+
+        $this->getJson("/api/v1/platform/companies/{$company->id}/subscription")
+            ->assertOk()
+            ->assertJsonPath('data.company_id', $company->id);
+
+        $this->getJson("/api/v1/platform/companies/{$company->id}/features")
+            ->assertOk()
+            ->assertJsonPath('data.company_id', $company->id);
+    }
+
     private function superAdmin(): SuperAdmin
     {
         return SuperAdmin::query()->create([

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -65,6 +65,8 @@ Note 2026-06-01 : le Plan 63 durcit les pics de charge. Les scenarios API/ops do
 
 Note 2026-06-01 : le Plan 67.5 fige la preuve notifications mobile production. Les scenarios API doivent verifier `POST/GET/DELETE /api/v1/device-tokens`, `POST /api/v1/push-notifications/send`, l'upsert FCM avec `company_id` quand la colonne existe, la suppression scopee a l'utilisateur courant et l'audit `CommunicationService`. Le garde mobile associe est `dev-hub/tools/validate-mobile-notification-production-proof.ps1`.
 
+Note 2026-06-01 : les endpoints platform detail `GET /api/v1/platform/companies/{company}/health`, `GET/PATCH /subscription` et `GET/PATCH /features` doivent verifier que `Company` est toujours charge depuis `public.companies`, meme apres creation client ou requete tenant. Les scenarios super-admin doivent tester creation entreprise puis ouverture immediate de la fiche client par UUID.
+
 ## Matrice complete des scenarios backend
 
 ### 1. Sante technique et bootstrap


### PR DESCRIPTION
## Summary
- Force public search_path before platform company health/subscription/features detail lookups
- Add regression test covering tenant search_path shadowing public.companies
- Update changelog, AGENTS and API scenario notes

## Validation
- php -l PlatformCompanyHealthController.php
- php -l PlatformCompanySubscriptionController.php
- php -l PlatformCompanyFeatureController.php
- php -l PlatformCompanyHealthApiTest.php
- dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD
- git diff --check origin/main..HEAD
