### PR TITLE
fix(ci,security): CodeQL high alerts, missing workflow permissions, phpstan-modules Larastan extension

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   phpstan-modules:
     name: PHPStan — Modules Architecture

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -33,10 +33,18 @@ jobs:
       - name: Resolve deployment source
         id: context
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WR_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WR_EVENT: ${{ github.event.workflow_run.event }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
               echo "should_deploy=false" >> "$GITHUB_OUTPUT"
               echo "ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -49,10 +57,16 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ github.event.workflow_run.conclusion }}" == "success" && "${{ github.event.workflow_run.event }}" == "push" && "${{ github.event.workflow_run.head_branch }}" == "main" ]]; then
+          # Defense in depth: only ever treat this as a deployable run when the
+          # upstream workflow_run (a) succeeded, (b) was itself triggered by a
+          # push (never pull_request/pull_request_target from a fork), (c) targeted
+          # main, and (d) ran in this same base repository (not a fork). This keeps
+          # the subsequent privileged checkout scoped to code that was already
+          # pushed to main by a trusted collaborator.
+          if [[ "${WR_CONCLUSION}" == "success" && "${WR_EVENT}" == "push" && "${WR_HEAD_BRANCH}" == "main" && "${WR_HEAD_REPO}" == "${BASE_REPO}" ]]; then
             echo "should_deploy=pending-validation" >> "$GITHUB_OUTPUT"
             echo "ref=main" >> "$GITHUB_OUTPUT"
-            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "sha=${WR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
           else
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
             echo "ref=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/i18n-enterprise.yml
+++ b/.github/workflows/i18n-enterprise.yml
@@ -22,6 +22,9 @@ on:
       - 'api/lang/**'
       - '.github/workflows/i18n-enterprise.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-and-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,9 @@ name: Lighthouse CI
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [4.23.2] - 2026-07-16
+
+### Fixed
+- **CI/Securite : alertes CodeQL high sur `deploy-main.yml`** : `github.event.workflow_run.head_branch` etait interpole directement dans un bloc `run:` shell (risque de cache-poisoning/injection) ; deplace vers une variable d'environnement (`WR_HEAD_BRANCH`). Le trigger `workflow_run` (privilegie, acces secrets) ne verifiait pas que le run d'origine provenait bien du repo de base (et non d'un fork) ; ajout d'une verification `head_repository == github.repository` en plus des checks existants conclusion/event/branch.
+- **CI : permissions GITHUB_TOKEN manquantes** : ajout d'un bloc `permissions: contents: read` explicite sur `architecture-check.yml`, `i18n-enterprise.yml` et `lighthouse.yml` (alertes CodeQL `actions/missing-workflow-permissions`).
+- **`api/phpstan-modules.neon` ne chargeait pas l'extension Larastan** : contrairement a `api/phpstan.neon`, l'include `vendor/larastan/larastan/extension.neon` etait absent, privant PHPStan de la connaissance des scopes Eloquent locaux (`scopeActive()` -> `active()`, `scopeForCountry()` -> `forCountry()`, `scopeForYear()` -> `forYear()`, etc.) et des relations magiques Eloquent. Cause racine des 36 erreurs "Call to an undefined method" qui faisaient echouer le job "PHPStan — Modules Architecture" sur `main` et sur PR #858.
+
+### Security
+- Activation de Dependabot alerts sur le repo (34 vulnerabilites detectees a l'activation : 11 high, 16 moderate, 7 low — suivi separe requis).
+- Branch protection `main` : revue obligatoire (1 approbation) desormais requise pour les contributeurs non-admin avant merge.
+
 ## [4.23.1] - 2026-07-16
 
 ### Added

--- a/api/phpstan-modules.neon
+++ b/api/phpstan-modules.neon
@@ -1,5 +1,6 @@
 includes:
     - phpstan-modules-baseline.neon
+    - vendor/larastan/larastan/extension.neon
 
 parameters:
     bootstrapFiles:


### PR DESCRIPTION
## Contexte
Suivi de l'audit du repo demandé le 2026-07-16. Ce PR couvre les points actionnables côté code parmi les 5 demandés :

1. ~~Rotation mot de passe Redis Upstash~~ → nécessite accès credentials Upstash/Render, hors périmètre code (voir note ci-dessous)
2. **Alertes CodeQL "high/error" sur `deploy-main.yml`** ✅ corrigées
3. ~~Activer Dependabot alerts~~ ✅ fait via API (`PUT /repos/.../vulnerability-alerts`) — 34 vulnérabilités déjà détectées (11 high, 16 moderate, 7 low), voir Security > Dependabot
4. ~~Branch protection `main`~~ ✅ fait via API : revue obligatoire (1 approbation) activée pour les non-admins ; `enforce_admins` laissé à `false` car `kitokoh` est actuellement le seul mainteneur humain — l'activer aurait bloqué tous ses merges solo.
5. **PHPStan bloquant PR #858** ✅ cause racine identifiée et corrigée

## Détail des changements

### `deploy-main.yml` — CodeQL high alerts
- **`actions/cache-poisoning/code-injection`** : `github.event.workflow_run.head_branch` était interpolé directement dans un bloc `run:` shell. Déplacé vers une variable d'environnement (`WR_HEAD_BRANCH`) avant utilisation.
- **`actions/untrusted-checkout/high`** : le trigger `workflow_run` (privilégié, accès secrets) ne vérifiait pas que le run d'origine provenait bien de ce repo (et non d'un fork). Ajout d'une vérification `head_repository == github.repository` en plus des checks existants (conclusion/event/branch).

### `architecture-check.yml`, `i18n-enterprise.yml`, `lighthouse.yml` — permissions manquantes
Ajout d'un bloc `permissions: contents: read` explicite. Aucun de ces jobs n'écrit dans le repo ni n'a besoin de plus que la lecture.

### `api/phpstan-modules.neon` — cause racine des 36 erreurs PHPStan
Le fichier n'incluait pas `vendor/larastan/larastan/extension.neon`, contrairement à `api/phpstan.neon` qui l'inclut. Sans Larastan, PHPStan ne connaît pas les scopes Eloquent locaux (`scopeActive()` → `active()`, `scopeForCountry()` → `forCountry()`, `scopeForYear()` → `forYear()`, etc.) ni les relations magiques Eloquent — ce qui explique la totalité des 36 erreurs "Call to an undefined method" qui font échouer le job "PHPStan — Modules Architecture" sur `main` et sur PR #858.

## Non traité dans ce PR (suivi séparé recommandé)
Les 7 alertes CodeQL medium `actions/excessive-secrets-exposure` sur `deploy-main.yml` et `mobile-distribute.yml` (`secrets[matrix.app.firebase_secret]`). Un fix propre nécessite de dérouler la matrice de distribution Firebase en jobs séparés par app (employee/manager/platform_admin/hr) — un refactor plus large nécessitant un environnement Flutter/PHP pour validation, hors périmètre de ce passage d'audit.

## ⚠️ Action manuelle requise (hors code)
Le mot de passe Redis Upstash committé en clair dans l'historique git (documenté dans `AUDIT.md`) reste à rotater manuellement sur le dashboard Upstash — aucun outil ne peut faire ça depuis le repo.

## Validation
- YAML validé avec `js-yaml` (pas de PHP/Composer disponible dans l'environnement d'édition pour lancer PHPStan localement — à confirmer par la CI sur ce PR).
