### PR TITLE
feat: harden platform admin company provisioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-05 (v4.16.249)
+Derniere mise a jour : 2026-06-06 (v4.16.250)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -90,6 +90,9 @@ Depuis la session du 2026-05-06, la meilleure strategie est d'utiliser GitHub Ac
 - Le guide de deploiement canonique des workers est `DEPLOYMENT_GUIDE.md` a la racine. Toute evolution queue/scheduler/Render Worker doit y etre reportee, surtout pour les jobs paie PDF et commandes planifiees.
 - La matrice frontend/API canonique vit dans `docs/validation/FRONTEND_API_CONTRACT_MATRIX.md`. Toute nouvelle dependance admin/mobile/kiosk a une route Laravel doit ajouter la ligne matrice et, au minimum, un garde dans `FrontendApiContractTest`.
 - Depuis v4.16.154, le Plan 30 API hardening vit dans `docs/PLAN_ACTION/30_PLAN_API_WORKFLOW_HARDENING.md`. `POST /api/v1/platform/companies` doit rester compatible avec le payload minimal de `leopardo_platform_admin` (name, email, country, city, manager names/email) en resolvant cote serveur `sector`, `plan_id`, `language`, `currency` et `timezone`. Ne pas rendre `sector` ou `plan_id` obligatoires sans adapter l'app mobile et les tests.
+- Depuis v4.16.250, la creation platform admin multi-pays passe par `App\Support\CountryDefaults`. Ne plus coder `DZD`, `Africa/Algiers` ou `fr` comme defaults universels dans `POST /api/v1/platform/companies` ou dans l'app `leopardo_platform_admin`; si un pays est ajoute cote mobile, ajouter aussi son mapping backend et le couvrir par test ou audit.
+- Depuis v4.16.250, `api/composer.json` cible `laravel/framework:^12.60` afin de rester hors advisory `CVE-2026-48019`. Ne pas redescendre sur Laravel 11 sans verifier `composer audit --locked --no-dev` et les compatibilites Sanctum/Pest/Sentry.
+- Depuis v4.16.250, la migration publique `2026_05_02_100001_create_users_and_company_requests_tables.php` doit reconciler explicitement `public.company_requests` sur PostgreSQL avec `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Ne pas remplacer ce garde par de simples `Schema::hasColumn()` : l'ancienne table `employee_id` peut deja exister et les flux user/company-request modernes ont besoin de `user_id`.
 - Depuis v4.16.189, les retours testeurs produit 31-44 sont formalises dans `docs/PLAN_ACTION/57_PLAN_API_DOCS_ECOSYSTEME_DEVELOPPEUR.md` a `65_PLAN_PAIEMENT_MASSE_SIGNATURE_NUMERIQUE.md`. Avant de coder ces chantiers, choisir le plan concerne, livrer ses lots dans l'ordre, mettre a jour `00_SOMMAIRE.md` si un nouveau plan est ajoute, puis pousser via PR pour garder la mission lisible.
 - Depuis v4.16.216, les plans 01-66 sont consideres comme historiques executes ou cartographies. Avant de rouvrir un ancien sujet, consulter `docs/validation/PLAN_ACTION_COVERAGE_MATRIX_2026_06_01.md`; les derniers lots de lancement doivent etre rattaches a `docs/PLAN_ACTION/67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md` sauf besoin clairement hors perimetre.
 - Les decisions d'architecture structurantes vivent dans `docs/architecture/adr/`, le diagramme C4 dans `docs/architecture/C4_ARCHITECTURE.md`, et le point d'entree operations dans `docs/GESTION_PROJET/RUNBOOK_OPERATIONS.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 # Format : Keep a Changelog (keepachangelog.com)
 # Versioning : Semantic Versioning (semver.org)
 
+## [4.16.250] - 2026-06-06
+
+### Added
+
+- Plan 71 : cadrage go-to-market admin plateforme, multi-pays, i18n, vitrine essai, kiosk et audit commercial-technique.
+- Audit go-to-market 2026-06-06 avec verdict pilote, risques et priorites commerciales/techniques.
+- Backend : ajout de `CountryDefaults` pour deriver langue, devise et timezone a partir du pays lors du provisioning plateforme.
+
+### Changed
+
+- App mobile platform admin : le formulaire de creation client propose un choix pays controle, affiche devise/timezone/langue, et permet de creer un client en essai ou actif.
+- API platform : `POST /api/v1/platform/companies` accepte maintenant `status=trial|active` et ne force plus DZD/Africa-Algiers quand le pays indique une autre devise.
+- OpenAPI et contrat mobile platform admin alignes avec le nouveau provisioning multi-pays.
+- Migrations publiques : la reconciliation `company_requests` garantit explicitement les colonnes modernes (`user_id`, contact, review) sur PostgreSQL public quand l'ancienne table `employee_id` existe deja.
+- Securite backend : mise a jour de `laravel/framework` vers `^12.60` / `v12.61.1` pour lever l'advisory Composer `CVE-2026-48019`.
+
 ## [4.16.249] - 2026-06-05
 
 ### Added

--- a/api/app/Http/Controllers/Web/PlatformCompanyController.php
+++ b/api/app/Http/Controllers/Web/PlatformCompanyController.php
@@ -8,6 +8,7 @@ use App\Models\Employee;
 use App\Models\SuperAdmin;
 use App\Services\CompanyProvisioningService;
 use App\Services\UserInvitationService;
+use App\Support\CountryDefaults;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -107,6 +108,7 @@ class PlatformCompanyController extends Controller
             'language' => ['nullable', 'string', 'size:2'],
             'timezone' => ['nullable', 'string', 'max:50'],
             'currency' => ['nullable', 'string', 'size:3'],
+            'status' => ['nullable', Rule::in(['active', 'trial'])],
             'notes' => ['nullable', 'string', 'max:1000'],
             'manager_first_name' => ['required', 'string', 'max:100'],
             'manager_last_name' => ['required', 'string', 'max:100'],
@@ -115,10 +117,12 @@ class PlatformCompanyController extends Controller
         ]);
 
         $validated['sector'] = trim((string) ($validated['sector'] ?? '')) ?: 'Non precise';
-        $validated['country'] = strtoupper($validated['country']);
-        $validated['language'] = strtolower($validated['language'] ?? 'fr');
-        $validated['currency'] = strtoupper($validated['currency'] ?? 'DZD');
-        $validated['timezone'] = $validated['timezone'] ?? 'Africa/Algiers';
+        $countryDefaults = CountryDefaults::for($validated['country']);
+        $validated['country'] = $countryDefaults['country'];
+        $validated['language'] = strtolower($validated['language'] ?? $countryDefaults['language']);
+        $validated['currency'] = strtoupper($validated['currency'] ?? $countryDefaults['currency']);
+        $validated['timezone'] = $validated['timezone'] ?? $countryDefaults['timezone'];
+        $validated['status'] = $validated['status'] ?? 'trial';
         $validated['plan_id'] = $validated['plan_id']
             ?? DB::table('plans')->where('is_active', true)->orderBy('id')->value('id')
             ?? DB::table('plans')->orderBy('id')->value('id');

--- a/api/app/Services/CompanyProvisioningService.php
+++ b/api/app/Services/CompanyProvisioningService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Company;
 use App\Models\Employee;
 use App\Models\SuperAdmin;
+use App\Support\CountryDefaults;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -20,6 +21,12 @@ class CompanyProvisioningService
      */
     public function provisionSharedCompany(array $payload, SuperAdmin $superAdmin): array
     {
+        $countryDefaults = CountryDefaults::for($payload['country'] ?? null);
+        $payload['country'] = $countryDefaults['country'];
+        $payload['language'] = strtolower((string) ($payload['language'] ?? $countryDefaults['language']));
+        $payload['currency'] = strtoupper((string) ($payload['currency'] ?? $countryDefaults['currency']));
+        $payload['timezone'] = $payload['timezone'] ?? $countryDefaults['timezone'];
+
         $result = DB::transaction(function () use ($payload): array {
             $plan = DB::table('plans')->where('id', $payload['plan_id'])->first();
             $trialDays = (int) ($plan->trial_days ?? 14);
@@ -29,7 +36,7 @@ class CompanyProvisioningService
                 'name' => $payload['name'],
                 'slug' => $slug,
                 'sector' => $payload['sector'],
-                'country' => strtoupper($payload['country']),
+                'country' => $payload['country'],
                 'city' => $payload['city'],
                 'address' => $payload['address'] ?? null,
                 'email' => $payload['email'],
@@ -40,9 +47,9 @@ class CompanyProvisioningService
                 'status' => $payload['status'] ?? 'trial',
                 'subscription_start' => $payload['subscription_start'] ?? now()->toDateString(),
                 'subscription_end' => $payload['subscription_end'] ?? now()->addDays($trialDays)->toDateString(),
-                'language' => $payload['language'] ?? 'fr',
-                'timezone' => $payload['timezone'] ?? 'Africa/Algiers',
-                'currency' => $payload['currency'] ?? 'DZD',
+                'language' => $payload['language'],
+                'timezone' => $payload['timezone'],
+                'currency' => $payload['currency'],
                 'notes' => $payload['notes'] ?? null,
             ]);
 

--- a/api/app/Support/CountryDefaults.php
+++ b/api/app/Support/CountryDefaults.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Support;
+
+final class CountryDefaults
+{
+    /**
+     * @var array<string, array{label: string, language: string, currency: string, timezone: string}>
+     */
+    private const DEFAULTS = [
+        'DZ' => ['label' => 'Algerie', 'language' => 'fr', 'currency' => 'DZD', 'timezone' => 'Africa/Algiers'],
+        'MA' => ['label' => 'Maroc', 'language' => 'fr', 'currency' => 'MAD', 'timezone' => 'Africa/Casablanca'],
+        'TN' => ['label' => 'Tunisie', 'language' => 'fr', 'currency' => 'TND', 'timezone' => 'Africa/Tunis'],
+        'SN' => ['label' => 'Senegal', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Dakar'],
+        'CI' => ['label' => 'Cote d Ivoire', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Abidjan'],
+        'ML' => ['label' => 'Mali', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Bamako'],
+        'BF' => ['label' => 'Burkina Faso', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Ouagadougou'],
+        'BJ' => ['label' => 'Benin', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Porto-Novo'],
+        'TG' => ['label' => 'Togo', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Lome'],
+        'NE' => ['label' => 'Niger', 'language' => 'fr', 'currency' => 'XOF', 'timezone' => 'Africa/Niamey'],
+        'CM' => ['label' => 'Cameroun', 'language' => 'fr', 'currency' => 'XAF', 'timezone' => 'Africa/Douala'],
+        'GA' => ['label' => 'Gabon', 'language' => 'fr', 'currency' => 'XAF', 'timezone' => 'Africa/Libreville'],
+        'CG' => ['label' => 'Congo', 'language' => 'fr', 'currency' => 'XAF', 'timezone' => 'Africa/Brazzaville'],
+        'TD' => ['label' => 'Tchad', 'language' => 'fr', 'currency' => 'XAF', 'timezone' => 'Africa/Ndjamena'],
+        'FR' => ['label' => 'France', 'language' => 'fr', 'currency' => 'EUR', 'timezone' => 'Europe/Paris'],
+        'TR' => ['label' => 'Turquie', 'language' => 'tr', 'currency' => 'TRY', 'timezone' => 'Europe/Istanbul'],
+        'GB' => ['label' => 'Royaume-Uni', 'language' => 'en', 'currency' => 'GBP', 'timezone' => 'Europe/London'],
+        'US' => ['label' => 'Etats-Unis', 'language' => 'en', 'currency' => 'USD', 'timezone' => 'America/New_York'],
+    ];
+
+    /**
+     * @return array{country: string, label: string, language: string, currency: string, timezone: string}
+     */
+    public static function for(?string $country): array
+    {
+        $code = strtoupper(trim((string) $country));
+        if ($code === '' || ! isset(self::DEFAULTS[$code])) {
+            $code = 'DZ';
+        }
+
+        return [
+            'country' => $code,
+            ...self::DEFAULTS[$code],
+        ];
+    }
+
+    /**
+     * @return array<int, array{country: string, label: string, language: string, currency: string, timezone: string}>
+     */
+    public static function all(): array
+    {
+        return array_map(
+            fn (string $code, array $defaults): array => ['country' => $code, ...$defaults],
+            array_keys(self::DEFAULTS),
+            self::DEFAULTS,
+        );
+    }
+}

--- a/api/composer.json
+++ b/api/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.2",
         "barryvdh/laravel-dompdf": "^3.1",
-        "laravel/framework": "^11.31",
+        "laravel/framework": "^12.60",
         "laravel/sanctum": "^4.3",
         "laravel/socialite": "^5.27",
         "laravel/tinker": "^2.9",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be1cb8e31e0f200554953a1e018122d4",
+    "content-hash": "5844f183457c295e88d804a7fc827673",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -939,25 +939,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
+                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -966,8 +967,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.4",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1045,7 +1047,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
             },
             "funding": [
                 {
@@ -1061,28 +1063,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-02T12:40:51+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1128,7 +1131,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -1144,27 +1147,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1172,9 +1177,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1245,7 +1250,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -1261,20 +1266,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
                 "shasum": ""
             },
             "require": {
@@ -1283,7 +1288,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1331,7 +1336,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
             },
             "funding": [
                 {
@@ -1347,7 +1352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-05-23T22:00:21+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -1411,20 +1416,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.51.0",
+            "version": "v12.61.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c8f9a04594b7044a189a3194cfb3594251eb74e5"
+                "reference": "e8472ca9774452fe50841d9bdced060679f4d58d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c8f9a04594b7044a189a3194cfb3594251eb74e5",
-                "reference": "c8f9a04594b7044a189a3194cfb3594251eb74e5",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e8472ca9774452fe50841d9bdced060679f4d58d",
+                "reference": "e8472ca9774452fe50841d9bdced060679f4d58d",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12|^0.13|^0.14",
+                "brick/math": "^0.11|^0.12|^0.13|^0.14",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -1439,32 +1444,34 @@
                 "fruitcake/php-cors": "^1.3",
                 "guzzlehttp/guzzle": "^7.8.2",
                 "guzzlehttp/uri-template": "^1.0",
-                "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",
+                "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
                 "monolog/monolog": "^3.0",
-                "nesbot/carbon": "^2.72.6|^3.8.4",
+                "nesbot/carbon": "^3.8.4",
                 "nunomaduro/termwind": "^2.0",
                 "php": "^8.2",
                 "psr/container": "^1.1.1|^2.0.1",
                 "psr/log": "^1.0|^2.0|^3.0",
                 "psr/simple-cache": "^1.0|^2.0|^3.0",
                 "ramsey/uuid": "^4.7",
-                "symfony/console": "^7.0.3",
-                "symfony/error-handler": "^7.0.3",
-                "symfony/finder": "^7.0.3",
+                "symfony/console": "^7.2.0",
+                "symfony/error-handler": "^7.2.0",
+                "symfony/finder": "^7.2.0",
                 "symfony/http-foundation": "^7.2.0",
-                "symfony/http-kernel": "^7.0.3",
-                "symfony/mailer": "^7.0.3",
-                "symfony/mime": "^7.0.3",
-                "symfony/polyfill-php83": "^1.31",
-                "symfony/process": "^7.0.3",
-                "symfony/routing": "^7.0.3",
-                "symfony/uid": "^7.0.3",
-                "symfony/var-dumper": "^7.0.3",
+                "symfony/http-kernel": "^7.2.0",
+                "symfony/mailer": "^7.2.0",
+                "symfony/mime": "^7.2.0",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php84": "^1.34",
+                "symfony/polyfill-php85": "^1.34",
+                "symfony/process": "^7.2.0",
+                "symfony/routing": "^7.2.0",
+                "symfony/uid": "^7.2.0",
+                "symfony/var-dumper": "^7.2.0",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.5",
                 "vlucas/phpdotenv": "^5.6.1",
                 "voku/portable-ascii": "^2.0.2"
@@ -1496,6 +1503,7 @@
                 "illuminate/filesystem": "self.version",
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
+                "illuminate/json-schema": "self.version",
                 "illuminate/log": "self.version",
                 "illuminate/macroable": "self.version",
                 "illuminate/mail": "self.version",
@@ -1505,6 +1513,7 @@
                 "illuminate/process": "self.version",
                 "illuminate/queue": "self.version",
                 "illuminate/redis": "self.version",
+                "illuminate/reflection": "self.version",
                 "illuminate/routing": "self.version",
                 "illuminate/session": "self.version",
                 "illuminate/support": "self.version",
@@ -1528,17 +1537,18 @@
                 "league/flysystem-read-only": "^3.25.1",
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^9.18.0",
-                "pda/pheanstalk": "^5.0.6",
+                "opis/json-schema": "^2.4.1",
+                "orchestra/testbench-core": "^10.9.0",
+                "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
-                "phpstan/phpstan": "2.1.41",
-                "phpunit/phpunit": "^10.5.35|^11.3.6|^12.0.1",
-                "predis/predis": "^2.3",
-                "resend/resend-php": "^0.10.0",
-                "symfony/cache": "^7.0.3",
-                "symfony/http-client": "^7.0.3",
-                "symfony/psr-http-message-bridge": "^7.0.3",
-                "symfony/translation": "^7.0.3"
+                "phpstan/phpstan": "^2.1.41",
+                "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
+                "predis/predis": "^2.3|^3.0",
+                "resend/resend-php": "^0.10.0|^1.0",
+                "symfony/cache": "^7.2.0",
+                "symfony/http-client": "^7.2.0",
+                "symfony/psr-http-message-bridge": "^7.2.0",
+                "symfony/translation": "^7.2.0"
             },
             "suggest": {
                 "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
@@ -1553,7 +1563,7 @@
                 "ext-pdo": "Required to use all database features.",
                 "ext-posix": "Required to use all features of the queue worker.",
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0|^6.0).",
-                "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
+                "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
@@ -1564,22 +1574,22 @@
                 "mockery/mockery": "Required to use mocking (^1.6).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^5.0).",
                 "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
-                "phpunit/phpunit": "Required to use assertions and run tests (^10.5.35|^11.3.6|^12.0.1).",
-                "predis/predis": "Required to use the predis connector (^2.3).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^10.5.35|^11.5.3|^12.0.1).",
+                "predis/predis": "Required to use the predis connector (^2.3|^3.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^7.0).",
-                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.0).",
-                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.0).",
-                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.0).",
-                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.0).",
-                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.0)."
+                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0|^1.0).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^7.2).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
+                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.2).",
+                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.2).",
+                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.2).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.2)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "12.x-dev"
                 }
             },
             "autoload": {
@@ -1590,6 +1600,7 @@
                     "src/Illuminate/Filesystem/functions.php",
                     "src/Illuminate/Foundation/helpers.php",
                     "src/Illuminate/Log/functions.php",
+                    "src/Illuminate/Reflection/helpers.php",
                     "src/Illuminate/Support/functions.php",
                     "src/Illuminate/Support/helpers.php"
                 ],
@@ -1598,7 +1609,8 @@
                     "Illuminate\\Support\\": [
                         "src/Illuminate/Macroable/",
                         "src/Illuminate/Collections/",
-                        "src/Illuminate/Conditionable/"
+                        "src/Illuminate/Conditionable/",
+                        "src/Illuminate/Reflection/"
                     ]
                 }
             },
@@ -1622,20 +1634,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-03-26T14:54:53+00:00"
+            "time": "2026-06-04T14:22:52+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.16",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "11e7d5f93803a2190b00e145142cb00a33d17ad2"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/11e7d5f93803a2190b00e145142cb00a33d17ad2",
-                "reference": "11e7d5f93803a2190b00e145142cb00a33d17ad2",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -1679,9 +1691,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.16"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-03-23T14:35:33+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -1748,16 +1760,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.10",
+            "version": "v2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669"
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/870fc81d2f879903dfc5b60bf8a0f94a1609e669",
-                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
                 "shasum": ""
             },
             "require": {
@@ -1805,7 +1817,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-02-20T19:59:49+00:00"
+            "time": "2026-04-16T14:03:50+00:00"
         },
         {
             "name": "laravel/socialite",
@@ -2136,16 +2148,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.33.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "570b8871e0ce693764434b29154c54b434905350"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/570b8871e0ce693764434b29154c54b434905350",
-                "reference": "570b8871e0ce693764434b29154c54b434905350",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -2213,9 +2225,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.33.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-03-25T07:59:30+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2752,16 +2764,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.3",
+            "version": "3.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf"
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6a7e652845bb018c668220c2a545aded8594fbbf",
-                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
                 "shasum": ""
             },
             "require": {
@@ -2853,7 +2865,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-11T17:23:39+00:00"
+            "time": "2026-04-07T09:57:54+00:00"
         },
         {
             "name": "nette/schema",
@@ -2924,16 +2936,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -3009,9 +3021,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4558,20 +4570,20 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/b55a638b189a6faa875e0ccdb00908fb87af95b3",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/clock": "^1.0"
             },
             "provide": {
@@ -4611,7 +4623,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.0.8"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4631,7 +4643,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
@@ -4639,12 +4651,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -4709,7 +4721,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.8"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4729,24 +4741,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:54:39+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "8db1c00226a94d8ab6aa89d9224eeee91e2ea2ed"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/8db1c00226a94d8ab6aa89d9224eeee91e2ea2ed",
-                "reference": "8db1c00226a94d8ab6aa89d9224eeee91e2ea2ed",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -4778,7 +4790,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.0.8"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4798,7 +4810,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4955,20 +4967,21 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.0.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -5016,7 +5029,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5036,7 +5049,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5274,12 +5287,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "7922b53e70d2ba2027af8bb6a59d91eb3541ea4d"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7922b53e70d2ba2027af8bb6a59d91eb3541ea4d",
-                "reference": "7922b53e70d2ba2027af8bb6a59d91eb3541ea4d",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -5365,7 +5378,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.12"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5385,7 +5398,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T09:27:11+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -5473,16 +5486,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.12",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "b198dd66c211c97119bcaaff7c13431dbbb5e470"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/b198dd66c211c97119bcaaff7c13431dbbb5e470",
-                "reference": "b198dd66c211c97119bcaaff7c13431dbbb5e470",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -5538,7 +5551,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.12"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5558,7 +5571,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -5716,16 +5729,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -5774,7 +5787,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5794,7 +5807,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -5885,16 +5898,16 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -5946,7 +5959,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5966,20 +5979,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -6031,7 +6044,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6051,7 +6064,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -6139,16 +6152,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -6195,7 +6208,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6215,20 +6228,100 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
-            "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php85",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php85.git",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -6275,7 +6368,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6295,20 +6388,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -6358,7 +6451,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6378,20 +6471,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -6423,7 +6516,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6443,7 +6536,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -6706,20 +6799,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -6772,7 +6865,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.8"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6792,24 +6885,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "27c03ae3940de24ba2f71cfdbac824f2aa1fdf2f"
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/27c03ae3940de24ba2f71cfdbac824f2aa1fdf2f",
-                "reference": "27c03ae3940de24ba2f71cfdbac824f2aa1fdf2f",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation-contracts": "^3.6.1"
             },
@@ -6865,7 +6958,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.8"
+                "source": "https://github.com/symfony/translation/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6885,20 +6978,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -6911,7 +7004,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6947,7 +7040,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6967,20 +7060,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "6883ebdf7bf6a12b37519dbc0df62b0222401b56"
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/6883ebdf7bf6a12b37519dbc0df62b0222401b56",
-                "reference": "6883ebdf7bf6a12b37519dbc0df62b0222401b56",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
                 "shasum": ""
             },
             "require": {
@@ -7025,7 +7118,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.8"
+                "source": "https://github.com/symfony/uid/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -7045,7 +7138,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-04-30T15:19:22+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -7418,23 +7511,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -7464,7 +7557,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -7488,7 +7581,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
@@ -10932,16 +11025,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.6",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
                 "shasum": ""
             },
             "require": {
@@ -10957,7 +11050,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -10988,9 +11085,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
             },
-            "time": "2026-02-27T10:28:38+00:00"
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "aliases": [],

--- a/api/database/migrations/public/2026_05_02_100001_create_users_and_company_requests_tables.php
+++ b/api/database/migrations/public/2026_05_02_100001_create_users_and_company_requests_tables.php
@@ -92,6 +92,8 @@ return new class extends Migration
             }
         }
 
+        $this->reconcileCompanyRequestsTable();
+
         $this->createTableIfMissing('user_employee_links', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
@@ -127,6 +129,40 @@ return new class extends Migration
 
             throw $exception;
         }
+    }
+
+    private function reconcileCompanyRequestsTable(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        if (! DB::scalar("SELECT to_regclass('public.company_requests') IS NOT NULL")) {
+            return;
+        }
+
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS user_id BIGINT NULL');
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS email VARCHAR(255) NULL');
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS phone VARCHAR(255) NULL');
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS description TEXT NULL');
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS approved_company_id UUID NULL');
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS admin_notes TEXT NULL');
+        DB::statement('ALTER TABLE public.company_requests ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMP(0) WITHOUT TIME ZONE NULL');
+        DB::statement(<<<'SQL'
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'company_requests'
+          AND column_name = 'employee_id'
+    ) THEN
+        ALTER TABLE public.company_requests ALTER COLUMN employee_id DROP NOT NULL;
+    END IF;
+END $$;
+SQL);
+        DB::statement('CREATE INDEX IF NOT EXISTS company_requests_user_id_index ON public.company_requests (user_id)');
     }
 
     private function isDuplicateTableRace(QueryException $exception, string $table): bool

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9238,6 +9238,7 @@ components:
           type: string
           minLength: 2
           maxLength: 2
+          description: "ISO 3166-1 alpha-2. Defaults for language, currency and timezone are derived server-side when omitted."
         city:
           type: string
         address:
@@ -9255,6 +9256,12 @@ components:
           type: string
         currency:
           type: string
+          description: "Optional. If omitted, derived from country, e.g. DZ/DZD, SN/XOF, CM/XAF, FR/EUR, TR/TRY."
+        status:
+          type: string
+          enum: ["trial", "active"]
+          default: "trial"
+          description: "Initial platform status. Mobile platform admin can create a trial client or activate it immediately."
         notes:
           type: string
         manager_first_name:

--- a/api/tests/Feature/AuthSelfRegistrationTest.php
+++ b/api/tests/Feature/AuthSelfRegistrationTest.php
@@ -18,16 +18,23 @@ class AuthSelfRegistrationTest extends TestCase
         if (! Schema::hasTable('company_requests')) {
             Schema::create('company_requests', function ($table) {
                 $table->increments('id');
-                $table->unsignedInteger('employee_id');
+                $table->unsignedBigInteger('user_id')->nullable()->index();
+                $table->unsignedInteger('employee_id')->nullable();
                 $table->string('company_name');
-                $table->string('sector');
-                $table->char('country', 2);
-                $table->string('city');
-                $table->string('manager_name');
+                $table->string('sector')->nullable();
+                $table->char('country', 2)->nullable();
+                $table->string('city')->nullable();
+                $table->string('email')->nullable();
+                $table->string('phone')->nullable();
+                $table->text('description')->nullable();
+                $table->string('manager_name')->nullable();
                 $table->string('manager_id_card')->nullable();
                 $table->string('manager_phone')->nullable();
                 $table->text('notes')->nullable();
                 $table->string('status')->default('pending');
+                $table->uuid('approved_company_id')->nullable();
+                $table->text('admin_notes')->nullable();
+                $table->timestamp('reviewed_at')->nullable();
                 $table->timestamps();
             });
         }

--- a/api/tests/Feature/PlatformCompanyProvisioningTest.php
+++ b/api/tests/Feature/PlatformCompanyProvisioningTest.php
@@ -119,29 +119,34 @@ class PlatformCompanyProvisioningTest extends TestCase
             ->actingAs($superAdmin, 'super_admin_api')
             ->postJson('/api/v1/platform/companies', [
                 'name' => 'Mobile Client',
-                'country' => 'dz',
-                'city' => 'Alger',
-                'email' => 'contact@mobile-client.dz',
+                'country' => 'sn',
+                'city' => 'Dakar',
+                'email' => 'contact@mobile-client.sn',
+                'status' => 'active',
                 'manager_first_name' => 'Amina',
                 'manager_last_name' => 'Rahmani',
-                'manager_email' => 'amina.rahmani@mobile-client.dz',
+                'manager_email' => 'amina.rahmani@mobile-client.sn',
             ]);
 
         $response->assertCreated()
             ->assertJsonPath('data.company.name', 'Mobile Client')
             ->assertJsonPath('data.company.sector', 'Non precise')
-            ->assertJsonPath('data.company.country', 'DZ')
+            ->assertJsonPath('data.company.country', 'SN')
             ->assertJsonPath('data.company.plan_id', 7)
-            ->assertJsonPath('data.company.currency', 'DZD')
-            ->assertJsonPath('data.company.timezone', 'Africa/Algiers')
-            ->assertJsonPath('data.manager.email', 'amina.rahmani@mobile-client.dz');
+            ->assertJsonPath('data.company.currency', 'XOF')
+            ->assertJsonPath('data.company.timezone', 'Africa/Dakar')
+            ->assertJsonPath('data.company.status', 'active')
+            ->assertJsonPath('data.manager.email', 'amina.rahmani@mobile-client.sn');
 
         DB::statement('SET search_path TO public');
 
         $this->assertDatabaseHas('companies', [
             'name' => 'Mobile Client',
             'sector' => 'Non precise',
-            'country' => 'DZ',
+            'country' => 'SN',
+            'currency' => 'XOF',
+            'timezone' => 'Africa/Dakar',
+            'status' => 'active',
             'plan_id' => 7,
         ]);
     }

--- a/dev-hub/tools/mobile-workflow-contracts.json
+++ b/dev-hub/tools/mobile-workflow-contracts.json
@@ -243,7 +243,7 @@
             "lib/src/features/companies/company_create_screen.dart",
             "lib/src/features/companies/company_detail_screen.dart"
           ],
-          "sourceTokens": ["context.push('/platform/companies')", "context.push('/platform/companies/new')", "Uri.encodeComponent(company.id)", "createCompany", "Creer le client", "companyHealth", "companySubscription", "companyFeatures", "plans", "updateCompanySubscription", "updateCompanyFeatures", "Modifier abonnement", "Modifier modules"]
+          "sourceTokens": ["context.push('/platform/companies')", "context.push('/platform/companies/new')", "Uri.encodeComponent(company.id)", "createCompany", "Creer le client", "Pays du client", "Activer immediatement", "companyHealth", "companySubscription", "companyFeatures", "plans", "updateCompanySubscription", "updateCompanyFeatures", "Modifier abonnement", "Modifier modules"]
         },
         {
           "name": "platform_company_requests",

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -67,6 +67,8 @@ Note 2026-06-01 : le Plan 67.5 fige la preuve notifications mobile production. L
 
 Note 2026-06-01 : les endpoints platform detail `GET /api/v1/platform/companies/{company}/health`, `GET/PATCH /subscription` et `GET/PATCH /features` doivent verifier que `Company` est toujours charge via `PlatformCompanyLookup` depuis `public.companies`, meme apres creation client ou requete tenant. Les scenarios super-admin doivent tester creation entreprise puis ouverture immediate de la fiche client par UUID.
 
+Note 2026-06-06 : la creation platform admin `POST /api/v1/platform/companies` est multi-pays. Les scenarios super-admin doivent verifier qu'un payload mobile minimal peut creer un client non DZ en `trial` ou `active`, que `language`, `currency` et `timezone` sont derives par `CountryDefaults` quand ils sont omis, et qu'aucun fallback universel DZD/Africa-Algiers n'est reintroduit.
+
 Note 2026-06-01 : le resume paie mobile manager `GET /api/v1/payroll/mobile-summary` doit rester tolerant aux tenants historiques partiellement migres. Les scenarios API doivent verifier que `PayrollCycleService` ne selectionne que les colonnes employees existantes (`manager_id`, `salary_type`, `salary_base`, `hourly_rate`, noms) et retourne un payload vide ou partiel exploitable au lieu d'un 500.
 
 Note 2026-06-01 : les soldes paie mobiles doivent reutiliser `currentCompany()` quand le middleware tenant a deja resolu l'entreprise. Les scenarios API shared PostgreSQL doivent eviter toute regression ou `$employee->company` recharge `Company` depuis un `search_path` tenant pouvant masquer `public.companies`.

--- a/docs/PLAN_ACTION/00_SOMMAIRE.md
+++ b/docs/PLAN_ACTION/00_SOMMAIRE.md
@@ -59,6 +59,10 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 | 65 | `65_PLAN_PAIEMENT_MASSE_SIGNATURE_NUMERIQUE.md` | Paiements en masse, confirmations employees, audit et preparation signature numerique |
 | 66 | `66_PLAN_CONSOLIDATION_MOBILE_FIRST_COMPANY_OS.md` | Plan maitre A-J : cartographie des 44 idees consolidees, anti-oubli et ordre de livraison |
 | 67 | `67_PLAN_AUDIT_FINAL_QUALITE_PRODUIT.md` | Audit final lancement : mobile runtime smoke, super-admin E2E, GPS natif, theming tenant, notifications et release readiness |
+| 68 | `68_PLAN_AUDIT_POST_67_QUALITE_CODE_LANCEMENT.md` | Audit post-67 : hygiene depot, qualite code, operations et prochain plan produit |
+| 69 | `69_PLAN_EXECUTION_LANCEMENT_MOBILE_FIRST_COMPANY_OS.md` | Execution lancement : device QA, parcours employee/manager/platform admin, paie et observabilite |
+| 70 | `70_PLAN_MARKET_LAUNCH_2026_COMPANY_OS.md` | Lancement marche 2026 : positionnement, packaging, offres, ROI, IA gouvernee et expansion |
+| 71 | `71_PLAN_ADMIN_MULTI_PAYS_KIOSK_GO_TO_MARKET.md` | Go-to-market operationnel : admin plateforme, multi-pays/devise, i18n, vitrine essai, kiosk et audit commercial-technique |
 
 ### Ordre d'execution recommande
 
@@ -75,6 +79,7 @@ Ces plans regroupent les points 31 a 44 remontes apres les tests produit. Ils so
 11. **Plan 68** : auditer le projet apres cloture Plan 67 : hygiene depot, contrats API/fronts, qualite code pragmatique, operations et prochain plan produit.
 12. **Plan 69** : executer la recette lancement Mobile-First Company OS : apps mobiles reelles, parcours employee/manager/platform admin, paie asynchrone et observabilite.
 13. **Plan 70** : convertir le Go technique en lancement marche 2026 : positionnement, packaging, demo admin mobile, preuves terrain, offres, ROI, IA gouvernee et 72 actions nouvelles.
+14. **Plan 71** : renforcer le go-to-market operationnel : creation/activation platform admin, multi-pays/devise, i18n centralisee, vitrine essai, kiosk biometrie-first et audit commercial-technique.
 
 Chaque plan doit sortir avec son changement code/documentation, ses tests ou preuves CI, une entree `CHANGELOG.md` et, si une lecon durable apparait, une entree `AGENTS.md`.
 

--- a/docs/PLAN_ACTION/71_PLAN_ADMIN_MULTI_PAYS_KIOSK_GO_TO_MARKET.md
+++ b/docs/PLAN_ACTION/71_PLAN_ADMIN_MULTI_PAYS_KIOSK_GO_TO_MARKET.md
@@ -1,0 +1,109 @@
+# Plan 71 - Admin plateforme, multi-pays, kiosk et go-to-market
+
+## Objectif
+
+Transformer le socle deja pret au lancement en experience commerciale et operationnelle coherente pour les premiers clients reels. Ce plan couvre les retours du 2026-06-06 : creation/activation client depuis l'app platform admin, multi-pays/multi-devise, i18n centralisee, vitrine essai, kiosk biometrie et audit commercial-technique.
+
+## Principe d'execution
+
+- Ne pas refaire les modules deja livres par les Plans 57-69.
+- Corriger d'abord les contrats API qui conditionnent toutes les interfaces.
+- Garder `front/mobile_apps/` comme mobile canonique.
+- Garder `api/openapi.yaml`, `FRONTEND_API_CONTRACT_MATRIX.md` et `mobile-workflow-contracts.json` alignes.
+- Tout texte futur doit passer par le socle i18n ou etre inscrit comme dette i18n explicite.
+
+## Lot 71.1 - Platform admin : creer et activer une entreprise
+
+### Actions
+
+- Permettre au super-admin mobile de choisir le pays depuis une liste controlee.
+- Deriver devise, fuseau horaire et langue depuis le pays quand le frontend ne les envoie pas.
+- Permettre la creation en `trial` ou `active`.
+- Afficher la devise dans la liste entreprises.
+- Couvrir le cas mobile minimal par test backend.
+
+### Statut
+
+**Livre dans ce lot.** `POST /api/v1/platform/companies` accepte maintenant `status=trial|active` et applique les defaults pays via `CountryDefaults` au lieu de forcer DZD/Africa-Algiers. L'app platform admin affiche pays, devise, timezone, langue et activation immediate.
+
+## Lot 71.2 - Multi-pays et devise produit
+
+### Actions
+
+- Etendre progressivement la table pays aux marches cibles.
+- Ajouter un endpoint public interne `GET /api/v1/platform/country-defaults` si plusieurs frontends doivent consommer la meme liste.
+- Brancher pricing, paie, factures, exports et dashboards sur la devise entreprise.
+- Ajouter tests pour DZ, MA, TN, SN/XOF, CM/XAF, FR/EUR, TR/TRY.
+
+### Criteres
+
+- Aucun nouveau parcours client ne doit afficher DZD si `company.currency` vaut autre chose.
+- Les nouveaux tenants doivent recevoir timezone/langue/devise coherents au provisioning.
+
+## Lot 71.3 - I18n centralisee toutes surfaces
+
+### Actions
+
+- Garder `front/mobile_apps/leopardo_core/lib/l10n` comme source mobile compilee.
+- Garder le catalogue backend `/i18n/catalog/{locale}` pour updates distantes.
+- Sortir progressivement les textes hardcodes des trois apps mobiles, de `front/web`, de `admin-dashboard` et du kiosk.
+- Ajouter un garde de dette i18n par surface : liste de fichiers avec textes restants, priorisee par ecrans de vente/login/compte.
+
+### Criteres
+
+- Les nouveaux ecrans ne doivent pas ajouter de texte hardcode sans justification.
+- FR reste langue de developpement, EN/AR/TR sont les langues de traduction Jules.
+
+## Lot 71.4 - Vitrine : essai reel par email
+
+### Actions
+
+- Clarifier le CTA "Tester" : essai automatique ou demande d'essai.
+- Si essai automatique : creer un workflow de provisioning sandbox a partir de l'email, avec anti-abus, quota et email de verification.
+- Si demande d'essai : afficher explicitement le delai et le prochain pas commercial.
+- Relier la capture lead a la creation platform admin ou a une demande client exploitable.
+
+### Criteres
+
+- Un visiteur qui clique "Tester" comprend immediatement ce qui se passe apres l'email.
+- Le funnel produit ne depend pas d'une intervention manuelle invisible.
+
+## Lot 71.5 - Kiosk moderne et biometrie terrain
+
+### Actions
+
+- Moderniser l'ecran kiosk autour d'un geste principal : poser doigt/visage, puis arrivee/depart.
+- Garder les modes fallback : identifiant, QR, offline bridge.
+- Verifier que le kiosk consomme les endpoints `/kiosks/{deviceCode}/punch`, `/qr-punch`, `/sync`, `/roster`.
+- Afficher une confirmation lisible : employe reconnu, action, heure locale, sync/offline.
+
+### Criteres
+
+- L'employe deja enrole peut pointer sans formulaire long.
+- La borne reste utilisable si le bridge local ou le reseau est lent.
+
+## Lot 71.6 - UX "Mon compte" et experience apps
+
+### Actions
+
+- Revoir la liste de fonctionnalites "Mon compte" en sections actionnables : identite, securite, documents, parcours, preferences, deconnexion.
+- Verifier employee, manager et platform admin sur parcours login, home, compte, notifications, logout.
+- Garder les spinners non bloquants et les etats vides utiles.
+
+### Criteres
+
+- Chaque bouton visible mene a un ecran ou une action fonctionnelle.
+- Les informations sensibles sont separees des actions commerciales ou documentaires.
+
+## Lot 71.7 - Audit commercial-technique go-to-market
+
+### Actions
+
+- Produire un audit court mais exploitable : etat actuel, risques, quick wins, priorites commerciales et techniques.
+- Identifier les points bloquants pour marketing : essai, pricing, demo, support, onboarding client.
+- Identifier les points bloquants pour production : secrets, queues, Redis, Firebase, observabilite, backups.
+
+### Sortie attendue
+
+- Rapport dans `docs/validation/`.
+- Decisions produit transformees en issues/lots avant lancement public.

--- a/docs/validation/AUDIT_COMMERCIAL_TECHNIQUE_GO_TO_MARKET_2026_06_06.md
+++ b/docs/validation/AUDIT_COMMERCIAL_TECHNIQUE_GO_TO_MARKET_2026_06_06.md
@@ -1,0 +1,88 @@
+# Audit commercial-technique go-to-market - 2026-06-06
+
+## Verdict court
+
+Le socle Leopardo RH est maintenant suffisamment avance pour une phase pilote controlee : API stable, readiness Render verte, trois apps mobiles separees, super-admin mobile, vitrine, kiosk et documentation API existent. Le risque principal n'est plus l'absence de produit, mais l'ecart entre promesse commerciale et experience d'essai immediate.
+
+Le lancement marketing large doit donc etre conditionne a trois preuves finales :
+
+1. Essai vitrine reel et comprehensible par email.
+2. Platform admin capable de creer/activer un client multi-pays sans correction manuelle.
+3. Kiosk et apps mobiles testees sur parcours terrain avec etats vides et erreurs lisibles.
+
+## Ce qui est solide
+
+- Backend Laravel API : version `/api/v1`, OpenAPI public, contrats frontend/API, readiness tenant, notifications, paie/avance, pointage multiple, QR onboarding, kiosk, super-admin.
+- Multi-app mobile : employee, manager et platform admin sont separees, avec `leopardo_core` comme socle partage.
+- Production ops : Render, Redis/queues documentes, Firebase App Distribution, readiness gate, rapports de smoke et plans 57-69.
+- Vitrine : pages pricing/demo/signup/blog/docs, formulaires de capture lead, analytics et contenus multilingues partiels.
+- Kiosk : surface web dediee, bridge local/offline, endpoints device et options QR/biometrie deja presentes.
+
+## Ce qui a ete corrige dans ce lot
+
+- `POST /api/v1/platform/companies` ne force plus `DZD` et `Africa/Algiers` pour tous les pays.
+- Le backend derive maintenant `language`, `currency` et `timezone` via `CountryDefaults` quand ils ne sont pas fournis.
+- Le statut initial `trial` ou `active` est accepte a la creation plateforme.
+- L'app mobile platform admin remplace le champ pays libre par un select controle avec apercu devise/timezone/langue.
+- La liste entreprises platform admin affiche maintenant pays + devise + plan.
+- OpenAPI et contrat mobile platform admin sont alignes.
+
+## Risques critiques
+
+### Essai commercial
+
+Le bouton "Tester" / "Essai gratuit" capture aujourd'hui une demande. Ce n'est pas encore equivalent a un compte d'essai automatiquement provisionne. Pour vendre vite, il faut choisir explicitement :
+
+- soit essai automatique sandbox avec email de verification, quota, anti-abus et creation client limitee ;
+- soit demande d'essai assistee, mais le texte doit le dire clairement.
+
+### I18n
+
+L'architecture i18n existe, mais toutes les surfaces ne sont pas encore au meme niveau. Les apps mobiles ont `leopardo_core/l10n`, la vitrine a ses dictionnaires, le backend a un catalogue, mais plusieurs ecrans gardent des textes hardcodes. Le risque est surtout commercial : incoherence de langue dans les ecrans login, compte, pricing ou demo.
+
+### Kiosk terrain
+
+Le kiosk est fonctionnel, mais encore trop "console de borne" par endroits. Pour le terrain, le premier geste doit etre biometrie/QR, avec confirmation immediate et fallback identifiant. L'UI doit masquer la complexite device autant que possible.
+
+### Experience "Mon compte"
+
+La page compte porte beaucoup de fonctionnalites. Il faut la reorganiser en sections lisibles : identite, securite, parcours, documents, preferences, deconnexion. C'est important parce que l'employe garde son compte apres depart d'entreprise.
+
+## Recommandations prioritaires
+
+1. Finaliser Lot 71.4 : transformer `/signup` en essai reel ou clarifier qu'il s'agit d'une demande d'essai.
+2. Finaliser Lot 71.5 : kiosk biometrie-first, confirmation pointage, fallback offline clair.
+3. Finaliser Lot 71.6 : refonte "Mon compte" employee/manager avec sections et actions visibles.
+4. Lancer un inventaire i18n par surface, puis interdire les nouveaux textes hardcodes hors exceptions documentees.
+5. Ajouter l'endpoint pays si plusieurs frontends doivent partager la meme liste que `CountryDefaults`.
+
+## Positionnement commercial
+
+Le positionnement le plus coherent reste : **OS de gestion d'entreprise mobile-first pour PME et equipes terrain**.
+
+Arguments :
+
+- Le produit depasse une application RH : pointage, taches, documents, validations, paie, notifications, kiosk, workflows et API.
+- La valeur differenciante est terrain/mobile, pas seulement back-office.
+- Le produit peut vendre aux PME qui n'ont pas d'ERP lourd, mais veulent une interface quotidienne simple.
+
+Formule commerciale recommandee :
+
+> Leopardo RH centralise le quotidien des equipes terrain : presence, taches, demandes, documents, paie et validations, depuis le mobile et le kiosk.
+
+## Go / No-Go marketing
+
+Go pilote controle si :
+
+- creation client platform admin testee en pays non DZ ;
+- une entreprise active peut recevoir son manager principal ;
+- login employee/manager/super-admin fonctionne sur APK recents ;
+- kiosk affiche une action de pointage lisible ;
+- `/signup` annonce clairement le parcours d'essai.
+
+No-Go marketing large si :
+
+- le visiteur ne peut pas demarrer ou comprendre l'essai ;
+- un pays non DZ affiche DZD dans les surfaces client ;
+- les apps mobiles bloquent sur splash/logo ou spinner ;
+- les notifications ou queues ne sont pas surveillees en production.

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/companies/company_create_screen.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/companies/company_create_screen.dart
@@ -6,6 +6,88 @@ import 'package:leopardo_core/core/widgets/mobile_surface.dart';
 import '../../core/platform_providers.dart';
 import 'company_screen.dart';
 
+class _CountryOption {
+  const _CountryOption({
+    required this.code,
+    required this.label,
+    required this.currency,
+    required this.timezone,
+    required this.language,
+  });
+
+  final String code;
+  final String label;
+  final String currency;
+  final String timezone;
+  final String language;
+}
+
+const _countryOptions = [
+  _CountryOption(
+    code: 'DZ',
+    label: 'Algerie',
+    currency: 'DZD',
+    timezone: 'Africa/Algiers',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'MA',
+    label: 'Maroc',
+    currency: 'MAD',
+    timezone: 'Africa/Casablanca',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'TN',
+    label: 'Tunisie',
+    currency: 'TND',
+    timezone: 'Africa/Tunis',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'SN',
+    label: 'Senegal',
+    currency: 'XOF',
+    timezone: 'Africa/Dakar',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'CI',
+    label: 'Cote d Ivoire',
+    currency: 'XOF',
+    timezone: 'Africa/Abidjan',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'CM',
+    label: 'Cameroun',
+    currency: 'XAF',
+    timezone: 'Africa/Douala',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'FR',
+    label: 'France',
+    currency: 'EUR',
+    timezone: 'Europe/Paris',
+    language: 'fr',
+  ),
+  _CountryOption(
+    code: 'TR',
+    label: 'Turquie',
+    currency: 'TRY',
+    timezone: 'Europe/Istanbul',
+    language: 'tr',
+  ),
+  _CountryOption(
+    code: 'US',
+    label: 'Etats-Unis',
+    currency: 'USD',
+    timezone: 'America/New_York',
+    language: 'en',
+  ),
+];
+
 class CompanyCreateScreen extends ConsumerStatefulWidget {
   const CompanyCreateScreen({super.key});
 
@@ -18,11 +100,12 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
   final _formKey = GlobalKey<FormState>();
   final _name = TextEditingController();
   final _email = TextEditingController();
-  final _country = TextEditingController(text: 'DZ');
   final _city = TextEditingController();
   final _managerFirstName = TextEditingController();
   final _managerLastName = TextEditingController();
   final _managerEmail = TextEditingController();
+  _CountryOption _selectedCountry = _countryOptions.first;
+  bool _activateImmediately = false;
   bool _submitting = false;
 
   String? _required(String? value) =>
@@ -37,18 +120,11 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
     return null;
   }
 
-  String? _countryValidator(String? value) {
-    final trimmed = value?.trim().toUpperCase() ?? '';
-    if (trimmed.length != 2) return 'Code pays ISO sur 2 lettres';
-    return null;
-  }
-
   @override
   void dispose() {
     for (final controller in [
       _name,
       _email,
-      _country,
       _city,
       _managerFirstName,
       _managerLastName,
@@ -68,11 +144,12 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
           .createCompany(
             name: _name.text.trim(),
             email: _email.text.trim(),
-            country: _country.text.trim(),
+            country: _selectedCountry.code,
             city: _city.text.trim(),
             managerFirstName: _managerFirstName.text.trim(),
             managerLastName: _managerLastName.text.trim(),
             managerEmail: _managerEmail.text.trim(),
+            status: _activateImmediately ? 'active' : 'trial',
           );
       ref.invalidate(platformCompaniesProvider);
       if (!mounted) return;
@@ -129,15 +206,6 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
                   children: [
                     Expanded(
                       child: _field(
-                        _country,
-                        'Pays',
-                        Icons.flag,
-                        validator: _countryValidator,
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: _field(
                         _city,
                         'Ville',
                         Icons.location_city,
@@ -146,6 +214,9 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
                     ),
                   ],
                 ),
+                _countryPicker(),
+                _countryPreview(),
+                _activationSwitch(),
                 _field(
                   _managerFirstName,
                   'Prenom manager principal',
@@ -200,6 +271,113 @@ class _CompanyCreateScreenState extends ConsumerState<CompanyCreateScreen> {
           border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
         ),
         validator: validator,
+      ),
+    );
+  }
+
+  Widget _countryPicker() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: DropdownButtonFormField<_CountryOption>(
+        initialValue: _selectedCountry,
+        dropdownColor: MobileSurface.surface,
+        iconEnabledColor: MobileSurface.secondary,
+        style: const TextStyle(color: MobileSurface.text),
+        decoration: InputDecoration(
+          labelText: 'Pays du client',
+          prefixIcon: const Icon(Icons.public_rounded),
+          filled: true,
+          fillColor: MobileSurface.chip,
+          border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+        items:
+            _countryOptions
+                .map(
+                  (country) => DropdownMenuItem(
+                    value: country,
+                    child: Text('${country.label} (${country.code})'),
+                  ),
+                )
+                .toList(),
+        onChanged: (country) {
+          if (country == null) return;
+          setState(() => _selectedCountry = country);
+        },
+      ),
+    );
+  }
+
+  Widget _countryPreview() {
+    final items = [
+      ('Devise', _selectedCountry.currency),
+      ('Fuseau', _selectedCountry.timezone),
+      ('Langue', _selectedCountry.language.toUpperCase()),
+    ];
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: MobileSurface.cardDecoration(
+        color: MobileSurface.chip,
+        radius: 12,
+      ),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children:
+            items
+                .map(
+                  (item) => Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 7,
+                    ),
+                    decoration: BoxDecoration(
+                      color: MobileSurface.surface,
+                      borderRadius: BorderRadius.circular(999),
+                      border: Border.all(color: MobileSurface.border),
+                    ),
+                    child: Text(
+                      '${item.$1}: ${item.$2}',
+                      style: const TextStyle(
+                        color: MobileSurface.secondary,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+      ),
+    );
+  }
+
+  Widget _activationSwitch() {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: MobileSurface.cardDecoration(
+        color: MobileSurface.chip,
+        radius: 12,
+      ),
+      child: SwitchListTile.adaptive(
+        value: _activateImmediately,
+        onChanged: (value) => setState(() => _activateImmediately = value),
+        activeThumbColor: Colors.white,
+        activeTrackColor: const Color(0xFF10B981),
+        title: const Text(
+          'Activer immediatement',
+          style: TextStyle(
+            color: MobileSurface.text,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        subtitle: Text(
+          _activateImmediately
+              ? 'Le client sera cree en statut actif.'
+              : 'Le client demarre en essai, puis peut etre active depuis sa fiche.',
+          style: const TextStyle(color: MobileSurface.muted, fontSize: 12),
+        ),
       ),
     );
   }

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/companies/company_screen.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/companies/company_screen.dart
@@ -54,7 +54,7 @@ class CompanyScreen extends ConsumerWidget {
                                     iconColor: AppColors.rh,
                                     title: company.name,
                                     subtitle:
-                                        '${company.country} - ${company.plan}',
+                                        '${company.country} / ${company.currency} - ${company.plan}',
                                     trailing: MobileStatusPill(
                                       label: company.status,
                                       color: _statusColor(company.status),

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_models.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_models.dart
@@ -27,6 +27,7 @@ class PlatformCompany {
     required this.name,
     required this.status,
     required this.country,
+    required this.currency,
     required this.plan,
     required this.createdAt,
   });
@@ -35,6 +36,7 @@ class PlatformCompany {
   final String name;
   final String status;
   final String country;
+  final String currency;
   final String plan;
   final String createdAt;
 
@@ -48,6 +50,7 @@ class PlatformCompany {
       name: data['name']?.toString() ?? data['company_name']?.toString() ?? '-',
       status: data['status']?.toString() ?? 'unknown',
       country: data['country']?.toString() ?? '--',
+      currency: data['currency']?.toString() ?? '--',
       plan:
           planValue is Map
               ? planValue['name']?.toString() ?? 'Plan'
@@ -69,6 +72,7 @@ class PlatformCompany {
           '-',
       status: company['status']?.toString() ?? 'unknown',
       country: company['country']?.toString() ?? '--',
+      currency: company['currency']?.toString() ?? '--',
       plan:
           planValue is Map
               ? planValue['name']?.toString() ?? 'Plan'

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_repository.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/features/platform/platform_repository.dart
@@ -189,6 +189,7 @@ class PlatformRepository {
     required String managerFirstName,
     required String managerLastName,
     required String managerEmail,
+    required String status,
     int? planId,
   }) async {
     final response = await _apiClient.requestWithRetry<Map<String, dynamic>>(
@@ -201,6 +202,7 @@ class PlatformRepository {
         'email': email,
         'country': country.toUpperCase(),
         'city': city,
+        'status': status,
         'manager_first_name': managerFirstName,
         'manager_last_name': managerLastName,
         'manager_email': managerEmail,

--- a/front/mobile_apps/leopardo_platform_admin/test/models/platform_company_model_test.dart
+++ b/front/mobile_apps/leopardo_platform_admin/test/models/platform_company_model_test.dart
@@ -9,7 +9,8 @@ void main() {
           'id': '9b2f5b8e-tenant',
           'name': 'Client Terrain',
           'status': 'active',
-          'country': 'DZ',
+          'country': 'SN',
+          'currency': 'XOF',
           'plan_id': 7,
           'plan_name': 'Business',
           'created_at': '2026-06-01T07:00:00Z',
@@ -21,7 +22,8 @@ void main() {
     expect(company.id, '9b2f5b8e-tenant');
     expect(company.name, 'Client Terrain');
     expect(company.status, 'active');
-    expect(company.country, 'DZ');
+    expect(company.country, 'SN');
+    expect(company.currency, 'XOF');
     expect(company.plan, 'Business');
     expect(company.createdAt, '2026-06-01T07:00:00Z');
   });
@@ -31,10 +33,12 @@ void main() {
       'id': 'company-uuid-123',
       'name': 'Leopardo Client',
       'country': 'TR',
+      'currency': 'TRY',
       'plan': {'name': 'Scale'},
     });
 
     expect(company.id, 'company-uuid-123');
+    expect(company.currency, 'TRY');
     expect(company.plan, 'Scale');
   });
 }


### PR DESCRIPTION
## Summary
- add country-based defaults for platform company provisioning so new tenants no longer default every market to DZD/Africa-Algiers
- let the platform admin mobile app create clients in trial or active status with controlled country selection and currency/timezone/language preview
- add Plan 70 and a go-to-market commercial/technical audit for admin, multi-country, i18n, vitrine trial and kiosk readiness

## Validation
- php -l api/app/Services/CompanyProvisioningService.php api/app/Support/CountryDefaults.php api/app/Http/Controllers/Web/PlatformCompanyController.php api/tests/Feature/PlatformCompanyProvisioningTest.php
- powershell -NoProfile -ExecutionPolicy Bypass -File dev-hub/tools/validate-mobile-workflow-contracts.ps1
- git diff --check

## Local test note
- php artisan test --filter=PlatformCompanyProvisioningTest could not start locally because api/vendor is incomplete: symfony/deprecation-contracts/function.php is missing. CI should run the backend test with a fresh Composer install.