### PR TITLE
fix: resolve kiosk companies from public schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - CI lancement : le smoke API peut maintenant resoudre automatiquement les tokens employee, manager et platform admin via `/demo-users` lorsque les secrets ne sont pas configures.
 - CI lancement : le smoke de creation entreprise platform admin peut maintenant verifier un statut `trial` ou `active` via `PlatformProvisioningStatus`.
 - CI lancement : le smoke kiosque peut maintenant sortir du `SKIP` via `IncludeKioskProvisioning` quand les secrets `LEOPARDO_KIOSK_DEVICE_CODE` / `LEOPARDO_KIOSK_TOKEN` ne sont pas fournis.
+- API kiosque : `roster` et `announcements` resolvent maintenant l'entreprise depuis `public.companies` afin d'eviter les 500 PostgreSQL quand `shared_tenants` masque la table publique.
 
 ## [4.16.249] - 2026-06-05
 

--- a/api/app/Http/Controllers/Api/V1/KioskController.php
+++ b/api/app/Http/Controllers/Api/V1/KioskController.php
@@ -10,6 +10,7 @@ use App\Models\Company;
 use App\Models\Employee;
 use App\Models\KioskAnnouncement;
 use App\Services\KioskAttendanceService;
+use App\Support\PlatformCompanyLookup;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -318,6 +319,10 @@ class KioskController extends Controller
             ->where('device_code', strtoupper($deviceCode))
             ->where('status', 'active')
             ->firstOrFail();
+
+        if ($kiosk->company_id !== null) {
+            $kiosk->setRelation('company', PlatformCompanyLookup::findOrFail((string) $kiosk->company_id));
+        }
 
         $token = (string) $request->header('X-Kiosk-Token', '');
         abort_if($token === '' || ! Hash::check($token, (string) $kiosk->sync_token_hash), 401, 'INVALID_KIOSK_TOKEN');

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -71,6 +71,8 @@ Note 2026-06-06 : la creation platform admin `POST /api/v1/platform/companies` e
 
 Note 2026-06-07 : le smoke lancement peut enregistrer un kiosque temporaire via `POST /api/v1/kiosks` avec le manager demo quand `IncludeKioskProvisioning` est active, puis verifier `GET /api/v1/kiosks/{deviceCode}/roster` et `GET /api/v1/kiosks/{deviceCode}/announcements` avec le `X-Kiosk-Token` recu. Les scenarios kiosque doivent rester tolerants aux tenants historiques dont les colonnes biometrie employees ou la table `kiosk_announcements` ne sont pas encore presentes, afin de retourner un payload exploitable plutot qu'un 500 Render.
 
+Note 2026-06-07 : les endpoints kiosque token-only doivent resoudre l'entreprise liee au device depuis `public.companies`, pas via une relation Eloquent dependante du `search_path` courant. Les scenarios Render/shared PostgreSQL doivent couvrir `register -> roster -> announcements` pour eviter qu'un schema `shared_tenants` masque `public.companies` et provoque un 500.
+
 Note 2026-06-01 : le resume paie mobile manager `GET /api/v1/payroll/mobile-summary` doit rester tolerant aux tenants historiques partiellement migres. Les scenarios API doivent verifier que `PayrollCycleService` ne selectionne que les colonnes employees existantes (`manager_id`, `salary_type`, `salary_base`, `hourly_rate`, noms) et retourne un payload vide ou partiel exploitable au lieu d'un 500.
 
 Note 2026-06-01 : les soldes paie mobiles doivent reutiliser `currentCompany()` quand le middleware tenant a deja resolu l'entreprise. Les scenarios API shared PostgreSQL doivent eviter toute regression ou `$employee->company` recharge `Company` depuis un `search_path` tenant pouvant masquer `public.companies`.


### PR DESCRIPTION
## Summary
- resolve kiosk company relation through public.companies using PlatformCompanyLookup
- keep kiosk roster/announcements resilient in shared PostgreSQL search_path contexts
- document the production Render 500 fix in the changelog

## Validation
- git diff --check
- Previous Render smoke reproduced: kiosk register 201, roster/announcements 500 before this fix