### PR TITLE
test: complete Expense module feature tests coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 - **Expense Routes — Middleware sécurisé** : Toutes les routes expense-claims sont maintenant protégées par `['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan']`. Suppression de la route `POST /approve` dupliquée (conservation uniquement de `PUT /approve`). Nettoyage des commentaires TODO dans `hr_extended.php`.
+## [4.17.6] - 2026-06-29
+
+### Added
+- **Tests Expense — Couverture complète** : 8 nouveaux tests Feature pour `ExpenseClaimController` couvrant : rejet avec raison, validation du champ `reason` obligatoire, interdiction non-manager d'approuver/rejeter, isolation cross-tenant (404) pour approve/reject, re-soumission impossible (422), accès cross-tenant à `show` (404).
 
 ## [4.17.4] - 2026-06-28
 


### PR DESCRIPTION
## Summary

Adds 8 new feature tests to `ExpenseClaimControllerTest` to achieve comprehensive coverage of the `ExpenseClaimController` business rules.

## New Tests

| Test | Scenario | Expected |
|------|----------|----------|
| `test_manager_can_reject_expense_claim_with_reason` | Manager rejects with a valid reason | 200 OK, status = rejected |
| `test_reject_requires_reason_field` | Manager rejects without providing reason | 422 Unprocessable |
| `test_non_manager_cannot_approve` | Regular employee tries to approve | 403 Forbidden |
| `test_non_manager_cannot_reject` | Regular employee tries to reject | 403 Forbidden |
| `test_manager_from_foreign_tenant_gets_404_on_approve` | Manager from another company approves | 404 Not Found |
| `test_manager_from_foreign_tenant_gets_404_on_reject` | Manager from another company rejects | 404 Not Found |
| `test_employee_cannot_submit_already_submitted_claim` | Employee submits a claim already in `submitted` status | 422 Unprocessable |
| `test_show_returns_404_for_cross_tenant` | Employee from another company views a claim | 404 Not Found |

## Coverage Areas

- **Reject flow**: reason validation + happy path
- **Manager-only enforcement**: `approve` and `reject` return 403 for non-managers of the same tenant
- **Cross-tenant isolation**: 404 on `approve`, `reject`, and `show` for foreign-tenant actors (security: don't leak resource existence)
- **Submit guard**: 422 when trying to re-submit a non-draft claim

All tests follow the existing patterns: `Company::factory()`, `Employee::factory()->managerRh()`, `ExpenseClaim::create()`, and `Sanctum::actingAs()`.