### PR TITLE
fix(hr): allow marketing manager_role in Store/UpdateEmployeeRequest validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [4.23.0] - 2026-07-16
+
+### Fixed
+- **Role manager `marketing` invalidable via l'API malgre le support modele existant (Module Marketing - Phase 0)** : la migration `2026_06_22_000001_add_marketing_to_manager_role_enum.php` documentait deja `manager_role = 'marketing'` (colonne VARCHAR) et `Employee::isMarketing()` existait deja dans le modele, mais `StoreEmployeeRequest`/`UpdateEmployeeRequest` validaient toujours `manager_role` avec `in:principal,rh,dept,comptable,superviseur` — sans `marketing`. Il etait donc impossible de creer/mettre a jour un manager avec ce sous-role via `POST /api/v1/employees` ou `PATCH /api/v1/employees/{id}`. Ajout de `marketing` a la liste autorisee dans les deux Requests. Prepare la Phase 1 du futur module Marketing (gestion des reseaux sociaux du tenant).
+
 ## [4.22.8] - 2026-07-12
 
 ### Added

--- a/api/app/Modules/HR/Interfaces/Api/V1/Requests/StoreEmployeeRequest.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Requests/StoreEmployeeRequest.php
@@ -49,7 +49,7 @@ class StoreEmployeeRequest extends FormRequest
             'salary_base' => ['nullable', 'numeric', 'min:0'],
             'hourly_rate' => ['nullable', 'numeric', 'min:0'],
             'role' => ['nullable', 'in:employee,manager'],
-            'manager_role' => ['nullable', 'in:principal,rh,dept,comptable,superviseur'],
+            'manager_role' => ['nullable', 'in:principal,rh,dept,comptable,superviseur,marketing'],
             'phone' => ['nullable', 'string', 'max:30'],
             'personal_email' => ['nullable', 'email', 'max:150'],
             'middle_name' => ['nullable', 'string', 'max:100'],

--- a/api/app/Modules/HR/Interfaces/Api/V1/Requests/UpdateEmployeeRequest.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Requests/UpdateEmployeeRequest.php
@@ -53,7 +53,7 @@ class UpdateEmployeeRequest extends FormRequest
             'salary_base' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'hourly_rate' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'role' => ['sometimes', 'nullable', 'in:employee,manager'],
-            'manager_role' => ['sometimes', 'nullable', 'in:principal,rh,dept,comptable,superviseur'],
+            'manager_role' => ['sometimes', 'nullable', 'in:principal,rh,dept,comptable,superviseur,marketing'],
             'status' => ['sometimes', 'nullable', 'in:active,suspended'],
             'phone' => ['sometimes', 'nullable', 'string', 'max:30'],
             'personal_email' => ['sometimes', 'nullable', 'email', 'max:150'],

--- a/api/tests/Feature/EmployeesRbacTest.php
+++ b/api/tests/Feature/EmployeesRbacTest.php
@@ -518,6 +518,53 @@ class EmployeesRbacTest extends TestCase
         ]);
     }
 
+    public function test_principal_manager_can_create_employee_with_marketing_manager_role(): void
+    {
+        $companyA = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $managerA = Employee::query()->create([
+            'company_id' => $companyA->id,
+            'email' => 'manager@a.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+
+        $token = $managerA->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/api/v1/employees', [
+                'first_name' => 'Sara',
+                'last_name' => 'Comm',
+                'email' => 'sara.marketing@a.test',
+                'password' => 'password123',
+                'role' => 'manager',
+                'manager_role' => 'marketing',
+            ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.manager_role', 'marketing');
+        $this->assertDatabaseHas('employees', [
+            'email' => 'sara.marketing@a.test',
+            'company_id' => $companyA->id,
+            'manager_role' => 'marketing',
+        ]);
+
+        $marketingManager = Employee::query()->where('email', 'sara.marketing@a.test')->first();
+        $this->assertTrue($marketingManager->isMarketing());
+    }
+
     public function test_manager_cannot_update_employee_to_duplicate_email_within_same_company(): void
     {
         $companyA = Company::query()->create([


### PR DESCRIPTION
Phase 0 of the Marketing module plan.

The `manager_role` column has accepted `marketing` since migration `2026_06_22_000001_add_marketing_to_manager_role_enum.php`, and `Employee::isMarketing()` already existed, but the FormRequest validation whitelist in `StoreEmployeeRequest`/`UpdateEmployeeRequest` never included it — making it impossible to actually create/update a manager with this sub-role via the API.

- Add `marketing` to the `in:` validation rule in both Requests
- Add regression test in `EmployeesRbacTest`
- CHANGELOG entry

Next phases (Marketing module backend/mobile) to follow in separate PRs.