### PR TITLE
fix(vercel): only build on Vercel when front/web changes

### DIFF
--- a/front/web/vercel.json
+++ b/front/web/vercel.json
@@ -3,7 +3,9 @@
   "devCommand": "npm run dev",
   "installCommand": "npm ci",
   "framework": "nextjs",
-  "regions": ["cdg1"],
+  "regions": [
+    "cdg1"
+  ],
   "headers": [
     {
       "source": "/(.*)",
@@ -77,6 +79,7 @@
   ],
   "cleanUrls": true,
   "trailingSlash": false,
+  "ignoreCommand": "bash -c 'if [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ; else git diff --quiet HEAD^ HEAD -- . ; fi'",
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
## Probleme

Actuellement, Vercel relance un build/deploiement a chaque push sur `main`, meme quand aucun fichier de `front/web` (le seul dossier heberge sur Vercel) n'a change. Cela gaspille des minutes de build et des slots de deploiement concurrents pour des changements qui ne touchent que le backend, le mobile, ou la documentation.

## Solution

Ajoute un `ignoreCommand` dans `front/web/vercel.json` (propriete officielle Vercel, voir docs: https://vercel.com/docs/project-configuration/vercel-json#ignorecommand) qui:

- Compare le diff Git entre `VERCEL_GIT_PREVIOUS_SHA` (le dernier commit deploye avec succes sur la branche) et le commit courant, limite au dossier `front/web` (Root Directory du projet Vercel).
- Si aucun changement dans `front/web`, exit code `0` -> le build est annule (CANCELED), aucune ressource consommee.
- Si un changement existe, exit code `1` -> le build continue normalement.
- Fallback sur `HEAD^ HEAD` quand `VERCEL_GIT_PREVIOUS_SHA` est vide (premier deploiement d une nouvelle branche).

## Validation locale

Teste directement sur des commits reels du repo:

- Commit `f0e2bac` (mobile uniquement, ne touche pas `front/web`) -> exit code `0` (skip)
- Commit `e18ef69` (touche `front/web/package.json`) -> exit code `1` (build)

```bash
cd front/web
git diff --quiet f0e2bac^ f0e2bac -- .   # exit 0 -> skip
git diff --quiet e18ef69^ e18ef69 -- .   # exit 1 -> build
```

## Notes

- Aucun changement de comportement pour Render (API) ou les workflows GitHub Actions existants (deploy-main.yml a deja sa propre logique de gating pour Render/Firebase, non affectee).
- Le champ `git.deploymentEnabled` existant (main/staging actives, develop desactive) est conserve tel quel.
