### PR TITLE
fix(ci): suite du fix CI — company_id manquant (Absence/ExpenseClaim), rejection_reason, EdgeSyncTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Format : Keep a Changelog (keepachangelog.com) 
 # Versioning : Semantic Versioning (semver.org) 
 
+## [4.22.3] - 2026-07-04
+
+### Fixed
+- **Suite du fix CI v4.22.2 : 160 echecs restants sur 899 tests (Backend + Backend Coverage)** :
+  - Modele canonique `App\Modules\Absence\Domain\Models\Absence` (utilise via le shim `App\Models\Absence`) ne declarait ni `company_id` (NOT NULL en base) dans `$fillable` ni le trait `BelongsToCompany` -> `QueryException: null value in column "company_id"`. Reecrit pour matcher le schema reel de la table `absences` (`days_count`, `proof_path`, `rejected_reason`) ; `AbsenceService::approve()`/`reject()` adaptes en consequence.
+  - Meme bug sur `App\Modules\Expense\Domain\Models\ExpenseClaim` : `company_id` absent du `$fillable`. Ajoute, avec `paid_at`/`payment_reference` (deja en base, absents du modele).
+  - Colonne `rejection_reason` manquante sur `expense_claims` : `ExpenseClaimController::reject()` y ecrit depuis l'origine du module mais ni la migration ni la fixture de test ne la definissaient -> `QueryException` au premier appel de `PUT .../reject`. Ajoutee a la migration additive `2026_07_04_000001_add_missing_updated_at_columns.php` et a la fixture de test.
+  - `EdgeSyncTest::actingAsCompanyAdmin()` creait un `App\Core\Auth\Domain\Models\User` avec `company_id`/`role` — colonnes qui n'existent pas sur ce modele dans ce codebase (c'est `Employee` qui les porte). Remplace par `Employee::factory()`.
+
 ## [4.22.2] - 2026-07-04
 
 ### Fixed

--- a/api/app/Modules/Absence/Domain/Models/Absence.php
+++ b/api/app/Modules/Absence/Domain/Models/Absence.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Absence\Domain\Models;
 
 use App\Core\Auth\Domain\Models\Employee;
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,42 +13,50 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * Domain model for the Absence aggregate.
  *
+ * Colonnes reelles de la table `absences`
+ * (migration tenant 2026_04_01_000103_create_attendance_absences_advances.php).
+ *
  * @property int    $id
+ * @property int|null $company_id
  * @property int    $employee_id
  * @property int    $absence_type_id
  * @property string $start_date
  * @property string $end_date
+ * @property int    $days_count
  * @property string $status  (pending|approved|rejected|cancelled)
  * @property string|null $reason
- * @property string|null $manager_comment
- * @property string|null $approved_at
+ * @property string|null $proof_path
+ * @property int|null $approved_by
+ * @property string|null $rejected_reason
  * @mixin \Illuminate\Database\Eloquent\Builder<static>
  */
 class Absence extends Model
 {
+    use BelongsToCompany;
     use HasFactory;
 
     protected $fillable = [
+        'company_id',
         'employee_id',
         'absence_type_id',
         'start_date',
         'end_date',
+        'days_count',
         'status',
         'reason',
-        'manager_comment',
-        'approved_at',
+        'proof_path',
         'approved_by',
+        'rejected_reason',
     ];
 
     protected $casts = [
-        'start_date'  => 'date',
-        'end_date'    => 'date',
-        'approved_at' => 'datetime',
+        'start_date' => 'date',
+        'end_date'   => 'date',
     ];
 
     public function employee(): BelongsTo
     {
-        return $this->belongsTo(\App\Core\Auth\Domain\Models\Employee::class);
+        return $this->belongsTo(Employee::class);
     }
 
     public function absenceType(): BelongsTo

--- a/api/app/Modules/Absence/Infrastructure/Services/AbsenceService.php
+++ b/api/app/Modules/Absence/Infrastructure/Services/AbsenceService.php
@@ -58,6 +58,7 @@ class AbsenceService
             'absence_type_id'  => $dto->absenceTypeId,
             'start_date'       => $dto->startDate,
             'end_date'         => $dto->endDate,
+            'days_count'       => max(1, $days),
             'status'           => 'pending',
             'reason'           => $dto->reason,
         ]);
@@ -73,10 +74,8 @@ class AbsenceService
         }
 
         $absence->update([
-            'status'          => 'approved',
-            'approved_by'     => $approvedBy,
-            'manager_comment' => $comment,
-            'approved_at'     => now(),
+            'status'      => 'approved',
+            'approved_by' => $approvedBy,
         ]);
 
         return $absence->fresh();
@@ -94,7 +93,7 @@ class AbsenceService
         $absence->update([
             'status'          => 'rejected',
             'approved_by'     => $rejectedBy,
-            'manager_comment' => $comment,
+            'rejected_reason' => $comment,
         ]);
 
         return $absence->fresh();

--- a/api/app/Modules/Expense/Domain/Models/ExpenseClaim.php
+++ b/api/app/Modules/Expense/Domain/Models/ExpenseClaim.php
@@ -5,23 +5,30 @@ declare(strict_types=1);
 namespace App\Modules\Expense\Domain\Models;
 
 use App\Core\Auth\Domain\Models\Employee;
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int    $id
+ * @property int|null $company_id
  * @property int    $employee_id
  * @property string $title
  * @property float  $total_amount
- * @property string $status  (draft|submitted|approved|rejected|reimbursed)
+ * @property string $status  (draft|submitted|approved|rejected|paid)
  * @property string|null $submitted_at
  * @property string|null $approved_at
+ * @property string|null $paid_at
+ * @property string|null $payment_reference
  * @mixin \Illuminate\Database\Eloquent\Builder<static>
  */
 class ExpenseClaim extends Model
 {
+    use BelongsToCompany;
+
     protected $fillable = [
+        'company_id',
         'employee_id',
         'title',
         'description',
@@ -30,8 +37,9 @@ class ExpenseClaim extends Model
         'status',
         'submitted_at',
         'approved_at',
+        'paid_at',
         'approved_by',
-        'rejection_reason',
+        'payment_reference',
     ];
 
     protected $casts = [

--- a/api/database/migrations/tenant/2026_07_04_000001_add_missing_updated_at_columns.php
+++ b/api/database/migrations/tenant/2026_07_04_000001_add_missing_updated_at_columns.php
@@ -14,14 +14,20 @@ use Illuminate\Support\Facades\Schema;
  * App\Modules\Expense\Domain\Models\ExpenseItem) utilisent les timestamps
  * par defaut (created_at + updated_at), ce qui fait echouer tout
  * INSERT/UPDATE via Eloquent (colonne "updated_at" inexistante).
+ *
+ * expense_claims : App\Modules\Expense\Interfaces\Api\V1\Controllers\ExpenseClaimController::reject()
+ * ecrit dans la colonne rejection_reason, absente de la migration d'origine
+ * 2026_05_10_000007_create_loans_and_expenses_tables.php -> QueryException
+ * 'column rejection_reason does not exist' au premier appel de
+ * PUT /expense-claims/{id}/reject.
  */
 return new class extends Migration
 {
-    private const TABLES = ['absence_types', 'expense_items'];
+    private const TIMESTAMP_TABLES = ['absence_types', 'expense_items'];
 
     public function up(): void
     {
-        foreach (self::TABLES as $tableName) {
+        foreach (self::TIMESTAMP_TABLES as $tableName) {
             if (Schema::hasTable($tableName) && ! Schema::hasColumn($tableName, 'updated_at')) {
                 Schema::table($tableName, function (Blueprint $table): void {
                     // PostgreSQL n'a pas d'equivalent natif au "ON UPDATE CURRENT_TIMESTAMP" de
@@ -32,16 +38,28 @@ return new class extends Migration
                 });
             }
         }
+
+        if (Schema::hasTable('expense_claims') && ! Schema::hasColumn('expense_claims', 'rejection_reason')) {
+            Schema::table('expense_claims', function (Blueprint $table): void {
+                $table->text('rejection_reason')->nullable();
+            });
+        }
     }
 
     public function down(): void
     {
-        foreach (self::TABLES as $tableName) {
+        foreach (self::TIMESTAMP_TABLES as $tableName) {
             if (Schema::hasTable($tableName) && Schema::hasColumn($tableName, 'updated_at')) {
                 Schema::table($tableName, function (Blueprint $table): void {
                     $table->dropColumn('updated_at');
                 });
             }
+        }
+
+        if (Schema::hasTable('expense_claims') && Schema::hasColumn('expense_claims', 'rejection_reason')) {
+            Schema::table('expense_claims', function (Blueprint $table): void {
+                $table->dropColumn('rejection_reason');
+            });
         }
     }
 };

--- a/api/tests/Feature/EdgeSync/EdgeSyncTest.php
+++ b/api/tests/Feature/EdgeSync/EdgeSyncTest.php
@@ -333,11 +333,15 @@ class EdgeSyncTest extends TestCase
 
     private function actingAsCompanyAdmin(Company $company): self
     {
-        $user = \App\Core\Auth\Domain\Models\User::factory()->create([
+        // App\Core\Auth\Domain\Models\User (table `users`) n'a pas de colonne
+        // company_id/role : ce sont les colonnes du modele tenant Employee.
+        // C'est Employee qui porte le role admin dans ce codebase.
+        $admin = \App\Core\Auth\Domain\Models\Employee::factory()->create([
             'company_id' => $company->id,
             'role'       => 'admin',
         ]);
-        return $this->actingAs($user, 'sanctum');
+
+        return $this->actingAs($admin, 'sanctum');
     }
 
     private function withEdgeToken(): void

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -1418,6 +1418,7 @@ trait CreatesMvpSchema
                 $table->timestampTz('paid_at')->nullable();
                 $table->unsignedInteger('approved_by')->nullable();
                 $table->string('payment_reference', 100)->nullable();
+                $table->text('rejection_reason')->nullable();
                 $table->timestamps();
             });
         }
@@ -1432,6 +1433,7 @@ trait CreatesMvpSchema
                 $table->date('date');
                 $table->string('receipt_path', 500)->nullable();
                 $table->timestampTz('created_at')->useCurrent();
+                $table->timestampTz('updated_at')->nullable();
             });
         }
 

--- a/api/tests/Support/sql/mvp_schema.pgsql.sql
+++ b/api/tests/Support/sql/mvp_schema.pgsql.sql
@@ -470,7 +470,8 @@ CREATE TABLE shared_tenants.absence_types (
     deducts_leave boolean NOT NULL DEFAULT true,
     requires_proof boolean NOT NULL DEFAULT false,
     max_days_once integer NULL,
-    created_at timestamptz NULL
+    created_at timestamptz NULL,
+    updated_at timestamptz NULL
 );
 
 CREATE TABLE shared_tenants.absences (


### PR DESCRIPTION
## Contexte

La PR #831 a corrige la cause racine principale du CI casse (75 shims sans namespace absolu + factory resolver DDD + rollback edge_nodes) et a ete mergee alors que je continuais l'investigation en parallele sur la branche source. Cette PR contient les 4 fixes supplementaires decouverts apres ce merge, qui font passer les echecs de 160 a (attendu) 0 sur les jobs `Backend` et `Backend Coverage (PHPUnit)`.

## Fixes

1. **`App\Modules\Absence\Domain\Models\Absence`** (canonique, via shim `App\Models\Absence`) n'avait ni `company_id` dans `$fillable` ni `BelongsToCompany`, alors que la colonne est `NOT NULL` en base -> `QueryException: null value in column "company_id"`. Reecrit pour matcher le schema reel de `absences` (`days_count`, `proof_path`, `rejected_reason` au lieu de `manager_comment`/`approved_at` qui n'existent pas). `AbsenceService::approve()`/`reject()` adaptes (aucun appelant actif trouve pour ces methodes).

2. Meme categorie de bug sur **`ExpenseClaim`** : `company_id` absent du `$fillable`. Ajoute, avec `paid_at`/`payment_reference` (deja en base, absents du modele).

3. Colonne **`rejection_reason`** manquante sur `expense_claims` : `ExpenseClaimController::reject()` y ecrit depuis l'origine du module (pas une regression recente) mais ni la migration ni la fixture de test PostgreSQL/sqlite ne la definissaient -> echec systematique au premier appel de `PUT .../reject`. Ajoutee a la migration additive `2026_07_04_000001_add_missing_updated_at_columns.php` (deja presente sur main, juste etendue) et a la fixture `CreatesMvpSchema`.

4. **`EdgeSyncTest::actingAsCompanyAdmin()`** creait un `App\Core\Auth\Domain\Models\User` avec `company_id`/`role` — colonnes qui n'existent pas sur ce modele dans ce codebase (c'est `Employee` qui les porte, comme partout ailleurs dans la suite de tests). Remplace par `Employee::factory()`.

## Verification
Ces 4 bugs representaient les dernieres causes visibles dans le run CI du 04/07 06:31 UTC (job `85109768907`, 160 echecs restants apres le merge de #831).