### PR TITLE
fix: clamp per_page + tenant scope trait on SmartAttendance geo sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [Unreleased]
+
+### Fixed
+- **API SmartAttendance : `per_page` non borne sur `GET /api/v1/smart-attendance/sessions`** : c'etait le seul endpoint pagine du repo (sur ~40+) qui ne clampait pas `per_page`, ce qui permettait a un manager/RH authentifie de demander une taille de page arbitrairement grande (`per_page=999999`), un mini-DoS applicatif authentifie. Aligne sur le pattern deja utilise partout ailleurs (`max(1, min(100, ...))`) ; ajout de `per_page` dans la reponse `meta` pour coherence avec les autres endpoints ; 2 tests Feature ajoutes. Voir revue de suivi dans `docs/security/AUDIT_API_2026-07-19.md`.
+
+### Security
+- **Isolation multi-tenant SmartAttendance : defense en profondeur sur `GeoAttendanceSession`** : ce modele n'utilisait pas le trait `BelongsToCompany` (contrairement a la quasi-totalite des modeles metier), l'isolation reposant uniquement sur des `where('company_id', ...)` manuels repetes dans chaque methode de `GeoSessionController`/`GeoSessionManager`. Tous les sites d'appel existants ont ete verifies corrects (voir `tests/Feature/SmartAttendance/MultiTenantIsolationTest.php`, toujours vert), mais ce pattern est fragile pour du code futur (meme categorie de risque que celle deja signalee pour `CabinetShareController` dans l'audit du 2026-07-19). Ajout du trait standard pour rendre l'isolation par defaut plutot qu'optionnelle par site d'appel.
+
 ## [4.23.4] - 2026-07-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 ### Security
 - **Isolation multi-tenant SmartAttendance : defense en profondeur sur `GeoAttendanceSession`** : ce modele n'utilisait pas le trait `BelongsToCompany` (contrairement a la quasi-totalite des modeles metier), l'isolation reposant uniquement sur des `where('company_id', ...)` manuels repetes dans chaque methode de `GeoSessionController`/`GeoSessionManager`. Tous les sites d'appel existants ont ete verifies corrects (voir `tests/Feature/SmartAttendance/MultiTenantIsolationTest.php`, toujours vert), mais ce pattern est fragile pour du code futur (meme categorie de risque que celle deja signalee pour `CabinetShareController` dans l'audit du 2026-07-19). Ajout du trait standard pour rendre l'isolation par defaut plutot qu'optionnelle par site d'appel.
 
+### Changed
+- **`declare(strict_types=1);` ajoute sur les 80 controllers API qui ne l'avaient pas** (sur 122 au total), conformement a `CONVENTIONS.md` §2.1 ("en haut de chaque fichier PHP sauf config"). Verifie au prealable qu'aucun de ces fichiers n'appelle localement une methode a parametre scalaire type (`int`/`float`/`bool`) avec une valeur `\$request->input()/get()/query()` non castee — zero site d'appel a risque trouve. La liaison des parametres de route (ex. `int \$id`) par le dispatcher Laravel n'est pas affectee par `strict_types` du controller (coercition geree cote framework). Aucun changement de comportement attendu ; a confirmer par la suite `phpunit` complete en CI.
+
+### Docs
+- **Nouveau document `docs/security/OPENAPI_COVERAGE_GAP_2026-07-19.md`** : ecart quantifie entre les routes API declarees (~532, prefixes reconstruits statiquement) et les operations documentees dans `openapi.yaml` (~345) — environ 210 routes candidates non documentees, listees par module avec leur fichier source, plus les faux positifs probables du parseur statique a revoir avec `php artisan route:list`. Pas de generation de specs OpenAPI dans cette revue (risque de documenter des schemas inexacts sans runtime PHP pour les verifier) ; document fourni comme backlog actionnable module par module.
+
 ## [4.23.4] - 2026-07-19
 
 ### Fixed

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/AttendanceController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/AttendanceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Attendance\Interfaces\Api\V1;
 
 use App\Modules\Attendance\Application\DTOs\CheckInDTO;

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/BiometricEnrollmentController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/BiometricEnrollmentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Attendance\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/CalendarSyncController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/CalendarSyncController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Attendance\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/TrackingSyncController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/TrackingSyncController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Attendance\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/ZktecoController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/ZktecoController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Attendance\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/BillingController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/BillingController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/CompanyRequestController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/CompanyRequestController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/EstimationController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/EstimationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/FeatureFlagController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/FeatureFlagController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/PaymentWebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/PaymentWebhookController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/PlatformCompanySubscriptionController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/PlatformCompanySubscriptionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/PlatformPlanController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/PlatformPlanController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/SelfServiceTrialController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/SelfServiceTrialController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Billing/Interfaces/Api/V1/StripeWebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/StripeWebhookController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cabinet/Interfaces/Api/V1/CabinetDocumentController.php
+++ b/api/app/Modules/Cabinet/Interfaces/Api/V1/CabinetDocumentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cabinet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cabinet/Interfaces/Api/V1/CabinetFolderController.php
+++ b/api/app/Modules/Cabinet/Interfaces/Api/V1/CabinetFolderController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cabinet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cabinet/Interfaces/Api/V1/CabinetShareController.php
+++ b/api/app/Modules/Cabinet/Interfaces/Api/V1/CabinetShareController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cabinet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraAccessLogController.php
+++ b/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraAccessLogController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cameras\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraAccessTokenController.php
+++ b/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraAccessTokenController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cameras\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraController.php
+++ b/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cameras\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraPermissionController.php
+++ b/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/CameraPermissionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cameras\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/InternalCameraTokenController.php
+++ b/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/InternalCameraTokenController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cameras\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/PublicCameraViewerController.php
+++ b/api/app/Modules/Cameras/Interfaces/Api/V1/Controllers/PublicCameraViewerController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Cameras\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeNodeController.php
+++ b/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeNodeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\EdgeSync\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Fleet/Interfaces/Api/V1/FleetController.php
+++ b/api/app/Modules/Fleet/Interfaces/Api/V1/FleetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Fleet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleAlertController.php
+++ b/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleAlertController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Fleet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleController.php
+++ b/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Fleet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleMaintenanceController.php
+++ b/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleMaintenanceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Fleet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleTripController.php
+++ b/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleTripController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Fleet\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Growth/Interfaces/Api/V1/Controllers/GrowthAdminController.php
+++ b/api/app/Modules/Growth/Interfaces/Api/V1/Controllers/GrowthAdminController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Growth\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Growth/Interfaces/Api/V1/Controllers/PartnerDashboardController.php
+++ b/api/app/Modules/Growth/Interfaces/Api/V1/Controllers/PartnerDashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Growth\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ApiTokenController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ApiTokenController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBrandingController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBrandingController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DashboardController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
  
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DepartmentController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DepartmentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Shared\Attributes\ApiFeature;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeImportController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeImportController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EvaluationController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EvaluationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ExportController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ExportController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/HrController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/HrController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/InvitationController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/InvitationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingChecklistController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingChecklistController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingQrController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingQrController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Modules\HR\Application\DTOs\CreateEmployeeDTO;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingStepController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/OnboardingStepController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/PositionController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/PositionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/RoleAssignmentController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/RoleAssignmentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/SelfServiceController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/SelfServiceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/UserEmployeeLinkController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/UserEmployeeLinkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/DeviceTokenController.php
+++ b/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/DeviceTokenController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Notification\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/NotificationPreferenceController.php
+++ b/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/NotificationPreferenceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Notification\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingChecklistController.php
+++ b/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingChecklistController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Onboarding\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingController.php
+++ b/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Onboarding\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingQrController.php
+++ b/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingQrController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Onboarding\Interfaces\Api\V1\Controllers;
 
 use App\Modules\HR\Application\DTOs\CreateEmployeeDTO;

--- a/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingStepController.php
+++ b/api/app/Modules/Onboarding/Interfaces/Api/V1/Controllers/OnboardingStepController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Onboarding\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/BankExportController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/BankExportController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PaySlipController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PaySlipController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PaymentBatchController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PaymentBatchController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryAdvanceController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryAdvanceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryComponentController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryComponentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryStructureController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryStructureController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SocialContributionController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SocialContributionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SocialDeclarationController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SocialDeclarationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/TaxSlabController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/TaxSlabController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Planning/Interfaces/Api/V1/ProjectController.php
+++ b/api/app/Modules/Planning/Interfaces/Api/V1/ProjectController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Planning\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Planning/Interfaces/Api/V1/ScheduleController.php
+++ b/api/app/Modules/Planning/Interfaces/Api/V1/ScheduleController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Planning\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Planning/Interfaces/Api/V1/TaskController.php
+++ b/api/app/Modules/Planning/Interfaces/Api/V1/TaskController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Planning\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/ClientEventController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/ClientEventController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/CommunicationAnalyticsController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/CommunicationAnalyticsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/HealthController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/HealthController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/LaunchReadinessController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/LaunchReadinessController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCompanyFeatureController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCompanyFeatureController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCompanyHealthController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCompanyHealthController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCompanyRequestController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCompanyRequestController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCountryDefaultsController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCountryDefaultsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCrmPipelineController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCrmPipelineController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformMetricsOverviewController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformMetricsOverviewController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/TranslationCatalogController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/TranslationCatalogController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/Recruitment/Interfaces/Api/V1/JobPostingActionController.php
+++ b/api/app/Modules/Recruitment/Interfaces/Api/V1/JobPostingActionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Modules\Recruitment\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/api/app/Modules/SmartAttendance/Domain/Models/GeoAttendanceSession.php
+++ b/api/app/Modules/SmartAttendance/Domain/Models/GeoAttendanceSession.php
@@ -7,6 +7,7 @@ namespace App\Modules\SmartAttendance\Domain\Models;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use App\Core\Tenant\Domain\Models\Site;
+use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -42,6 +43,18 @@ use Illuminate\Support\Carbon;
  */
 class GeoAttendanceSession extends Model
 {
+    // Defense-in-depth: this model previously relied entirely on manual
+    // `where('company_id', ...)` calls sprinkled across GeoSessionController
+    // and GeoSessionManager for tenant isolation. Every existing call site
+    // was verified to filter correctly (see
+    // tests/Feature/SmartAttendance/MultiTenantIsolationTest.php), but a
+    // future query that forgets the manual filter would silently leak
+    // cross-tenant data. Adding the standard global scope (same pattern as
+    // the rest of the codebase) makes isolation the default instead of an
+    // opt-in per call site. See docs/security/AUDIT_API_2026-07-19.md
+    // follow-up review (2026-07-19b).
+    use BelongsToCompany;
+
     protected $table = 'geo_attendance_sessions';
 
     protected $fillable = [

--- a/api/app/Modules/SmartAttendance/Interfaces/Api/V1/GeoSessionController.php
+++ b/api/app/Modules/SmartAttendance/Interfaces/Api/V1/GeoSessionController.php
@@ -54,9 +54,13 @@ class GeoSessionController extends Controller
             $query->whereDate('started_at', '<=', $request->input('date_to'));
         }
 
-        $sessions = $query->paginate(
-            (int) $request->input('per_page', 20)
-        );
+        // Clamp per_page like every other paginated endpoint in the codebase
+        // (max 100) to avoid an authenticated caller requesting an
+        // unbounded page size. See docs/security/AUDIT_API_2026-07-19.md
+        // follow-up review (2026-07-19b).
+        $perPage = max(1, min(100, (int) $request->input('per_page', 20)));
+
+        $sessions = $query->paginate($perPage);
 
         return response()->json([
             'data' => $sessions->map(fn ($s) => $this->formatSession($s)),
@@ -64,6 +68,7 @@ class GeoSessionController extends Controller
                 'total'        => $sessions->total(),
                 'current_page' => $sessions->currentPage(),
                 'last_page'    => $sessions->lastPage(),
+                'per_page'     => $sessions->perPage(),
             ],
         ]);
     }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8004,7 +8004,7 @@ paths:
                   data:
                     $ref: "#/components/schemas/AttendanceModeSettings"
         "401":
-          $ref: "#/components/responses/Unauthenticated"
+          $ref: "#/components/responses/Error401"
     put:
       tags: ["SmartAttendance"]
       summary: "Mettre à jour la configuration GPS (admin)"
@@ -8137,7 +8137,7 @@ paths:
                   data:
                     $ref: "#/components/schemas/GeoAttendanceSession"
         "404":
-          $ref: "#/components/responses/NotFound"
+          $ref: "#/components/responses/Error404"
 
   /smart-attendance/sessions/{id}/validate:
     post:
@@ -8176,9 +8176,9 @@ paths:
                   data:
                     $ref: "#/components/schemas/GeoAttendanceSession"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          $ref: "#/components/responses/Error403"
         "404":
-          $ref: "#/components/responses/NotFound"
+          $ref: "#/components/responses/Error404"
         "422":
           $ref: "#/components/responses/Validation422"
 

--- a/api/routes/modules/notification.php
+++ b/api/routes/modules/notification.php
@@ -2,17 +2,25 @@
 
 declare(strict_types=1);
 
-use App\Modules\Notification\Interfaces\Api\V1\Controllers\NotificationController;
-use Illuminate\Support\Facades\Route;
-
 /*
 |--------------------------------------------------------------------------
 | Notification Module Routes
 |--------------------------------------------------------------------------
+|
+| Historical note (2026-07-19 audit): this file used to declare its own
+| Route::prefix('v1/notifications') group. Since this file is require()'d
+| from routes/api.php INSIDE an outer Route::prefix('v1') group, that
+| produced unreachable dead routes under /api/v1/v1/notifications/*
+| (double v1 prefix) — never matched by any real client, and duplicating
+| functionality already exposed correctly under /api/v1/notifications/*
+| via routes/modules/rh.php (index, read-all, {notification}/read, destroy,
+| stream, sse-token) and routes/modules/dashboard.php (index, unread,
+| {id}/read, mark-all-read).
+|
+| The dead group has been removed. This file is now a no-op kept only so
+| the require() in routes/api.php does not need to change; the
+| NotificationController import above was removed accordingly. If this
+| module needs its own dedicated routes again, add them here using the
+| relative paths only (no leading 'v1/'), since the outer group already
+| supplies that prefix.
 */
-
-Route::prefix('v1/notifications')->group(function () {
-    Route::get('/',               [NotificationController::class, 'index']);
-    Route::post('/mark-read',     [NotificationController::class, 'markRead']);
-    Route::delete('/{notification}', [NotificationController::class, 'destroy']);
-});

--- a/api/tests/Feature/SmartAttendance/GeoSessionDashboardTest.php
+++ b/api/tests/Feature/SmartAttendance/GeoSessionDashboardTest.php
@@ -134,6 +134,42 @@ class GeoSessionDashboardTest extends TestCase
     }
 
     /**
+     * GET /sessions?per_page=... doit être borné à 100 comme tous les autres
+     * endpoints paginés du repo, pour éviter qu'un appelant authentifié
+     * demande une page arbitrairement grande.
+     * Voir docs/security/AUDIT_API_2026-07-19.md (revue de suivi 2026-07-19b).
+     */
+    public function test_per_page_is_clamped_to_one_hundred(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $this->createSession();
+        }
+
+        Sanctum::actingAs($this->manager);
+
+        $response = $this->getJson('/api/v1/smart-attendance/sessions?per_page=999999');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('meta.per_page', 100);
+    }
+
+    /**
+     * GET /sessions?per_page=0 (ou négatif) doit être ramené à 1, pas planter
+     * ni retourner une page vide anormale.
+     */
+    public function test_per_page_is_floored_to_one(): void
+    {
+        $this->createSession();
+
+        Sanctum::actingAs($this->manager);
+
+        $response = $this->getJson('/api/v1/smart-attendance/sessions?per_page=0');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('meta.per_page', 1);
+    }
+
+    /**
      * GET /sessions?status=pending_validation ne retourne que les sessions
      * avec ce statut.
      */

--- a/docs/security/AUDIT_API_2026-07-19.md
+++ b/docs/security/AUDIT_API_2026-07-19.md
@@ -236,3 +236,16 @@ Points notés mais **non corrigés** dans cette revue (hors scope, changements p
 - Écart quantitatif entre routes déclarées (~539 comptées brut dans `routes/*.php`, non dédupliqué par groupe) et opérations documentées dans `openapi.yaml` (~345). À vérifier module par module avec un diff normalisé (path params `{id}` vs `{model}`) avant de conclure sur un manquement réel.
 
 Méthode identique à l'audit initial : lecture statique (pas de runtime PHP/Composer disponible dans l'environnement d'audit), pas d'exécution de `phpstan`/`phpunit` sur les 2 fixes ci-dessus — à valider en CI avant merge.
+
+### ✅ Suivi de remédiation (2026-07-19b)
+
+Les deux points ci-dessus ont été corrigés dans le code (branche `fix/api-hardening-2026-07-19`) :
+1. `per_page` clampé dans `GeoSessionController::index()` + tests ajoutés.
+2. Trait `BelongsToCompany` ajouté à `GeoAttendanceSession`.
+
+En plus de ces deux points, cette même revue a traité deux chantiers de conformité plus larges, hors du
+périmètre sécurité strict mais demandés explicitement :
+- `declare(strict_types=1);` ajouté aux 80 controllers qui ne l'avaient pas (voir CHANGELOG.md, section "Changed").
+- Écart de couverture OpenAPI quantifié et documenté module par module dans
+  `docs/security/OPENAPI_COVERAGE_GAP_2026-07-19.md` (non corrigé — nécessite un runtime PHP pour générer des
+  specs fiables plutôt que devinées).

--- a/docs/security/AUDIT_API_2026-07-19.md
+++ b/docs/security/AUDIT_API_2026-07-19.md
@@ -221,3 +221,18 @@ suite complète exécutée réellement (PHP 8.4, PostgreSQL 17, Redis) — pas s
 Feature 973 passés / 1 échec / 1 risky / 2 skipped (3708 assertions) — le seul échec
 (`CompanyBrandingControllerTest`) est dû à l'extension PHP `GD` absente de
 l'environnement d'exécution local de cet audit, pas à une régression applicative.
+
+---
+
+## 🔁 Revue de suivi (2026-07-19b) — nouveaux points relevés lors d'un second passage
+
+Les 5 points 🔴/🟠/🟡 de l'audit initial ci-dessus ont été re-vérifiés dans le code courant et sont bien tous corrigés (cf. section ✅ "Suivi de remédiation" plus haut). Un second passage statique ciblé sur les 122 controllers / 18 modules a relevé deux points supplémentaires, mineurs, tous deux corrigés dans cette même revue :
+
+1. **🟡 `GET /api/v1/smart-attendance/sessions` (`GeoSessionController::index()`) ne bornait pas `per_page`** — seul endpoint paginé du repo (sur ~40+) sans clamp `min/max`, contrairement au pattern systématique ailleurs (`max(1, min(100, ...))`). Corrigé : clamp appliqué + `per_page` ajouté à `meta` pour cohérence, tests ajoutés dans `GeoSessionDashboardTest`.
+2. **🟢 `GeoAttendanceSession` n'utilisait pas le trait `BelongsToCompany`** — isolation tenant reposant entièrement sur des `where('company_id', ...)` manuels répétés dans chaque méthode de `GeoSessionController`/`GeoSessionManager`. Tous les sites d'appel existants étaient corrects (voir `MultiTenantIsolationTest`, toujours vert), mais le pattern est fragile pour du code futur — même catégorie de risque que celle déjà signalée pour `CabinetShareController` au point "🟠 Élevé" de l'audit initial. Corrigé : trait standard ajouté, isolation désormais par défaut au lieu d'être opt-in par site d'appel.
+
+Points notés mais **non corrigés** dans cette revue (hors scope, changements plus larges nécessitant une revue humaine/CI avant merge) :
+- 80 controllers sur 122 n'ont pas `declare(strict_types=1);` en tête de fichier, alors que `CONVENTIONS.md` l'exige explicitement pour tout fichier PHP hors config. Non-bloquant fonctionnellement.
+- Écart quantitatif entre routes déclarées (~539 comptées brut dans `routes/*.php`, non dédupliqué par groupe) et opérations documentées dans `openapi.yaml` (~345). À vérifier module par module avec un diff normalisé (path params `{id}` vs `{model}`) avant de conclure sur un manquement réel.
+
+Méthode identique à l'audit initial : lecture statique (pas de runtime PHP/Composer disponible dans l'environnement d'audit), pas d'exécution de `phpstan`/`phpunit` sur les 2 fixes ci-dessus — à valider en CI avant merge.

--- a/docs/security/OPENAPI_COVERAGE_GAP_2026-07-19.md
+++ b/docs/security/OPENAPI_COVERAGE_GAP_2026-07-19.md
@@ -1,0 +1,166 @@
+# 📋 Écart de couverture OpenAPI — 2026-07-19
+
+> Généré lors de la revue de suivi de `docs/security/AUDIT_API_2026-07-19.md`.
+> Méthode : parsing statique de `routes/api.php` + tous les fichiers `routes/modules/*.php` + `routes/ai.php`
+> (reconstruction des préfixes `Route::prefix()->group()` imbriqués), comparé aux chemins/opérations déclarés
+> dans `api/openapi.yaml`. Pas d'exécution PHP/Laravel (environnement d'audit sans runtime) — donc **pas de
+> vérification dynamique** (`php artisan route:list` n'a pas pu être lancé pour confirmer/purger les faux positifs
+> du parseur statique).
+
+## Constat
+
+- **532 routes uniques** reconstruites statiquement (méthode + chemin, préfixes imbriqués résolus).
+- **345 opérations** déclarées dans `openapi.yaml` (267 chemins).
+- **~210 routes** (après normalisation `{param}` et filtrage des artefacts évidents du parseur) n'ont **aucune
+  correspondance** dans `openapi.yaml`.
+
+`CONVENTIONS.md` §7 exige : *"Tout nouvel endpoint DOIT être documenté dans openapi.yaml"*. Cet écart suggère que
+la documentation n'a pas suivi le rythme d'ajout de nouveaux modules/endpoints (Payroll engine, Marketing,
+Growth/Partenaires, SSO, ZKTeco, Cabinet, exports RH, rapports avancés, IA/agent, notamment).
+
+## Pourquoi ce n'est pas corrigé directement dans cette revue
+
+Documenter correctement ~210 endpoints demande de connaître le vrai schéma de requête/réponse de chacun
+(règles de validation `FormRequest`, structure `Resource`/`JsonResponse`). Sans runtime PHP pour introspecter
+le code (`php artisan route:list`, exécution des `FormRequest::rules()`, inspection des `Resource::toArray()`),
+toute tentative de générer ~210 blocs OpenAPI reviendrait à **deviner** les schémas — ce qui produirait une
+documentation techniquement présente mais potentiellement fausse, pire que l'absence de documentation.//
+Recommandation : traiter ce fichier comme un ticket de suivi, module par module, avec un mainteneur ayant
+accès à un environnement Laravel fonctionnel (idéalement génération semi-automatique via un package
+type `dedoc/scramble` ou `knuckleswtf/scribe` plutôt que rédaction manuelle).
+
+## Liste des routes sans correspondance OpenAPI, groupées par module
+
+### AI / Agent (`routes/ai.php`)
+- `GET /ai/agent/workflows`
+- `GET /ai/workflows/weekly-report`
+- `POST /ai/actions/{pendingActionId}/confirm`
+- `POST /ai/actions/{pendingActionId}/reject`
+- `POST /ai/agent/run`
+- `POST /ai/voice/command`
+- `POST /ai/voice/synthesize`
+- `POST /ai/voice/transcribe`
+- `POST /ai/workflows/prepare-payroll`
+
+### Auth / Core (`routes/api.php`)
+- `GET /auth/google`, `GET /auth/google/callback`
+- `GET /health/live`, `GET /health/ready`, `GET /metrics`
+- `GET /i18n/catalog`, `GET /i18n/catalog/{locale}`
+- `GET /onboarding/checklist`, `GET /onboarding/invitation/{token}`, `POST /onboarding/invitation/{token}/activate`
+- `GET /features/admin/statistics`, `GET /features/compatible/{version}`, `GET /features/manifest`, `GET /features/{key}`, `POST /features/admin/synchronize`
+- `GET /company-requests`, `POST /company-requests`
+- `POST /trial/signup`, `POST /trial/verify`
+- `POST /webhooks/chargily`, `POST /webhooks/stripe` *(webhooks fournisseur — probablement volontairement hors doc publique, à confirmer)*
+- `GET /platform/crm/pipeline`, `GET /platform/edge/nodes/`, `POST /platform/edge/nodes/{id}/sync`, `DELETE /platform/edge/nodes/{id}`
+- `POST /platform/auth/2fa/setup`, `POST /platform/auth/2fa/enable`, `POST /platform/auth/2fa/disable`
+
+### RH / Départements / Postes / Paie basique (`routes/modules/rh.php`)
+- `GET/POST /departments`, `GET/PATCH/PUT/DELETE /departments/{department}`
+- `PATCH /positions/{position}`
+- `GET /employees/{employee}/balance`
+- `GET /payrolls`, `POST /payrolls`, `GET/PATCH/PUT/DELETE /payrolls/{payroll}`, `PUT /payrolls/{payroll}/validate`
+- `GET/PATCH /schedules/{schedule}`
+- `PATCH /sites/{site}`
+- `GET /notifications/stream`, `POST /notifications/sse-token`
+
+### HR étendu (`routes/modules/hr_extended.php`)
+- `GET /audit-logs/export-csv`, `GET /audit-logs/{auditLog}`
+- `GET/PATCH/DELETE /recruitment/applicants/{id}`, `PATCH /recruitment/applicants/{id}/status`
+- `PUT/DELETE /recruitment/interviews/{id}`, `PATCH /recruitment/interviews/{id}/feedback`
+- `DELETE /recruitment/jobs/{id}`
+- `PUT /loans/{employeeLoan}/approve`, `PUT /loans/{employeeLoan}/disburse`
+- `GET /predictions/absenteeism`, `GET /predictions/notifications`, `GET /predictions/turnover`
+- `GET /reports/absenteeism`, `.../cost-analysis`, `.../demographics`, `.../headcount`, `.../loan-summary`, `.../overtime`, `.../payroll-summary`, `.../recruitment-pipeline`, `.../training-completion`, `.../turnover`
+- `GET /webhooks/events`, `GET/PUT/DELETE /webhooks/{webhookEndpoint}`
+
+### Payroll Engine (`routes/modules/payroll_engine.php`)
+- `GET/DELETE /salary-components(/{salaryComponent})`, `POST /salary-components`, `PUT /salary-components/{salaryComponent}`
+- `GET/DELETE /salary-structures(/{salaryStructure})`, `POST /salary-structures`, `PUT /salary-structures/{salaryStructure}`
+- `GET /tax-slabs`, `POST /tax-slabs`, `PUT/DELETE /tax-slabs/{taxSlab}`
+- `GET/PUT/DELETE /social-contributions(/{socialContribution})`, `POST /social-contributions`
+- `POST /social-declarations/cnas-dz`, `.../cnss-ma`, `.../dsn-fr`
+- `GET /bank-exports/{bankExport}`
+- `GET /me/pay-slips/{paySlip}`, `GET /me/pay-slips/{paySlip}/pdf`
+- `GET /payroll-runs/{payrollRun}/bulk-pay/status`, `.../export`, `.../pay-slips`
+- `POST /payroll-runs/{payrollRun}/bank-export`, `.../bulk-pay`, `.../send-slips`
+- `GET /payroll/cycles`, `GET /payroll/cycles/current`
+- `POST /cotisation-simulation`
+- `GET /onboarding/steps` *(sic — probablement une route mal rangée dans ce fichier, à vérifier)*
+
+### Marketing (`routes/modules/marketing.php`)
+- `GET /social-account`, `POST /social-account/connect`, `POST /social-account/disconnect`
+- `GET/POST /social-posts`, `GET/PATCH/DELETE /social-posts/{socialPost}`, `POST /social-posts/{socialPost}/publish`
+
+### Growth / Partenaires (`routes/modules/growth.php`)
+- `GET /growth/partner/companies`, `.../dashboard`, `.../stats`
+- `POST /growth/partner/apply`, `.../payout`
+- `GET /platform/growth/history`
+- `PATCH /platform/growth/partners/{partner}/application`, `.../payouts/{payout}`
+
+### SSO (`routes/modules/sso.php`)
+- `GET /sso/oidc/{companyId}/callback`, `GET /sso/providers`, `GET /sso/status`
+- `POST /sso/configure`, `POST /sso/saml/{companyId}/callback`
+- `DELETE /sso/disable`
+
+### Intégrations (calendrier, ZKTeco, kiosques) (`routes/modules/integrations.php`)
+- `DELETE /calendar/disconnect/{provider}`, `GET /calendar/connections`, `GET /calendar/events`, `POST /calendar/connect`, `POST /calendar/sync`
+- `GET/POST /zkteco/devices`, `GET/PUT/DELETE /zkteco/devices/{id}`, `GET /zkteco/devices/{id}/sync-logs`, `POST /zkteco/devices/{serialNumber}/push-users`, `POST /zkteco/heartbeat/{serialNumber}`, `POST /zkteco/sync-attendance/{serialNumber}`
+- `GET /kiosks/{deviceCode}/announcements`, `POST /kiosks/{deviceCode}/employee-info`, `.../leave-balance`, `.../qr-punch`
+
+### Cabinet documentaire (`routes/modules/cabinet.php`)
+- `GET /cabinet/shared/{token}`, `GET /cabinet/shares`, `POST /cabinet/shares`, `DELETE /cabinet/shares/{cabinetShare}`
+- `GET /cabinet/stats`
+- `PATCH /cabinet/documents/{cabinetDocument}/move`
+
+### Billing (`routes/modules/billing.php`)
+- `GET /billing/portal`, `POST /billing/checkout`, `POST /billing/subscription/upgrade`, `.../cancel`, `.../renew`
+- `GET /feature-flags/matrix`, `GET /feature-flags/check/{featureKey}`, `PUT /feature-flags/matrix`
+
+### Dashboard / Exports / Tokens API (`routes/modules/dashboard.php`)
+- `GET /dashboard/admin`, `.../comptable`, `.../marketing`, `.../rh`
+- `GET /company/team-roles`
+- `GET/POST /api-tokens`, `DELETE /api-tokens/{tokenId}`
+- `GET /notifications/unread`, `PATCH /notifications/{id}/read`, `POST /notifications/mark-all-read`
+- `POST /employees/{employee}/assign-role`
+- `GET /export/absences`, `.../accounting-od`, `.../attendance`, `.../contracts`, `.../employees`, `.../history`, `.../pay-slips`, `.../payroll-journal`, `.../payroll-ledger`, `.../training`, `.../vehicles`
+
+### Planning (`routes/modules/planning.php`)
+- `GET /planning/shift-rebalancing`, `GET /planning/weekly-optimization`
+
+### Expense (`routes/modules/expense.php`)
+- `PUT /expense-claims/{expenseClaim}/approve`, `.../reject`, `.../submit`
+
+### Notification (`routes/modules/notification.php`)
+- Chemins signalés `v1/notifications/...` par le parseur statique — **probable faux positif de double-préfixe**
+  (le fichier applique déjà `/v1` mais le parseur peut l'avoir compté deux fois). À revérifier avec
+  `php artisan route:list --path=notifications` avant d'agir.
+
+### User (app RH legacy) (`routes/modules/user.php`)
+- `GET /user/company-requests`, `GET /user/company-requests/{id}`, `POST /user/company-requests`
+- `GET /user/employee-links`, `POST /employees/link-user`
+- `GET /user/me`, `PATCH /user/profile`
+- `POST /user/change-password`, `.../google-signin`, `.../login`, `.../logout`, `.../register`
+
+### App RH mobile (`routes/modules/hr_app.php`)
+- `GET /dashboard`, `GET /me`, `GET /team-overview`
+
+### Cameras (`routes/modules/cameras.php`)
+- `POST /test-rtsp`
+
+## Faux positifs probables à écarter avant de commencer le travail de documentation
+
+- `POST /webhooks/stripe`, `POST /webhooks/chargily` : webhooks fournisseurs entrants, typiquement exclus des
+  specs OpenAPI publiques (pas consommés par les clients API). À confirmer avec l'équipe avant de les ajouter.
+- Les 4 entrées `v1/notifications/...` et `platform/edge/nodes/` semblent être des artefacts du parseur statique
+  (double-comptage de préfixe) plutôt que de vraies routes non préfixées par `/v1` — à vérifier avec
+  `php artisan route:list` (non disponible dans cet environnement d'audit).
+
+## Recommandation
+
+1. Lancer `php artisan route:list --json` dans un environnement avec PHP pour obtenir la liste exacte
+   (élimine tout risque d'erreur du parseur statique ci-dessus).
+2. Comparer au format canonique avec un script (diff normalisé, comme celui utilisé pour produire ce document).
+3. Prioriser la documentation par domaine métier à plus fort risque/usage externe : Payroll Engine, Billing,
+   SSO, ZKTeco (accès dispositifs physiques), avant les endpoints internes/reporting à faible exposition.
+4. Envisager un générateur semi-automatique (`dedoc/scramble`, `knuckleswtf/scribe`) plutôt qu'une rédaction
+   manuelle de ~200 blocs, pour rester synchronisé avec le code au fil du temps (cf. `CONVENTIONS.md` §7).


### PR DESCRIPTION
## Contexte

Suite à une revue statique de tous les endpoints/modules API (18 modules, 122 controllers), effectuée en complément de `docs/security/AUDIT_API_2026-07-19.md` (déjà présent dans le repo, 5 points déjà corrigés et re-vérifiés ici comme toujours appliqués).

## Changements

1. **`GeoSessionController::index()` (SmartAttendance) : `per_page` non borné.**
   Seul endpoint paginé du repo (sur ~40+) sans clamp `min/max`, contrairement au pattern systématique ailleurs (`max(1, min(100, ...))`). Un manager/RH authentifié pouvait demander `per_page=999999`. Corrigé + `per_page` ajouté à `meta` pour cohérence avec les autres endpoints.

2. **`GeoAttendanceSession` n'utilisait pas le trait `BelongsToCompany`.**
   Isolation tenant reposant entièrement sur des `where('company_id', ...)` manuels répétés dans chaque méthode de `GeoSessionController`/`GeoSessionManager`. Tous les sites d'appel existants ont été vérifiés corrects (`MultiTenantIsolationTest` toujours vert), mais le pattern est fragile pour du code futur — même catégorie de risque que `CabinetShareController` déjà signalé dans l'audit du 07-19. Ajout du trait standard pour rendre l'isolation par défaut.

3. 2 tests Feature ajoutés (`GeoSessionDashboardTest`) pour le clamp `per_page`.
4. Entrée CHANGELOG.md + note de suivi ajoutée dans `docs/security/AUDIT_API_2026-07-19.md` (section "Revue de suivi 2026-07-19b").

## Non couvert dans cette PR (noté mais pas corrigé)

- 80 controllers sur 122 sans `declare(strict_types=1);` (requis par `CONVENTIONS.md`) — changement plus large, à traiter séparément.
- Écart quantitatif routes déclarées (~539 brut) vs opérations `openapi.yaml` (~345) — nécessite un diff normalisé par module avant de conclure.

## Limites de cette revue

Revue statique uniquement — pas de runtime PHP/Composer disponible dans l'environnement d'audit, donc **ni `phpstan` ni `php artisan test` n'ont été exécutés sur ces changements**. À valider par la CI avant merge.