### PR TITLE
test(web): scope staging smoke acquisition form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 ### Fixed
 
 - API manager/mobile : `GET /api/v1/employees` rattache maintenant le `currentCompany()` resolu par le middleware tenant au payload liste, afin de garder `company`, `currency` et `features` non nuls sur Render/shared PostgreSQL meme si `shared_tenants` masque `public.companies`.
+- E2E staging vitrine : le smoke cible l'entree acquisition email de la landing au lieu de supposer que le premier formulaire est toujours une newsletter.
 - CI lancement : correction du passage de `LEOPARDO_API_BASE_URL` au workflow `Launch API Profile Smoke` et protection du script contre les tokens absents afin de produire `SKIP` au lieu de faux echecs manager.
 - CI lancement : durcissement supplementaire du smoke API avec splat PowerShell interne pour que les tokens vides ne decalient jamais les parametres.
 - CI lancement : correction du workflow manuel `Launch API Profile Smoke` pour transmettre `BaseUrl` via splat hashtable PowerShell au lieu d'un array positionnel.

--- a/front/web/e2e/staging-smoke.spec.ts
+++ b/front/web/e2e/staging-smoke.spec.ts
@@ -35,12 +35,12 @@ test.describe('Web vitrine staging smoke', () => {
     await expect(page.locator('body')).toContainText(/Conditions|Terms|CGU/i);
   });
 
-  test('keeps locale and newsletter entry points in the delivered HTML', async ({ page }) => {
+  test('keeps locale and email acquisition entry points in the delivered HTML', async ({ page }) => {
     await open(page, '/');
 
     await expect(page.locator('body')).toContainText(/Francais|English|Turkce|العربية/i);
 
     await expect(page.locator('input[type="email"]').first()).toHaveAttribute('placeholder', /email/i);
-    await expect(page.locator('form button[type="submit"]').first()).toContainText(/OK|Subscribe|Inscrire/i);
+    await expect(page.locator('form button[type="submit"]').first()).toContainText(/Tester|Try|Dene|جرّب/i);
   });
 });


### PR DESCRIPTION
## Summary
- update staging smoke wording now that the landing page first email form is the guided trial capture
- avoid assuming the first form is newsletter after the homepage hero trial entry point
- document the E2E staging fix in CHANGELOG

## Validation
- git diff --check
- npx playwright test e2e/staging-smoke.spec.ts --list (front/web)