### PR TITLE
fix(mobile): make main() async in employee/manager/hr apps (await before runApp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [4.23.4] - 2026-07-19
+
+### Fixed
+- **Bug de compilation Dart dans `leopardo_employee`, `leopardo_manager`, `leopardo_hr` : `void main() { ... await ... }`** : les trois `main.dart` declaraient `main()` sans le mot-cle `async` alors que le corps de la fonction contient `await SentryFlutter.init(...)`. C'est une erreur de compilation Dart (pas seulement un avertissement du guard CI `validate-mobile-runtime-smoke.ps1`, qui l'a detectee) ; seul `leopardo_platform_admin` avait deja la signature correcte `Future<void> main() async`. Corrige en alignant les 3 apps sur `Future<void> main() async { ... }`. Ce bug bloquait le job `Mobile Apps CI - Flutter` sur `main` depuis plusieurs commits.
+
 ## [4.23.3] - 2026-07-19
 
 ### Security

--- a/front/mobile_apps/leopardo_employee/lib/main.dart
+++ b/front/mobile_apps/leopardo_employee/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:leopardo_core/core/widgets/startup_gate.dart';
 import 'app.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   FlutterError.onError = (details) {

--- a/front/mobile_apps/leopardo_hr/lib/main.dart
+++ b/front/mobile_apps/leopardo_hr/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:leopardo_core/core/widgets/startup_gate.dart';
 import 'app.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   FlutterError.onError = (details) {

--- a/front/mobile_apps/leopardo_manager/lib/main.dart
+++ b/front/mobile_apps/leopardo_manager/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:leopardo_core/core/widgets/startup_gate.dart';
 import 'app.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   FlutterError.onError = (details) {


### PR DESCRIPTION
## Contexte

`Mobile Apps CI - Flutter` echoue sur `main` depuis plusieurs commits (voir `validate-mobile-runtime-smoke.ps1`, guard `Assert-NoAwaitBeforeRunApp`).

## Root cause

`front/mobile_apps/leopardo_{employee,manager,hr}/lib/main.dart` declaraient `void main() { ... }` **sans** `async`, alors que le corps de la fonction appelle `await SentryFlutter.init(...)`. C'est une **vraie erreur de compilation Dart** (pas seulement le linter maison qui se plaint) : `await` est illegal dans une fonction non-async.

Seul `leopardo_platform_admin` avait deja la signature correcte `Future<void> main() async`.

## Fix

Aligne les 3 apps sur `Future<void> main() async { ... }`, identique au pattern deja utilise par `platform_admin`. Aucun autre changement de logique.

## Verification

Environnement d'audit sans runtime Flutter/Dart disponible ; ce fix s'appuie sur la CI GitHub Actions (Flutter stable) pour valider la compilation. CHANGELOG.md mis a jour (gate de gouvernance).