### PR TITLE
Integrate Multi-Level Approval for Absences

### DIFF
--- a/api/app/Http/Controllers/Api/V1/AbsenceController.php
+++ b/api/app/Http/Controllers/Api/V1/AbsenceController.php
@@ -8,9 +8,9 @@ use App\Http\Requests\Api\V1\Absence\RejectAbsenceRequest;
 use App\Http\Requests\Api\V1\Absence\StoreAbsenceRequest;
 use App\Http\Resources\Api\V1\AbsenceResource;
 use App\Models\Absence;
+use Illuminate\Http\JsonResponse;
 use App\Models\Employee;
 use App\Services\AbsenceService;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Carbon;
@@ -112,7 +112,7 @@ class AbsenceController extends Controller
         ]));
     }
 
-    public function approve(Request $request, Absence $absence): AbsenceResource
+    public function approve(Request $request, Absence $absence): AbsenceResource|JsonResponse
     {
         /** @var Employee $actor */
         $actor = $request->user();
@@ -123,6 +123,13 @@ class AbsenceController extends Controller
 
         if (! $actor->isManager()) {
             abort(403);
+        }
+
+        if ($absence->isPendingApproval()) {
+            return response()->json([
+                'message' => 'This absence is under a multi-level approval workflow. Please use the approvals API.',
+                'approval_request_id' => $absence->approvalRequest?->id,
+            ], 422);
         }
 
         $absence = $this->absenceService->approve($absence, $actor);
@@ -133,7 +140,7 @@ class AbsenceController extends Controller
         ]));
     }
 
-    public function reject(RejectAbsenceRequest $request, Absence $absence): AbsenceResource
+    public function reject(RejectAbsenceRequest $request, Absence $absence): AbsenceResource|JsonResponse
     {
         /** @var Employee $actor */
         $actor = $request->user();
@@ -144,6 +151,13 @@ class AbsenceController extends Controller
 
         if (! $actor->isManager()) {
             abort(403);
+        }
+
+        if ($absence->isPendingApproval()) {
+            return response()->json([
+                'message' => 'This absence is under a multi-level approval workflow. Please use the approvals API.',
+                'approval_request_id' => $absence->approvalRequest?->id,
+            ], 422);
         }
 
         $absence = $this->absenceService->reject($absence, $request->validated('rejected_reason'));

--- a/api/app/Models/Absence.php
+++ b/api/app/Models/Absence.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Approvable;
 use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -27,6 +28,7 @@ use Illuminate\Support\Carbon;
  */
 class Absence extends Model
 {
+    use Approvable;
     use BelongsToCompany;
     use HasFactory;
 

--- a/api/app/Services/AbsenceService.php
+++ b/api/app/Services/AbsenceService.php
@@ -10,8 +10,10 @@ use App\Exceptions\AbsenceNotPendingException;
 use App\Exceptions\InsufficientLeaveBalanceException;
 use App\Models\Absence;
 use App\Models\AbsenceType;
+use App\Models\ApprovalWorkflow;
 use App\Models\Employee;
 use App\Models\LeaveBalanceLog;
+use App\Models\LeavePolicy;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -50,6 +52,22 @@ class AbsenceService
             'status' => 'pending',
             'reason' => $data['reason'] ?? null,
         ]);
+
+        $policy = LeavePolicy::where('company_id', $employee->company_id)
+            ->where('absence_type_id', $type->id)
+            ->where('active', true)
+            ->first();
+
+        if ($policy?->requires_approval) {
+            $hasWorkflow = ApprovalWorkflow::where('company_id', $employee->company_id)
+                ->where('model_type', Absence::class)
+                ->where('active', true)
+                ->exists();
+
+            if ($hasWorkflow) {
+                $absence->submitForApproval();
+            }
+        }
 
         AbsenceRequested::dispatch($absence);
 

--- a/api/tests/Feature/MultiLevelAbsenceApprovalTest.php
+++ b/api/tests/Feature/MultiLevelAbsenceApprovalTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Absence;
+use App\Models\AbsenceType;
+use App\Models\ApprovalRequest;
+use App\Models\ApprovalWorkflow;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\LeavePolicy;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class MultiLevelAbsenceApprovalTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_submitting_absence_triggers_multi_level_approval_workflow(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        $absenceType = AbsenceType::factory()->create(['company_id' => $company->id, 'deducts_leave' => false]);
+
+        // Create Leave Policy requiring approval
+        LeavePolicy::create([
+            'company_id' => $company->id,
+            'absence_type_id' => $absenceType->id,
+            'name' => 'Test Policy',
+            'accrual_type' => 'yearly',
+            'requires_approval' => true,
+            'approval_levels' => 2,
+            'active' => true,
+        ]);
+
+        // Create Approval Workflow for Absences
+        ApprovalWorkflow::create([
+            'company_id' => $company->id,
+            'name' => 'Absence Workflow',
+            'model_type' => Absence::class,
+            'levels' => [
+                ['level' => 1, 'approver_type' => 'manager'],
+                ['level' => 2, 'approver_type' => 'hr'],
+            ],
+            'active' => true,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->postJson('/api/v1/absences', [
+            'absence_type_id' => $absenceType->id,
+            'start_date' => now()->addDay()->toDateString(),
+            'end_date' => now()->addDays(3)->toDateString(),
+            'reason' => 'Need a break',
+        ]);
+
+        $response->assertStatus(201);
+        $absenceId = $response->json('data.id');
+
+        // Verify Absence is pending
+        $this->assertDatabaseHas('absences', [
+            'id' => $absenceId,
+            'status' => 'pending',
+        ]);
+
+        // Verify Approval Request was created
+        $this->assertDatabaseHas('approval_requests', [
+            'company_id' => $company->id,
+            'approvable_type' => Absence::class,
+            'approvable_id' => $absenceId,
+            'status' => 'pending',
+            'current_level' => 1,
+        ]);
+    }
+
+    public function test_legacy_approval_is_blocked_when_multi_level_workflow_is_active(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        $absenceType = AbsenceType::factory()->create(['company_id' => $company->id, 'deducts_leave' => false]);
+
+        LeavePolicy::create([
+            'company_id' => $company->id,
+            'absence_type_id' => $absenceType->id,
+            'name' => 'Test Policy',
+            'requires_approval' => true,
+            'active' => true,
+        ]);
+
+        ApprovalWorkflow::create([
+            'company_id' => $company->id,
+            'name' => 'Absence Workflow',
+            'model_type' => Absence::class,
+            'levels' => [['level' => 1, 'approver_type' => 'manager']],
+            'active' => true,
+        ]);
+
+        Sanctum::actingAs($employee);
+        $response = $this->postJson('/api/v1/absences', [
+            'absence_type_id' => $absenceType->id,
+            'start_date' => now()->addDay()->toDateString(),
+            'end_date' => now()->addDays(2)->toDateString(),
+        ]);
+        $absenceId = $response->json('data.id');
+
+        // Manager tries to approve via legacy endpoint
+        Sanctum::actingAs($manager);
+        $approveResponse = $this->putJson("/api/v1/absences/{$absenceId}/approve");
+
+        $approveResponse->assertStatus(422);
+        $approveResponse->assertJsonFragment([
+            'message' => 'This absence is under a multi-level approval workflow. Please use the approvals API.',
+        ]);
+
+        // Verify absence still pending
+        $this->assertEquals('pending', Absence::find($absenceId)->status);
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -375,6 +375,86 @@ trait CreatesMvpSchema
             $table->timestampTz('created_at')->nullable();
         });
 
+        Schema::create('leave_policies', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->uuid('company_id')->index();
+            $table->unsignedInteger('absence_type_id');
+            $table->string('name', 150);
+            $table->string('accrual_type', 20)->default('yearly');
+            $table->decimal('accrual_amount', 6, 2)->default(0);
+            $table->decimal('max_balance', 6, 2)->nullable();
+            $table->boolean('carry_forward')->default(false);
+            $table->decimal('carry_forward_max', 6, 2)->nullable();
+            $table->unsignedSmallInteger('carry_forward_expiry_days')->nullable();
+            $table->boolean('requires_approval')->default(true);
+            $table->unsignedSmallInteger('approval_levels')->default(1);
+            $table->unsignedSmallInteger('min_notice_days')->default(0);
+            $table->unsignedSmallInteger('max_consecutive_days')->nullable();
+            $table->json('applicable_roles')->nullable();
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('leave_accruals', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+            $table->unsignedInteger('employee_id');
+            $table->unsignedBigInteger('leave_policy_id');
+            $table->decimal('amount', 6, 2);
+            $table->string('type', 30)->default('accrual');
+            $table->string('description', 255)->nullable();
+            $table->date('effective_date');
+            $table->unsignedInteger('created_by')->nullable();
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
+        Schema::create('leave_balances', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+            $table->unsignedInteger('employee_id');
+            $table->unsignedInteger('absence_type_id');
+            $table->decimal('balance', 6, 2)->default(0);
+            $table->decimal('used', 6, 2)->default(0);
+            $table->decimal('pending', 6, 2)->default(0);
+            $table->unsignedSmallInteger('year');
+            $table->timestampTz('updated_at')->useCurrent();
+        });
+
+        Schema::create('approval_workflows', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+            $table->string('name', 150);
+            $table->string('model_type', 100);
+            $table->json('levels');
+            $table->decimal('auto_approve_below', 12, 2)->nullable();
+            $table->unsignedSmallInteger('escalation_hours')->nullable();
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('approval_requests', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+            $table->unsignedBigInteger('workflow_id');
+            $table->string('approvable_type', 100);
+            $table->unsignedBigInteger('approvable_id');
+            $table->unsignedInteger('requester_id');
+            $table->unsignedSmallInteger('current_level')->default(1);
+            $table->string('status', 20)->default('pending');
+            $table->timestamps();
+        });
+
+        Schema::create('approval_decisions', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('approval_request_id');
+            $table->unsignedSmallInteger('level');
+            $table->unsignedInteger('approver_id');
+            $table->string('decision', 20);
+            $table->text('comment')->nullable();
+            $table->timestampTz('decided_at')->nullable();
+            $table->timestampTz('created_at')->useCurrent();
+        });
+
         Schema::create('salary_advances', function (Blueprint $table): void {
             $table->increments('id');
             $table->uuid('company_id')->index();


### PR DESCRIPTION
I have implemented the multi-level approval workflow integration for the Absence module, which was an unimplemented task identified in the action plans.

Key changes:
1.  **Absence Model**: Integrated the generic multi-level approval system by adding the `Approvable` trait.
2.  **Absence Service**: Modified the creation flow to automatically initiate an `ApprovalRequest` if the active `LeavePolicy` requires approval and a matching `ApprovalWorkflow` for absences is configured.
3.  **Absence Controller**: Updated the legacy `approve` and `reject` endpoints to return a `422 Unprocessable Entity` error when a multi-level workflow is active, directing the user to use the dedicated approvals API.
4.  **Testing Infrastructure**: Updated the `CreatesMvpSchema` trait to include the necessary tables (`leave_policies`, `approval_workflows`, `approval_requests`, etc.) for the in-memory SQLite test environment.
5.  **Verification**: Added a new feature test `MultiLevelAbsenceApprovalTest.php` that verifies both the automatic triggering of workflows and the protection of legacy endpoints. Existing leave-related tests were also verified to ensure no regressions.

---
*PR created automatically by Jules for task [2757310729159128119](https://jules.google.com/task/2757310729159128119) started by @kitokoh*