### PR TITLE
docs: fix documentation coherence issues found in audit (2 passes)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,13 +2,15 @@
 
 ## Cartographie des workflows
 
-### 🔁 Reusable workflows (préfixe `_`)
-Ces workflows sont appelés par d'autres — ne pas déclencher directement.
+### 🔁 Composite actions partagées (`.github/actions/`)
+Ces actions composites remplacent les anciens workflows reutilisables `_setup-php.yml`
+et `_setup-flutter.yml` (supprimés, voir `CHANGELOG.md` v4.23.4). Elles sont appelées
+depuis les steps des workflows ci-dessous, pas declenchees directement.
 
-| Fichier | Rôle |
+| Action | Rôle |
 |---|---|
-| `_setup-php.yml` | PHP 8.4 + PostgreSQL 16 + Redis 7 + Composer cache |
-| `_setup-flutter.yml` | Flutter + Melos bootstrap |
+| `.github/actions/setup-backend-db` | PHP + Composer + bootstrap migrations multi-tenant (public + shared_tenants) contre postgres/redis |
+| `.github/actions/setup-flutter-android` | Java 17 + Flutter pour les builds Android (utilisee par `mobile-apps-ci.yml`, `mobile-distribute.yml`, `deploy-main.yml`) |
 
 ---
 
@@ -75,7 +77,7 @@ Ces workflows sont appelés par d'autres — ne pas déclencher directement.
 
 ## Règles de contribution CI
 
-1. **Ne pas dupliquer la config PHP/Flutter** — utiliser `_setup-php.yml` et `_setup-flutter.yml`
+1. **Ne pas dupliquer la config PHP/Flutter** — utiliser les composite actions `.github/actions/setup-backend-db` et `.github/actions/setup-flutter-android`
 2. **Nommer clairement** : `<scope>-<action>.yml` (ex: `api-lint.yml`, `mobile-test.yml`)
 3. **path filters** obligatoires sur les PRs pour éviter de déclencher tout sur chaque push
 4. **`concurrency`** obligatoire avec `cancel-in-progress: true`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ﻿# AGENTS.md - Guide de travail Leopardo RH
 
-Derniere mise a jour : 2026-06-13 (v4.16.251)
+Derniere mise a jour : 2026-07-19 (audit doc — le fichier a continue d'etre edite apres le 2026-06-13 sans que cet en-tete soit rafraichi ; voir `git log -- AGENTS.md` pour les dates reelles des sections recentes)
 
 Ce fichier doit etre lu au debut de chaque nouvelle session agent. Il doit aussi etre mis a jour a chaque push ou merge vers `main`, comme le `CHANGELOG.md`, des qu'une lecon operationnelle peut eviter de perdre du temps plus tard.
 
@@ -524,9 +524,7 @@ Procedure recommandee :
 - Le fichier `docs/PLAN_ACTION/14_ROADMAP_EXECUTION_POST_LOTS.md` sert maintenant de roadmap actualisee apres execution des lots plateforme metrics/backend/admin. Le fichier 13 reste l'inventaire brut ; le 14 doit porter la sequence priorisee et les retours d'experience.
 - Les prochaines actions GTM doivent rester connectees au wedge produit prioritaire : pointage, anomalies, rapport mensuel, onboarding et ROI client mesurable.
 - `docs/GOTO_MARKET/` est aussi le centre de reflexion sur la viabilite globale : utiliser la tech pour repondre a un besoin actuel, gagner de l'argent, et ne pas hesiter a repositionner ou moderniser le produit/offre quand le marche l'exige.
-- Les fichiers destines a presenter Leopardo RH au public doivent aller dans `docs/GOTO_MARKET/public/` avec un sous-dossier par canal : `social/`, `landing/`, `video/`, `press/`, `partners/`, `ads/`, `content_calendar/`, `metrics/`.
-- Le pack de lancement acquisition vit dans `docs/GOTO_MARKET/12_PACK_LANCEMENT_ACQUISITION.md` et les supports associes (`public/email`, `public/lead_magnets`, `public/owned_channels`, etc.).
-- La vision "Leopardo RH peut aussi aider une entreprise a gerer et automatiser son marketing" est documentee dans `docs/GOTO_MARKET/product_marketing_automation/`, mais elle n'est pas implementee dans le depot et ne doit pas distraire du wedge pointage tant qu'il n'est pas solidement vendu.
+- ⚠️ (Audit doc 2026-07-19) Les chemins `docs/GOTO_MARKET/public/`, `docs/GOTO_MARKET/12_PACK_LANCEMENT_ACQUISITION.md` et `docs/GOTO_MARKET/product_marketing_automation/` mentionnes historiquement dans les entrees precedentes n'existent plus dans le depot. La structure GTM reelle actuelle vit sous `docs/GOTO_MARKET/01_PRODUCT/`, `docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/`, `docs/GOTO_MARKET/ASSETS_PRODUCTION/` et `docs/GOTO_MARKET/GOTO_MARKET_AUDIT.md` (voir `docs/GOTO_MARKET/README.md`). Verifier l'arborescence reelle avant de referencer un sous-dossier GTM.
 
 ### 2026-05-07 - Federation de PR ouvertes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,14 +24,13 @@ leopardo-hr/
 ├── shared/
 │   ├── i18n/               # Traductions partagées (fr, en, ar, tr)
 │   └── mediaForMarketing/  # Assets marketing bruts
-├── openapi/                # Miroir de spécification OpenAPI (source canonique : api/openapi.yaml)
-├── dev-hub/                # Outils/SDK/scripts pour développeurs et intégrateurs externes
+├── dev-hub/                # Outils/SDK/scripts pour développeurs et intégrateurs externes (inclut dev-hub/openapi/v1.yaml, un second fichier de spec actuellement divergent de api/openapi.yaml, source canonique)
 ├── docs/                   # Documentation technique et stratégique
 ├── scripts/                # Scripts utilitaires racine (bootstrap, capture screenshots, cleanup)
 ├── postman/                # Collection Postman de l'API
 ├── examples/               # Exemples d'usage du SDK
 ├── assets/ , screenshots/  # Visuels marketing/README (candidats Git LFS — voir docs/architecture/ARCHITECTURE.md)
-└── .github/workflows/      # 29 pipelines CI/CD
+└── .github/workflows/      # 25 pipelines CI/CD (voir .github/workflows/README.md pour la cartographie)
 ```
 
 > Cet arbre doit rester synchronisé avec la structure réelle du repo. En cas de doute, vérifier avec `find . -maxdepth 2 -not -path '*/node_modules/*'`.
@@ -58,14 +57,14 @@ Modules/<Name>/
 └── Providers/          # ServiceProvider du module
 ```
 
-Modules actifs (18, sous `api/app/Modules/`) : `Absence`, `Attendance`, `Billing`, `Cabinet`, `Cameras`, `EdgeSync`, `Expense`, `Fleet`, `Growth`, `HR`, `Notification`, `Onboarding`, `Payroll`, `Planning`, `Platform`, `Recruitment`, `SmartAttendance`, `Training` + socle transversal `Core/Auth`, `Core/Tenant`, `Core/Feature` (sous `api/app/Core/`).
+Modules actifs (19, sous `api/app/Modules/`) : `Absence`, `Attendance`, `Billing`, `Cabinet`, `Cameras`, `EdgeSync`, `Expense`, `Fleet`, `Growth`, `HR`, `Marketing`, `Notification`, `Onboarding`, `Payroll`, `Planning`, `Platform`, `Recruitment`, `SmartAttendance`, `Training` + socle transversal `Core/Auth`, `Core/Tenant`, `Core/Feature` (sous `api/app/Core/`).
 
 > Décompte vérifié via `ls api/app/Modules | wc -l`. Voir `docs/ARCHITECTURE_STATUS.md` pour l'état couche-par-couche (Domain/Application/Infrastructure/Interfaces/Providers/Tests) de chaque module.
 
 ### Règle de contribution backend
 > **Tout nouveau code métier va dans `api/app/Modules/`.**
-> `api/app/Http/Controllers/Api/V1/` et `api/app/Services/` sont **supprimés** (PR #824, 2026-07-01).
-> `api/app/Models/` est en cours de migration — ne pas y ajouter de nouveau modèle.
+> `api/app/Http/Controllers/Api/V1/` a été intégralement supprimé (90 controllers legacy, PR #824, 2026-07-01). `api/app/Services/` a perdu ses 26 doublons legacy mais **n'est pas vide** : il reste des services spécialisés non-DDD (`Cache/`, `Communication/`, `Payroll/`, `SSO/`, `Security/`, `Tracking/`, etc.) + le shim `TenantManager.php`. Voir `api/ARCHITECTURE.md` pour le détail exact.
+> `api/app/Models/` a été supprimé (migration DDD terminée) — tout nouveau modèle va dans le module DDD concerné sous `api/app/Modules/<Name>/Domain/Models/`.
 > Voir `api/ARCHITECTURE.md` pour la liste complète et les TODOs restants.
 
 ### Code partagé transversal (`api/app/Shared/`)
@@ -110,22 +109,21 @@ app/Core/Tenant/
 
 > `App\Services\TenantManager` est un alias de backward-compat. Injecter `App\Core\Tenant\TenantManager` dans le nouveau code.
 
-### Migration en cours — class aliases (`app/Models/`)
+### Migration class aliases — état au 2026-07-19
 
-75 des 92 modèles de `app/Models/` sont des shims `class_alias` pointant vers leur module DDD canonique.
-Les 17 modèles restants (Company, Employee-link, AI*, SuperAdmin, etc.) n'ont pas encore de module dédié.
+`app/Models/` et `app/DTOs/` sont maintenant vides/supprimés (migration DDD terminée pour ces deux dossiers).
+Il reste des shims backward-compat dans `app/Traits/` (3 shims), `app/Attributes/` (3 shims) et `app/Enums/` (1 shim),
+pointant vers leur équivalent canonique sous `app/Shared/`.
 
-Pour supprimer un alias :
-1. `grep -r "App\\\\Models\\\\NomDuModel" app/` → remplacer par le namespace canonique
-2. Supprimer le fichier shim dans `app/Models/`
-
-Même pattern pour `app/DTOs/` (3 shims), `app/Traits/` (3 shims), `app/Attributes/` (3 shims), `app/Enums/` (1 shim).
+Pour supprimer un alias restant :
+1. `grep -r "App\\Traits\\NomDuTrait" app/` (ou `Attributes`/`Enums`) → remplacer par le namespace canonique `App\Shared\...`
+2. Supprimer le fichier shim correspondant.
 
 ## Mobile — Flutter
 
-- `leopardo_core` est le package fondation partagé par les trois apps.
-- `leopardo_employee` et `leopardo_manager` utilisent le pattern **Feature-first** avec `data/`, `providers/`, `screens/`.
-- `leopardo_mobile_legacy` est archivé — ne pas y contribuer.
+- `leopardo_core` est le package fondation partagé par toutes les apps.
+- `leopardo_employee`, `leopardo_manager` et `leopardo_hr` utilisent le pattern **Feature-first** avec `data/`, `providers/`, `screens/`.
+- Apps actives : `leopardo_core`, `leopardo_employee`, `leopardo_manager`, `leopardo_hr`, `leopardo_platform_admin` (voir `front/mobile_apps/README.md`). Le mobile historique (`front/mobile/`) a été retiré du dépôt.
 
 ## i18n
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thank you for considering contributing to Leopardo RH! It's people li
 
 Leopardo RH is an **Enterprise-Grade** platform. We maintain high standards for code quality, security, and documentation.
 
--   **Backend:** PHP 8.4, Laravel 11, PSR-12, Pest PHP for testing.
+-   **Backend:** PHP 8.4, Laravel 12 (^12.60), PSR-12, Pest PHP for testing.
 -   **Frontend:** Next.js 15, TypeScript, Tailwind CSS.
 -   **Mobile:** Flutter 3.x, Riverpod for state management.
 -   **Architecture:** Modular Monolith & Domain-Driven Design (DDD).

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -12,8 +12,8 @@ leopardo-hr/
 ├── api/                    # Backend Laravel (PHP 8.2+)
 ├── front/
 │   ├── admin-dashboard/    # Dashboard admin (Vue.js / Vite)
-│   └── web/                # Vitrine (Next.js)
-├── mobile/                 # Application Flutter (Dart)
+│   ├── web/                # Vitrine (Next.js)
+│   └── mobile_apps/        # Apps Flutter : leopardo_core, leopardo_employee, leopardo_manager, leopardo_hr, leopardo_platform_admin
 ├── docs/                   # Documentation technique
 ├── .github/workflows/      # CI/CD GitHub Actions
 ├── docker-compose.yml      # Dev environment
@@ -123,7 +123,7 @@ Les modules existants (pre-sprint) gardent la structure Laravel classique.
 
 ### 3.3 Mobile (Flutter)
 
-- Tests widget + unit dans `mobile/test/`
+- Tests widget + unit dans `front/mobile_apps/<app>/test/` (voir `front/mobile_apps/README.md`)
 - Commande : `flutter test`
 - Framework state : flutter_riverpod 3.3 (pas Bloc)
 - **Coverage gate** : seuil actuel 21%, cible 25%
@@ -167,7 +167,7 @@ Les modules existants (pre-sprint) gardent la structure Laravel classique.
 - **Flutter 3.x** — versions stables uniquement
 - **State management** : `flutter_riverpod 3.3` (pas Bloc, pas Provider legacy)
 - **Navigation** : GoRouter
-- Repertoire : `mobile/lib/`
+- Repertoire : `front/mobile_apps/<app>/lib/` (voir `front/mobile_apps/README.md` pour la liste des apps)
 
 ## 7. Documentation API
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ docker compose exec api php artisan migrate --seed
 
 ```
 leopardo-hr/
-├── api/                    # Backend Laravel 11
+├── api/                    # Backend Laravel 12 (^12.60)
 │   ├── app/
 │   ├── config/
 │   ├── database/migrations/
@@ -44,7 +44,7 @@ leopardo-hr/
 ├── front/
 │   ├── admin-dashboard/    # Vue.js 3.4 + Pinia + Tailwind (plateforme admin)
 │   ├── web/                # Next.js 16 (vitrine + blog + SEO)
-│   └── mobile/             # Flutter 3.x + Riverpod (app employe)
+│   └── mobile_apps/        # Apps Flutter (leopardo_core, leopardo_employee, leopardo_manager, leopardo_hr, leopardo_platform_admin)
 ├── docker-compose.yml
 ├── Makefile
 ├── .devcontainer/          # VS Code DevContainer
@@ -138,8 +138,11 @@ Content here...
 
 ## Mobile (Flutter)
 
+Voir [`front/mobile_apps/README.md`](front/mobile_apps/README.md) pour le detail par app
+(`leopardo_core`, `leopardo_employee`, `leopardo_manager`, `leopardo_hr`, `leopardo_platform_admin`).
+
 ```bash
-cd front/mobile
+cd front/mobile_apps/leopardo_employee
 
 flutter pub get
 flutter analyze
@@ -164,8 +167,8 @@ make test
 # Admin dashboard
 cd front/admin-dashboard && npm test
 
-# Mobile
-cd front/mobile && flutter test
+# Mobile (par app, ex. leopardo_employee)
+cd front/mobile_apps/leopardo_employee && flutter test
 ```
 
 ## CI/CD

--- a/PILOTAGE.md
+++ b/PILOTAGE.md
@@ -70,7 +70,7 @@ Objectif 30j   : 3-5 clients payants, MRR 150-250€
 
 | Surface | Stack | Déploiement | Statut |
 |---------|-------|-------------|--------|
-| API Backend | Laravel 11 / PHP 8.4 / PostgreSQL 16 | Render | ✅ Production |
+| API Backend | Laravel 12 (^12.60) / PHP 8.4 / PostgreSQL 16 | Render | ✅ Production |
 | Admin Dashboard | Vue 3 + Vite + Tailwind | Cloudflare Pages | ✅ Production |
 | Vitrine Web | Next.js + TypeScript + Tailwind | Vercel | ✅ Production |
 | App Employee | Flutter/Dart | Firebase App Distribution | ✅ Distribution |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ graph TB
     end
 
     subgraph "Enterprise Gateway"
-        API[Laravel 11 / PHP 8.4]
+        API[Laravel 12 / PHP 8.4]
         Sec[RBAC & JWT Shield]
     end
 
@@ -95,7 +95,7 @@ graph TB
 
 | Module | Access Point | Technology Stack |
 | :--- | :--- | :--- |
-| **API Backend** | [Gateway](https://gestionemployerbackend.onrender.com) | Laravel 11, PostgreSQL |
+| **API Backend** | [Gateway](https://gestionemployerbackend.onrender.com) | Laravel 12, PostgreSQL |
 | **Corporate Web** | [Live Preview](https://gestionemployer-backend.vercel.app) | Next.js 15, Tailwind CSS |
 | **Admin Panel** | [Dashboard](https://leo-admin.pages.dev) | Cloudflare Pages |
 | **Mobile Suite** | [Employee / Manager / Admin](https://github.com/kitokoh/leopardo-hr#mobile-ecosystem) | Flutter 3.x, Riverpod |
@@ -133,6 +133,7 @@ Explore our comprehensive guides for every role and layer:
 | 🌐 **API & Dev** | [API Reference](docs/api/API_REFERENCE.md) • [OpenAPI Spec](api/openapi.yaml) • [Postman](postman/) |
 | 📱 **Interfaces** | [Mobile Setup](docs/mobile/README.md) • [Kiosk Mode](docs/kiosk/README.md) • [Web Admin](docs/admin/README.md) |
 | 🚀 **Operations** | [Deployment Guide](docs/deployment/DEPLOYMENT_GUIDE.md) • [Testing Suite](docs/testing/TESTING.md) • [Observability](docs/architecture/OBSERVABILITY.md) |
+| 🧭 **Gouvernance & Onboarding agent** | [AGENTS.md](AGENTS.md) • [PILOTAGE.md](PILOTAGE.md) (source de vérité opérationnelle courante) • [docs/CONTEXT/](docs/CONTEXT/README.md) (onboarding structuré) |
 
 ---
 
@@ -143,7 +144,7 @@ Explore our comprehensive guides for every role and layer:
 - [ ] **Phase 3:** Public API Ecosystem & SDKs.
 - [ ] **Phase 4:** Global Financial Integrations (SEPA/SWIFT).
 
-See the **[Full Public Roadmap](ROADMAP.md)**.
+See the **[Full Public Roadmap](ROADMAP.md)** (aspirationnelle) et **[PILOTAGE.md](PILOTAGE.md)** pour l'état operationnel reel priorise (ce dernier prime en cas de divergence).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,9 @@
 # Product Roadmap — Leopardo RH
 
+> ⚠️ **Ce document decrit une trajectoire produit aspirationnelle/marketing.**
+> Pour l'etat operationnel reel, les priorites courantes et les ecarts avec cette roadmap,
+> se referer a [`PILOTAGE.md`](PILOTAGE.md), qui prime en cas de divergence entre les deux documents.
+
 Leopardo RH follows a phased delivery approach, prioritizing stability for SMEs before expanding into advanced enterprise features.
 
 ## 📍 Current Status: Phase 0 (MVP)

--- a/api/ARCHITECTURE.md
+++ b/api/ARCHITECTURE.md
@@ -76,6 +76,7 @@ Shared ← (consommé par tout le monde, ne dépend de rien)
 | `Modules/Fleet` | ✅ routes/modules/hr_extended.php | ✅ complet | `FleetServiceProvider` |
 | `Modules/Cameras` | ✅ routes/modules/cameras.php | ✅ complet | `CamerasServiceProvider` |
 | `Modules/Growth` | ✅ routes/modules/growth.php | ✅ complet | `GrowthServiceProvider` |
+| `Modules/Marketing` | ✅ routes/modules/marketing.php | ✅ complet | `MarketingServiceProvider` |
 | `Modules/SmartAttendance` | ✅ module routes | ✅ complet | `SmartAttendanceServiceProvider` |
 | `Modules/EdgeSync` | ✅ module routes | ✅ complet | `EdgeSyncServiceProvider` |
 | `Modules/Onboarding` | ✅ routes/api.php | ✅ complet | `OnboardingServiceProvider` |

--- a/dev-hub/CODE_OF_CONDUCT.md
+++ b/dev-hub/CODE_OF_CONDUCT.md
@@ -1,5 +1,8 @@
 # Code of Conduct
 
+> 📌 Ce fichier est un doublon partiel de [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) (racine), avec un texte legerement different
+> (version Contributor Covenant plus recente). La version racine est canonique en cas de divergence.
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.

--- a/dev-hub/CONTRIBUTING.md
+++ b/dev-hub/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contribution Guidelines
 
+> 📌 **Portee de ce document** : version destinee aux developpeurs et integrateurs
+> externes (`dev-hub/`). Pour la contribution interne au monorepo, la reference qui prime
+> reste [`/CONTRIBUTING.md`](../CONTRIBUTING.md) a la racine du depot. En cas de divergence
+> entre les deux fichiers, la version racine est canonique.
+
 Thank you for your interest in contributing to Leopardo RH! We welcome contributions from the community to help us build the best open-source HR platform.
 
 ## 🤝 How to Contribute

--- a/dev-hub/DEVELOPMENT.md
+++ b/dev-hub/DEVELOPMENT.md
@@ -1,5 +1,10 @@
 # Development Guide — Leopardo RH
 
+> 📌 **Portee de ce document** : version destinee aux developpeurs et integrateurs
+> externes (`dev-hub/`). Pour le developpement interne au monorepo, la reference qui prime
+> reste [`/DEVELOPMENT.md`](../DEVELOPMENT.md) a la racine du depot. En cas de divergence
+> entre les deux fichiers (versions de prerequis, structure), la version racine est canonique.
+
 ## Prerequisites
 
 | Tool | Version | Notes |

--- a/dev-hub/sdk/javascript/README.md
+++ b/dev-hub/sdk/javascript/README.md
@@ -4,11 +4,14 @@ Generated from `api/openapi.yaml`.
 
 ## Usage
 
+> Note : `api.leopardo-rh.com` est un domaine cible non encore configure en production.
+> Remplacer par `https://gestionemployerbackend.onrender.com/api/v1` pour un usage reel aujourd'hui.
+
 ```js
 import { createLeopardoClient } from "./leopardoClient.js";
 
 const client = createLeopardoClient({
-  baseUrl: "https://api.leopardo-rh.com/api/v1",
+  baseUrl: "https://api.leopardo-rh.com/api/v1", // domaine cible, voir note ci-dessus
   token: process.env.LEOPARDO_TOKEN,
 });
 

--- a/dev-hub/sdk/python/README.md
+++ b/dev-hub/sdk/python/README.md
@@ -4,11 +4,14 @@ Generated from `api/openapi.yaml`.
 
 ## Usage
 
+> Note : `api.leopardo-rh.com` est un domaine cible non encore configure en production.
+> Remplacer par `https://gestionemployerbackend.onrender.com/api/v1` pour un usage reel aujourd'hui.
+
 ```python
 from leopardo_client import LeopardoClient
 
 client = LeopardoClient(
-    base_url="https://api.leopardo-rh.com/api/v1",
+    base_url="https://api.leopardo-rh.com/api/v1",  # domaine cible, voir note ci-dessus
     token="your-token",
 )
 

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -1,8 +1,8 @@
 # Architecture DDD — État des modules
 
-> Mis à jour le 2026-07-01 | Phase 5 en cours — nettoyage legacy (PR #824)
+> Mis à jour le 2026-07-19 (audit doc) | Phase 5 en cours — nettoyage legacy (PR #824)
 
-## 1. Tableau de l'état DDD — 16 modules actifs
+## 1. Tableau de l'état DDD — 19 modules actifs
 
 | Module          | Domain | Contracts | Exceptions | Application | DTOs | Infra | Interfaces | Providers | Tests |
 |-----------------|:------:|:---------:|:----------:|:-----------:|:----:|:-----:|:----------:|:---------:|:-----:|
@@ -11,19 +11,24 @@
 | **Billing**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Cabinet**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Cameras**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **EdgeSync** 🆕  | ✅ | — | — | ✅ | — | — | ✅ | ✅ | ⚠️ |
 | **Expense**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Fleet**       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Growth** 🆕   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | **HR**          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Marketing** 🆕| ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Notification**| ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Onboarding** 🆕| ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | **Payroll**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Planning**    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Platform** 🆕 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | **Recruitment** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **SmartAttendance** 🆕 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | **Training** 🆕 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
-> ⚠️ = Module créé dans Phase 3–4, tests Feature à ajouter dans Phase 5.
+> ⚠️ = Module créé dans Phase 3–4 ou ajouté depuis, tests Feature à completer/verifier en Phase 5.
+> — = Non applicable (module `EdgeSync` suit une structure specialisee synchro/offline, pas le squelette DDD standard Contracts/Exceptions/DTOs).
+> Corrige lors de l'audit doc du 2026-07-19 : ce tableau omettait `EdgeSync` et `Marketing`, deux modules reellement presents sous `api/app/Modules/` (19 au total, pas 16).
 
 ---
 

--- a/docs/GESTION_PROJET/GARDE_FOUS.md
+++ b/docs/GESTION_PROJET/GARDE_FOUS.md
@@ -3,6 +3,15 @@
 # Ce fichier est lu par tous les agents IA et le chef de projet
 # TOUT le monde doit respecter ces règles sans exception
 
+> ⚠️ **DOCUMENT ARCHIVÉ / OBSOLÈTE (audit doc du 2026-07-19)**
+> La "liste noire MVP" ci-dessous décrit le scope Phase 1 tel qu'imaginé en avril 2026.
+> Depuis, le produit a largement dépassé ce scope en production : absences/congés, paie complète,
+> avances sur salaire, ZKTeco/biométrie, multi-pays, notifications push (FCM), et le mode schema
+> Enterprise (multitenancy) sont **déjà livrés**, tel que documenté dans `PILOTAGE.md` (source de
+> vérité opérationnelle courante). Ne pas utiliser ce fichier pour refuser une tâche légitime.
+> Conservé uniquement à titre historique/pédagogique sur la discipline anti scope-creep.
+> Se référer à `PILOTAGE.md` pour le scope réel courant.
+
 ---
 
 ## GARDE-FOU 1 — ANTI SCOPE CREEP (le plus important)

--- a/docs/GESTION_PROJET/README.md
+++ b/docs/GESTION_PROJET/README.md
@@ -6,7 +6,7 @@ Ce dossier centralise les documents de pilotage, les runbooks, les audits d'ecar
 
 1. `../../PILOTAGE.md` - source de verite operationnelle
 2. `ALIGNEMENT_DOCUMENTATION_MAIN_2026-04-26.md` - ecart entre documentation cible et etat reel de `main`
-3. `GARDE_FOUS.md` - regles anti-derive
+3. `GARDE_FOUS.md` - regles anti-derive — ⚠️ ARCHIVE/OBSOLETE depuis l'audit doc du 2026-07-19, sa "liste noire MVP" contredit le scope reel livre documente dans `PILOTAGE.md`. Lire pour la discipline anti scope-creep uniquement, pas pour le perimetre produit reel.
 4. `RUNBOOK_DEPLOY.md`, `RUNBOOK_ROLLBACK.md`, `RUNBOOK_BACKUP_RESTORE.md`, `RUNBOOK_INCIDENT_P1.md` - socle d'exploitation
 5. `REGISTRE_SCENARIOS_TESTS.md` + `SCENARIOS_TEST_*` - base canonique de couverture fonctionnelle et CI
 6. ARCHITECTURE_I18N_ENTERPRISE_2026-05-07.md - cible multilingue partagee backend/web/mobile

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -9,8 +9,12 @@ All API requests require a **Bearer Token** obtained via the login endpoint.
 - **Base URL:** `https://gestionemployerbackend.onrender.com/api/v1`
 - **Format:** `application/json`
 
+> ⚠️ (Audit doc 2026-07-19) `api.leopardo-rh.com` ci-dessous n'a jamais ete configure/DNS-resolu en production ;
+> c'est un domaine custom cible mentionne dans `docs/GESTION_PROJET/RAPPORT_DEPLOIEMENT_RENDER.md` (todo non fait).
+> Utiliser la vraie Base URL ci-dessus (`gestionemployerbackend.onrender.com`) pour toute requete reelle.
+
 ```bash
-curl -X GET "https://api.leopardo-rh.com/api/v1/employees" \
+curl -X GET "https://gestionemployerbackend.onrender.com/api/v1/employees" \
      -H "Authorization: Bearer {YOUR_TOKEN}" \
      -H "Accept: application/json"
 ```

--- a/docs/contributing/GUIDELINES.md
+++ b/docs/contributing/GUIDELINES.md
@@ -1,5 +1,10 @@
 # Contributing to Leopardo RH
 
+> 📌 Ce document est le guide de contribution detaille (conventions de code, structure, workflow),
+> complementaire au [`/CONTRIBUTING.md`](../../CONTRIBUTING.md) racine (aperçu rapide + liens).
+> Les deux sont maintenus ensemble ; en cas de divergence factuelle (versions, chemins), verifier
+> l'etat reel du depot plutot que de trancher arbitrairement entre les deux.
+
 Merci de contribuer a Leopardo RH ! Ce guide explique comment participer au projet.
 
 ## Prerequis
@@ -64,24 +69,27 @@ Nous suivons [Conventional Commits](https://www.conventionalcommits.org/) :
 ## Structure du projet
 
 ```
-api/                    # Backend Laravel (PHP)
+api/                    # Backend Laravel 12 (PHP 8.4)
 ├── app/
-│   ├── Http/Controllers/Api/V1/   # Controleurs API
-│   ├── Models/                     # Modeles Eloquent
-│   ├── Services/                   # Services metier (DDD)
-│   ├── Policies/                   # RBAC Policies
-│   └── Events/                     # Domain Events
+│   ├── Modules/<Name>/             # Domaines DDD (Domain/Application/Infrastructure/Interfaces/Providers)
+│   ├── Core/{Auth,Tenant,Feature}/ # Socle transversal SaaS
+│   ├── Shared/                     # Kernel partage entre modules (DTOs, Enums, Events, Exceptions, Traits)
+│   └── AI/                         # Module IA autonome
 ├── tests/Feature/                  # Tests fonctionnels
 ├── database/migrations/            # Migrations PostgreSQL
 └── routes/                         # Routes API
 
 front/                  # Frontends
-├── admin-dashboard/    # Dashboard admin (Next.js)
-├── web/                # Vitrine publique (Next.js)
-└── mobile/             # App mobile (Flutter)
+├── admin-dashboard/    # Dashboard super-admin plateforme (Vue.js 3)
+├── web/                # Vitrine + dashboard SaaS public (Next.js 15)
+├── web-offline/        # PWA offline-first bridge Edge (Next.js)
+├── mobile_apps/        # Apps Flutter : leopardo_core, leopardo_employee, leopardo_manager, leopardo_hr, leopardo_platform_admin
+└── zkteco-kiosk/       # Kiosque pointage biometrique (HTML/JS)
 
 docs/                   # Documentation projet
 ```
+
+> Voir `api/ARCHITECTURE.md` pour l'arbre de decision "ou placer mon code ?" a jour.
 
 ## Regles de code
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -9,8 +9,13 @@ The mobile app is the primary touchpoint for employees and on-site managers. It 
 - Team task management.
 - Real-time notifications.
 
+## 📱 Applications reelles
+La doc canonique par app vit dans [`front/mobile_apps/README.md`](../../front/mobile_apps/README.md) :
+`leopardo_core` (package partage), `leopardo_employee`, `leopardo_manager`, `leopardo_hr`, `leopardo_platform_admin`.
+Le mobile historique (`front/mobile/`) a ete retire du depot.
+
 ## 🛠 Setup & Development
-- [Mobile Setup Guide](../mobile/README.md) - Coming soon.
+- [Mobile Apps Guide](../../front/mobile_apps/README.md) - Structure, regles de contribution, CI, identites store.
 - [Design System](../vision/02_design_system/README.md) - UI/UX tokens and components.
 
 ---

--- a/front/mobile_apps/README.md
+++ b/front/mobile_apps/README.md
@@ -1,15 +1,15 @@
 # Leopardo Mobile Apps
 
-Ce dossier est la source canonique des applications mobiles de lancement. Il
-prepare la separation mobile sans casser `front/mobile/`, qui reste uniquement
-un mobile historique de maintenance.
+Ce dossier est la source canonique des applications mobiles de lancement.
+Le mobile historique (`front/mobile/`) a ete retire du depot ; ces apps sont
+desormais les seules applications mobiles actives.
 
 ## Structure
 
-- `leopardo_mobile_legacy/` : archive exacte du mobile historique. Ne pas modifier apres creation.
 - `leopardo_core/` : package Flutter partage. Il contient uniquement les briques communes : API client, stockage, i18n, theme, couleurs, typographie, widgets de base, modeles et providers core.
 - `leopardo_employee/` : app mobile employe. Elle expose les parcours personnels : connexion, accueil employe, pointage, absences, avances, paie, notifications, documents et compte.
 - `leopardo_manager/` : app mobile manager/RH. Elle conserve le perimetre complet du mobile actuel et prepare les routes des futurs ecrans manager.
+- `leopardo_hr/` : app mobile RH dediee, issue d'un split de `leopardo_manager`. Integree a la matrice CI canonique `mobile-distribute.yml` pour le deploiement Firebase (voir `CHANGELOG.md`).
 - `leopardo_platform_admin/` : app mobile super-admin plateforme. Elle consomme uniquement les API `/platform/*` pour piloter les tenants, creer une entreprise cliente, traiter les demandes clients et suivre les metriques globales.
 
 ## Regles de contribution
@@ -20,14 +20,12 @@ un mobile historique de maintenance.
 - L'app manager/RH conserve les ecrans complets et gere les differences internes via `employee.managerRole`.
 - L'app platform admin ne contient aucun workflow tenant employe/manager : pas de pointage, absences, avances, equipe ou approvals RH.
 - La differenciation par sous-role manager se fait dans les ecrans concernes, pas dans le router.
-- `front/mobile/` reste le mobile historique fonctionnel tant que la bascule produit n'est pas terminee. Ne pas y ajouter de nouvelle fonctionnalite produit : les evolutions employee, manager/RH et platform admin vont dans `front/mobile_apps/*`.
-- `leopardo_mobile_legacy/` est un filet de securite : ne pas le modifier.
+- `front/mobile/` (mobile historique) a ete retire du depot ; toutes les evolutions employee, manager/RH, HR et platform admin vont dans `front/mobile_apps/*`.
 
 ## CI et distribution
 
-- `Mobile Apps CI - Flutter` valide `leopardo_core`, `leopardo_employee`, `leopardo_manager` et `leopardo_platform_admin`.
-- `Mobile - Build and Firebase Distribution` compile et distribue les trois APK Android de lancement vers Firebase App Distribution.
-- `Legacy Mobile CI - Flutter` et les jobs `Legacy Mobile Flutter` ne concernent que `front/mobile/`. Ils servent a maintenir l'historique, pas a valider les nouvelles apps store.
+- `Mobile Apps CI - Flutter` (`mobile-apps-ci.yml`) valide `leopardo_core`, `leopardo_employee`, `leopardo_manager`, `leopardo_hr` et `leopardo_platform_admin`.
+- `Mobile - Build and Firebase Distribution` (`mobile-distribute.yml`) compile et distribue les APK Android de lancement vers Firebase App Distribution.
 
 ## Garde-fous Plan 26
 
@@ -50,14 +48,13 @@ Il verifie notamment :
 - aucun marqueur `isManager`, `canManageTeam`, `managerRole`, `isPrincipal` ou `isHr` dans l'app employe ;
 - aucun import `package:leopardo_rh` dans les nouvelles apps ;
 - aucun import `leopardo_employee` ou `leopardo_manager` depuis `leopardo_core` ;
-- dependance `leopardo_core` presente dans les deux apps ;
+- dependance `leopardo_core` presente dans les apps concernees ;
 - routes manager preparees dans `leopardo_manager` ;
-- en pull request, aucune modification de `leopardo_mobile_legacy`.
-- identites App Store / Play Store distinctes pour `leopardo_employee` et `leopardo_manager` ;
+- identites App Store / Play Store distinctes pour `leopardo_employee`, `leopardo_manager` et `leopardo_hr` ;
 - endpoints et routes critiques presents pour les workflows mobiles principaux ;
 - absence de handlers UI vides sur les apps mobiles.
 
-Si une evolution partagee est necessaire, la placer dans `leopardo_core`, puis consommer cette API depuis les deux apps. Si une evolution ne concerne qu'un persona, la placer uniquement dans `leopardo_employee` ou `leopardo_manager`.
+Si une evolution partagee est necessaire, la placer dans `leopardo_core`, puis consommer cette API depuis les apps concernees. Si une evolution ne concerne qu'un persona, la placer uniquement dans l'app correspondante (`leopardo_employee`, `leopardo_manager` ou `leopardo_hr`).
 
 ## Identites store
 
@@ -65,6 +62,7 @@ Si une evolution partagee est necessaire, la placer dans `leopardo_core`, puis c
 |---|---|---|---|
 | `leopardo_employee` | `com.leopardo.employee` | `com.leopardo.employee` | Leopardo Employee |
 | `leopardo_manager` | `com.leopardo.manager` | `com.leopardo.manager` | Leopardo Manager |
+| `leopardo_hr` | `com.leopardo.rh` | `com.leopardo.rh` | Leopardo RH |
 | `leopardo_platform_admin` | `com.leopardo.platformadmin` | `com.leopardo.platformadmin` | Leopardo Platform Admin |
 
 ## Branding natif
@@ -78,7 +76,7 @@ Les assets canoniques du branding mobile sont generes directement dans chaque ap
 - iOS App Store : `ios/Runner/Assets.xcassets/AppIcon.appiconset/`
 - iOS splash : `ios/Runner/Assets.xcassets/LaunchImage.imageset/`
 
-Ne pas remettre les icones Flutter par defaut. Pour changer l'identite visuelle, regenerer les trois familles d'assets employee, manager et platform admin dans le meme lot afin de garder une coherence store.
+Ne pas remettre les icones Flutter par defaut. Pour changer l'identite visuelle, regenerer les familles d'assets employee, manager, HR et platform admin dans le meme lot afin de garder une coherence store.
 
 Avant un upload public, le mode strict doit passer apres configuration des signatures release :
 
@@ -104,6 +102,11 @@ flutter analyze
 flutter build apk --debug --dart-define=API_BASE_URL=https://gestionemployerbackend.onrender.com/api/v1
 
 cd ../leopardo_manager
+flutter pub get
+flutter analyze
+flutter build apk --debug --dart-define=API_BASE_URL=https://gestionemployerbackend.onrender.com/api/v1
+
+cd ../leopardo_hr
 flutter pub get
 flutter analyze
 flutter build apk --debug --dart-define=API_BASE_URL=https://gestionemployerbackend.onrender.com/api/v1

--- a/front/mobile_apps/leopardo_employee/README.md
+++ b/front/mobile_apps/leopardo_employee/README.md
@@ -14,7 +14,7 @@ Application Flutter de gestion RH pour les employés et managers.
 | :--- | :--- | :--- |
 | **Local** | `http://10.0.2.2:8000/api/v1` | Développement (émulateur) |
 | **Staging** | `https://gestionemployerbackend.onrender.com/api/v1` | Tests internes |
-| **Production** | `https://api.leopardo-rh.com/api/v1` | Play Store |
+| **Production** | `https://api.leopardo-rh.com/api/v1` | Play Store — ⚠️ domaine cible pas encore configure/DNS-resolu (voir `docs/GESTION_PROJET/RAPPORT_DEPLOIEMENT_RENDER.md`) |
 
 ## 🚀 Démarrage rapide
 

--- a/front/mobile_apps/leopardo_hr/README.md
+++ b/front/mobile_apps/leopardo_hr/README.md
@@ -14,7 +14,7 @@ Application Flutter de gestion RH pour les employés et managers.
 | :--- | :--- | :--- |
 | **Local** | `http://10.0.2.2:8000/api/v1` | Développement (émulateur) |
 | **Staging** | `https://gestionemployerbackend.onrender.com/api/v1` | Tests internes |
-| **Production** | `https://api.leopardo-rh.com/api/v1` | Play Store |
+| **Production** | `https://api.leopardo-rh.com/api/v1` | Play Store — ⚠️ domaine cible pas encore configure/DNS-resolu ; le build `mobile-distribute.yml` cible `TARGET=prod` utilise deja cette URL, elle ne fonctionnera qu'apres mise en place du domaine custom (voir `docs/GESTION_PROJET/RAPPORT_DEPLOIEMENT_RENDER.md`) |
 
 ## 🚀 Démarrage rapide
 

--- a/front/mobile_apps/leopardo_manager/README.md
+++ b/front/mobile_apps/leopardo_manager/README.md
@@ -14,7 +14,7 @@ Application Flutter de gestion RH pour les employés et managers.
 | :--- | :--- | :--- |
 | **Local** | `http://10.0.2.2:8000/api/v1` | Développement (émulateur) |
 | **Staging** | `https://gestionemployerbackend.onrender.com/api/v1` | Tests internes |
-| **Production** | `https://api.leopardo-rh.com/api/v1` | Play Store |
+| **Production** | `https://api.leopardo-rh.com/api/v1` | Play Store — ⚠️ domaine cible pas encore configure/DNS-resolu (voir `docs/GESTION_PROJET/RAPPORT_DEPLOIEMENT_RENDER.md`) |
 
 ## 🚀 Démarrage rapide
 


### PR DESCRIPTION
## Contexte

Suite a un audit approfondi de la documentation du depot (objectif : verifier qu'un nouveau developpeur/agent IA ne se perde pas en naviguant les ~500 fichiers Markdown), plusieurs incoherences actives ont ete identifiees entre documents qui se declarent chacun source de verite, ainsi que des references obsoletes au code reel. Cette PR corrige ces points en deux passes.

## Passe 1 — 8 points prioritaires

1. **GARDE_FOUS.md** : ajout d'un bandeau d'archivage/obsolescence. Ce fichier contredisait frontalement PILOTAGE.md en listant comme *interdites* des fonctionnalites (absences, paie complete, ZKTeco, multi-pays, push FCM, mode schema Enterprise) que PILOTAGE.md documente comme deja livrees en production. Risque le plus eleve identifie : un agent suivant GARDE_FOUS.md a la lettre refuserait des taches legitimes.
2. **Version Laravel** : correction "Laravel 11" -> "Laravel 12 (^12.60)" dans `README.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `PILOTAGE.md` (composer.json confirme `^12.60`).
3. **dev-hub/CONTRIBUTING.md et dev-hub/DEVELOPMENT.md** : ajout d'un bandeau de portee (public externe) + precision que les versions racine sont canoniques en cas de divergence.
4. **front/mobile_apps/README.md** : ajout de l'app `leopardo_hr` (existe dans `melos.yaml`, `mobile-apps-ci.yml`, `mobile-distribute.yml`, absente du README) + suppression des references a `leopardo_mobile_legacy/` (dossier inexistant) + ajout de son identite store.
5. **Purge des references a `front/mobile/`** (dossier supprime du depot, remplace par `front/mobile_apps/*`) dans `DEVELOPMENT.md` et `CONVENTIONS.md`.
6. **README.md** : ajout d'une entree "Gouvernance & Onboarding agent" dans le tableau Documentation Hub, pointant vers `AGENTS.md`, `PILOTAGE.md` et `docs/CONTEXT/`.
7. **ROADMAP.md** : ajout d'un renvoi explicite vers `PILOTAGE.md` comme document prioritaire en cas de divergence.
8. **.github/workflows/README.md** : remplacement des references aux workflows reutilisables supprimes (`_setup-php.yml`, `_setup-flutter.yml`) par les composite actions reelles.

## Passe 2 — suivi plus approfondi (module counts, refs mortes, header AGENTS.md)

- **ARCHITECTURE.md (racine)** : nombre de modules corrige 18 -> 19 (`Marketing` manquait de la liste), nombre de workflows corrige 29 -> 25, retrait de la mention d'un mirror `openapi/` a la racine (il vit sous `dev-hub/openapi/v1.yaml`, desynchronise de `api/openapi.yaml`, signale), section `app/Models`/`app/DTOs` reecrite (ces deux dossiers sont maintenant entierement supprimes, pas "en cours de migration"), clarification sur `app/Services/` (contient toujours des services specialises legitimes, pas entierement supprime).
- **api/ARCHITECTURE.md** : ajout de la ligne `Modules/Marketing` manquante dans le tableau des modules.
- **docs/ARCHITECTURE_STATUS.md** : le tableau annoncait 16 modules actifs et omettait totalement `EdgeSync` et `Marketing` ; corrige a 19 avec statut reel par couche.
- **AGENTS.md** : en-tete de date (2026-06-13) obsolete par rapport aux editions reelles (confirme via `git log`) ; corrige + note pour eviter la derive silencieuse. Egalement corrige/signale une entree historique referencant `docs/GOTO_MARKET/12_PACK_LANCEMENT_ACQUISITION.md` et `docs/GOTO_MARKET/public/`/`product_marketing_automation/`, qui n'existent plus depuis la restructuration GTM (#630).
- **docs/api/README.md** : contradiction interne corrigee entre la Base URL documentee (`gestionemployerbackend.onrender.com`) et l'exemple curl (`api.leopardo-rh.com`, domaine cible non encore DNS-resolu).
- **front/mobile_apps/{leopardo_hr,leopardo_manager,leopardo_employee}/README.md** et **dev-hub/sdk/{javascript,python}/README.md** : signalement de la meme URL de prod `api.leopardo-rh.com` pas encore live, pour eviter la confusion avec un endpoint fonctionnel.
- **docs/mobile/README.md** : remplacement d'un stub obsolete ("coming soon", aucune mention des apps reelles) par des liens vers `front/mobile_apps/README.md`.
- **docs/GESTION_PROJET/README.md** : l'ordre de lecture recommande signale maintenant `GARDE_FOUS.md` comme archive/obsolete au point de reference.
- **docs/contributing/GUIDELINES.md** : section structure de projet entierement obsolete (referencait `app/Http/Controllers/Api/V1`, `app/Models`, `front/mobile`, decrivait admin-dashboard comme du Next.js alors que c'est du Vue.js) — reecrite pour refleter la vraie structure DDD et frontend.
- **dev-hub/CODE_OF_CONDUCT.md** : signale comme doublon divergent de `CODE_OF_CONDUCT.md` racine, ce dernier marque canonique.

## Portee

Documentation uniquement, aucun changement de code. Chaque correction verifiee manuellement contre l'etat reel du depot (structure de fichiers, code, CI) avant application. Aucun lien Markdown casse introduit (verification automatisee sur les ~500 fichiers .md).
