### PR TITLE
fix: qualify platform company lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.235)
+Derniere mise a jour : 2026-06-01 (v4.16.236)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -117,7 +117,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.171, `dev-hub/tools/mobile-workflow-contracts.json` couvre aussi `leopardo_platform_admin`. Toute nouvelle action mobile super-admin doit declarer sa route `/platform/*`, son endpoint `/platform/*` et ses tokens d'ecran dans ce contrat, en plus de garder le Plan 29 vert.
 - Depuis v4.16.184, le Plan 56 durcit l'app mobile `leopardo_platform_admin` : pas d'hydratation `/platform/auth/me` sans token local, gestion explicite du `202 TWO_FA_REQUIRED`, bouton compte demo super-admin et validation email/code pays sur la creation client.
 - Depuis v4.16.172, la fiche client mobile platform admin vit sur `/platform/companies/:companyId` et consomme `/platform/companies/{company}/health`, `/subscription` et `/features`. `PlatformCompany.id` doit rester une string pour supporter les UUID de `public.companies`; ne pas le recaster en int.
-- Depuis v4.16.235, les endpoints detail platform admin (`/platform/companies/{company}/health`, `/subscription`, `/features`) doivent forcer `SET search_path TO public` avant de charger `Company`. Sans ce garde, une creation client ou une requete tenant precedente peut laisser PostgreSQL chercher l'UUID dans le mauvais schema et produire un faux `404`.
+- Depuis v4.16.236, les endpoints detail platform admin (`/platform/companies/{company}/health`, `/subscription`, `/features`) doivent charger `Company` via `PlatformCompanyLookup`, qui force `SET search_path TO public` puis lit la table qualifiee `public.companies`. Sans ce garde, une creation client ou une requete tenant precedente peut laisser PostgreSQL chercher l'UUID dans le mauvais schema et produire un faux `404/500`.
 - Depuis v4.16.218, `leopardo_platform_admin` doit garder `PlatformRepository.createCompany()` avec retour `PlatformCompany` et redirection vers `/platform/companies/{companyId}` apres creation. Ne pas revenir a un `void` silencieux : le super-admin doit voir la fiche du client cree sans attendre un refresh manuel.
 - Depuis v4.16.173, cette fiche client est actionnable : edition abonnement via `GET /platform/plans` + `PATCH /platform/companies/{company}/subscription`, et edition modules via `PATCH /platform/companies/{company}/features`. Le module `rh` reste verrouille actif cote UI comme cote API.
 - Depuis v4.16.174, `shared/i18n/sync/sync-mobile.js` ecrit les catalogues ARB a la fois dans `front/mobile/lib/l10n` et `front/mobile_apps/leopardo_core/lib/l10n`. Ne pas laisser Jules traduire seulement l'ancien mobile : les apps employee/manager/platform admin lisent le core.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.236] - 2026-06-01
+
+### Fixed
+
+- API platform admin : les endpoints detail entreprise utilisent maintenant `PlatformCompanyLookup` avec table qualifiee `public.companies` afin d'eviter les faux `404/500` lies au `search_path` PostgreSQL sur Render.
+
 ## [4.16.235] - 2026-06-01
 
 ### Fixed

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanyFeatureController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanyFeatureController.php
@@ -5,17 +5,15 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Models\Company;
 use App\Services\FeatureFlag;
+use App\Support\PlatformCompanyLookup;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class PlatformCompanyFeatureController extends Controller
 {
     public function show(string $companyId): JsonResponse
     {
-        DB::statement('SET search_path TO public');
-
-        $company = Company::query()->findOrFail($companyId);
+        $company = PlatformCompanyLookup::findOrFail($companyId);
 
         return new JsonResponse([
             'data' => [
@@ -28,9 +26,7 @@ class PlatformCompanyFeatureController extends Controller
 
     public function update(Request $request, string $companyId): JsonResponse
     {
-        DB::statement('SET search_path TO public');
-
-        $company = Company::query()->findOrFail($companyId);
+        $company = PlatformCompanyLookup::findOrFail($companyId);
 
         $validated = $request->validate([
             'features' => ['required', 'array'],

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanyHealthController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanyHealthController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
-use App\Models\Company;
 use App\Services\PlatformCompanyHealthService;
+use App\Support\PlatformCompanyLookup;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -22,9 +22,7 @@ class PlatformCompanyHealthController extends Controller
 
     public function __invoke(string $companyId, PlatformCompanyHealthService $healthService): JsonResponse
     {
-        DB::statement('SET search_path TO public');
-
-        $company = Company::query()->findOrFail($companyId);
+        $company = PlatformCompanyLookup::findOrFail($companyId);
 
         return new JsonResponse($healthService->build($company));
     }

--- a/api/app/Http/Controllers/Api/V1/PlatformCompanySubscriptionController.php
+++ b/api/app/Http/Controllers/Api/V1/PlatformCompanySubscriptionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Models\Company;
+use App\Support\PlatformCompanyLookup;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -13,9 +14,7 @@ class PlatformCompanySubscriptionController extends Controller
 {
     public function show(string $companyId): JsonResponse
     {
-        DB::statement('SET search_path TO public');
-
-        $company = Company::query()->findOrFail($companyId);
+        $company = PlatformCompanyLookup::findOrFail($companyId);
 
         return new JsonResponse([
             'data' => $this->payload($company),
@@ -24,9 +23,7 @@ class PlatformCompanySubscriptionController extends Controller
 
     public function update(Request $request, string $companyId): JsonResponse
     {
-        DB::statement('SET search_path TO public');
-
-        $company = Company::query()->findOrFail($companyId);
+        $company = PlatformCompanyLookup::findOrFail($companyId);
 
         $validated = $request->validate([
             'plan_id' => ['required', 'integer', Rule::exists('plans', 'id')],

--- a/api/app/Support/PlatformCompanyLookup.php
+++ b/api/app/Support/PlatformCompanyLookup.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Company;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\DB;
+
+class PlatformCompanyLookup
+{
+    public static function findOrFail(string $companyId): Company
+    {
+        DB::statement('SET search_path TO public');
+
+        $row = DB::table(self::table())
+            ->where('id', $companyId)
+            ->first();
+
+        if (! $row) {
+            throw (new ModelNotFoundException)->setModel(Company::class, [$companyId]);
+        }
+
+        return (new Company)->newFromBuilder((array) $row);
+    }
+
+    private static function table(): string
+    {
+        return DB::getDriverName() === 'pgsql' ? 'public.companies' : 'companies';
+    }
+}

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -65,7 +65,7 @@ Note 2026-06-01 : le Plan 63 durcit les pics de charge. Les scenarios API/ops do
 
 Note 2026-06-01 : le Plan 67.5 fige la preuve notifications mobile production. Les scenarios API doivent verifier `POST/GET/DELETE /api/v1/device-tokens`, `POST /api/v1/push-notifications/send`, l'upsert FCM avec `company_id` quand la colonne existe, la suppression scopee a l'utilisateur courant et l'audit `CommunicationService`. Le garde mobile associe est `dev-hub/tools/validate-mobile-notification-production-proof.ps1`.
 
-Note 2026-06-01 : les endpoints platform detail `GET /api/v1/platform/companies/{company}/health`, `GET/PATCH /subscription` et `GET/PATCH /features` doivent verifier que `Company` est toujours charge depuis `public.companies`, meme apres creation client ou requete tenant. Les scenarios super-admin doivent tester creation entreprise puis ouverture immediate de la fiche client par UUID.
+Note 2026-06-01 : les endpoints platform detail `GET /api/v1/platform/companies/{company}/health`, `GET/PATCH /subscription` et `GET/PATCH /features` doivent verifier que `Company` est toujours charge via `PlatformCompanyLookup` depuis `public.companies`, meme apres creation client ou requete tenant. Les scenarios super-admin doivent tester creation entreprise puis ouverture immediate de la fiche client par UUID.
 
 ## Matrice complete des scenarios backend
 


### PR DESCRIPTION
## Summary
- Add PlatformCompanyLookup to load platform companies from public.companies explicitly
- Use it for platform health/subscription/features detail endpoints
- Update operational docs and changelog

## Validation
- php -l api/app/Support/PlatformCompanyLookup.php
- php -l platform company detail controllers
- dev-hub/tools/check-governance.ps1 -BaseRef origin/main -HeadRef HEAD
- git diff --check origin/main..HEAD
