### PR TITLE
fix(ci): PA2-AUTO-002 - détection de cycle dans les dépendances PLAN_ACTION2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [4.22.4] - 2026-07-04
+
+### Added
+- **PA2-AUTO-002 — Validation des dependances tickets PLAN_ACTION2 (#762)** : `dev-hub/tools/validate-plan-action2.ps1` detecte maintenant les cycles de dependances entre tickets PA2 (DFS sur le graphe `Dependencies` du CSV), en plus des dependances vers un ID inconnu deja couvertes. Le script echoue avec le chemin complet du cycle (ex: `PA2-X -> PA2-Y -> PA2-X`).
+
+### Fixed
+- **Cycle de dependance reel detecte dans `03_GITHUB_PROJECT_IMPORT.csv`** : `PA2-MKT-007` (Funnel CRM marketing) et `PA2-ADM-004` (Pipeline CRM platform) se referencaient mutuellement. Le pipeline admin affiche les leads produits par le funnel marketing — la dependance correcte est unidirectionnelle (`PA2-ADM-004 -> PA2-MKT-007`) ; la dependance inverse sur `PA2-MKT-007` a ete retiree.
+
 ## [4.22.3] - 2026-07-04
 
 ### Fixed

--- a/dev-hub/tools/validate-plan-action2.ps1
+++ b/dev-hub/tools/validate-plan-action2.ps1
@@ -61,6 +61,71 @@ if ($missing.Count -gt 0) {
     throw "Missing PLAN_ACTION2 dependencies:`n$($missing -join "`n")"
 }
 
+$dependencyMap = @{}
+foreach ($row in $rows) {
+    $id = ($row.Title -split " ")[0]
+    $deps = @()
+    if (-not [string]::IsNullOrWhiteSpace($row.Dependencies)) {
+        $deps = ($row.Dependencies -split ";") | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    }
+    $dependencyMap[$id] = $deps
+}
+
+function Find-PlanAction2Cycle {
+    param(
+        [hashtable]$Graph
+    )
+
+    $state = @{}     # 0 = unvisited, 1 = in-progress, 2 = done
+    $pathStack = New-Object System.Collections.Generic.List[string]
+
+    function Visit {
+        param([string]$Node)
+
+        $state[$Node] = 1
+        $pathStack.Add($Node)
+
+        foreach ($dep in $Graph[$Node]) {
+            if (-not $Graph.ContainsKey($dep)) {
+                continue
+            }
+            if ($state[$dep] -eq 1) {
+                $cycleStart = $pathStack.IndexOf($dep)
+                $cycleNodes = $pathStack.GetRange($cycleStart, $pathStack.Count - $cycleStart)
+                $cycleNodes.Add($dep)
+                return ($cycleNodes -join " -> ")
+            }
+            if ($state[$dep] -ne 2) {
+                $found = Visit -Node $dep
+                if ($found) {
+                    return $found
+                }
+            }
+        }
+
+        $pathStack.RemoveAt($pathStack.Count - 1)
+        $state[$Node] = 2
+        return $null
+    }
+
+    foreach ($node in $Graph.Keys) {
+        if ($state[$node] -eq 2 -or $state[$node] -eq 1) {
+            continue
+        }
+        $cycle = Visit -Node $node
+        if ($cycle) {
+            return $cycle
+        }
+    }
+
+    return $null
+}
+
+$cycle = Find-PlanAction2Cycle -Graph $dependencyMap
+if ($cycle) {
+    throw "Dependency cycle detected in PLAN_ACTION2 tickets: $cycle"
+}
+
 if (Test-Path $BacklogPath) {
     $backlog = Get-Content $BacklogPath -Raw
     $notDocumented = $ids | Where-Object { $backlog -notmatch [regex]::Escape($_) }

--- a/docs/PLAN_ACTION2/03_GITHUB_PROJECT_IMPORT.csv
+++ b/docs/PLAN_ACTION2/03_GITHUB_PROJECT_IMPORT.csv
@@ -5,7 +5,7 @@ Title,Priority,Area,Surface,Dependencies,Acceptance Criteria
 "PA2-MKT-004 Page download commerciale","P1","Acquisition","front/web","","Liens apps reels ou fallback signup; pas d'ancre morte"
 "PA2-MKT-005 Ressources au lieu de blog archaique","P1","Acquisition","front/web","","Navigation Ressources avec guides/articles/docs/download et SEO"
 "PA2-MKT-006 Trust proof et social proof","P1","Acquisition","front/web","","Section preuve prudente avec assets existants et chiffres non trompeurs"
-"PA2-MKT-007 Funnel CRM marketing","P2","Acquisition","front/web; API CRM","PA2-ADM-004","signup/demo/contact/newsletter creent des leads sources"
+"PA2-MKT-007 Funnel CRM marketing","P2","Acquisition","front/web; API CRM","","signup/demo/contact/newsletter creent des leads sources"
 "PA2-ONB-001 Trial self-service de bout en bout","P0","Onboarding","API; front/web","","Entreprise manager plan trial email welcome et retour credentials ou next-step"
 "PA2-ONB-002 Activation client platform admin","P0","Onboarding","API; admin web; mobile admin","","Creer voir activer client; pays devise langue timezone; tests contrat"
 "PA2-ONB-003 Onboarding wizard manager","P1","Onboarding","front/web; mobile manager","PA2-ONB-001","Premiere connexion guide horaires employes branding regles kiosk"


### PR DESCRIPTION
## Résumé
Implémente PA2-AUTO-002 (issue #762) : le script `validate-plan-action2.ps1` refusait déjà une dépendance vers un ID inconnu, mais ne détectait pas les cycles de dépendances entre tickets.

## Changements
- Ajout d'une détection de cycle (DFS) sur le graphe `Dependencies` des tickets PA2. En cas de cycle, le script échoue avec le chemin complet (ex: `PA2-X -> PA2-Y -> PA2-X`).
- **Bug réel trouvé en testant le script** : `PA2-MKT-007` (Funnel CRM marketing) et `PA2-ADM-004` (Pipeline CRM platform) se référençaient mutuellement dans `03_GITHUB_PROJECT_IMPORT.csv`. Logiquement le pipeline admin affiche les leads produits par le funnel marketing, donc la dépendance correcte est unidirectionnelle (`ADM-004 -> MKT-007`). La dépendance inverse a été retirée.
- CHANGELOG.md mis à jour (convention du projet).

## Tests
```
pwsh -File ./dev-hub/tools/validate-plan-action2.ps1
# PLAN_ACTION2 OK: 130 tickets, unique IDs, dependencies resolved.
```
Testé aussi avec un cycle injecté manuellement pour confirmer la détection (rollback avant commit).

Closes #762