### PR TITLE
feat(marketing): Phase 1 - social_accounts/social_posts schema and models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [4.23.1] - 2026-07-16
+
+### Added
+- **Module Marketing (Phase 1) : schema et modeles de base** : creation du module `api/app/Modules/Marketing/` (Domain/Providers), suivant le pattern DDD des modules existants (Growth, Notification).
+  - Migrations tenant `create_social_accounts_table` et `create_social_posts_table`.
+  - `social_accounts` : connexion d'un tenant a un profil d'agregateur de publication (Ayrshare par defaut). Ne stocke volontairement aucun token OAuth Meta/LinkedIn/X brut — uniquement une reference chiffree (`provider_profile_ref`, cast `encrypted`, `hidden` en serialisation) au profil agregateur, qui gere lui-meme le cycle de vie OAuth. Reduit la surface d'exposition par rapport a un stockage de tokens par plateforme.
+  - `social_posts` : contenu, medias, plateformes cibles, statut (`draft|scheduled|publishing|published|failed`), planification, tracking des tentatives et erreurs. Prevu pour etre consomme par le futur job `PublishScheduledSocialPost` (Phase 4).
+  - Modeles Eloquent `SocialAccount`/`SocialPost` avec `BelongsToCompany` (isolation tenant standard du projet), casts, relation `hasMany`/`belongsTo`.
+  - `MarketingServiceProvider` enregistre dans `bootstrap/providers.php`.
+  - Tests Feature (`SocialAccountModelTest`) verifiant migrations + comportement modeles + chiffrement au repos. `phpstan-modules.neon` : 0 erreur sur le nouveau module. Formate via Pint.
+  - Pas encore d'endpoints API/Policies/UI (Phases 2-6 a suivre).
+
+## [4.23.0] - 2026-07-16
+
+### Fixed
+- **Role manager `marketing` invalidable via l'API malgre le support modele existant (Module Marketing - Phase 0)** : la migration `2026_06_22_000001_add_marketing_to_manager_role_enum.php` documentait deja `manager_role = 'marketing'` (colonne VARCHAR) et `Employee::isMarketing()` existait deja dans le modele, mais `StoreEmployeeRequest`/`UpdateEmployeeRequest` validaient toujours `manager_role` avec `in:principal,rh,dept,comptable,superviseur` — sans `marketing`. Il etait donc impossible de creer/mettre a jour un manager avec ce sous-role via `POST /api/v1/employees` ou `PATCH /api/v1/employees/{id}`. Ajout de `marketing` a la liste autorisee dans les deux Requests. Prepare la Phase 1 du futur module Marketing (gestion des reseaux sociaux du tenant).
+
 ## [4.22.8] - 2026-07-12
 
 ### Added

--- a/api/app/Modules/Marketing/Domain/Contracts/SocialAccountRepositoryInterface.php
+++ b/api/app/Modules/Marketing/Domain/Contracts/SocialAccountRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Marketing\Domain\Contracts;
+
+use App\Modules\Marketing\Domain\Models\SocialAccount;
+
+interface SocialAccountRepositoryInterface
+{
+    public function findForCompany(string $companyId, string $provider = 'ayrshare'): ?SocialAccount;
+}

--- a/api/app/Modules/Marketing/Domain/Exceptions/SocialAccountNotFoundException.php
+++ b/api/app/Modules/Marketing/Domain/Exceptions/SocialAccountNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Marketing\Domain\Exceptions;
+
+use App\Shared\Exceptions\DomainException;
+
+class SocialAccountNotFoundException extends DomainException
+{
+    public static function forCompany(string $companyId): self
+    {
+        return new self("Aucun compte social connecte pour l'entreprise {$companyId}.");
+    }
+}

--- a/api/app/Modules/Marketing/Domain/Models/SocialAccount.php
+++ b/api/app/Modules/Marketing/Domain/Models/SocialAccount.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Marketing\Domain\Models;
+
+use App\Shared\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string|null $company_id
+ * @property string $provider
+ * @property string $provider_profile_ref
+ * @property array<int, string>|null $connected_platforms
+ * @property string|null $display_name
+ * @property string $status
+ * @property string|null $last_error
+ * @property Carbon|null $connected_at
+ * @property int|null $created_by
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ *
+ * @mixin Builder<static>
+ */
+class SocialAccount extends Model
+{
+    use BelongsToCompany;
+
+    protected $fillable = [
+        'company_id',
+        'provider',
+        'provider_profile_ref',
+        'connected_platforms',
+        'display_name',
+        'status',
+        'last_error',
+        'connected_at',
+        'created_by',
+    ];
+
+    protected $hidden = [
+        'provider_profile_ref',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'provider_profile_ref' => 'encrypted',
+            'connected_platforms' => 'array',
+            'connected_at' => 'datetime',
+        ];
+    }
+
+    /** @return HasMany<SocialPost, $this> */
+    public function posts(): HasMany
+    {
+        return $this->hasMany(SocialPost::class);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+}

--- a/api/app/Modules/Marketing/Domain/Models/SocialPost.php
+++ b/api/app/Modules/Marketing/Domain/Models/SocialPost.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Marketing\Domain\Models;
+
+use App\Shared\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string|null $company_id
+ * @property int $social_account_id
+ * @property int|null $created_by
+ * @property string $content
+ * @property array<int, string>|null $media_paths
+ * @property array<int, string> $target_platforms
+ * @property string $status
+ * @property Carbon|null $scheduled_at
+ * @property Carbon|null $published_at
+ * @property string|null $provider_post_ref
+ * @property string|null $error_message
+ * @property int $attempts
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ *
+ * @mixin Builder<static>
+ */
+class SocialPost extends Model
+{
+    use BelongsToCompany;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_SCHEDULED = 'scheduled';
+
+    public const STATUS_PUBLISHING = 'publishing';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    public const STATUS_FAILED = 'failed';
+
+    protected $fillable = [
+        'company_id',
+        'social_account_id',
+        'created_by',
+        'content',
+        'media_paths',
+        'target_platforms',
+        'status',
+        'scheduled_at',
+        'published_at',
+        'provider_post_ref',
+        'error_message',
+        'attempts',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'media_paths' => 'array',
+            'target_platforms' => 'array',
+            'scheduled_at' => 'datetime',
+            'published_at' => 'datetime',
+            'attempts' => 'integer',
+        ];
+    }
+
+    /** @return BelongsTo<SocialAccount, $this> */
+    public function socialAccount(): BelongsTo
+    {
+        return $this->belongsTo(SocialAccount::class);
+    }
+
+    public function isDue(): bool
+    {
+        return $this->status === self::STATUS_SCHEDULED
+            && $this->scheduled_at !== null
+            && $this->scheduled_at->isPast();
+    }
+}

--- a/api/app/Modules/Marketing/Providers/MarketingServiceProvider.php
+++ b/api/app/Modules/Marketing/Providers/MarketingServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Marketing\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class MarketingServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // Bind Marketing module contracts here (Phase 2: SocialAccountRepositoryInterface).
+    }
+
+    public function boot(): void
+    {
+        // Boot Marketing module — routes loaded via routes/modules/marketing.php (Phase 3).
+    }
+}

--- a/api/bootstrap/providers.php
+++ b/api/bootstrap/providers.php
@@ -1,5 +1,24 @@
 <?php
 
+use App\Modules\Absence\Providers\AbsenceServiceProvider;
+use App\Modules\Attendance\Providers\AttendanceServiceProvider;
+use App\Modules\Billing\Providers\BillingServiceProvider;
+use App\Modules\Cabinet\Providers\CabinetServiceProvider;
+use App\Modules\Cameras\Providers\CamerasServiceProvider;
+use App\Modules\EdgeSync\Providers\EdgeSyncServiceProvider;
+use App\Modules\Expense\Providers\ExpenseServiceProvider;
+use App\Modules\Fleet\Providers\FleetServiceProvider;
+use App\Modules\Growth\Providers\GrowthServiceProvider;
+use App\Modules\HR\Providers\HRServiceProvider;
+use App\Modules\Marketing\Providers\MarketingServiceProvider;
+use App\Modules\Notification\Providers\NotificationServiceProvider;
+use App\Modules\Onboarding\Providers\OnboardingServiceProvider;
+use App\Modules\Payroll\Providers\PayrollServiceProvider;
+use App\Modules\Planning\Providers\PlanningServiceProvider;
+use App\Modules\Platform\Providers\PlatformServiceProvider;
+use App\Modules\Recruitment\Providers\RecruitmentServiceProvider;
+use App\Modules\SmartAttendance\Providers\SmartAttendanceServiceProvider;
+use App\Modules\Training\Providers\TrainingServiceProvider;
 use App\Providers\AppServiceProvider;
 use App\Providers\AuthServiceProvider;
 use App\Providers\EventServiceProvider;
@@ -12,26 +31,28 @@ return [
     EventServiceProvider::class,
     FeatureDetectionServiceProvider::class,
     FeatureRegistryServiceProvider::class,
-    App\Modules\HR\Providers\HRServiceProvider::class,
-    App\Modules\Payroll\Providers\PayrollServiceProvider::class,
-    App\Modules\Attendance\Providers\AttendanceServiceProvider::class,
-    App\Modules\Planning\Providers\PlanningServiceProvider::class,
-    App\Modules\Recruitment\Providers\RecruitmentServiceProvider::class,
-    App\Modules\Cabinet\Providers\CabinetServiceProvider::class,
-    App\Modules\Fleet\Providers\FleetServiceProvider::class,
-    App\Modules\Billing\Providers\BillingServiceProvider::class,
-    App\Modules\Cameras\Providers\CamerasServiceProvider::class,
+    HRServiceProvider::class,
+    PayrollServiceProvider::class,
+    AttendanceServiceProvider::class,
+    PlanningServiceProvider::class,
+    RecruitmentServiceProvider::class,
+    CabinetServiceProvider::class,
+    FleetServiceProvider::class,
+    BillingServiceProvider::class,
+    CamerasServiceProvider::class,
     // — New DDD modules (Phase 2)
-    App\Modules\Growth\Providers\GrowthServiceProvider::class,
-    App\Modules\Absence\Providers\AbsenceServiceProvider::class,
+    GrowthServiceProvider::class,
+    AbsenceServiceProvider::class,
     // — SmartAttendance module
-    App\Modules\SmartAttendance\Providers\SmartAttendanceServiceProvider::class,
-    App\Modules\Expense\Providers\ExpenseServiceProvider::class,
-    App\Modules\Notification\Providers\NotificationServiceProvider::class,
+    SmartAttendanceServiceProvider::class,
+    ExpenseServiceProvider::class,
+    NotificationServiceProvider::class,
     // — New DDD modules (Phase 3–4)
-    App\Modules\Platform\Providers\PlatformServiceProvider::class,
-    App\Modules\Onboarding\Providers\OnboardingServiceProvider::class,
-    App\Modules\Training\Providers\TrainingServiceProvider::class,
+    PlatformServiceProvider::class,
+    OnboardingServiceProvider::class,
+    TrainingServiceProvider::class,
     // — EdgeSync module
-    App\Modules\EdgeSync\Providers\EdgeSyncServiceProvider::class,
+    EdgeSyncServiceProvider::class,
+    // — Marketing module (Phase 1)
+    MarketingServiceProvider::class,
 ];

--- a/api/database/migrations/tenant/2026_07_16_000001_create_social_accounts_table.php
+++ b/api/database/migrations/tenant/2026_07_16_000001_create_social_accounts_table.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Module Marketing — Phase 1.
+ *
+ * social_accounts : connexion d'un tenant a un profil d'agregateur de
+ * publication reseaux sociaux (Ayrshare ou equivalent). On ne stocke
+ * volontairement PAS de tokens OAuth Meta/LinkedIn/X bruts ici : c'est
+ * l'agregateur qui gere le cycle de vie OAuth et le refresh cote lui.
+ * On ne persiste que la reference chiffree au profil (ex: Ayrshare
+ * Profile Key) necessaire pour appeler leur API en son nom.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('social_accounts')) {
+            return;
+        }
+
+        Schema::create('social_accounts', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+
+            // Fournisseur d'agregation (ayrshare, buffer, ...). Permet de changer
+            // de fournisseur plus tard sans migration de schema.
+            $table->string('provider', 30)->default('ayrshare');
+
+            // Reference chiffree au profil cote agregateur (ex: Ayrshare Profile Key).
+            // Chiffre via cast Eloquent 'encrypted', jamais logue en clair.
+            $table->text('provider_profile_ref');
+
+            // Plateformes activees pour ce profil (linkedin, facebook_page,
+            // facebook_group, twitter, ...). Informatif, la verite reste cote
+            // agregateur mais utile pour l'UI sans appel reseau.
+            $table->json('connected_platforms')->nullable();
+
+            $table->string('display_name', 120)->nullable();
+            $table->string('status', 20)->default('active'); // active|revoked|error
+            $table->text('last_error')->nullable();
+            $table->timestampTz('connected_at')->nullable();
+
+            $table->unsignedInteger('created_by')->nullable();
+
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('updated_at')->useCurrent();
+
+            $table->unique(['company_id', 'provider']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('social_accounts');
+    }
+};

--- a/api/database/migrations/tenant/2026_07_16_000002_create_social_posts_table.php
+++ b/api/database/migrations/tenant/2026_07_16_000002_create_social_posts_table.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Module Marketing — Phase 1.
+ *
+ * social_posts : contenu a publier/planifier sur une ou plusieurs
+ * plateformes via le social_account du tenant. Consomme par le job
+ * planifie PublishScheduledSocialPost (Phase 4).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('social_posts')) {
+            return;
+        }
+
+        Schema::create('social_posts', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id')->index();
+            $table->unsignedBigInteger('social_account_id')->index();
+
+            $table->unsignedInteger('created_by')->nullable()->index();
+
+            $table->text('content');
+            // Chemins/URLs des medias (S3-compatible), pas les binaires.
+            $table->json('media_paths')->nullable();
+
+            // Plateformes cibles pour cette publication precise
+            // (ex: ["linkedin", "facebook_page"]).
+            $table->json('target_platforms');
+
+            $table->string('status', 20)->default('draft')->index();
+            // draft | scheduled | publishing | published | failed
+
+            $table->timestampTz('scheduled_at')->nullable()->index();
+            $table->timestampTz('published_at')->nullable();
+
+            // Reference agregateur (ex: Ayrshare post id) pour retrouver le
+            // statut ou traiter les webhooks de confirmation plus tard.
+            $table->string('provider_post_ref', 120)->nullable();
+
+            $table->text('error_message')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('updated_at')->useCurrent();
+
+            $table->index(['company_id', 'status', 'scheduled_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('social_posts');
+    }
+};

--- a/api/tests/Feature/Marketing/SocialAccountModelTest.php
+++ b/api/tests/Feature/Marketing/SocialAccountModelTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Marketing;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Marketing\Domain\Models\SocialAccount;
+use App\Modules\Marketing\Domain\Models\SocialPost;
+use Illuminate\Support\Facades\DB;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Module Marketing — Phase 1.
+ *
+ * Verifies the social_accounts / social_posts migrations run cleanly and
+ * that the Eloquent models behave as expected (tenant scoping, casts,
+ * relation). No HTTP endpoints exist yet — those land in Phase 3.
+ */
+class SocialAccountModelTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    public function test_social_account_can_be_created_and_is_scoped_to_company(): void
+    {
+        $company = Company::factory()->create();
+
+        $account = SocialAccount::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'provider' => 'ayrshare',
+            'provider_profile_ref' => 'profile-key-123',
+            'connected_platforms' => ['linkedin', 'facebook_page'],
+            'display_name' => 'Leopardo Marketing',
+            'status' => 'active',
+        ]);
+
+        $this->assertDatabaseHas('social_accounts', [
+            'id' => $account->id,
+            'company_id' => $company->id,
+            'provider' => 'ayrshare',
+            'display_name' => 'Leopardo Marketing',
+            'status' => 'active',
+        ]);
+
+        $this->assertTrue($account->isActive());
+        $this->assertSame(['linkedin', 'facebook_page'], $account->connected_platforms);
+
+        // provider_profile_ref must never be exposed via array/JSON serialization.
+        $this->assertArrayNotHasKey('provider_profile_ref', $account->toArray());
+
+        // Stored value must be encrypted at rest, never the raw plaintext.
+        $raw = DB::table('social_accounts')
+            ->where('id', $account->id)
+            ->value('provider_profile_ref');
+        $this->assertNotSame('profile-key-123', $raw);
+    }
+
+    public function test_social_post_belongs_to_social_account_and_reports_due_state(): void
+    {
+        $company = Company::factory()->create();
+
+        $account = SocialAccount::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'provider' => 'ayrshare',
+            'provider_profile_ref' => 'profile-key-456',
+            'status' => 'active',
+        ]);
+
+        $duePost = SocialPost::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'social_account_id' => $account->id,
+            'content' => 'Journee portes ouvertes ce vendredi !',
+            'target_platforms' => ['linkedin'],
+            'status' => SocialPost::STATUS_SCHEDULED,
+            'scheduled_at' => now()->subMinute(),
+        ]);
+
+        $futurePost = SocialPost::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'social_account_id' => $account->id,
+            'content' => 'Publication planifiee pour demain.',
+            'target_platforms' => ['facebook_page'],
+            'status' => SocialPost::STATUS_SCHEDULED,
+            'scheduled_at' => now()->addDay(),
+        ]);
+
+        $this->assertTrue($duePost->isDue());
+        $this->assertFalse($futurePost->isDue());
+        $this->assertTrue($duePost->socialAccount->is($account));
+    }
+}


### PR DESCRIPTION
Phase 1/6 of the Marketing module plan.

Adds the `api/app/Modules/Marketing/` module skeleton (Domain/Providers) following the existing Growth/Notification DDD pattern.

- Migrations: `social_accounts`, `social_posts` (tenant schema)
- `social_accounts` intentionally stores only an encrypted aggregator profile reference (Ayrshare Profile Key), not raw per-platform OAuth tokens — the aggregator owns OAuth lifecycle/refresh. Reduces stored-secret surface vs the original plan draft.
- `social_posts`: content/media/target platforms/status/scheduling, ready to be consumed by the Phase 4 `PublishScheduledSocialPost` job.
- Eloquent models with `BelongsToCompany` tenant scoping, matching existing module conventions.
- `MarketingServiceProvider` registered.
- Feature test verifying migrations against Postgres + model behavior + at-rest encryption.
- `phpstan-modules.neon`: 0 errors. Pint-formatted.

No endpoints/policies/UI yet (Phases 2-6 to follow).

Builds on top of main independently of #856 (Phase 0).