### PR TITLE
docs: finalize plan 69 payroll finance smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.241] - 2026-06-01
+
+### Added
+
+- Plan 69.5 : ajout du rapport `PAYROLL_FINANCE_API_SMOKE_2026_06_01.md` avec preuve Render avance double validation, paiement masse, documents PDF asynchrones, confirmation employe, resume paie mobile et solde employe manager.
+
 ## [4.16.240] - 2026-06-01
 
 ### Fixed

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -116,6 +116,10 @@ Stabiliser le cycle financier mobile-first : avance double validation, solde emp
 
 Rapport paie/finance + tests backend cibles si un workflow manque.
 
+### Statut
+
+**Go apres corrections #686/#688/#689.** Le smoke Render confirme l'avance double validation (`manager-approve`, `mark-paid`, `confirm-received`), le recu avance asynchrone, le cycle paie demo avec 11 bulletins, le payment batch marque paye, la confirmation employe d'un item, le resume mobile manager et le solde employe par manager. Rapport : `docs/validation/PAYROLL_FINANCE_API_SMOKE_2026_06_01.md`.
+
 ## Lot 69.6 - Observabilite lancement
 
 ### Objectif

--- a/docs/validation/PAYROLL_FINANCE_API_SMOKE_2026_06_01.md
+++ b/docs/validation/PAYROLL_FINANCE_API_SMOKE_2026_06_01.md
@@ -1,0 +1,39 @@
+# Smoke API paie / finance - 2026-06-01
+
+## Contexte
+
+Validation Render du lot 69.5 apres corrections #686, #688 et #689.
+
+- API : `https://gestionemployerbackend.onrender.com/api/v1`
+- Manager demo : `ahmed.benali@techcorp-algerie.dz`
+- Employe demo : `karim.aouad@techcorp-algerie.dz`
+- Branche source : `main`
+
+## Resultats
+
+| Parcours | Resultat |
+|---|---|
+| Creation avance employe | OK - avance #6 creee en `pending` |
+| Validation manager avance | OK - `validation_status=manager_approved` |
+| Declaration paiement avance | OK - `validation_status=payment_declared` |
+| Confirmation reception employe | OK - `validation_status=employee_confirmed` |
+| Recu avance asynchrone | OK - document `advance_receipt` disponible |
+| Creation structure salariale demo | OK - structure #1 creee pour permettre le calcul de paie demo |
+| Creation / calcul / validation payroll run | OK - run #2 valide, 11 bulletins generes |
+| Creation payment batch | OK - batch #1 cree avec 11 items |
+| Marquage paiement masse | OK - batch `paid`, documents generes en arriere-plan |
+| Confirmation employe payment item | OK - item #10 confirme par Karim |
+| Resume paie manager mobile | OK - `GET /payroll/mobile-summary`, 12 lignes, total restant `1125679` |
+| Solde employe par manager | OK - `GET /employees/1/balance`, restant `180000` |
+
+## Corrections livrees
+
+- #686 : selection schema-aware des colonnes employees dans le resume paie mobile.
+- #688 : reutilisation de `currentCompany()` pour eviter les erreurs `search_path` sur les soldes paie.
+- #689 : alignement du parametre route `{employee}` et fallback partiel par employe dans le resume mobile.
+
+## Decision
+
+Verdict : **Go pour le lot 69.5**.
+
+Le socle finance mobile-first couvre maintenant les cas critiques attendus avant lancement : avance double validation, paiement declare, confirmation employe, paiement masse, documents PDF asynchrones, resume manager et solde employe. Les donnees creees pendant le smoke restent des traces QA demo sur TechCorp.


### PR DESCRIPTION
## Summary
- document Plan 69.5 payroll/finance Render smoke results
- mark the payroll finance lot as Go after fixes #686/#688/#689
- add changelog entry for the validation report

## Verification
- Render smoke: advances double validation, payment batch, async payment documents, employee confirmation, payroll mobile summary, employee balance
- git diff --check