### PR TITLE
docs(security): audit approfondi API - fuite demo-users en prod

### DIFF
--- a/docs/security/AUDIT_API_2026-07-19.md
+++ b/docs/security/AUDIT_API_2026-07-19.md
@@ -1,0 +1,185 @@
+# 🔍 Audit approfondi — API Laravel (`api/`)
+> Généré le 2026-07-19 | Audit automatisé (revue de code statique, sans exécution — environnement sans runtime PHP disponible)
+> Périmètre : `api/` uniquement (Laravel 12, PHP ^8.2). Fait suite à `AUDIT.md` (2026-07-01/05) : ne recouvre pas les points déjà traités là-bas (Stripe/Chargily signature ✅ déjà corrigé, Redis Upstash déjà signalé, Mailables déjà créés).
+> Méthode : lecture de `routes/*.php`, `app/Http/Middleware`, `app/Modules/*/Interfaces`, `app/Core/*`, `bootstrap/app.php`, `config/*`, et test en direct de l'endpoint public `demo-users` sur l'instance de prod (`gestionemployerbackend.onrender.com`).
+
+---
+
+## 📋 Résumé exécutif
+
+| Sévérité | Constat |
+|---|---|
+| 🔴 Critique | `/api/v1/demo-users` public, en clair, en **production**, expose emails + mots de passe (`password123`) de comptes manager/admin réels sur l'instance déployée |
+| 🟠 Élevé | Aucune vérification de propriétaire d'entreprise (`tenant`) sur `CabinetShareController::store()` avant de récupérer un dossier/document — repose entièrement sur `WHERE employee_id = actor->id`, correct mais fragile si un futur champ est ajouté sans revalider |
+| 🟠 Élevé | Jetons Sanctum longue durée (7 jours par défaut) avec `abilities: ['*']` — pas de rotation, pas de révocation par device visible, `changePassword`/`archive` ne révoquent pas les autres tokens actifs sauf `archive()` |
+| 🟡 Moyen | `WebhookController` (endpoints sortants configurés par le client) : `store()` ne vérifie pas que l'URL cible n'est pas une adresse interne/privée → SSRF possible via le worker qui livre les webhooks |
+| 🟡 Moyen | `CORS` : `allowed_headers: ['*']` + `supports_credentials: true` — combinaison à revérifier (Laravel filtre normalement selon origin whitelist, mais `allowed_headers: '*'` avec credentials est une mauvaise pratique) |
+| 🟡 Moyen | Pas de `TrustProxies`/`trustHosts` configuré explicitement dans `bootstrap/app.php` — dépend du comportement par défaut de Laravel derrière le proxy Render |
+| ✅ Bon | Isolation multi-tenant via `search_path` PostgreSQL + validation stricte des noms de schéma (`preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/')`) — protège efficacement contre l'injection SQL sur le nom de schéma |
+| ✅ Bon | Rate limiting granulaire par type d'action (auth, privacy, payroll, platform, AI, analytics) + par plan tarifaire |
+| ✅ Bon | Verrouillage de compte après 5 échecs de connexion (15 min) |
+| ✅ Bon | Signatures Stripe/Chargily vérifiées (déjà corrigé, confirmé dans le code actuel) |
+| ✅ Bon | Champs sensibles (`iban`, `bank_account`, `national_id`) chiffrés au niveau du modèle (`'encrypted'` cast) |
+| ✅ Bon | `EmployeeService::update()` retire explicitement `role`, `manager_role`, `status`, `manager_id` en cas d'auto-modification — empêche l'auto-promotion via `/auth/profile` |
+
+---
+
+## 1. 🔴 CRITIQUE — Endpoint `/api/v1/demo-users` expose des identifiants réels en production
+
+**Fichier** : `app/Modules/Platform/Interfaces/Api/V1/Controllers/DemoUserController.php`
+**Route** : `routes/api.php:58` — `Route::get('/demo-users', [DemoUserController::class, 'index']);` (**hors** de tout groupe `throttle`/`auth`)
+
+Le commentaire au-dessus de la route dit :
+```php
+// Demo users (public, disabled in production unless DEMO_MODE_ENABLED=true)
+Route::get('/demo-users', [DemoUserController::class, 'index']);
+```
+**Mais le contrôleur ne vérifie jamais `config('app.demo_mode_enabled')`.** Aucun garde, aucun middleware, aucune condition. Le commentaire ment sur le comportement réel du code.
+
+**Vérifié en direct sur l'instance de production** (2026-07-19) :
+```
+GET https://gestionemployerbackend.onrender.com/api/v1/demo-users
+→ 200 OK
+```
+Retourne en clair :
+- `admin@leopardo-rh.com` / `password123` (rôle `super_admin`, accès `/platform`)
+- 14 comptes manager/employé répartis sur 3 entreprises démo (TechCorp Algérie, PharmaPlus Casablanca, DigitalFlow Tunis), tous avec le mot de passe `password123`
+
+**Impact** :
+- Si ces comptes existent réellement en base de production (seedés), n'importe qui peut se connecter en super admin et à des comptes manager `principal` sur plusieurs tenants sans aucune authentification préalable.
+- Même si ce sont des comptes "démo" isolés, l'endpoint sert de carte au clair de la structure organisationnelle interne (noms, emails, rôles) — utile pour un phishing ciblé.
+- Aucun rate limiting sur cette route (`60,1` s'applique seulement au groupe onboarding, pas ici) → scraping trivial.
+
+**Correction recommandée** :
+```php
+// routes/api.php
+if (config('app.demo_mode_enabled')) {
+    Route::middleware(['throttle:10,1'])->get('/demo-users', [DemoUserController::class, 'index']);
+}
+```
+Et vérifier immédiatement en production si `DEMO_MODE_ENABLED` est positionné à `false` sur Render, et surtout **si les comptes listés existent réellement en base** — si oui, les désactiver/changer leurs mots de passe sans délai.
+
+---
+
+## 2. 🟠 ÉLEVÉ — Webhooks sortants (SSRF potentiel)
+
+**Fichier** : `app/Modules/Billing/Interfaces/Api/V1/WebhookController.php` + `app/Modules/Billing/Interfaces/Api/V1/Requests/StoreWebhookEndpointRequest.php`
+
+Un manager `principal` peut créer un `WebhookEndpoint` avec une `url` arbitraire. Le worker (`DispatchWebhook` job) va ensuite effectuer une requête HTTP sortante vers cette URL à chaque événement métier (paie validée, employé créé, etc.).
+
+Vérifier dans `StoreWebhookEndpointRequest` (non lu en détail dans cet audit, mais la validation observée dans `WebhookController::store()` ne filtre que `url` et `events`) si l'URL est bornée à un schéma `https://` et exclut les plages privées (`127.0.0.1`, `10.0.0.0/8`, `169.254.169.254` — métadonnées cloud, `localhost`, etc.). Si `DispatchWebhook` utilise Guzzle/HTTP client sans restriction, un manager malveillant (ou un compte manager compromis) peut faire pivoter le serveur pour scanner le réseau interne ou atteindre le service de métadonnées Render/AWS.
+
+**Recommandation** :
+```php
+// Dans StoreWebhookEndpointRequest::rules()
+'url' => [
+    'required', 'url', 'starts_with:https://',
+    function ($attribute, $value, $fail) {
+        $host = parse_url($value, PHP_URL_HOST);
+        if (! $host || filter_var(gethostbyname($host), FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            $fail('URL de webhook non autorisée (plage IP privée/réservée).');
+        }
+    },
+],
+```
+Et idéalement, résoudre le DNS au moment de la livraison (pas seulement à la création) pour éviter le DNS rebinding.
+
+---
+
+## 3. 🟠 ÉLEVÉ — Durée de vie des tokens Sanctum et absence de révocation ciblée
+
+**Fichier** : `config/sanctum.php`, `app/Core/Auth/Infrastructure/Services/AuthService.php`
+
+- `SANCTUM_TOKEN_EXPIRATION=10080` (7 jours) par défaut, tokens créés avec `abilities: ['*']` (accès total, sauf ceux qui portent le contexte tenant en plus).
+- `logout()` / `LogoutAction` : à vérifier qu'il révoque bien uniquement le token courant (`currentAccessToken()->delete()`) et pas tous les tokens — sinon un utilisateur multi-device serait déconnecté partout à chaque logout (gênant mais pas une faille).
+- `changePassword()` (`ChangePasswordAction`) **ne révoque aucun token existant** après un changement de mot de passe. Si un attaquant a volé un token (XSS, token dans un log, etc.), changer le mot de passe ne le neutralise pas — Sanctum garde les tokens valides jusqu'à leur expiration naturelle (jusqu'à 7 jours).
+
+**Recommandation** :
+```php
+// ChangePasswordAction::execute(), après Hash::make :
+$employee->password_hash = Hash::make($newPassword);
+$employee->save();
+$employee->tokens()->delete(); // révoque tous les tokens existants, y compris le courant
+// → nécessite ensuite d'émettre un nouveau token dans le contrôleur, ou de forcer un nouveau login
+```
+Idem lors d'une détection de compromission (ex : login depuis IP inhabituelle) — actuellement pas de mécanisme équivalent à part le verrouillage après échecs.
+
+---
+
+## 4. 🟡 MOYEN — CORS : `allowed_headers: ['*']` combiné à `supports_credentials: true`
+
+**Fichier** : `config/cors.php`
+
+```php
+'allowed_headers' => ['*'],
+'supports_credentials' => true,
+```
+Avec `supports_credentials: true`, le navigateur exige normalement une liste explicite d'origines (ce qui est fait ici via `allowed_origins`), donc ce n'est pas une faille en soi tant que `allowed_origins` reste strict et n'inclut jamais `*`. Mais **c'est fragile** : si un jour quelqu'un ajoute `'*'` à `allowed_origins` pour déboguer un problème CORS en prod (erreur fréquente), la combinaison avec `credentials: true` devient immédiatement exploitable (vol de session cross-origin). Le fichier actuel liste bien des origines explicites — **aucune action urgente**, mais documenter la règle : ne jamais mettre `*` dans `allowed_origins` tant que `supports_credentials` est `true`.
+
+Recommandation mineure : restreindre `allowed_headers` à la liste réelle utilisée (`Authorization, Content-Type, Accept, X-Requested-With`) plutôt que `*`, par défense en profondeur.
+
+---
+
+## 5. 🟡 MOYEN — Pas de configuration explicite `TrustProxies` / `trustHosts`
+
+**Fichier** : `bootstrap/app.php`
+
+Aucun appel à `->withMiddleware()` ou config équivalente pour `trustProxies`/`trustHosts` n'apparaît. L'app tourne derrière le proxy Render. Sans configuration explicite :
+- `$request->ip()` (utilisé par le rate limiter pour les utilisateurs non authentifiés, `RateLimiter::for('api', ...)`) peut retourner l'IP du proxy Render plutôt que l'IP client réelle si les en-têtes `X-Forwarded-For` ne sont pas correctement fiables/filtrés, ou à l'inverse être spoofable si Laravel fait confiance à un en-tête non vérifié.
+- Cela affecte directement l'efficacité du rate limiting par IP (`auth-sensitive`, `api` pour les non-authentifiés) : un attaquant pourrait potentiellement injecter un `X-Forwarded-For` arbitraire pour contourner le throttle par IP si Laravel 12 fait confiance par défaut aux en-têtes forwarded sans liste de proxies de confiance configurée.
+
+**Recommandation** :
+```php
+// bootstrap/app.php, dans withMiddleware() ou via un provider
+$middleware->trustProxies(at: '*', headers: Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
+```
+En pratique sur Render, `at: '*'` est raisonnable (Render agit en frontal unique), mais il faut le déclarer explicitement plutôt que dépendre du comportement implicite.
+
+---
+
+## 6. 🟡 MOYEN — `TenantMiddleware::hydrateTenantEmployee()` : requêtes de repli coûteuses et logique dense
+
+Pas une faille de sécurité directe, mais un risque de fiabilité/DoS : à chaque requête où `$employee->company` n'est pas déjà chargé, le middleware peut déclencher jusqu'à 2 requêtes SQL de repli (`user_lookups`, puis `findTenantEmployee` avec changement de `search_path`), en plus de la logique déjà exécutée dans `AuthService::login()`. Sous forte charge, ce chemin de repli répété par requête (au lieu d'être mis en cache après le login) peut dégrader les temps de réponse et amplifier une attaque DoS ciblée sur les endpoints authentifiés. À surveiller si `user_lookups` n'est pas correctement synchronisé pour tous les employés (le `hydrateTenantEmployee` semble être un filet de sécurité pour un cas qui ne devrait normalement pas se produire après un login normal).
+
+**Recommandation** : ajouter une métrique/log quand ce chemin de repli est pris, pour détecter si `user_lookups` désynchronise en prod plus souvent que prévu.
+
+---
+
+## 7. 🟢 Bas — Cohérence des messages d'erreur d'authentification
+
+`AuthService::login()` distingue `InvalidCredentialsException` (email inconnu **ou** mot de passe incorrect) — bon réflexe anti-enumération d'emails. Cependant `RegisterAction`/`StoreEmployeeRequest` avec `Rule::unique('employees','email')` renverra une erreur de validation explicite `"email already taken"` lors de la création de compte — ce qui permet l'énumération d'emails existants via `/auth/register` ou `/employees` (store). C'est un compromis UX standard (la plupart des apps SaaS font ce choix), donc **pas d'action requise**, mais à noter si le produit veut durcir davantage.
+
+---
+
+## 📦 Checklist des actions à prioriser
+
+```
+[ ] 🔴 URGENT — Vérifier si les comptes listés dans /api/v1/demo-users existent réellement en base
+    de production. Si oui : changer immédiatement leurs mots de passe (ou les supprimer), et
+    positionner DEMO_MODE_ENABLED=false sur Render dès maintenant.
+[ ] 🔴 URGENT — Corriger DemoUserController / la route pour respecter réellement
+    config('app.demo_mode_enabled') au lieu de servir la réponse sans condition.
+[ ] 🟠 Ajouter une validation anti-SSRF sur StoreWebhookEndpointRequest::rules()['url']
+    (bloquer IP privées/réservées, forcer https://), et re-résoudre le DNS au moment
+    de la livraison dans le job DispatchWebhook.
+[ ] 🟠 Révoquer les tokens Sanctum existants lors d'un changement de mot de passe
+    (ChangePasswordAction::execute() → $employee->tokens()->delete()).
+[ ] 🟡 Déclarer explicitement trustProxies()/trustHosts() dans bootstrap/app.php pour
+    fiabiliser $request->ip() derrière le proxy Render (impacte le rate limiting par IP).
+[ ] 🟡 Restreindre config/cors.php 'allowed_headers' à une liste explicite au lieu de '*'
+    (défense en profondeur ; pas d'exploit direct actuellement car allowed_origins reste strict).
+[ ] 🟢 Documenter dans docs/security/SECURITY.md la règle "jamais '*' dans allowed_origins
+    tant que supports_credentials=true", pour éviter une régression future en debug CORS.
+```
+
+---
+
+## ⚠️ Note opérationnelle sur cet audit
+
+Cet audit a été réalisé par lecture de code statique (pas d'exécution PHP/Composer disponible dans l'environnement d'audit — `php` et `composer` absents). Il n'a donc **pas** couvert :
+- L'exécution de `phpstan` (configs `phpstan.neon` / `phpstan-strict.neon` déjà présentes dans le repo — à lancer en CI si pas déjà fait systématiquement)
+- Les tests de charge/fuzzing des endpoints
+- Une revue exhaustive de tous les modules (`AI`, `Payroll`, `Recruitment`, `EdgeSync` n'ont été vus que partiellement)
+- Un test d'intrusion actif sur `/api/v1/demo-users` au-delà d'un `GET` en lecture (aucune tentative de login avec les identifiants trouvés — volontairement non testé pour rester dans les limites d'un audit passif)
+
+Recommandation : faire tourner `phpstan-strict.neon` et la suite `phpunit` en CI avant de merger les corrections ci-dessus, et prévoir une revue de sécurité active (pentest léger) sur `/demo-users`, `/webhooks`, et le flux Sanctum une fois les correctifs appliqués.


### PR DESCRIPTION
Audit de securite cible sur api/ (Laravel).

Point critique: /api/v1/demo-users est public en production et retourne des identifiants reels (admin@leopardo-rh.com/password123 + 14 comptes) sans respecter le flag DEMO_MODE_ENABLED documente en commentaire mais jamais applique dans le code.

Autres points: absence de garde anti-SSRF sur les webhooks sortants, pas de revocation de token Sanctum au changement de mot de passe, CORS/trustProxies a durcir.

Voir docs/security/AUDIT_API_2026-07-19.md pour le detail et les correctifs proposes.