### PR TITLE
Audit CI/CD complet + correctifs P0 (fragments orphelins, chemins cassés, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,22 +10,108 @@ updates:
         patterns:
           - "*"
 
+  # npm — backend Laravel front-end tooling (Vite assets), pas un vrai front-end
   - package-ecosystem: "npm"
     directory: "/api"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      frontend-dependencies:
+      backend-frontend-dependencies:
         patterns:
           - "*"
 
-  - package-ecosystem: "pub"
-    directory: "/mobile"
+  # npm — vitrine publique Next.js
+  - package-ecosystem: "npm"
+    directory: "/front/web"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      flutter-dependencies:
+      web-marketing-dependencies:
+        patterns:
+          - "*"
+
+  # npm — admin dashboard Vue.js
+  - package-ecosystem: "npm"
+    directory: "/front/admin-dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      admin-dashboard-dependencies:
+        patterns:
+          - "*"
+
+  # npm — web offline (PWA/offline-first companion app)
+  - package-ecosystem: "npm"
+    directory: "/front/web-offline"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      web-offline-dependencies:
+        patterns:
+          - "*"
+
+  # pub — apps Flutter reelles du monorepo (front/mobile_apps/*)
+  - package-ecosystem: "pub"
+    directory: "/front/mobile_apps/leopardo_core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      flutter-core-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/front/mobile_apps/leopardo_employee"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      flutter-employee-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/front/mobile_apps/leopardo_manager"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      flutter-manager-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/front/mobile_apps/leopardo_hr"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      flutter-hr-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/front/mobile_apps/leopardo_platform_admin"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      flutter-platform-admin-dependencies:
+        patterns:
+          - "*"
+
+  # github-actions — maintient les actions tierces a jour (CVE, SHA pinning)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-dependencies:
         patterns:
           - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,79 +130,10 @@ jobs:
               }
             }
 
-  build-artifacts:
-    name: Build legacy release artifacts
-    runs-on: ubuntu-latest
-    needs: create-release
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Setup Java 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-
-      - name: Place legacy google-services.json if available
-        shell: bash
-        run: |
-          # Historical single mobile app only. Store-ready multi-app Android
-          # builds are distributed by mobile-distribute.yml.
-          for SRC in "google-services.json" "api/google-services.json"; do
-            if [[ -f "${SRC}" ]]; then
-              mkdir -p front/mobile/android/app
-              cp "${SRC}" front/mobile/android/app/google-services.json
-              break
-            fi
-          done
-
-      - name: Build legacy release APK
-        working-directory: front/mobile
-        run: |
-          flutter pub get
-          flutter build apk --release \
-            --dart-define=API_BASE_URL=https://api.leopardo-rh.com/api/v1
-
-      - name: Upload APK to release
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const tag = `${{ steps.tag.outputs.tag }}`;
-            const { owner, repo } = context.repo;
-
-            const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
-            const apkPath = 'front/mobile/build/app/outputs/flutter-apk/app-release.apk';
-
-            if (fs.existsSync(apkPath)) {
-              const data = fs.readFileSync(apkPath);
-              await github.rest.repos.uploadReleaseAsset({
-                owner,
-                repo,
-                release_id: release.data.id,
-                name: `leopardo-rh-legacy-${tag}.apk`,
-                data,
-                headers: { 'content-type': 'application/vnd.android.package-archive' },
-              });
-              core.info('APK uploaded to release.');
-            } else {
-              core.warning('APK file not found, skipping upload.');
-            }
+  # NOTE (audit CI/CD 2026-07-19): le job legacy "build-artifacts" qui buildait
+  # front/mobile a ete retire. Ce dossier a ete supprime du repo dans #754 et
+  # remplace par les apps splittees sous front/mobile_apps/*. Chaque push d'un
+  # tag v* faisait donc echouer ce job (working-directory inexistant).
+  # Les APKs multi-app store-ready sont deja construits et distribues par
+  # mobile-distribute.yml (Firebase App Distribution) et par le job
+  # distribute-mobile de deploy-main.yml. Voir AUDIT_CICD_2026-07-19.md section 1.2.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -750,55 +750,6 @@ jobs:
           echo "Backend coverage threshold not met."
           exit 1
 
-            echo "- Smoke build: ${{ steps.mobile_smoke_build.outcome }}"
-          } > "${summary_file}"
-
-      - name: Upload mobile quality summary
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: legacy-mobile-quality-summary
-          path: front/mobile/quality-summary.md
-          if-no-files-found: ignore
-
-      - name: Upload mobile test artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: legacy-mobile-test-reports
-          path: |
-            front/mobile/coverage/lcov.info
-            front/mobile/coverage/summary.txt
-            front/mobile/coverage/threshold.txt
-            front/mobile/test-results.json
-            front/mobile/quality-summary.md
-            front/mobile/test/**/*
-          if-no-files-found: ignore
-
-      - name: Fail mobile job if analyze failed
-        if: steps.mobile_analyze.outcome == 'failure'
-        run: |
-          echo "Flutter analyze failed."
-          exit 1
-
-      - name: Fail mobile job if tests failed
-        if: steps.mobile_tests.outcome == 'failure'
-        run: |
-          echo "Flutter tests failed."
-          exit 1
-
-      - name: Fail mobile job if coverage gate failed
-        if: steps.mobile_coverage_gate.outcome == 'failure'
-        run: |
-          echo "Mobile coverage threshold not met."
-          exit 1
-
-      - name: Fail mobile job if smoke build failed
-        if: steps.mobile_smoke_build.outcome == 'failure'
-        run: |
-          echo "Android smoke build failed."
-          exit 1
-
   governance-gates:
     name: Governance Gates (changelog + canonical files)
     runs-on: ubuntu-latest
@@ -876,7 +827,6 @@ jobs:
           set -euo pipefail
           BACKEND_SUMMARY="artifacts/backend-quality-summary/backend-quality-summary.md"
           BACKEND_COVERAGE_SUMMARY="artifacts/backend-coverage-summary/backend-coverage-summary.md"
-          MOBILE_SUMMARY="artifacts/mobile-quality-summary/quality-summary.md"
           cat > ci-report.md <<EOF
           # CI Report — Leopardo RH
 

--- a/AUDIT_CICD_2026-07-19.md
+++ b/AUDIT_CICD_2026-07-19.md
@@ -1,0 +1,229 @@
+# 🔍 AUDIT CI/CD — Leopardo RH (2026-07-19)
+
+> Périmètre : les 28 workflows GitHub Actions sous `.github/workflows/`, `dependabot.yml`, et leur cohérence avec la structure réelle du monorepo.
+> Méthode : lecture exhaustive de chaque fichier + validation outillée (`actionlint` v1.7.12 avec intégration `shellcheck` 0.10.0) + vérification croisée avec l'arborescence du repo et l'historique git.
+> Ne pas confondre avec `AUDIT.md` (audit fonctionnel du 2026-07-01, section 6 uniquement CI) : ce document est un audit CI/CD dédié, plus profond et à jour au 2026-07-19.
+
+---
+
+## 📋 Résumé exécutif
+
+| Catégorie | Constat | Sévérité |
+|---|---|---|
+| Bug YAML actif | `tests.yml` contient un fragment de script orphelin (lignes 753-754) issu d'une fusion/rebase ratée — 4 steps mobiles legacy sont invoqués mais n'existent plus dans le job | 🔴 Critique |
+| Chemin cassé | `release.yml` build encore `front/mobile` (supprimé depuis #754, remplacé par `front/mobile_apps/*`) — tout tag `v*` échoue ce job | 🔴 Critique |
+| Dependabot mal configuré | `directory: "/mobile"` n'existe pas ; écosystème `npm` limité à `/api`, oubliant `front/web`, `front/admin-dashboard`, `front/web-offline` ; aucun écosystème `github-actions` | 🟠 Élevé |
+| Duplication massive | Le bloc setup PHP+PostgreSQL+Redis (~50 lignes) est copié-collé à l'identique dans `tests.yml` (×2), `coverage-gate.yml`, `backend-jobs-ci.yml` — 4 copies désynchronisables | 🟠 Élevé |
+| Reusable workflows morts | `_setup-php.yml` et `_setup-flutter.yml` existent, sont bien conçus, mais ne sont appelés par **aucun** autre workflow | 🟡 Moyen |
+| Pas de pinning par SHA | Toutes les actions tierces (`shivammathur/setup-php`, `subosito/flutter-action`, `treosh/lighthouse-ci-action`, `wzieba/Firebase-Distribution-Github-Action`, `trufflesecurity/trufflehog@main`) sont épinglées par tag mutable, pas par SHA | 🟠 Élevé (supply chain) |
+| Action obsolète | `treosh/lighthouse-ci-action@v10` tourne sur un runtime Node trop ancien pour GitHub Actions (détecté par actionlint) | 🟡 Moyen |
+| `trufflehog@main` | Scan de secrets épinglé sur la branche `main` du projet tiers, donc non reproductible et vecteur d'attaque potentiel si le repo amont est compromis | 🟠 Élevé |
+| Versions d'actions incohérentes | Mélange `actions/checkout@v4` et `@v5`, `actions/upload-artifact@v4` et `@v5` dans des workflows différents | 🟡 Moyen |
+| Secret réel dans l'historique | `AUDIT.md` documente un mot de passe Redis Upstash committé en clair dans l'historique git (repo public) — toujours non résolu | 🔴 Critique (déjà connu, non-CI mais impacte la sécurité globale) |
+| CodeQL PHP non couvert | Le job "CodeQL (Backend)" est un stub qui ne fait qu'écrire un message — aucune analyse statique de sécurité réelle sur le code PHP (SAST) | 🟠 Élevé |
+| Complexité `tests.yml` | 983 lignes, 9 jobs, logique de détection de changements dupliquée avec `deploy-main.yml` (patterns de chemin divergents à surveiller) | 🟡 Moyen |
+| Déploiement en cascade fragile | `deploy-main.yml` se déclenche sur `workflow_run` de `tests.yml`/`web-ci.yml` ; `deploy-staging.yml` se déclenche indépendamment sur push vers `main` avec sa propre logique de polling (jusqu'à 10 min) — deux pipelines de déploiement parallèles et faiblement coordonnés | 🟡 Moyen |
+| `owasp-zap.yml` / `e2e-staging.yml` déclenchés par `workflow_run` sur "Deploy - Leopardo RH" | Cohérent, mais aucun des deux ne vérifie `conclusion == 'success'` du déploiement `deploy-api` spécifiquement (seulement du workflow parent) | 🟡 Moyen |
+| Secrets vs Variables | Bon usage global de `vars.*` pour les seuils non sensibles, mais pas de documentation centralisée des secrets requis par workflow (dispersés dans `AUDIT.md`) | 🟢 Faible |
+| Bonnes pratiques présentes | `concurrency` avec `cancel-in-progress` cohérent, `permissions` least-privilege déclarées sur presque tous les workflows top-level, path filters sur la plupart des CI, `continue-on-error` + gates explicites bien utilisés dans `tests.yml`, secrets validés avant usage (`database-backup.yml`, `deploy-main.yml`) | 🟢 Positif |
+
+**Total : 3 bugs actifs cassant des jobs, 1 dette de sécurité supply-chain notable, 1 duplication structurelle majeure, plusieurs incohérences de versioning.**
+
+---
+
+## 1. 🔴 Bugs actifs (cassent des workflows aujourd'hui)
+
+### 1.1 `tests.yml` — fragment de script orphelin (lignes ~740-800)
+
+Constat outillé (`actionlint` + `shellcheck`) :
+
+```
+tests.yml:749:9: shellcheck SC1089 error: Parsing stopped here. Is this keyword correctly matched up?
+tests.yml:749:92: property "mobile_smoke_build" is not defined in object type {...}
+tests.yml:779:13: property "mobile_analyze" is not defined ...
+tests.yml:785:13: property "mobile_tests" is not defined ...
+tests.yml:791:13: property "mobile_coverage_gate" is not defined ...
+tests.yml:797:13: property "mobile_smoke_build" is not defined ...
+```
+
+Le job `backend-coverage` se termine à la ligne 751 par `exit 1`, puis un bloc orphelin apparaît :
+
+```yaml
+      - name: Fail coverage job if threshold gate failed
+        if: steps.backend_coverage_gate.outcome == 'failure'
+        run: |
+          echo "Backend coverage threshold not met."
+          exit 1
+
+            echo "- Smoke build: ${{ steps.mobile_smoke_build.outcome }}"
+          } > "${summary_file}"
+
+      - name: Upload mobile quality summary
+        ...
+      - name: Fail mobile job if analyze failed
+        if: steps.mobile_analyze.outcome == 'failure'
+        ...
+```
+
+Ces 5 derniers steps du job `backend-coverage` référencent des `steps.mobile_*` qui **n'ont jamais été définis dans ce job** (probablement les restes d'un ancien job `mobile-tests` supprimé lors d'un refactor, mal fusionné). Conséquence :
+- Le YAML reste syntaxiquement valide (les steps existent, juste avec des conditions toujours fausses), donc **le workflow ne casse pas au parsing**, mais ces 5 steps sont du code mort qui s'exécute à chaque run, uploade un artefact `legacy-mobile-quality-summary` vide/inexistant, et pollue les logs avec des `if` toujours skippés.
+- Risque réel : un futur refactor qui renomme `backend_coverage_gate` cassera silencieusement ces conditions déjà cassées, sans qu'on s'en rende compte.
+
+**Recommandation** : supprimer entièrement ce fragment orphelin (5 steps, lignes ~753-800) du job `backend-coverage`. La CI mobile "légitime" est déjà gérée par `mobile-apps-ci.yml`.
+
+### 1.2 `release.yml` — référence à `front/mobile` supprimé
+
+```yaml
+      - name: Build legacy release APK
+        working-directory: front/mobile
+        run: |
+          flutter pub get
+          flutter build apk --release ...
+```
+
+`front/mobile` a été supprimé du repo dans le commit `cdc9a6a8` (#754, "Feat/p0 commercial conversion") au profit de `front/mobile_apps/{employee,manager,hr,platform_admin,core}`. Tout push d'un tag `v*` va faire échouer le job `build-artifacts` sur `working-directory: front/mobile` (dossier inexistant) — bien que `create-release` (le job qui crée réellement la release GitHub) réussisse avant, donc l'échec est visible mais moins visible qu'un blocage total.
+
+**Recommandation** : soit retirer complètement ce job legacy (les APKs multi-app sont déjà distribués via `mobile-distribute.yml`), soit le réécrire en matrice sur `front/mobile_apps/*` comme le fait `mobile-distribute.yml`.
+
+### 1.3 `dependabot.yml` — chemin `pub` inexistant + couverture npm incomplète
+
+```yaml
+  - package-ecosystem: "pub"
+    directory: "/mobile"       # ❌ n'existe pas, devrait être un des front/mobile_apps/*
+    ...
+  - package-ecosystem: "npm"
+    directory: "/api"          # npm dans /api sert le tooling frontend Laravel (Vite), pas les vrais front-ends
+```
+
+Conséquences :
+- **Aucune mise à jour Dependabot n'est jamais proposée pour les apps Flutter** (5 pubspec.yaml sous `front/mobile_apps/*`), alors que Dependabot pour `pub` est configuré mais pointe dans le vide.
+- **`front/web` (Next.js, exposé publiquement), `front/admin-dashboard` (Vue) et `front/web-offline` n'ont aucune surveillance de vulnérabilités npm automatisée.** Seul `api/package.json` (assets Vite du backend) est couvert.
+- Aucun écosystème `github-actions` n'est déclaré : les versions d'actions tierces (`shivammathur/setup-php@v2`, `subosito/flutter-action@v2`, etc.) ne reçoivent jamais de PR de mise à jour automatique, y compris pour des CVE.
+
+**Recommandation** : reconfigurer `dependabot.yml` avec un `directory` par app Flutter réelle, ajouter 3 entrées `npm` (`front/web`, `front/admin-dashboard`, `front/web-offline`), ajouter un écosystème `github-actions` avec `directory: "/"`.
+
+---
+
+## 2. 🟠 Dette de sécurité supply-chain
+
+### 2.1 Pas de pinning par SHA sur les actions tierces (non-GitHub)
+
+Actions concernées, épinglées par tag mutable :
+- `shivammathur/setup-php@v2`
+- `subosito/flutter-action@v2`
+- `treosh/lighthouse-ci-action@v10`
+- `wzieba/Firebase-Distribution-Github-Action@v1`
+- `dawidd6/action-send-mail@v3`
+- `trufflesecurity/trufflehog@main` ⚠️ le plus risqué : pointe vers une branche, pas un tag
+
+Un tag Git peut être déplacé par le mainteneur (ou par un attaquant compromettant le compte du mainteneur) sans que le SHA change de vérité — c'est le vecteur classique des attaques de la chaîne d'approvisionnement CI/CD (cf. incident `tj-actions/changed-files` 2025). Les actions officielles `actions/*` et `github/codeql-action/*` sont maintenues par GitHub et présentent un risque bien plus faible ; ce n'est pas le cas des actions tierces ci-dessus.
+
+**Recommandation** : épingler par SHA complet (`uses: shivammathur/setup-php@<sha>  # v2.x.x`) au moins pour `trufflehog` (accès direct aux secrets du repo) et idéalement pour toutes les actions tierces non-GitHub. Dependabot peut maintenir ces SHA à jour automatiquement une fois l'écosystème `github-actions` ajouté (voir 1.3).
+
+### 2.2 Versions d'actions GitHub incohérentes entre workflows
+
+```
+actions/checkout@v4   → architecture-check.yml, i18n-enterprise.yml, lighthouse.yml
+actions/checkout@v5   → tous les autres (23 fichiers)
+actions/upload-artifact@v4 → majorité
+actions/upload-artifact@v5 → k6-load-smoke.yml, launch-api-profile-smoke.yml, launch-observability-smoke.yml, deploy-main.yml (mobile artifact)
+```
+
+Pas un bug en soi, mais une incohérence qui complique la maintenance et peut cacher des comportements différents entre workflows (v5 de `checkout` change par exemple le comportement par défaut de `persist-credentials`). À uniformiser sur la dernière version stable partout.
+
+### 2.3 CodeQL PHP non fonctionnel
+
+```yaml
+  analyze-backend:
+    name: CodeQL (Backend)
+    steps:
+      - name: Backend CodeQL compatibility note
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## CodeQL (Backend)
+          This repository's backend is PHP, but GitHub CodeQL does not recognize `php`
+          as a supported language in this workflow environment.
+          ...
+```
+
+Ce job ne fait qu'écrire un message dans le step summary — **aucune analyse SAST n'est réellement exécutée sur le code PHP**, alors que c'est le langage backend principal (auth, RBAC, paiements Stripe/Chargily, multi-tenant). Le commentaire indique correctement que CodeQL ne supporte pas officiellement PHP en action native, mais des alternatives existent (voir plan d'action).
+
+### 2.4 Secret réel déjà exposé dans l'historique git (rappel, hors périmètre CI strict)
+
+`AUDIT.md` (section finale) documente qu'un vrai mot de passe Upstash Redis a été committé en clair dans l'historique et reste récupérable par quiconque clone le repo public. Ce n'est pas un bug de configuration CI, mais cela affaiblit directement la valeur du `secret-scan.yml` (TruffleHog scanne les futurs commits, pas l'historique déjà public) : le secret exposé n'est plus détectable comme "nouveau" par TruffleHog une fois qu'il est déjà dans main depuis longtemps, sauf scan explicite `--since-commit` sur tout l'historique.
+
+**Recommandation immédiate (hors CI, déjà notée dans AUDIT.md, toujours non cochée)** : rotation du mot de passe Upstash + purge d'historique coordonnée (BFG/filter-repo).
+
+---
+
+## 3. 🟠 Duplication structurelle et dette de maintenance
+
+### 3.1 Setup PHP+PostgreSQL+Redis dupliqué 4 fois
+
+Le bloc suivant (services `postgres`/`redis`, `.env` inline, bootstrap des schémas `public`/`shared_tenants`, migrations) est copié à l'identique dans :
+- `tests.yml` job `backend-tests` (~90 lignes)
+- `tests.yml` job `backend-coverage` (~90 lignes, quasi identique)
+- `coverage-gate.yml` (~90 lignes)
+- `backend-jobs-ci.yml` (~90 lignes)
+
+= environ **360 lignes dupliquées** dans le repo pour la même logique. Un reusable workflow `_setup-php.yml` existe déjà et couvre l'essentiel (PHP, cache Composer, `.env`, install) mais :
+1. N'est appelé par personne.
+2. Ne couvre pas le bootstrap spécifique multi-tenant (`shared_tenants` schema + migrations `public`/`tenant`).
+
+**Impact concret** : quand la stratégie multi-tenant a changé (ajout du schema `shared_tenants`), il a fallu modifier ce bloc à 4 endroits. Un oubli à l'un des 4 endroits produirait une CI qui teste sur une base de données mal migrée, silencieusement.
+
+### 3.2 `_setup-flutter.yml` mort également
+
+```yaml
+# _setup-flutter.yml (reusable, jamais appelé)
+```
+`mobile-apps-ci.yml`, `mobile-distribute.yml`, `deploy-main.yml` (distribute-mobile), et `release.yml` répètent chacun `actions/setup-java@v5` + `subosito/flutter-action@v2` avec des paramètres quasi identiques.
+
+### 3.3 Logique de détection de changements (`paths-filter` maison) dupliquée avec des regex divergentes
+
+`tests.yml` (`detect-changes`) et `deploy-main.yml` (`Detect changed areas for deployment gating`) réimplémentent chacun, en bash, une détection de fichiers changés via `git diff`/`git show`, avec des motifs `grep -E` presque identiques mais **pas strictement synchronisés** :
+
+```
+tests.yml:        '^(front/admin-dashboard/|\.github/workflows/web-ci\.yml)'
+deploy-main.yml:  '^(front/admin-dashboard/|\.github/workflows/web-ci\.yml|\.github/workflows/deploy-main\.yml|docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS\.md|docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS\.md)'
+```
+
+Ce n'est pas un bug aujourd'hui (le second est un sur-ensemble raisonnable du premier), mais c'est fragile : toute future modification de périmètre "web_changed" doit être répercutée manuellement aux deux endroits, sans garde-fou. L'action officielle `dorny/paths-filter` (ou équivalent) éliminerait cette classe de bug pour un coût de maintenance quasi nul.
+
+---
+
+## 4. 🟡 Fiabilité des pipelines de déploiement
+
+### 4.1 Deux pipelines de déploiement faiblement coordonnés
+
+- `deploy-main.yml` : déclenché par `workflow_run` sur `Tests - Leopardo RH` et `Web CI - Leopardo Admin`, avec revérification explicite des conclusions via l'API GitHub (`github-script`) — **design solide et défensif** (commentaire en dur explique le raisonnement de sécurité, bon signe).
+- `deploy-staging.yml` : déclenché indépendamment sur `push: [main]`, avec sa propre logique de polling manuel (boucle JS jusqu'à 10 minutes cherchant un check nommé contenant "Backend" et "PHP") pour attendre la CI.
+
+Problèmes :
+- Ces deux workflows peuvent démarrer en parallèle sur le même push et déployer sur Render à des moments différents sans se coordonner (pas de `needs` croisé, pas de `concurrency` partagée).
+- Le polling de `deploy-staging.yml` cherche un check dont le nom contient `"Backend"` ET `"PHP"` — fragile si le nom du job change (ex. renommage `"Backend (PHP 8.4 + PostgreSQL 16 + Redis 7)"` → cassé silencieusement si quelqu'un renomme juste ce job).
+- En cas de timeout (10 min), `deploy-staging.yml` déploie **quand même**, de manière "optimiste" (`core.warning('CI did not complete in time. Deploying anyway (optimistic).')`) — c'est documenté et intentionnel, mais c'est un choix de fiabilité risqué à faire valider explicitement par l'équipe plutôt que de le laisser en config par défaut.
+
+### 4.2 `owasp-zap.yml` et `e2e-staging.yml` ne vérifient pas quel job du déploiement a réussi
+
+Les deux se déclenchent sur `workflow_run` de `"Deploy - Leopardo RH"` avec `types: [completed]` et vérifient `github.event.workflow_run.conclusion == 'success'`. Mais `deploy-main.yml` a 3 jobs (`prepare`, `deploy-api`, `distribute-mobile`) : la "conclusion" du workflow parent est un succès seulement si tous les jobs déclenchés réussissent, ce qui est correct dans ce cas précis — mais si `distribute-mobile` échoue pour une raison indépendante de l'API (ex: build Flutter cassé), tout le workflow "Deploy" est marqué en échec, et `owasp-zap.yml`/`e2e-staging.yml` sont alors **skippés même si le déploiement API a réellement réussi**. Couplage excessif entre le statut mobile et le statut du smoke-test API.
+
+---
+
+## 5. 🟢 Points forts à conserver
+
+- **Permissions least-privilege** déclarées explicitement sur presque tous les workflows (`contents: read` par défaut, élévation ciblée uniquement où nécessaire : `contents: write` pour auto-fix Pint/release, `security-events: write` pour CodeQL).
+- **Path filters** bien utilisés sur la majorité des workflows pour éviter les runs inutiles (corrigé depuis l'audit fonctionnel du 2026-07-01).
+- **Secrets validés avant usage** avec message explicite si absent (`database-backup.yml`, `deploy-main.yml`, `deploy-staging.yml`) plutôt que d'échouer avec une erreur curl cryptique.
+- **Gate de déploiement défensif** dans `deploy-main.yml` avec commentaire explicite sur le raisonnement anti-fork/anti-pull_request_target.
+- **Coverage gate progressif** documenté (`BACKEND_COVERAGE_MIN` configurable, avec objectif de ratchet vers 65%).
+- **`database-backup.yml`** bien conçu : chiffrement `age` optionnel, validation de secrets avant exécution, séparation backup quotidien / drill mensuel de restauration.
+- **CODEOWNERS** et **Dependabot** existent (même si mal configurés pour ce dernier) — la structure gouvernance est en place, il manque juste la maintenance.
+
+---
+
+## 6. Références croisées
+
+- Audit fonctionnel précédent : `AUDIT.md` (section 6, 2026-07-01/07-05) — les points CI qu'il listait (paths filter, pattern `web_changed`) ont bien été corrigés depuis ; ce document ne les retraite pas.
+- Audit sécurité API en cours sur la branche `audit/api-security-2026-07-19` (hors périmètre CI, complémentaire).
+- Sortie brute `actionlint` : voir `docs/validation/actionlint-2026-07-19.txt` (généré par cet audit, à archiver).

--- a/PLAN_ACTION_CICD_2026-07-19.md
+++ b/PLAN_ACTION_CICD_2026-07-19.md
@@ -1,0 +1,54 @@
+# 🛠️ Plan d'action CI/CD — Leopardo RH
+
+> Compagnon de `AUDIT_CICD_2026-07-19.md`. Chaque item référence la section de l'audit.
+> Statut : `[ ]` à faire, `[x]` fait dans cette PR, `[~]` fait partiellement / nécessite une action manuelle hors-repo (secrets, settings GitHub).
+
+---
+
+## Priorité P0 — Bugs actifs à corriger immédiatement
+
+- [x] **(Audit §1.1)** Supprimer le fragment de script orphelin dans `tests.yml` (job `backend-coverage`, steps `mobile_*` fantômes lignes ~753-800). Zéro risque de régression : ce code ne fait déjà rien d'utile aujourd'hui.
+- [x] **(Audit §1.2)** Corriger `release.yml` : soit supprimer le job `build-artifacts` (legacy, remplacé par `mobile-distribute.yml`), soit le réécrire en matrice sur `front/mobile_apps/*`. → Choix fait : suppression du job legacy, avec commentaire renvoyant vers `mobile-distribute.yml`.
+- [x] **(Audit §1.3)** Corriger `dependabot.yml` :
+  - `pub` : un `directory` par app Flutter réelle (`front/mobile_apps/leopardo_core`, `leopardo_employee`, `leopardo_manager`, `leopardo_hr`, `leopardo_platform_admin`).
+  - `npm` : ajouter `front/web`, `front/admin-dashboard`, `front/web-offline` en plus de `api`.
+  - Ajouter écosystème `github-actions` (`directory: "/"`) pour recevoir les CVE et mises à jour des actions tierces automatiquement.
+
+## Priorité P1 — Sécurité supply-chain (à planifier, 1-2 sprints)
+
+- [ ] **(Audit §2.1)** Épingler par SHA complet au minimum `trufflesecurity/trufflehog` (actuellement `@main`, le plus risqué car il tourne avec accès en lecture au repo). Ensuite étendre progressivement à `shivammathur/setup-php`, `subosito/flutter-action`, `treosh/lighthouse-ci-action`, `wzieba/Firebase-Distribution-Github-Action`, `dawidd6/action-send-mail`.
+  - Une fois l'écosystème `github-actions` de Dependabot actif (fait en P0), Dependabot propose déjà les PR de bump de SHA — pas de script custom nécessaire.
+- [ ] **(Audit §2.2)** Uniformiser toutes les actions GitHub officielles sur la dernière version stable (`actions/checkout@v5`, `actions/upload-artifact@v5` partout). Vérifier le changelog de `checkout@v5` (`persist-credentials`) avant bascule sur les workflows qui font des `git push` (auto-fix Pint, release, fix-composer-lock).
+- [ ] **(Audit §2.3)** Combler le trou SAST PHP :
+  - Option recommandée : job dédié `Psalm` ou renforcement de `phpstan-modules.neon`/`phpstan-strict.neon` déjà présents dans le repo mais pas systématiquement exécutés en CI bloquante — vérifier s'ils tournent réellement quelque part (`architecture-check.yml` exécute `phpstan-modules.neon`, mais `phpstan-strict.neon` ne semble appelé par aucun workflow).
+  - Alternative complémentaire : intégrer `semgrep` (gratuit, open-source, supporte PHP nativement) en job CI dédié pour combler l'absence de CodeQL PHP réel.
+- [ ] **(Audit §2.4, hors CI)** Rotation immédiate du mot de passe Redis Upstash exposé dans l'historique git + purge d'historique coordonnée avec l'équipe (BFG Repo-Cleaner ou `git filter-repo`). Action déjà notée dans `AUDIT.md`, toujours non cochée — à traiter en priorité absolue en dehors de ce plan CI mais mentionnée ici car elle affaiblit la valeur de `secret-scan.yml`.
+
+## Priorité P2 — Réduction de dette / duplication (moyen terme)
+
+- [ ] **(Audit §3.1)** Étendre `_setup-php.yml` pour couvrir le bootstrap multi-tenant (schema `shared_tenants` + migrations `public`/`tenant`), puis migrer `tests.yml` (×2 jobs), `coverage-gate.yml`, `backend-jobs-ci.yml` pour l'appeler via `uses: ./.github/workflows/_setup-php.yml` + `needs`. Réduction attendue : ~300 lignes de duplication.
+- [ ] **(Audit §3.2)** Faire de même pour `_setup-flutter.yml` : migrer `mobile-apps-ci.yml`, `mobile-distribute.yml`, `deploy-main.yml` (distribute-mobile) pour l'appeler.
+- [ ] **(Audit §3.3)** Remplacer la détection de fichiers changés maison (`git diff` + `grep -E`) par `dorny/paths-filter@v3` (bien maintenu, épinglable par SHA) dans `tests.yml` et `deploy-main.yml`, avec une configuration YAML centralisée des patterns partagés plutôt que deux regex divergentes à maintenir manuellement.
+
+## Priorité P3 — Fiabilité des déploiements (à discuter avec l'équipe avant de changer le comportement)
+
+- [ ] **(Audit §4.1)** Décider explicitement : `deploy-staging.yml` doit-il continuer à déployer "de manière optimiste" après 10 minutes de timeout CI ? Si non, changer le comportement par défaut en échec bloquant, avec un input `workflow_dispatch` explicite pour forcer le déploiement optimiste en cas de besoin ponctuel.
+- [ ] **(Audit §4.1)** Remplacer le polling par nom de check partiel (`r.name.includes('Backend') && r.name.includes('PHP')`) par une référence stricte au nom exact du job (`"Backend (PHP 8.4 + PostgreSQL 16 + Redis 7)"`), ou mieux : utiliser `workflow_run` comme le fait déjà `deploy-main.yml` plutôt qu'un polling manuel — supprimerait la fenêtre de 10 minutes et la logique de retry.
+- [ ] **(Audit §4.2)** Découpler `owasp-zap.yml`/`e2e-staging.yml` du statut global du workflow `Deploy - Leopardo RH` : vérifier spécifiquement la conclusion du job `deploy-api` via l'API GitHub (comme le fait déjà `deploy-main.yml` pour ses propres gates) plutôt que la conclusion globale du workflow, pour éviter qu'un échec de build mobile bloque les smoke tests API.
+
+## Priorité P4 — Hygiène générale (continu)
+
+- [ ] Documenter dans un seul fichier (`docs/CI_CD_SECRETS.md` ou équivalent) la liste complète des secrets et variables GitHub Actions requis par workflow, avec leur portée (repo vs environment). Actuellement dispersé entre `AUDIT.md` et la mémoire de l'équipe.
+- [ ] Ajouter un job `actionlint` (+ shellcheck intégré) en CI dédiée sur PR touchant `.github/workflows/**`, pour éviter la régression du bug §1.1 à l'avenir. Coût : quasi nul (actionlint tourne en quelques secondes), gain : détection immédiate de scripts orphelins / expressions invalides.
+- [ ] Revoir périodiquement (trimestriel) la liste des workflows pour identifier de nouveaux jobs morts/legacy (comme `_setup-php.yml`/`_setup-flutter.yml` aujourd'hui).
+
+---
+
+## Ce qui a été livré dans cette PR (2026-07-19)
+
+1. `AUDIT_CICD_2026-07-19.md` — audit complet (ce document est son plan associé).
+2. Correctifs P0 :
+   - `tests.yml` : suppression du fragment orphelin `mobile_*`.
+   - `release.yml` : suppression du job legacy `build-artifacts` pointant vers `front/mobile` (dossier supprimé).
+   - `.github/dependabot.yml` : correction des chemins Flutter réels + extension npm aux 3 front-ends manquants + ajout écosystème `github-actions`.
+3. Le reste (P1-P4) est documenté et priorisé mais volontairement **non implémenté dans cette PR** car cela demande des décisions produit/sécurité (rotation de secrets, comportement de déploiement optimiste, choix d'outil SAST) qui doivent être validées par l'équipe avant modification du comportement de production.


### PR DESCRIPTION
## Résumé

Audit complet des 28 workflows GitHub Actions du repo (validation outillée avec `actionlint` + `shellcheck` intégré, lecture exhaustive, vérification croisée avec l'arborescence réelle et l'historique git).

- 📄 `AUDIT_CICD_2026-07-19.md` — audit détaillé par catégorie de sévérité
- 📄 `PLAN_ACTION_CICD_2026-07-19.md` — plan d'action priorisé P0-P4

## Correctifs appliqués dans cette PR (P0 uniquement)

1. **`tests.yml`** : suppression d'un fragment de script orphelin dans le job `backend-coverage` (steps `mobile_analyze`/`mobile_tests`/`mobile_coverage_gate`/`mobile_smoke_build` jamais définis dans ce job — confirmé par `actionlint`: erreur de parsing shellcheck SC1089 + 4 propriétés d'expression indéfinies). Nettoyage de la variable `MOBILE_SUMMARY` devenue inutilisée.
2. **`release.yml`** : suppression du job legacy `build-artifacts` qui référence `front/mobile`, dossier supprimé du repo depuis #754. Ce job échouait sur **chaque tag `v*`** poussé. Les APKs multi-app sont déjà gérés par `mobile-distribute.yml` et `deploy-main.yml`.
3. **`.github/dependabot.yml`** : correction du chemin `pub` inexistant (`/mobile` → un `directory` par app Flutter réelle sous `front/mobile_apps/*`), extension de la couverture `npm` à `front/web`, `front/admin-dashboard`, `front/web-offline` (seul `api/package.json` était surveillé auparavant), ajout de l'écosystème `github-actions`.

## Non inclus dans cette PR (documenté dans le plan d'action, P1-P4)

- Pinning par SHA des actions tierces (supply-chain hardening), en particulier `trufflehog@main`
- Déduplication du setup PHP/PostgreSQL/Redis (dupliqué 4×, reusable workflows `_setup-php.yml`/`_setup-flutter.yml` existants mais jamais appelés)
- CodeQL PHP actuellement un stub (pas de SAST réel sur le backend)
- Fiabilité des deux pipelines de déploiement parallèles (`deploy-main.yml` / `deploy-staging.yml`)

Ces points nécessitent des décisions produit/sécurité de l'équipe avant tout changement de comportement en production — voir le plan d'action pour le détail complet.

## Validation

```
$ actionlint
# 0 finding sur tests.yml et release.yml (avant: 6 findings incluant 1 erreur de parsing shellcheck)
```

⚠️ Note sécurité : GitHub signale déjà 34 vulnérabilités Dependabot sur `main` (11 high, 16 moderate, 7 low), cohérent avec la couverture Dependabot incomplète documentée dans cet audit.