### PR TITLE
docs: add launch observability smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.244] - 2026-06-01
+
+### Added
+
+- Plan 69.6 : ajout du rapport `LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md` avec preuve Render health/live/ready, manager digest et launch-readiness, et verdict go-live conditionnel lie a `communication_governance`.
+
 ## [4.16.243] - 2026-06-01
 
 ### Fixed

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -136,6 +136,10 @@ Preparer une lecture simple du lancement : health API, queue health, erreurs 5xx
 
 Cockpit de lancement documentaire et procedures d'escalade simples.
 
+### Statut
+
+**Go technique, go-live conditionnel.** Le smoke Render confirme `health`, `live`, `ready`, `manager-digest` et `launch-readiness` apres correction #691. Le cockpit retourne un score `43` et `go_live_ready=false` avec un bloqueur requis `communication_governance` (`preferences_configured=1`, aucun echec communication 7j). Rapport : `docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md`.
+
 ## Priorite
 
 1. Lot 69.1

--- a/docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md
+++ b/docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md
@@ -1,0 +1,41 @@
+# Smoke observabilite lancement - 2026-06-01
+
+## Contexte
+
+Validation Render du lot 69.6 apres correction #691 sur `GET /api/v1/launch-readiness`.
+
+- API : `https://gestionemployerbackend.onrender.com/api/v1`
+- Persona : manager demo `ahmed.benali@techcorp-algerie.dz`
+- Branche source : `main`
+
+## Smoke technique
+
+| Signal | Resultat |
+|---|---|
+| `GET /health` | OK - `status=ok` |
+| `GET /health/live` | OK - `status=ok` |
+| `GET /health/ready` | OK - `status=ok` |
+| `GET /dashboard/manager-digest` | OK - payload operationnel avec `team_scope`, `team_size`, presences et actions |
+| `GET /launch-readiness` | OK apres #691 |
+
+## Readiness lancement tenant
+
+| Indicateur | Valeur |
+|---|---|
+| Score | `43` |
+| Go-live ready | `false` |
+| Bloqueurs requis | `1` |
+| Bloqueur | `communication_governance` |
+| Detail bloqueur | `preferences_configured=1`, `communication_failures_7d=0` |
+
+## Interpretation
+
+Le cockpit technique est exploitable : health, ready, digest manager et readiness repondent sans 500/404.
+
+Le verdict lancement TechCorp reste **Go conditionnel / No-go marketing large** tant que les preferences de communication ne sont pas initialisees pour tous les utilisateurs actifs. Ce signal est fonctionnel, pas une panne API.
+
+## Actions suivantes recommandees
+
+- Backfiller les `notification_preferences` manquantes pour les demos et nouveaux tenants.
+- Ajouter un smoke post-seed qui compare `preferences_configured` au nombre d'employes actifs.
+- Continuer a surveiller les workflows post-merge : deploy, E2E staging, OWASP et distribution mobile.


### PR DESCRIPTION
## Summary
- add Plan 69.6 Render observability smoke report
- record launch-readiness result and communication governance blocker
- update Plan 69 and changelog

## Validation
- git diff --check