### PR TITLE
fix: run readiness backfills on Render runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.246)
+Derniere mise a jour : 2026-06-01 (v4.16.247)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -71,6 +71,7 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - `DemoCompanyOnceSeeder` doit verifier les slugs demo (`techcorp-algerie`, `pharmaplus-casablanca`, `digitalflow-tunis`) et non la simple presence d'une entreprise en `shared_tenants`; en mode shared, les vrais clients utilisent aussi ce schema.
 - Si le lock `demo_company_seed_v2` existe mais que ces slugs demo manquent, il doit etre considere stale et supprime par le seeder avant de relancer le seed. Ne pas reparer ce cas par SQL manuel tant que le seeder sait le faire.
 - Depuis v4.16.246, `DemoCompanyOnceSeeder` doit aussi backfiller les signaux readiness des demos existantes quand le lock est deja pose : salaire actif minimal, geofence, kiosque actif et client event recent. Si `/api/v1/launch-readiness` reste sous 70 sur TechCorp apres deploy, verifier ce backfill avant de modifier le controleur.
+- Depuis v4.16.247, ces backfills readiness doivent rester actifs meme si `DISABLE_DEMO_SEEDING=true` : ce flag bloque la creation/recreation des demos dans tous les environnements, pas la reparation non destructive des demos existantes. `notifications:backfill-preferences` doit aussi garder `SET search_path TO shared_tenants, public` pour ecrire dans le schema tenant reel lu par `/api/v1/launch-readiness`.
 - Les notifications web/mobile doivent rester vivantes : polling/refresh visible, badge non lu et action de lecture immediate. Toute refonte SSE/WebSocket doit conserver un fallback polling pour Render/proxy/mobile.
 - Dans `tests.yml`, ne pas faire porter la dette mobile historique a des PR backend/web en declenchant `mobile-tests` uniquement parce que le workflow lui-meme change. Le job mobile doit rester cale sur `mobile/**` tant que la base n'est pas completement assainie.
 - Pour `Backend Quality`, garder Pint et PHPStan en gates diff-aware sur les fichiers PHP backend modifies. Cela bloque les nouvelles regressions sans faire porter la dette historique hors perimetre au PR courant. Garder les artefacts et la visibilite du baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.247] - 2026-06-01
+
+### Fixed
+
+- Readiness Render : `DemoCompanyOnceSeeder` repare maintenant les signaux readiness des demos existantes meme quand `DISABLE_DEMO_SEEDING=true`, sans creer/recreer de demos.
+- Bootstrap notifications : `notifications:backfill-preferences` force le `search_path` PostgreSQL sur `shared_tenants, public` afin de creer les preferences dans le schema consomme par les APIs tenant.
+
 ## [4.16.246] - 2026-06-01
 
 ### Fixed

--- a/api/app/Console/Commands/BackfillNotificationPreferences.php
+++ b/api/app/Console/Commands/BackfillNotificationPreferences.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Services\Communication\NotificationPreferenceProvisioner;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class BackfillNotificationPreferences extends Command
 {
@@ -15,6 +16,10 @@ class BackfillNotificationPreferences extends Command
 
     public function handle(NotificationPreferenceProvisioner $provisioner): int
     {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants, public');
+        }
+
         $stats = $provisioner->backfill(
             companyId: is_string($this->option('company')) ? $this->option('company') : null,
             dryRun: (bool) $this->option('dry-run'),

--- a/api/database/seeders/DemoCompanyOnceSeeder.php
+++ b/api/database/seeders/DemoCompanyOnceSeeder.php
@@ -20,14 +20,7 @@ class DemoCompanyOnceSeeder extends Seeder
 
     public function run(): void
     {
-        $isProduction = app()->environment('production');
         $disabled = filter_var(env('DISABLE_DEMO_SEEDING', false), FILTER_VALIDATE_BOOLEAN);
-
-        if ($isProduction && $disabled) {
-            $this->command?->info('DemoCompanyOnceSeeder skipped (DISABLE_DEMO_SEEDING=true).');
-
-            return;
-        }
 
         DB::statement('SET search_path TO public');
 
@@ -36,6 +29,17 @@ class DemoCompanyOnceSeeder extends Seeder
         $existingDemoSlugs = DB::table('companies')
             ->whereIn('slug', self::DEMO_SLUGS)
             ->pluck('slug');
+
+        if ($disabled) {
+            if ($existingDemoSlugs->isNotEmpty()) {
+                $this->backfillDemoLeaveBalances();
+                $this->backfillDemoLaunchReadinessSignals();
+            }
+
+            $this->command?->info('DemoCompanyOnceSeeder skipped creation (DISABLE_DEMO_SEEDING=true).');
+
+            return;
+        }
 
         $alreadyRan = DB::table('seed_locks')
             ->where('lock_key', self::LOCK_KEY)

--- a/api/tests/Feature/DemoUserControllerTest.php
+++ b/api/tests/Feature/DemoUserControllerTest.php
@@ -154,6 +154,63 @@ class DemoUserControllerTest extends TestCase
         $this->assertArrayHasKey('attendance_geofence', $metadata);
     }
 
+    public function test_demo_once_seeder_backfills_existing_demo_readiness_when_demo_creation_is_disabled(): void
+    {
+        putenv('DISABLE_DEMO_SEEDING=true');
+        $_ENV['DISABLE_DEMO_SEEDING'] = 'true';
+        $_SERVER['DISABLE_DEMO_SEEDING'] = 'true';
+
+        try {
+            Schema::create('seed_locks', function (Blueprint $table): void {
+                $table->string('lock_key')->primary();
+                $table->timestampTz('ran_at')->nullable();
+                $table->timestampsTz();
+            });
+
+            $companies = collect(['techcorp-algerie', 'pharmaplus-casablanca', 'digitalflow-tunis'])
+                ->mapWithKeys(fn (string $slug): array => [
+                    $slug => Company::factory()->create([
+                        'slug' => $slug,
+                        'schema_name' => 'shared_tenants',
+                        'tenancy_type' => 'shared',
+                        'status' => 'active',
+                        'metadata' => [],
+                    ]),
+                ]);
+
+            $employeeId = DB::table('shared_tenants.employees')->insertGetId([
+                'company_id' => $companies['techcorp-algerie']->id,
+                'first_name' => 'Disabled',
+                'last_name' => 'Backfill',
+                'email' => 'disabled.backfill@techcorp-algerie.dz',
+                'password_hash' => Hash::make('password123'),
+                'role' => 'employee',
+                'status' => 'active',
+                'salary_type' => 'fixed',
+                'salary_base' => 0,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $this->seed(DemoCompanyOnceSeeder::class);
+
+            $this->assertGreaterThan(0, (float) DB::table('shared_tenants.employees')
+                ->where('id', $employeeId)
+                ->value('salary_base'));
+            $this->assertTrue(DB::table('shared_tenants.attendance_kiosks')
+                ->where('company_id', $companies['techcorp-algerie']->id)
+                ->where('status', 'active')
+                ->exists());
+            $this->assertTrue(DB::table('shared_tenants.client_events')
+                ->where('company_id', $companies['techcorp-algerie']->id)
+                ->where('event_name', 'launch_readiness_backfilled')
+                ->exists());
+        } finally {
+            putenv('DISABLE_DEMO_SEEDING');
+            unset($_ENV['DISABLE_DEMO_SEEDING'], $_SERVER['DISABLE_DEMO_SEEDING']);
+        }
+    }
+
     public function test_demo_login_recovers_missing_lookup_from_shared_tenant_schema(): void
     {
         $company = Company::factory()->create([

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -144,6 +144,8 @@ Cockpit de lancement documentaire et procedures d'escalade simples.
 
 **Backfill demo prepare.** `DemoCompanyOnceSeeder` complete aussi les signaux demo necessaires au seuil readiness (`payroll_base`, `attendance_entry`, `client_experience_tracking`) quand les entreprises demo existent deja. Rapport : `docs/validation/LAUNCH_DEMO_READINESS_BACKFILL_2026_06_01.md`.
 
+**Correctif runtime Render.** Les backfills readiness restent actifs meme si `DISABLE_DEMO_SEEDING=true` et le backfill preferences force le schema `shared_tenants, public`, afin que le cockpit lise les memes donnees que les APIs tenant apres deploy.
+
 ## Priorite
 
 1. Lot 69.1


### PR DESCRIPTION
## Summary
- keep non-destructive demo readiness backfills active even when DISABLE_DEMO_SEEDING=true
- force notifications:backfill-preferences to write in shared_tenants, public on PostgreSQL
- add regression coverage and update Plan 69/CHANGELOG/AGENTS

## Validation
- php -l api/database/seeders/DemoCompanyOnceSeeder.php
- php -l api/app/Console/Commands/BackfillNotificationPreferences.php
- php -l api/tests/Feature/DemoUserControllerTest.php
- git diff --check