### PR TITLE
docs: add market launch audit and context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-01 (v4.16.247)
+Derniere mise a jour : 2026-06-05 (v4.16.249)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -65,6 +65,9 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Depuis v4.16.127, la racine API Render expose aussi `/tester-guide` et `/api-explorer`. Garder ces pages publiques, legeres et coherentes avec `DemoCompanySeeder` pour que QA/dev puissent valider web client, mobile, admin plateforme et API sans preparer de payloads a la main.
 - Le login demo doit rester robuste meme si `public.user_lookups` est incomplet : `AuthService` peut retrouver l'employe dans les schemas tenants connus puis regenerer le lookup. Ne pas supprimer ce fallback sans fournir une commande ops de reparation demo.
 - Depuis v4.16.234, le compte super-admin expose par `/api/v1/demo-users` doit rester réellement utilisable sur les environnements demo : `DemoCompanyOnceSeeder` resynchronise `admin@leopardo-rh.com` / `password123` et retire le 2FA demo si necessaire. Si l'app `leopardo_platform_admin` retourne `INVALID_CREDENTIALS` avec les credentials publics, verifier d'abord ce seeder/deploy avant de toucher au client mobile.
+- Depuis v4.16.249, le bouton demo de `leopardo_platform_admin` doit remplir `admin@leopardo-rh.com` / `password123`. `validate-mobile-plan29.ps1` garde ce contrat; ne pas remettre l'ancien mot de passe `admin`.
+- Le contexte rapide pour nouveaux agents vit dans `docs/CONTEXT/`. Avant un audit large, lire ce dossier avec `AGENTS.md`, `CHANGELOG.md` et les rapports `docs/validation/*`.
+- Le positionnement marche courant vit dans `docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/`. Le produit doit etre vendu comme `Mobile-First Company OS` pour PME terrain, pas comme simple SIRH generaliste.
 - Le smoke auth marche exige toujours `POST /api/v1/auth/login` puis `GET /api/v1/auth/me` avec le token. En mode shared, `TenantMiddleware` doit pouvoir rehydrater l'employe Sanctum via `public.user_lookups` avant de poser le tenant.
 - En auth shared PostgreSQL, ne pas supposer que `Company` se resout via le `search_path` courant : si un schema tenant contient une table `companies`, il peut masquer `public.companies`. `AuthService` et `TenantMiddleware` doivent recharger l'entreprise depuis `public.companies` avant de conclure `COMPANY_NOT_FOUND`.
 - Depuis v4.16.128, `/api/v1/demo-users` est un contrat public de documentation QA, pas un endpoint secret : ne pas le rebloquer via `DEMO_MODE_ENABLED=false`. Pour desactiver l'auto-seed Render, utiliser `DISABLE_DEMO_SEEDING=true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.249] - 2026-06-05
+
+### Added
+
+- Go-to-market 2026 : ajout du dossier `docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/` avec audit marche/produit, positionnement, messaging, offres et direction commerciale.
+- Plan 70 : ajout de `70_PLAN_MARKET_LAUNCH_2026_COMPANY_OS.md` avec 72 actions nouvelles pour readiness marche, monetisation, preuves terrain, IA gouvernee, operations et expansion.
+- Contexte IA : ajout de `docs/CONTEXT/` pour donner a un nouvel agent le contexte produit, technique, operationnel et les priorites courantes.
+- Validation : ajout de `MARKET_LAUNCH_AUDIT_2026_06_05.md` avec verdict go pilote payant controle et sources marche 2026.
+
+### Fixed
+
+- Mobile Platform Admin : le bouton `Utiliser le compte demo` remplit maintenant le mot de passe seede `password123` au lieu de l'ancien `admin`.
+- Mobile Plan 29 : le garde CI bloque maintenant un retour au mauvais mot de passe demo platform admin.
+
 ## [4.16.248] - 2026-06-01
 
 ### Changed

--- a/dev-hub/tools/validate-mobile-plan29.ps1
+++ b/dev-hub/tools/validate-mobile-plan29.ps1
@@ -80,6 +80,12 @@ if (Test-Path -LiteralPath $appRoot) {
             Add-Failure "Platform admin contains empty UI handler in $($match.Path):$($match.LineNumber)"
         }
     }
+
+    Assert-Contains $appContent "admin@leopardo-rh.com" "Platform admin demo login"
+    Assert-Contains $appContent "password123" "Platform admin demo login"
+    if ($appContent.Contains("_passwordController.text = 'admin';")) {
+        Add-Failure "Platform admin demo login must use the seeded password password123, not the stale password admin."
+    }
 }
 
 Assert-Contains `

--- a/docs/CONTEXT/01_PRODUCT_CONTEXT.md
+++ b/docs/CONTEXT/01_PRODUCT_CONTEXT.md
@@ -1,0 +1,37 @@
+# Product context
+
+## Vision
+
+Leopardo HR est un **Mobile-First Company OS** pour PME terrain. Le produit relie employes, managers/RH et administrateurs plateforme autour des operations quotidiennes:
+
+- presence et pointage;
+- horaires, sites, taches;
+- absences, avances, paie et documents;
+- notifications et communication;
+- onboarding, QR, dossiers employes;
+- pilotage client et readiness;
+- API/OpenAPI pour ecosysteme.
+
+## Surfaces produit
+
+- `front/mobile_apps/leopardo_employee`: app employe.
+- `front/mobile_apps/leopardo_manager`: app manager/RH.
+- `front/mobile_apps/leopardo_platform_admin`: app super-admin plateforme.
+- `front/mobile_apps/leopardo_core`: code partage mobile.
+- `front/web`: vitrine/portail client web.
+- `front/admin-dashboard`: dashboard plateforme web.
+- `api`: backend Laravel.
+- `front/zkteco-kiosk`: kiosque terrain.
+
+## Personas
+
+- Employe terrain: veut pointer, consulter documents, demander absence/avance.
+- Manager/RH: veut voir equipe, valider, corriger, planifier.
+- Dirigeant: veut visibilite, couts, alertes, conformite.
+- Super-admin plateforme: veut creer clients, plans, modules, health.
+- Partenaire: veut API, docs, webhooks, SDK.
+
+## Promesse
+
+Rendre l'entreprise visible et actionnable depuis le mobile, sans Excel ni processus disperses.
+

--- a/docs/CONTEXT/02_TECHNICAL_CONTEXT.md
+++ b/docs/CONTEXT/02_TECHNICAL_CONTEXT.md
@@ -1,0 +1,31 @@
+# Technical context
+
+## Stack
+
+- Backend: Laravel, PostgreSQL multi-tenant schema, Sanctum, queues.
+- Mobile: Flutter 3.x, Riverpod 3.x, apps separees Employee/Manager/Platform Admin.
+- Push: Firebase/FCM, mais aucune dependance externe ne doit bloquer le premier ecran.
+- CI/CD: GitHub Actions source de verite.
+- Deploiement: Render, Vercel, Firebase App Distribution.
+
+## Invariants critiques
+
+- Ne jamais bloquer `runApp()` sur Firebase, FCM, Hive, Google Sign-In, API ou reseau.
+- `StartupGate` doit rester le premier garde anti-ecran noir.
+- `PushNotificationService` doit rester lazy: pas de `FirebaseMessaging.instance` avant init Firebase protegee.
+- Les routes tenant doivent rester scopees par tenant/company.
+- Ne pas reutiliser les routes tenant `/device-tokens` pour le super-admin platform.
+- `api/openapi.yaml` est la spec canonique.
+- Mettre a jour `CHANGELOG.md` et `AGENTS.md` pour tout changement comportemental.
+
+## Commandes utiles
+
+- Mobile guard: `powershell -ExecutionPolicy Bypass -File dev-hub/tools/validate-mobile-runtime-smoke.ps1`
+- Platform admin guard: `powershell -ExecutionPolicy Bypass -File dev-hub/tools/validate-mobile-plan29.ps1`
+- Release readiness: `powershell -ExecutionPolicy Bypass -File dev-hub/tools/release-readiness.ps1 -Strict`
+- PR checks: `gh pr checks <numero>`
+
+## Limitations locales connues
+
+La machine Windows peut ne pas avoir PHP/Flutter/Dart. Dans ce cas, GitHub Actions est la preuve de verite.
+

--- a/docs/CONTEXT/03_OPERATIONAL_CONTEXT.md
+++ b/docs/CONTEXT/03_OPERATIONAL_CONTEXT.md
@@ -1,0 +1,38 @@
+# Operational context
+
+## Etat de lancement
+
+Le dernier rapport readiness indique un Go technique controle, avec reserve operationnelle: recette sur vrais appareils et testeurs reels.
+
+Preuves importantes:
+
+- `docs/validation/RELEASE_READINESS_REPORT_2026_06_01.md`
+- `docs/validation/MOBILE_RELEASE_DEVICE_QA_2026_06_01.md`
+- `docs/validation/MOBILE_RUNTIME_SMOKE_REPORT_2026_06_01.md`
+- `docs/validation/PLATFORM_ADMIN_API_SMOKE_2026_06_01.md`
+- `docs/PLAN_ACTION/69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md`
+
+## Comptes demo
+
+- Platform Admin: `admin@leopardo-rh.com` / `password123`
+- Les autres comptes sont exposes par `/api/v1/demo-users`.
+
+## Risques restants
+
+- Recette device physique encore a produire apres chaque distribution Firebase.
+- Kiosk/ZKTeco a tester sur materiel reel.
+- Portail developpeur/sandbox pas encore complet.
+- Stress test authentifie encore a etendre.
+- Positionnement/pricing a valider par pilotes payants.
+
+## Procedure de travail
+
+1. Fetch `origin/main`.
+2. Creer branche `codex/...`.
+3. Corriger petit lot.
+4. Lancer gardes locaux possibles.
+5. Pousser PR.
+6. Attendre GitHub Actions.
+7. Merger et supprimer branche.
+8. Revenir aligner `main`.
+

--- a/docs/CONTEXT/04_CURRENT_PRIORITIES.md
+++ b/docs/CONTEXT/04_CURRENT_PRIORITIES.md
@@ -1,0 +1,28 @@
+# Current priorities
+
+## P0
+
+- Prouver login demo mobile Platform Admin sur APK Firebase actuel.
+- Re-distribuer APK apres correction si le code mobile change.
+- Produire recette device datee pour Employee, Manager et Platform Admin.
+
+## P1
+
+- Transformer le produit en parcours sectoriels vendables.
+- Finaliser pricing Starter/Growth/Scale.
+- Produire scripts de vente, objections et ROI.
+- Stabiliser preuve charge p95/p99 sur endpoints critiques.
+
+## P2
+
+- Offline-first avance.
+- Portail developpeur sandbox.
+- Webhooks signes.
+- IA RH gouvernee et auditable.
+
+## P3
+
+- Marketplace open-core.
+- White-label cabinets.
+- Programme revendeurs.
+

--- a/docs/CONTEXT/README.md
+++ b/docs/CONTEXT/README.md
@@ -1,0 +1,13 @@
+# CONTEXT - Leopardo HR
+
+Ce dossier sert de contexte rapide pour une nouvelle IA ou un nouvel intervenant.
+
+## Lire dans cet ordre
+
+1. `01_PRODUCT_CONTEXT.md`
+2. `02_TECHNICAL_CONTEXT.md`
+3. `03_OPERATIONAL_CONTEXT.md`
+4. `04_CURRENT_PRIORITIES.md`
+
+Regle: `origin/main` est la source de verite. Avant toute action, lire `AGENTS.md`, `CHANGELOG.md`, puis verifier l'etat Git.
+

--- a/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/01_AUDIT_MARCHE_ET_PRODUIT.md
+++ b/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/01_AUDIT_MARCHE_ET_PRODUIT.md
@@ -1,0 +1,80 @@
+# Audit marche et produit - Leopardo HR 2026
+
+## 1. Resume executif
+
+Leopardo HR dispose maintenant d'un socle technique solide: API Laravel multi-tenant, apps mobiles Employee/Manager/Platform Admin, Firebase Distribution, OpenAPI, observabilite, launch-readiness, workflows CI et preuves de smoke Render. Le depot indique un **Go technique controle** autour de 93/100, avec une reserve majeure: recette terrain sur vrais appareils et validation commerciale.
+
+Le marche HR tech 2026 pousse dans le sens de Leopardo, mais impose de mieux formuler la valeur: les acheteurs ne veulent pas "plus de modules", ils veulent moins de dispersion, moins de taches repetitives, une paie fiable, une presence terrain fiable, une experience employe simple et une IA gouvernee.
+
+## 2. Sources marche utilisees
+
+- S&P Global Market Intelligence, HR technology market forecast 2026: le marche reste porte par HCM, employee experience, people analytics et talent intelligence, mais les acheteurs gardent une priorite forte sur les fondamentaux operationnels: cout, conformite et performance workforce. Source: https://www.spglobal.com/market-intelligence/en/news-insights/research/2026/02/hr-tech-market-2025
+- Gartner, AI in HR 2025: l'IA se diffuse dans tout le cycle employe, mais doit etre gouvernee et reliee aux objectifs business. Source: https://www.gartner.com/en/newsroom/press-releases/2025-10-16-ai-in-hr-separate-hype-from-reality-to-achieve-business-goals
+- Gartner Digital Markets, HR software buyer insights 2025: investissements prevus en succession, HR analytics, LMS, talent, WFM/HCM et employee engagement; integrations et IA influencent fortement les achats. Source: https://www.gartner.com/en/digital-markets/insights/hr-software-trends-buyer-insights-2025
+- Deloitte 2025 Global Human Capital Trends: l'IA transforme les organisations mais la valeur vient de l'equilibre humain/technologie, de la capacite a agir et de la redefinition des competences. Source: https://www.deloitte.com/us/en/insights/topics/talent/human-capital-trends.html
+- Nucleus Research, SMB HCM Technology Value Matrix 2026: les PME attendent automatisation, analytics embarques, assistance IA et architectures unifiees autour HCM, paie, finance et workforce management. Source: https://nucleusresearch.com/research/single/smb-hcm-technology-value-matrix-2026/
+- Paycom 2026 HR priorities: les organisations souffrent de workflows repetitifs, de multiples fournisseurs et de donnees HCM fragmentees. Source: https://www.paycom.com/about/press-room/automation-tech-forward-solutions-dominate-hr-priorities-for-2026-paycom-report-reveals/
+
+## 3. Lecture marche
+
+### Ce que le marche achete vraiment
+
+1. Unification: moins d'outils, moins de double saisie, moins de fichiers Excel.
+2. Paie et presence fiables: erreurs de paie, absences et horaires sont des douleurs immediates.
+3. Mobile et self-service: les employes veulent agir sans attendre le RH.
+4. Analytics actionnables: pas seulement des graphiques, mais des alertes et decisions.
+5. Automatisation: workflows repetitifs, approvals, documents, notifications, onboarding.
+6. Conformite: donnees RH, audit, RBAC, pays, paie, RGPD et gouvernance IA.
+7. IA utile mais prudente: assistant RH, analyse anomalies, aide decisionnelle, pas de boite noire.
+
+### Opportunite Leopardo
+
+Leopardo est bien place sur les PME terrain: securite privee, BTP, logistique, restauration, services multi-sites, cabinets qui gerent plusieurs clients. Ces segments ont des douleurs quotidiennes plus fortes que les bureaux classiques: presence, horaires, absences, avances, documents, communication, preuve terrain.
+
+### Risque strategique
+
+Le risque n'est plus seulement technique. Le risque principal est le **positionnement trop large**. "Plateforme RH complete" est une categorie encombrée. "Mobile-First Company OS pour PME terrain" est plus defendable.
+
+## 4. Audit produit a partir du depot
+
+### Forces livrees
+
+- API Laravel multi-tenant avec separation public/tenant.
+- Apps mobiles separees Employee, Manager/RH et Platform Admin.
+- Demo users Render et pages testeur/API Explorer.
+- Presence, pointage GPS/timezone, multi-punch, taches, absences, avances, paie, documents PDF.
+- Notifications, preferences, CommunicationService, FCM et garde runtime anti-ecran noir.
+- Platform admin: login super-admin, creation client, fiche client, subscription, features, health.
+- OpenAPI canonique et documentation `/docs`.
+- Release readiness, observabilite, backup/restore, security docs, RBAC matrix.
+- CI GitHub Actions consideree source de verite.
+
+### Manques critiques pour lancement marche
+
+- Recette appareil physique documentee par version Firebase, modele Android, capture et utilisateur demo.
+- Parcours demo mobile Platform Admin corrige cote UI: le compte demo doit remplir `password123`.
+- Packaging commercial final: offres simples, limites claires, ROI par secteur.
+- Scripts de vente et objections par persona.
+- Preuves de charge p95 et cout par tenant/client.
+- Domaine, emails transactionnels, onboarding commercial et support.
+- IA gouvernee en mode "copilote RH" avec limites, journalisation et consentement.
+- Portail developpeur/sandbox partenaire encore futur.
+
+## 5. Verdict
+
+Leopardo peut etre positionne pour un lancement controle, mais pas encore pour une explosion client sans discipline commerciale et operations. La priorite n'est pas d'ajouter 20 modules; c'est de transformer les modules existants en parcours vendables, mesurables et prouvables.
+
+Score actuel estime:
+
+| Axe | Score |
+|---|---:|
+| Socle technique | 9/10 |
+| Readiness mobile | 8/10 |
+| Readiness API | 9/10 |
+| Readiness operations | 8.5/10 |
+| Positionnement marche | 7/10 |
+| Monétisation | 6.5/10 |
+| Preuves terrain | 6/10 |
+
+Decision: **Go controle pour pilotes payants**, pas encore "scale sans reserve".
+

--- a/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/02_POSITIONNEMENT_ET_MESSAGING.md
+++ b/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/02_POSITIONNEMENT_ET_MESSAGING.md
@@ -1,0 +1,99 @@
+# Positionnement et messaging - Leopardo HR
+
+## Categorie
+
+**Mobile-First Company OS** pour PME terrain.
+
+Alternative courte:
+
+> Le cockpit mobile qui connecte presence, paie, absences, taches, documents, notifications et pilotage RH.
+
+## Promesse centrale
+
+> Leopardo donne a une PME la visibilite et le controle d'une grande entreprise, sans consultant, sans Excel, depuis le mobile.
+
+## Positionnement marche
+
+Leopardo n'est pas:
+
+- un simple outil de pointage;
+- un SIRH desktop adapte au mobile;
+- un ERP lourd;
+- une app de chat interne;
+- une couche IA decorative.
+
+Leopardo est:
+
+- le systeme quotidien de l'entreprise;
+- le lien entre terrain, RH, managers et direction;
+- la preuve operationnelle: qui travaille, ou, sur quoi, avec quel statut;
+- la base qui transforme presence, paie, communication et documents en decisions.
+
+## ICP prioritaire
+
+### ICP 1 - PME terrain multi-sites
+
+- 20 a 250 employes.
+- Managers sur site, RH centralise, direction peu outillee.
+- Secteurs: securite, BTP, logistique, nettoyage, restauration, retail, maintenance.
+- Douleur: absence de visibilite temps reel, paie contestee, paperasse.
+
+### ICP 2 - Cabinet RH/comptable qui gere plusieurs PME
+
+- Besoin de standardiser onboarding, paie, documents et reporting.
+- Valeur: multi-client, preuves, exports et accompagnement.
+
+### ICP 3 - Franchise ou groupe local
+
+- Plusieurs sites, process repetables.
+- Valeur: pilotage central + autonomie locale.
+
+## Messages par persona
+
+### Dirigeant
+
+> Vous ne pilotez plus votre entreprise avec des appels WhatsApp et des fichiers Excel. Leopardo vous montre chaque jour les presences, les alertes, les couts, les documents et les actions importantes.
+
+### RH
+
+> Moins de relances, moins de doubles saisies, moins d'erreurs. Les employes mettent a jour leurs demandes, les managers valident, la paie s'appuie sur des donnees propres.
+
+### Manager terrain
+
+> Vous savez qui est la, qui est en retard, quelle tache est terminee et quelle demande attend votre validation.
+
+### Employe
+
+> Votre espace personnel dans la poche: pointage, absences, bulletins, notifications, documents, demandes et suivi.
+
+### Partenaire integrateur
+
+> Une API documentee, un produit mobile-first et une base multi-tenant pour vendre des offres RH modernes aux PME.
+
+## Pitch 15 secondes
+
+Leopardo HR est un Company OS mobile-first pour PME terrain. Il remplace Excel, WhatsApp et les processus disperses par une app mobile pour employes, managers et administrateurs: presence, absences, paie, documents, notifications et pilotage.
+
+## Pitch 60 secondes
+
+Les PME terrain ont souvent un probleme simple: elles ne savent pas vraiment, en temps reel, qui travaille, ou, sur quelle tache, avec quel impact sur la paie et les operations. Leopardo HR centralise ces donnees dans un Company OS mobile-first. Les employes pointent, demandent leurs absences et consultent leurs documents. Les managers valident, pilotent les equipes et suivent les anomalies. La plateforme admin gere les clients, plans et modules. Le tout est API-first, multi-tenant, documente et pret pour une mise en marche progressive.
+
+## Objections et reponses
+
+| Objection | Reponse |
+|---|---|
+| "On a deja Excel/WhatsApp" | Justement: Leopardo garde la simplicite du mobile mais ajoute preuve, audit, paie et pilotage. |
+| "Un SIRH est trop lourd" | Leopardo commence par les parcours quotidiens: presence, demandes, validations, documents. |
+| "Nos employes ne sont pas tech" | Le produit est mobile-first, role-based et concu pour limiter la formation. |
+| "Et si internet tombe?" | Le lancement ne doit jamais bloquer l'interface; l'offline sync devient une priorite produit. |
+| "L'IA RH est risquee" | Leopardo doit vendre une IA gouvernee: aide, audit, limites, jamais decision opaque. |
+| "Combien de temps pour demarrer?" | Objectif commercial: demo en 15 minutes, pilote en 48h, valeur en 7 jours. |
+
+## Slogan candidates
+
+1. Votre entreprise, enfin visible depuis le terrain.
+2. Le Company OS mobile des PME qui bougent.
+3. Presence, paie, equipes: tout votre terrain dans la poche.
+4. Moins d'Excel. Plus de controle. Depuis le mobile.
+5. Le cockpit RH et operations pour PME terrain.
+

--- a/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/03_DIRECTION_COMMERCIALE_ET_OFFRES.md
+++ b/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/03_DIRECTION_COMMERCIALE_ET_OFFRES.md
@@ -1,0 +1,118 @@
+# Direction commerciale et offres
+
+## Principe
+
+Vendre un resultat, pas une liste de modules.
+
+Resultat promis:
+
+- moins d'erreurs de paie;
+- moins de temps perdu en relances;
+- meilleure visibilite terrain;
+- onboarding plus rapide;
+- pilotage RH/actionnable;
+- conformité et audit.
+
+## Packaging recommande
+
+### Starter Terrain
+
+Pour equipes jusqu'a 25 employes.
+
+- Employee app
+- Presence simple
+- Absences
+- Notifications
+- Documents basiques
+- Support email
+
+Objectif: acquisition et petites PME.
+
+### Growth Company OS
+
+Pour 25 a 150 employes.
+
+- Tout Starter
+- Manager app
+- Taches, horaires, corrections
+- Paie et avances
+- Branding tenant
+- Reporting et launch-readiness
+- Support prioritaire
+
+Objectif: coeur de revenu.
+
+### Scale / Multi-site
+
+Pour 150+ employes, franchises, groupes et cabinets.
+
+- Tout Growth
+- Multi-sites avance
+- Exports comptables
+- API/webhooks
+- SSO/2FA avance
+- SLA, audit et accompagnement
+
+Objectif: comptes plus rentables.
+
+## Motion de vente
+
+### Etape 1 - Diagnostic 20 minutes
+
+Questions:
+
+- Combien d'employes terrain?
+- Comment vous suivez presence/retards aujourd'hui?
+- Combien de temps la paie prend chaque mois?
+- Combien d'erreurs/contestations par mois?
+- Qui valide absences/avances?
+- Combien de sites?
+- Quels outils utilises: Excel, WhatsApp, papier, ERP?
+
+### Etape 2 - Demo role-based
+
+Ne pas montrer tout le produit. Montrer:
+
+1. employe: login, pointage, demande, document;
+2. manager: equipe, validation, anomalie;
+3. dirigeant/RH: dashboard, paie, readiness.
+
+### Etape 3 - Pilote 7 jours
+
+Definition pilote:
+
+- 1 entreprise;
+- 1 manager;
+- 5 a 20 employes;
+- 1 site;
+- pointage + absence + notifications + document;
+- rapport de fin de semaine.
+
+### Etape 4 - Conversion
+
+Critere de conversion:
+
+- au moins 70% des employes invites se connectent;
+- au moins 5 jours de donnees presence;
+- au moins 1 workflow valide;
+- rapport ROI remis au dirigeant.
+
+## KPI business
+
+- Activation: entreprise creee, manager connecte, 5 employes invites.
+- Time-to-value: premier pointage ou premiere demande < 24h.
+- Adoption: WAU employee, WAU manager.
+- Retention: usage semaine 4.
+- Expansion: nouveaux sites/modules.
+- Revenue: MRR, ARPA, churn logo, churn revenue.
+- Support: tickets par tenant, temps resolution.
+
+## Priorites marketing
+
+1. Page "terrain" claire: securite, BTP, logistique.
+2. Demo interactive avec comptes pre-remplis.
+3. Preuves: captures, video courte, rapport pilote.
+4. Offre pilote payant faible friction.
+5. Partenariats cabinets RH/comptables.
+6. Contenu SEO autour pointage, paie, absences, PME terrain.
+

--- a/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/README.md
+++ b/docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/README.md
@@ -1,0 +1,19 @@
+# Leopardo HR - Market Launch 2026
+
+Date: 2026-06-05  
+Objectif: positionner Leopardo HR pour un lancement marche en tant que **Mobile-First Company OS** pour PME terrain.
+
+## Contenu
+
+- `01_AUDIT_MARCHE_ET_PRODUIT.md` : audit croise produit/repo/marche 2026.
+- `02_POSITIONNEMENT_ET_MESSAGING.md` : categorie, promesse, segments, objections, pitchs.
+- `03_DIRECTION_COMMERCIALE_ET_OFFRES.md` : packaging, ICP, canaux, motion de vente.
+
+## Decision strategique
+
+Leopardo ne doit pas se vendre comme un simple logiciel RH. Le marche 2026 valorise les plateformes qui consolident les donnees employes, paie, presence, communication, analytics et automatisation. La categorie a pousser est:
+
+> **Mobile-First Company OS for field and growing SMEs**
+
+Le produit doit promettre une chose simple: rendre l'entreprise visible, pilotable et actionnable depuis le telephone, meme quand les equipes sont sur le terrain.
+

--- a/docs/GOTO_MARKET/README.md
+++ b/docs/GOTO_MARKET/README.md
@@ -62,6 +62,7 @@ Permettre à **n'importe quelle partie prenante** de comprendre en moins de 30 m
 
 | Besoin | Fichier à lire |
 |--------|----------------|
+| Audit marche 2026 et positionnement actualise | [`2026_MARKET_LAUNCH_COMPANY_OS/README.md`](2026_MARKET_LAUNCH_COMPANY_OS/README.md) |
 | Comprendre le projet en 5 min | [`99_EXECUTIVE/READ_FIRST.md`](99_EXECUTIVE/READ_FIRST.md) |
 | Pitch investisseur | [`99_EXECUTIVE/ONE_PAGER.md`](99_EXECUTIVE/ONE_PAGER.md) |
 | Former un commercial | [`04_SALES/SALES_PLAYBOOK.md`](04_SALES/SALES_PLAYBOOK.md) |

--- a/docs/PLAN_ACTION/00_SOMMAIRE.md
+++ b/docs/PLAN_ACTION/00_SOMMAIRE.md
@@ -74,6 +74,7 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 10. **Plan 67** : executer les derniers lots de preuve produit avant marketing : runtime mobile, platform admin, GPS, branding applique, notifications et release readiness.
 11. **Plan 68** : auditer le projet apres cloture Plan 67 : hygiene depot, contrats API/fronts, qualite code pragmatique, operations et prochain plan produit.
 12. **Plan 69** : executer la recette lancement Mobile-First Company OS : apps mobiles reelles, parcours employee/manager/platform admin, paie asynchrone et observabilite.
+13. **Plan 70** : convertir le Go technique en lancement marche 2026 : positionnement, packaging, demo admin mobile, preuves terrain, offres, ROI, IA gouvernee et 72 actions nouvelles.
 
 Chaque plan doit sortir avec son changement code/documentation, ses tests ou preuves CI, une entree `CHANGELOG.md` et, si une lecon durable apparait, une entree `AGENTS.md`.
 

--- a/docs/PLAN_ACTION/70_PLAN_MARKET_LAUNCH_2026_COMPANY_OS.md
+++ b/docs/PLAN_ACTION/70_PLAN_MARKET_LAUNCH_2026_COMPANY_OS.md
@@ -1,0 +1,103 @@
+# Plan 70 - Market Launch 2026 Company OS
+
+Date: 2026-06-05  
+Objectif: transformer Leopardo HR en offre marche vendable, prouvable et scalable apres les Plans 67-69.
+
+## P0 - Bloquants lancement et confiance demo
+
+1. Corriger le mot de passe demo mobile Platform Admin: `password123`, pas `admin`.
+2. Ajouter un garde CI qui bloque tout retour au mauvais mot de passe demo.
+3. Re-distribuer les trois APK Firebase depuis `main` apres correction demo admin.
+4. Rejouer la recette device Employee sur Android reel.
+5. Rejouer la recette device Manager sur Android reel.
+6. Rejouer la recette device Platform Admin sur Android reel.
+7. Documenter appareil, version, SHA, capture et resultat par app.
+8. Produire une video courte de login demo par app.
+9. Valider que chaque app affiche une erreur lisible hors ligne.
+10. Valider que Firebase/FCM indisponible ne bloque aucun lancement.
+11. Valider que backend Render lent ne bloque pas l'ecran login.
+12. Valider que `/api/v1/demo-users` reste accessible en prod.
+13. Ajouter un smoke API quotidien demo employee/manager/platform.
+14. Ajouter un badge README "demo status" ou lien vers rapport smoke.
+15. Mettre a jour le guide testeur avec le bon mot de passe Platform Admin.
+
+## P1 - Parcours vendables
+
+16. Construire un parcours demo "PME securite privee" de bout en bout.
+17. Construire un parcours demo "BTP chantier" de bout en bout.
+18. Construire un parcours demo "logistique multi-sites" de bout en bout.
+19. Ajouter des donnees demo sectorielles dans les seeders.
+20. Ajouter des templates horaires par secteur.
+21. Ajouter des templates taches terrain par secteur.
+22. Ajouter des modeles de politiques absences par pays/secteur.
+23. Ajouter un rapport PDF pilote 7 jours.
+24. Ajouter un export CSV paie/presence pret cabinet.
+25. Ajouter un onboarding manager en 5 etapes dans l'app.
+26. Ajouter un onboarding employee ultra court apres invitation.
+27. Ajouter une checklist super-admin pour creer un client pilote.
+28. Ajouter un ecran "valeur obtenue" apres 7 jours de donnees.
+29. Ajouter un cockpit support demo tenants.
+30. Ajouter un script de reset propre des demos.
+
+## P1 - Go-to-market et monetisation
+
+31. Finaliser les offres Starter, Growth, Scale.
+32. Definir limites par plan: employes, sites, modules, exports, support.
+33. Definir prix tests par region: Maghreb, Afrique de l'Ouest, Europe.
+34. Creer une page pricing orientee ROI.
+35. Creer une page secteur "securite privee".
+36. Creer une page secteur "BTP".
+37. Creer une page secteur "logistique".
+38. Creer un one-pager commercial par secteur.
+39. Creer un script demo 15 minutes.
+40. Creer un script discovery call 20 minutes.
+41. Creer une matrice objections/reponses.
+42. Creer un calculateur ROI simple.
+43. Creer un modele de proposition pilote payant.
+44. Creer une sequence email pilote 14 jours.
+45. Creer une bibliotheque de captures produit.
+
+## P2 - Produit et differenciation 2026
+
+46. Renforcer offline-first: file d'attente locale pour actions critiques.
+47. Ajouter sync status visible dans les apps mobiles.
+48. Ajouter un mode "lecture seule offline" pour documents/profil.
+49. Ajouter alertes anomalies paie/presence.
+50. Ajouter assistant RH gouverne pour questions employees.
+51. Ajouter journal d'audit IA et refus de decision opaque.
+52. Ajouter politique IA par tenant.
+53. Ajouter analytics adoption employe/manager.
+54. Ajouter score de readiness par tenant dans platform admin mobile.
+55. Ajouter exports comptables locaux prioritaires.
+56. Ajouter webhooks signes production.
+57. Ajouter portail developpeur sandbox.
+58. Ajouter tokens API partenaires scopes.
+59. Ajouter examples SDK pour workflows sectoriels.
+60. Ajouter support mobile money en discovery technique.
+
+## P2 - Operations scale
+
+61. Etendre k6 aux endpoints authentifies critiques.
+62. Publier p95/p99 par endpoint critique.
+63. Mesurer cout par tenant Render/Firebase/DB.
+64. Ajouter alertes budget Firebase.
+65. Ajouter runbook incident mobile distribution.
+66. Ajouter runbook reset demo production.
+67. Ajouter dashboard support "tenant stuck".
+68. Ajouter verification migrations tenant avant onboarding client.
+69. Ajouter test restore backup mensuel visible dans rapport client.
+
+## P3 - Expansion
+
+70. Preparer marketplace open-core partenaires.
+71. Preparer white-label par cabinet.
+72. Preparer programme revendeurs/integrateurs.
+
+## Critere de cloture Plan 70
+
+- Demo admin mobile corrigee et prouvee.
+- Les trois apps ont une recette device datee.
+- Une offre commerciale claire existe.
+- Trois secteurs cibles ont un parcours demo et un message dedie.
+- Les KPI activation/adoption/revenue sont mesurables.
+

--- a/docs/validation/MARKET_LAUNCH_AUDIT_2026_06_05.md
+++ b/docs/validation/MARKET_LAUNCH_AUDIT_2026_06_05.md
@@ -1,0 +1,52 @@
+# Market launch audit - 2026-06-05
+
+## Decision
+
+**Go pilote payant controle. No-go scale massif sans recette device et packaging final.**
+
+## Observations
+
+- Le depot est techniquement avance: API, mobile multi-app, platform admin, docs, CI, OpenAPI, readiness.
+- Le marche 2026 favorise consolidation, automatisation, analytics, experience employe et IA gouvernee.
+- Le positionnement doit eviter "SIRH complet" et pousser "Mobile-First Company OS".
+- Le dernier bug concret trouve pendant cet audit est le bouton demo Platform Admin mobile: il remplissait `admin` au lieu de `password123`.
+
+## Corrections realisees dans ce lot
+
+- `front/mobile_apps/leopardo_platform_admin/lib/src/features/auth/platform_login_screen.dart`: compte demo corrige avec `password123`.
+- `dev-hub/tools/validate-mobile-plan29.ps1`: garde CI contre retour du mauvais mot de passe.
+- `front/mobile_apps/leopardo_platform_admin/README.md`: credentials demo documentes.
+- Nouveau dossier go-to-market 2026.
+- Nouveau dossier contexte IA.
+- Nouveau Plan 70 avec 72 actions.
+
+## Validation API Render
+
+Commande smoke PowerShell:
+
+- `GET https://gestionemployerbackend.onrender.com/api/v1/demo-users`
+- `POST https://gestionemployerbackend.onrender.com/api/v1/platform/auth/login`
+- `GET https://gestionemployerbackend.onrender.com/api/v1/platform/auth/me`
+
+Resultat:
+
+- demo-users: `200`
+- platform login: `200`
+- token recu: oui
+- platform auth me: `200`
+- compte: `admin@leopardo-rh.com`
+- `two_fa_enabled=false`
+
+## Score
+
+| Axe | Score |
+|---|---:|
+| Technique backend/API | 9/10 |
+| Mobile runtime | 8.5/10 |
+| Platform admin demo | 9/10 apres correction code |
+| Go-to-market clarity | 8/10 apres nouveau dossier |
+| Preuves terrain | 6/10 |
+| Scale readiness | 7.5/10 |
+
+Score global: **82/100 pour lancement pilote payant**, **pas encore production massive sans reserve**.
+

--- a/front/mobile_apps/leopardo_platform_admin/README.md
+++ b/front/mobile_apps/leopardo_platform_admin/README.md
@@ -13,6 +13,7 @@ Application Flutter reservee aux super-admins Leopardo RH. Elle administre la pl
 ## Perimetre Plan 29
 
 - Connexion super-admin via `/platform/auth/login`
+- Compte demo Render : `admin@leopardo-rh.com` / `password123`
 - Hydratation session via `/platform/auth/me`
 - Deconnexion via `/platform/auth/logout`
 - Cockpit metriques via `/platform/metrics/overview`

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/auth/platform_login_screen.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/auth/platform_login_screen.dart
@@ -22,7 +22,7 @@ class _PlatformLoginScreenState extends ConsumerState<PlatformLoginScreen> {
 
   void _fillDemoAccount() {
     _emailController.text = 'admin@leopardo-rh.com';
-    _passwordController.text = 'admin';
+    _passwordController.text = 'password123';
     _twoFactorController.clear();
   }
 


### PR DESCRIPTION
## Summary
- add 2026 market launch go-to-market dossier with product/market audit, positioning, messaging, commercial direction and sources
- add Plan 70 with 72 new launch-market actions
- add docs/CONTEXT onboarding pack for future AI agents
- fix Platform Admin mobile demo autofill password to password123 and guard it in Plan 29 validation

## Validation
- powershell -ExecutionPolicy Bypass -File dev-hub/tools/validate-mobile-plan29.ps1
- powershell -ExecutionPolicy Bypass -File dev-hub/tools/validate-mobile-runtime-smoke.ps1
- Render smoke: POST /api/v1/platform/auth/login + GET /api/v1/platform/auth/me with admin@leopardo-rh.com/password123
- git diff --check