### PR TITLE
PA2-SEC-002: RBAC department scope for manager_role=dept

### DIFF
--- a/api/app/Core/Auth/Domain/Models/Employee.php
+++ b/api/app/Core/Auth/Domain/Models/Employee.php
@@ -124,6 +124,8 @@ class Employee extends Authenticatable implements HasApiTokensContract
     protected $fillable = [
         'company_id',
         'schedule_id',
+        'department_id',
+        'position_id',
         'site_id',
         'matricule',
         'zkteco_id',
@@ -256,6 +258,32 @@ class Employee extends Authenticatable implements HasApiTokensContract
     public function isDept(): bool
     {
         return $this->hasManagerRole('dept');
+    }
+
+    /**
+     * Whether this actor's manager scope is limited to a single department
+     * (currently only `manager_role = 'dept'`). Company-wide roles
+     * (principal, rh, comptable, marketing) and self-service employees
+     * are not department-scoped.
+     */
+    public function isDepartmentScoped(): bool
+    {
+        return $this->isDept();
+    }
+
+    /**
+     * Whether $target sits within this department-scoped actor's own
+     * department. Returns false when the actor has no department
+     * assigned (fail closed) so a misconfigured dept manager sees
+     * nothing rather than everything.
+     */
+    public function managesDepartmentOf(self $target): bool
+    {
+        if ($this->department_id === null) {
+            return false;
+        }
+
+        return $this->department_id === $target->department_id;
     }
 
     /**

--- a/api/app/Modules/Attendance/Infrastructure/Services/AttendanceAnomalyService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/AttendanceAnomalyService.php
@@ -13,12 +13,19 @@ class AttendanceAnomalyService
      * @param  array{employee_id?: int|null, date_from?: string|null, date_to?: string|null, per_page?: int|null}  $filters
      * @return array<string, mixed>
      */
-    public function summarize(string $companyId, array $filters = []): array
+    public function summarize(string $companyId, array $filters = [], ?int $departmentId = null): array
     {
         $company = Company::query()->find($companyId);
         $dateTo = Carbon::parse($filters['date_to'] ?? now('UTC')->toDateString())->toDateString();
         $dateFrom = Carbon::parse($filters['date_from'] ?? Carbon::parse($dateTo)->subDays(30)->toDateString())->toDateString();
         $limit = max(1, min(100, (int) ($filters['per_page'] ?? 50)));
+
+        $departmentEmployeeIds = $departmentId !== null
+            ? \App\Core\Auth\Domain\Models\Employee::query()
+                ->where('company_id', $companyId)
+                ->where('department_id', $departmentId)
+                ->pluck('id')
+            : null;
 
         $logs = AttendanceLog::query()
             ->with(['employee:id,company_id,first_name,last_name,matricule'])
@@ -42,6 +49,7 @@ class AttendanceAnomalyService
             ->where('company_id', $companyId)
             ->whereBetween('date', [$dateFrom, $dateTo])
             ->when($filters['employee_id'] ?? null, fn ($query, $employeeId) => $query->where('employee_id', $employeeId))
+            ->when($departmentEmployeeIds !== null, fn ($query) => $query->whereIn('employee_id', $departmentEmployeeIds))
             ->orderByDesc('date')
             ->orderByDesc('id')
             ->get();

--- a/api/app/Modules/Attendance/Infrastructure/Services/AttendanceMonthlyReportService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/AttendanceMonthlyReportService.php
@@ -12,14 +12,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AttendanceMonthlyReportService
 {
-    public function build(Company $company, string $month): array
+    public function build(Company $company, string $month, ?int $departmentId = null): array
     {
         $start = Carbon::createFromFormat('Y-m-d', $month.'-01', $company->timezone)->startOfMonth();
         $end = $start->copy()->endOfMonth();
 
         $employees = Employee::query()
-            ->select(['id', 'company_id', 'first_name', 'last_name', 'matricule', 'status', 'salary_type', 'salary_base', 'hourly_rate'])
+            ->select(['id', 'company_id', 'department_id', 'first_name', 'last_name', 'matricule', 'status', 'salary_type', 'salary_base', 'hourly_rate'])
             ->where('company_id', $company->id)
+            ->when($departmentId !== null, fn ($query) => $query->where('department_id', $departmentId))
             ->orderBy('id')
             ->get();
 
@@ -39,6 +40,7 @@ class AttendanceMonthlyReportService
             ])
             ->where('company_id', $company->id)
             ->whereBetween('date', [$start->toDateString(), $end->toDateString()])
+            ->when($departmentId !== null, fn ($query) => $query->whereIn('employee_id', $employees->pluck('id')))
             ->get();
 
         $logsByEmployee = $logs->groupBy('employee_id');

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/AttendanceController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/AttendanceController.php
@@ -100,9 +100,13 @@ class AttendanceController extends Controller
             $perPage = $request->integer('per_page', 50);
 
             $paginator = Employee::query()
-                ->select(['id', 'company_id', 'first_name', 'last_name', 'email', 'role', 'status'])
+                ->select(['id', 'company_id', 'department_id', 'first_name', 'last_name', 'email', 'role', 'status'])
                 ->where('company_id', $actor->company_id)
                 ->where('status', 'active')
+                ->when(
+                    $actor->isDepartmentScoped(),
+                    fn ($query) => $query->where('department_id', $actor->department_id ?? -1)
+                )
                 ->orderBy('id')
                 ->paginate(max(1, min(100, $perPage)));
 
@@ -195,6 +199,15 @@ class AttendanceController extends Controller
             // Manager viewing all employees: scope to own company to prevent cross-tenant data leakage.
             // AttendanceLog has no global company scope, so we must add the WHERE clause explicitly.
             $query->where('company_id', $actor->company_id);
+
+            if ($actor->isDepartmentScoped()) {
+                // manager_role=dept is scoped to their own department only (PA2-SEC-002).
+                $departmentEmployeeIds = Employee::query()
+                    ->where('company_id', $actor->company_id)
+                    ->where('department_id', $actor->department_id ?? -1)
+                    ->pluck('id');
+                $query->whereIn('employee_id', $departmentEmployeeIds);
+            }
         }
 
         if (! empty($validated['date_from'])) {
@@ -228,7 +241,11 @@ class AttendanceController extends Controller
         $this->authorize('viewAny', AttendanceLog::class);
 
         return new JsonResponse(
-            $anomalyService->summarize($actor->company_id, $request->validated())
+            $anomalyService->summarize(
+                $actor->company_id,
+                $request->validated(),
+                $actor->isDepartmentScoped() ? ($actor->department_id ?? -1) : null,
+            )
         );
     }
 
@@ -245,7 +262,11 @@ class AttendanceController extends Controller
         $validated = $request->validated();
         $month = $validated['month'] ?? now($company->timezone)->format('Y-m');
         $format = $validated['format'] ?? 'json';
-        $report = $reportService->build($company, $month);
+        $report = $reportService->build(
+            $company,
+            $month,
+            $actor->isDepartmentScoped() ? ($actor->department_id ?? -1) : null,
+        );
 
         return match ($format) {
             'csv' => $reportService->toCsv($report),

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DepartmentController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DepartmentController.php
@@ -22,10 +22,14 @@ class DepartmentController extends Controller
             abort(403);
         }
 
-        $departments = Department::query()
-            ->with('manager:id,first_name,last_name')
-            ->orderBy('name')
-            ->get();
+        $query = Department::query()->with('manager:id,first_name,last_name');
+
+        if ($user->isDepartmentScoped()) {
+            // manager_role=dept is scoped to their own department only (PA2-SEC-002).
+            $query->where('id', $user->department_id ?? -1);
+        }
+
+        $departments = $query->orderBy('name')->get();
 
         return DepartmentResource::collection($departments);
     }
@@ -43,17 +47,15 @@ class DepartmentController extends Controller
 
     public function show(Request $request, Department $department): DepartmentResource
     {
-        /** @var Employee $user */
-        $user = $request->user();
-        if (! $user->isManager()) {
-            abort(403);
-        }
+        $this->authorize('view', $department);
 
         return new DepartmentResource($department->load('manager', 'positions'));
     }
 
     public function update(UpdateDepartmentRequest $request, Department $department): DepartmentResource
     {
+        $this->authorize('update', $department);
+
         $department->update($request->validated());
 
         return new DepartmentResource($department->fresh());
@@ -61,11 +63,7 @@ class DepartmentController extends Controller
 
     public function destroy(Request $request, Department $department): JsonResponse
     {
-        /** @var Employee $user */
-        $user = $request->user();
-        if (! $user->isManager()) {
-            abort(403);
-        }
+        $this->authorize('delete', $department);
 
         $department->delete();
 

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
@@ -84,6 +84,12 @@ class EmployeeController extends Controller
             ])
             ->select($this->employeeIndexColumns());
 
+        if ($actor->isDepartmentScoped()) {
+            // manager_role=dept is scoped to their own department only (PA2-SEC-002).
+            // Fail closed: an actor without a department sees nothing rather than everything.
+            $query->where('department_id', $actor->department_id ?? -1);
+        }
+
         if (! empty($validated['status'])) {
             $query->where('status', $validated['status']);
         }

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EvaluationController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EvaluationController.php
@@ -54,6 +54,14 @@ class EvaluationController extends Controller
         if (! $actor->isManager()) {
             $query->where('employee_id', $actor->id);
         } else {
+            if ($actor->isDepartmentScoped()) {
+                // manager_role=dept is scoped to their own department only (PA2-SEC-002).
+                $departmentEmployeeIds = Employee::query()
+                    ->where('company_id', $actor->company_id)
+                    ->where('department_id', $actor->department_id ?? -1)
+                    ->pluck('id');
+                $query->whereIn('employee_id', $departmentEmployeeIds);
+            }
             if ($request->filled('employee_id')) {
                 $query->where('employee_id', $request->integer('employee_id'));
             }
@@ -79,7 +87,22 @@ class EvaluationController extends Controller
     {
         /** @var Employee $actor */
         $actor = $request->user();
+
+        $this->authorize('create', Evaluation::class);
+
         $data = $request->validated();
+
+        if ($actor->isDepartmentScoped()) {
+            // manager_role=dept can only evaluate employees within their own
+            // department (PA2-SEC-002).
+            $target = Employee::query()
+                ->where('company_id', $actor->company_id)
+                ->findOrFail($data['employee_id']);
+
+            if (! $actor->managesDepartmentOf($target)) {
+                abort(403);
+            }
+        }
 
         if (Evaluation::where('employee_id', $data['employee_id'])->where('evaluator_id', $actor->id)->where('period', $data['period'])->exists()) {
             return response()->json(['error' => ['code' => 'EVALUATION_ALREADY_EXISTS', 'message' => 'Une évaluation existe déjà pour cet employé sur cette période.']], 422);

--- a/api/app/Modules/Planning/Interfaces/Api/V1/ScheduleController.php
+++ b/api/app/Modules/Planning/Interfaces/Api/V1/ScheduleController.php
@@ -123,6 +123,12 @@ class ScheduleController extends Controller
         );
         $employees = Employee::query()
             ->where('company_id', $actor->company_id)
+            ->when(
+                $actor->isDepartmentScoped(),
+                // manager_role=dept can only assign schedules to employees in their own
+                // department (PA2-SEC-002); fail closed when the actor has no department.
+                fn ($query) => $query->where('department_id', $actor->department_id ?? -1)
+            )
             ->whereIn('id', $employeeIds)
             ->get(['id']);
 

--- a/api/app/Policies/AttendancePolicy.php
+++ b/api/app/Policies/AttendancePolicy.php
@@ -24,7 +24,19 @@ class AttendancePolicy
 
     public function viewForEmployee(Employee $actor, Employee $target): bool
     {
-        return $actor->isManager() || $actor->id === $target->id;
+        if ($actor->id === $target->id) {
+            return true;
+        }
+
+        if (! $actor->isManager()) {
+            return false;
+        }
+
+        if ($actor->isDepartmentScoped()) {
+            return $actor->managesDepartmentOf($target);
+        }
+
+        return true;
     }
 
     public function update(Employee $actor, AttendanceLog $log): bool

--- a/api/app/Policies/DepartmentPolicy.php
+++ b/api/app/Policies/DepartmentPolicy.php
@@ -16,17 +16,33 @@ class DepartmentPolicy
 
     public function view(Employee $actor, Department $department): bool
     {
-        return $department->company_id === $actor->company_id;
+        if ($department->company_id !== $actor->company_id) {
+            return false;
+        }
+
+        if ($actor->isDepartmentScoped()) {
+            return $actor->department_id !== null && $actor->department_id === $department->id;
+        }
+
+        return true;
     }
 
     public function create(Employee $actor): bool
     {
-        return $actor->isManager();
+        return $actor->hasManagerRole('principal', 'rh');
     }
 
     public function update(Employee $actor, Department $department): bool
     {
-        return $department->company_id === $actor->company_id && $actor->isManager();
+        if ($department->company_id !== $actor->company_id || ! $actor->isManager()) {
+            return false;
+        }
+
+        if ($actor->isDepartmentScoped()) {
+            return $actor->department_id !== null && $actor->department_id === $department->id;
+        }
+
+        return true;
     }
 
     public function delete(Employee $actor, Department $department): bool

--- a/api/app/Policies/EmployeePolicy.php
+++ b/api/app/Policies/EmployeePolicy.php
@@ -13,7 +13,19 @@ class EmployeePolicy
 
     public function view(Employee $actor, Employee $employee): bool
     {
-        return $actor->isManager() || $actor->id === $employee->id;
+        if ($actor->id === $employee->id) {
+            return true;
+        }
+
+        if (! $actor->isManager()) {
+            return false;
+        }
+
+        if ($actor->isDepartmentScoped()) {
+            return $actor->managesDepartmentOf($employee);
+        }
+
+        return true;
     }
 
     public function create(Employee $actor): bool

--- a/api/app/Policies/EvaluationPolicy.php
+++ b/api/app/Policies/EvaluationPolicy.php
@@ -18,7 +18,11 @@ class EvaluationPolicy
             return false;
         }
 
-        return $actor->isManager() || $actor->id === $evaluation->employee_id;
+        if ($actor->id === $evaluation->employee_id) {
+            return true;
+        }
+
+        return $this->managesEvaluatedEmployee($actor, $evaluation);
     }
 
     public function create(Employee $actor): bool
@@ -32,7 +36,7 @@ class EvaluationPolicy
             return false;
         }
 
-        return $actor->isManager();
+        return $this->managesEvaluatedEmployee($actor, $evaluation);
     }
 
     public function delete(Employee $actor, Evaluation $evaluation): bool
@@ -41,7 +45,7 @@ class EvaluationPolicy
             return false;
         }
 
-        return $actor->isManager();
+        return $this->managesEvaluatedEmployee($actor, $evaluation);
     }
 
     public function submit(Employee $actor, Evaluation $evaluation): bool
@@ -50,7 +54,7 @@ class EvaluationPolicy
             return false;
         }
 
-        return $actor->isManager();
+        return $this->managesEvaluatedEmployee($actor, $evaluation);
     }
 
     public function acknowledge(Employee $actor, Evaluation $evaluation): bool
@@ -60,6 +64,25 @@ class EvaluationPolicy
         }
 
         return $actor->id === $evaluation->employee_id;
+    }
+
+    /**
+     * PA2-SEC-002: manager_role=dept may only act on evaluations for employees
+     * within their own department. Company-wide manager roles are unaffected.
+     */
+    private function managesEvaluatedEmployee(Employee $actor, Evaluation $evaluation): bool
+    {
+        if (! $actor->isManager()) {
+            return false;
+        }
+
+        if (! $actor->isDepartmentScoped()) {
+            return true;
+        }
+
+        $target = $evaluation->employee;
+
+        return $target !== null && $actor->managesDepartmentOf($target);
     }
 }
 

--- a/api/tests/Feature/Security/DepartmentScopedRbacTest.php
+++ b/api/tests/Feature/Security/DepartmentScopedRbacTest.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
+use App\Modules\HR\Domain\Models\Department;
+use App\Modules\HR\Domain\Models\Evaluation;
+use App\Modules\Planning\Domain\Models\Schedule;
+use Illuminate\Support\Facades\Hash;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-SEC-002: manager_role=dept doit etre reellement scope au departement
+ * de l'acteur (via Employee.department_id), pour EmployeePolicy,
+ * AttendancePolicy, SchedulePolicy (via ScheduleController), EvaluationPolicy
+ * et DepartmentPolicy.
+ */
+class DepartmentScopedRbacTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    /**
+     * @return array{
+     *     company: Company,
+     *     deptA: Department,
+     *     deptB: Department,
+     *     managerA: Employee,
+     *     managerB: Employee,
+     *     managerNoDept: Employee,
+     *     employeeA: Employee,
+     *     employeeB: Employee,
+     * }
+     */
+    private function seedScopedCompany(): array
+    {
+        $company = Company::query()->create([
+            'name' => 'Company Scoped',
+            'slug' => 'company-scoped',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'scoped@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $deptA = Department::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Department A',
+        ]);
+
+        $deptB = Department::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Department B',
+        ]);
+
+        $managerA = Employee::query()->create([
+            'company_id' => $company->id,
+            'department_id' => $deptA->id,
+            'email' => 'manager-a@scoped.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'dept',
+            'status' => 'active',
+        ]);
+
+        $managerB = Employee::query()->create([
+            'company_id' => $company->id,
+            'department_id' => $deptB->id,
+            'email' => 'manager-b@scoped.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'dept',
+            'status' => 'active',
+        ]);
+
+        $managerNoDept = Employee::query()->create([
+            'company_id' => $company->id,
+            'department_id' => null,
+            'email' => 'manager-nodept@scoped.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'dept',
+            'status' => 'active',
+        ]);
+
+        $employeeA = Employee::query()->create([
+            'company_id' => $company->id,
+            'department_id' => $deptA->id,
+            'email' => 'employee-a@scoped.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $employeeB = Employee::query()->create([
+            'company_id' => $company->id,
+            'department_id' => $deptB->id,
+            'email' => 'employee-b@scoped.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        return [
+            'company' => $company,
+            'deptA' => $deptA,
+            'deptB' => $deptB,
+            'managerA' => $managerA,
+            'managerB' => $managerB,
+            'managerNoDept' => $managerNoDept,
+            'employeeA' => $employeeA,
+            'employeeB' => $employeeB,
+        ];
+    }
+
+    public function test_dept_manager_lists_only_employees_of_own_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/employees');
+
+        $response->assertOk();
+
+        $emails = collect($response->json('data'))->pluck('email')->all();
+        $this->assertContains('manager-a@scoped.test', $emails);
+        $this->assertContains('employee-a@scoped.test', $emails);
+        $this->assertNotContains('employee-b@scoped.test', $emails);
+        $this->assertNotContains('manager-b@scoped.test', $emails);
+    }
+
+    public function test_dept_manager_without_department_sees_no_employees(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerNoDept']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/employees');
+
+        $response->assertOk();
+
+        $this->assertSame([], $response->json('data'));
+    }
+
+    public function test_dept_manager_cannot_view_employee_from_other_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $ownDept = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/employees/'.$seed['employeeA']->id);
+        $ownDept->assertOk();
+
+        $otherDept = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/employees/'.$seed['employeeB']->id);
+        $otherDept->assertForbidden();
+    }
+
+    public function test_dept_manager_attendance_today_scoped_to_own_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/attendance/today');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.mode', 'collection');
+
+        $ids = collect($response->json('data.items'))
+            ->pluck('employee_id')
+            ->all();
+
+        $this->assertContains($seed['employeeA']->id, $ids);
+        $this->assertNotContains($seed['employeeB']->id, $ids);
+    }
+
+    public function test_dept_manager_cannot_view_attendance_for_employee_outside_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/attendance?employee_id='.$seed['employeeB']->id);
+
+        $response->assertForbidden();
+    }
+
+    public function test_dept_manager_attendance_index_all_scoped_to_own_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        AttendanceLog::query()->create([
+            'company_id' => $seed['company']->id,
+            'employee_id' => $seed['employeeA']->id,
+            'date' => now()->toDateString(),
+            'session_number' => 1,
+            'status' => 'complete',
+        ]);
+
+        AttendanceLog::query()->create([
+            'company_id' => $seed['company']->id,
+            'employee_id' => $seed['employeeB']->id,
+            'date' => now()->toDateString(),
+            'session_number' => 1,
+            'status' => 'complete',
+        ]);
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/attendance');
+
+        $response->assertOk();
+
+        $employeeIds = collect($response->json('data'))->pluck('employee_id')->all();
+        $this->assertContains($seed['employeeA']->id, $employeeIds);
+        $this->assertNotContains($seed['employeeB']->id, $employeeIds);
+    }
+
+    public function test_dept_manager_can_only_assign_schedule_to_own_department_employees(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $schedule = Schedule::query()->create([
+            'company_id' => $seed['company']->id,
+            'name' => 'Standard',
+            'start_time' => '09:00:00',
+            'end_time' => '17:00:00',
+        ]);
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $ownDeptResponse = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/api/v1/schedules/'.$schedule->id.'/assign-employees', [
+                'employee_ids' => [$seed['employeeA']->id],
+            ]);
+        $ownDeptResponse->assertOk();
+
+        $seed['employeeA']->refresh();
+        $this->assertSame($schedule->id, $seed['employeeA']->schedule_id);
+
+        $otherDeptResponse = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/api/v1/schedules/'.$schedule->id.'/assign-employees', [
+                'employee_ids' => [$seed['employeeB']->id],
+            ]);
+        $otherDeptResponse->assertStatus(422);
+
+        $seed['employeeB']->refresh();
+        $this->assertNotSame($schedule->id, $seed['employeeB']->schedule_id);
+    }
+
+    public function test_dept_manager_cannot_view_department_of_another_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $ownDept = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/departments/'.$seed['deptA']->id);
+        $ownDept->assertOk();
+
+        $otherDept = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/departments/'.$seed['deptB']->id);
+        $otherDept->assertForbidden();
+    }
+
+    public function test_dept_manager_department_index_scoped_to_own_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/departments');
+
+        $response->assertOk();
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertContains($seed['deptA']->id, $ids);
+        $this->assertNotContains($seed['deptB']->id, $ids);
+    }
+
+    public function test_dept_manager_cannot_create_evaluation_for_employee_outside_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/api/v1/evaluations', [
+                'employee_id' => $seed['employeeB']->id,
+                'period' => '2026-01',
+            ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_dept_manager_can_create_evaluation_for_own_department_employee(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/api/v1/evaluations', [
+                'employee_id' => $seed['employeeA']->id,
+                'period' => '2026-01',
+            ]);
+
+        $response->assertCreated();
+    }
+
+    public function test_dept_manager_evaluation_index_scoped_to_own_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        Evaluation::query()->create([
+            'company_id' => $seed['company']->id,
+            'employee_id' => $seed['employeeA']->id,
+            'evaluator_id' => $seed['managerA']->id,
+            'period' => '2026-01',
+            'status' => 'draft',
+        ]);
+
+        Evaluation::query()->create([
+            'company_id' => $seed['company']->id,
+            'employee_id' => $seed['employeeB']->id,
+            'evaluator_id' => $seed['managerB']->id,
+            'period' => '2026-01',
+            'status' => 'draft',
+        ]);
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/evaluations');
+
+        $response->assertOk();
+
+        $employeeIds = collect($response->json('data'))->pluck('employee.id')->all();
+        $this->assertContains($seed['employeeA']->id, $employeeIds);
+        $this->assertNotContains($seed['employeeB']->id, $employeeIds);
+    }
+
+    public function test_dept_manager_cannot_view_or_update_evaluation_outside_department(): void
+    {
+        $seed = $this->seedScopedCompany();
+
+        $evaluation = Evaluation::query()->create([
+            'company_id' => $seed['company']->id,
+            'employee_id' => $seed['employeeB']->id,
+            'evaluator_id' => $seed['managerB']->id,
+            'period' => '2026-01',
+            'status' => 'draft',
+        ]);
+
+        $token = $seed['managerA']->createToken('tests')->plainTextToken;
+
+        $show = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/evaluations/'.$evaluation->id);
+        $show->assertForbidden();
+
+        $update = $this->withHeader('Authorization', "Bearer {$token}")
+            ->patchJson('/api/v1/evaluations/'.$evaluation->id, [
+                'score' => 4.5,
+            ]);
+        $update->assertForbidden();
+    }
+}


### PR DESCRIPTION
Implements PA2-SEC-002 from docs/PLAN_ACTION2/02_BACKLOG_ATOMIQUE.md.

**Problem**: managers with `manager_role=dept` were only gated by `hasManagerRole()`, with no filtering by `department_id`, so they had company-wide visibility instead of being scoped to their own department (confirmed by docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md).

**Changes**:
- `Employee`: new `isDepartmentScoped()` / `managesDepartmentOf()` helpers (fail-closed when actor has no `department_id`). Also fixed `department_id`/`position_id` missing from `$fillable` (was silently dropped on create/update).
- `EmployeePolicy` + `EmployeeController::index`: dept managers scoped to their department's employees.
- `AttendancePolicy` + `AttendanceController` (today/index/anomalies/monthlyReport) + `AttendanceAnomalyService`/`AttendanceMonthlyReportService`: dept-scoped attendance data.
- `DepartmentPolicy` + `DepartmentController`: dept managers restricted to their own department; controller now consistently authorizes via the policy.
- `ScheduleController::assignEmployees`: dept managers can only assign schedules to employees in their own department.
- `EvaluationPolicy` + `EvaluationController`: dept managers scoped to evaluations for their department's employees.

**Tests**: new `tests/Feature/Security/DepartmentScopedRbacTest.php` covers all 5 policies per the ticket DoD (13 tests, all passing on Postgres). Also reran `EmployeesRbacTest`, `ApiManagerMiddlewareTest`, `AdminMiddlewareRbacTest`, and the attendance/schedule/evaluation suites on Postgres — all green, no regressions.

Note: full `php artisan test` (default sqlite driver) has ~163 pre-existing failures unrelated to this change (Postgres-only SQL in other modules); confirmed identical failure count on `main` before this branch's changes.