### PR TITLE
docs: mark launch readiness green after runtime backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.248] - 2026-06-01
+
+### Changed
+
+- Readiness lancement : mise a jour des rapports Plan 69 apres smoke Render post-#695 (`launch-readiness score=100`, `go_live_ready=true`, zero bloqueur requis) et cloture du lot observabilite API.
+
 ## [4.16.247] - 2026-06-01
 
 ### Fixed

--- a/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md
@@ -138,13 +138,15 @@ Cockpit de lancement documentaire et procedures d'escalade simples.
 
 ### Statut
 
-**Go technique, go-live conditionnel.** Le smoke Render confirme `health`, `live`, `ready`, `manager-digest` et `launch-readiness` apres correction #691. Le cockpit retourne un score `43` et `go_live_ready=false` avec un bloqueur requis `communication_governance` (`preferences_configured=1`, aucun echec communication 7j). Rapport : `docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md`.
+**Go technique API.** Le smoke Render confirme `health`, `ready`, `manager-digest` et `launch-readiness` apres corrections #691/#693/#694/#695. Le cockpit retourne maintenant `score=100`, `go_live_ready=true`, `required_blockers=0`, avec preferences notifications, paie minimale, geofence/kiosque et tracking client backfilles. Rapport : `docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md`.
 
 **Correctif prepare.** Le backfill `notifications:backfill-preferences` cree/repare les preferences notifications des employes actifs et l'entrypoint Render l'execute apres les seeders. Rapport : `docs/validation/LAUNCH_COMMUNICATION_GOVERNANCE_FIX_2026_06_01.md`.
 
 **Backfill demo prepare.** `DemoCompanyOnceSeeder` complete aussi les signaux demo necessaires au seuil readiness (`payroll_base`, `attendance_entry`, `client_experience_tracking`) quand les entreprises demo existent deja. Rapport : `docs/validation/LAUNCH_DEMO_READINESS_BACKFILL_2026_06_01.md`.
 
 **Correctif runtime Render.** Les backfills readiness restent actifs meme si `DISABLE_DEMO_SEEDING=true` et le backfill preferences force le schema `shared_tenants, public`, afin que le cockpit lise les memes donnees que les APIs tenant apres deploy.
+
+**Lot 69.6 cloture.** Les workflows `main` post-merge #695 sont verts : Tests, Deploy Staging, Deploy Render, E2E staging, OWASP et distribution Firebase des trois apps. Le dernier blocage restant est hors code : recette device physique a rejouer par testeurs.
 
 ## Priorite
 

--- a/docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md
+++ b/docs/validation/LAUNCH_OBSERVABILITY_SMOKE_2026_06_01.md
@@ -2,7 +2,7 @@
 
 ## Contexte
 
-Validation Render du lot 69.6 apres correction #691 sur `GET /api/v1/launch-readiness`.
+Validation Render du lot 69.6 apres corrections #691, #693, #694 et #695 sur `GET /api/v1/launch-readiness`.
 
 - API : `https://gestionemployerbackend.onrender.com/api/v1`
 - Persona : manager demo `ahmed.benali@techcorp-algerie.dz`
@@ -16,26 +16,28 @@ Validation Render du lot 69.6 apres correction #691 sur `GET /api/v1/launch-read
 | `GET /health/live` | OK - `status=ok` |
 | `GET /health/ready` | OK - `status=ok` |
 | `GET /dashboard/manager-digest` | OK - payload operationnel avec `team_scope`, `team_size`, presences et actions |
-| `GET /launch-readiness` | OK apres #691 |
+| `GET /launch-readiness` | OK - score go-live complet apres #695 |
 
 ## Readiness lancement tenant
 
 | Indicateur | Valeur |
 |---|---|
-| Score | `43` |
-| Go-live ready | `false` |
-| Bloqueurs requis | `1` |
-| Bloqueur | `communication_governance` |
-| Detail bloqueur | `preferences_configured=1`, `communication_failures_7d=0` |
+| Score | `100` |
+| Go-live ready | `true` |
+| Bloqueurs requis | `0` |
+| Communication governance | `preferences_configured=11`, `communication_failures_7d=0` |
+| Payroll base | `payroll_ready_employees=11` |
+| Attendance entry | `geofence_configured=true`, `active_kiosks=1` |
+| Client experience tracking | `client_events_7d=1` |
 
 ## Interpretation
 
 Le cockpit technique est exploitable : health, ready, digest manager et readiness repondent sans 500/404.
 
-Le verdict lancement TechCorp reste **Go conditionnel / No-go marketing large** tant que les preferences de communication ne sont pas initialisees pour tous les utilisateurs actifs. Ce signal est fonctionnel, pas une panne API.
+Le verdict lancement TechCorp passe a **Go technique API / observabilite** : tous les checks requis et optionnels du cockpit sont complets apres execution des backfills runtime Render.
 
 ## Actions suivantes recommandees
 
-- Backfiller les `notification_preferences` manquantes pour les demos et nouveaux tenants.
-- Ajouter un smoke post-seed qui compare `preferences_configured` au nombre d'employes actifs.
+- Garder `notifications:backfill-preferences` et le backfill demo readiness dans l'entrypoint Render.
 - Continuer a surveiller les workflows post-merge : deploy, E2E staging, OWASP et distribution mobile.
+- Rejouer une recette terrain device sur les APK Firebase avant campagne marketing large.

--- a/docs/validation/RELEASE_READINESS_REPORT_2026_06_01.md
+++ b/docs/validation/RELEASE_READINESS_REPORT_2026_06_01.md
@@ -2,9 +2,9 @@
 
 ## Decision
 
-**Go conditionnel - score 91/100.**
+**Go technique controle - score 93/100.**
 
-Le depot est maintenant auditable par surface avant marketing : API, employee mobile, manager/RH mobile, platform admin mobile, vitrine web et kiosk ont chacun une preuve, un garde ou un workflow CI associe. La condition restante avant declaration "Go sans reserve" est operationnelle : rejouer une recette terrain avec vrais appareils/testeurs et verifier les workflows `main` post-merge de chaque lot.
+Le depot est maintenant auditable par surface avant marketing : API, employee mobile, manager/RH mobile, platform admin mobile, vitrine web et kiosk ont chacun une preuve, un garde ou un workflow CI associe. Depuis #695, le cockpit Render `/api/v1/launch-readiness` retourne `score=100`, `go_live_ready=true` et `required_blockers=0` pour TechCorp. La condition restante avant declaration "Go sans reserve" est operationnelle : rejouer une recette terrain avec vrais appareils/testeurs.
 
 ## Validation executee
 
@@ -21,6 +21,7 @@ Le depot est maintenant auditable par surface avant marketing : API, employee mo
 | `dev-hub/tools/validate-mobile-notification-production-proof.ps1` | Couvert par Mobile Apps CI |
 | `dev-hub/tools/validate-mobile-workflow-contracts.ps1` | Couvert par Mobile Apps CI |
 | PR #668 | Backend, coverage, OpenAPI, mobile apps analyze/build, security et Vercel verts avant merge |
+| PR #695 + smoke Render | OK, `launch-readiness score=100`, `go_live_ready=true`, backfills runtime appliques |
 
 ## Score par profil
 
@@ -32,7 +33,7 @@ Le depot est maintenant auditable par surface avant marketing : API, employee mo
 | API publique / partenaires | 92/100 | OpenAPI canonique, `/docs`, `/api-explorer`, contrats push/device-token, tests backend/coverage | Portail developpeur sandbox/tokens partenaires reste un lot futur |
 | Vitrine web / portail client | 86/100 | `front/web` present, CI dediee, liens marketing canoniques documentes | Continuer SEO contenu, preuves Lighthouse et parcours essai gratuit |
 | Kiosk / ZKTeco | 84/100 | Front kiosk present, API base normalisee, scenarios kiosk documentes | Recette device physique et mode offline a rejouer avec materiel client |
-| Operations / CI/CD | 93/100 | 23 workflows, backup/restore, OpenAPI CI, secret scan, CodeQL, queues/Redis runbooks | Monitoring externe SLA et alerting incident P1 a verifier en prod |
+| Operations / CI/CD | 95/100 | 23 workflows, backup/restore, OpenAPI CI, secret scan, CodeQL, queues/Redis runbooks, launch-readiness 100/100 | Monitoring externe SLA et alerting incident P1 a verifier en prod |
 
 ## Risques classes
 
@@ -54,4 +55,4 @@ Le depot est maintenant auditable par surface avant marketing : API, employee mo
 
 ## Conclusion
 
-Le niveau produit est suffisant pour une mise en marche controlee et une campagne marketing progressive. Le statut reste **Go conditionnel** parce que les preuves terrain device/kiosk et le stress test volume cible doivent encore etre executes hors CI.
+Le niveau produit est suffisant pour une mise en marche controlee et une campagne marketing progressive. Le statut est **Go technique controle** : l'API et l'observabilite de lancement sont vertes, mais les preuves terrain device/kiosk et le stress test volume cible doivent encore etre executes hors CI avant promesse commerciale large.


### PR DESCRIPTION
## Summary
- update Plan 69 observability status after PR #695 runtime backfills
- record Render smoke result: launch-readiness score=100, go_live_ready=true, zero required blockers
- adjust release readiness wording from conditional blocker to controlled technical go

## Validation
- git diff --check
- Render smoke after #695: health ok, ready ok, manager digest ok, launch-readiness score=100