### PR TITLE
fix(api): PA2-ARCH-008 - point d'enregistrement unique pour Gate::policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 
+## [Unreleased]
+
+### Fixed
+- **PA2-ARCH-008 : point d'enregistrement unique pour les Gate::policy** : `AppServiceProvider::boot()` et `AuthServiceProvider::boot()` enregistraient chacun un jeu de `Gate::policy(...)` avec des doublons (Attendance, Employee, Evaluation, FeaturePlanMatrix, OnboardingStep, Payroll, Recruitment, Subscription, Training, Vehicle) et une vraie divergence sur `Invoice` : `AppServiceProvider` le liait a `BillingPolicy`, `AuthServiceProvider` a `InvoicePolicy` — seul le dernier provider bootstrappe (`AuthServiceProvider`, enregistre apres dans `bootstrap/providers.php`) l'emportait en pratique, donc `InvoicePolicy` etait deja la policy effective, mais implicitement et fragilement (un simple reordonnancement des providers aurait bascule silencieusement vers `BillingPolicy`). Tous les `Gate::policy(...)` vivent desormais exclusivement dans `AuthServiceProvider::boot()` ; `AppServiceProvider::boot()` ne garde que ses `Gate::define(...)` (export). La divergence `Invoice` est tranchee explicitement et documentee en faveur de `InvoicePolicy` (scoping `company_id` + roles dedies view/create/pay, plus fine que `BillingPolicy`). Nouveau test `tests/Unit/Providers/PolicyRegistrationTest.php` : verifie qu'un seul des deux providers appelle encore `Gate::policy(...)`, que `Invoice` resout sans ambiguite vers `InvoicePolicy`, et que les modeles deplaces (`Employee`, `OnboardingStep`, `FeaturePlanMatrix`) resolvent toujours une policy. Verifie : `php artisan test --filter="Billing|Invoice|Policy|Onboarding|Marketing|Recruitment|Fleet|Vehicle|Attendance|Payroll"` — 65 failed / 166 passed apres (contre 65 failed / 163 passed avant, la difference etant les 3 nouveaux tests de regression) ; les 65 echecs sont identiques avant/apres (via `git stash`) et pre-existent (incompatibilites SQLite type `EXTRACT(MONTH FROM ...)` / `SET search_path`, sans lien avec ce changement).
+
 ## [4.23.4] - 2026-07-19
 
 ### Fixed

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -5,30 +5,8 @@ namespace App\Providers;
 use App\AI\LLMClient;
 use App\AI\Providers\ClaudeClient;
 use App\AI\Providers\OpenAIClient;
-use App\Modules\Recruitment\Domain\Models\Applicant;
-use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use App\Core\Auth\Domain\Models\Employee;
-use App\Modules\HR\Domain\Models\Evaluation;
-use App\Modules\Billing\Domain\Models\FeaturePlanMatrix;
-use App\Modules\Billing\Domain\Models\Invoice;
-use App\Modules\Recruitment\Domain\Models\JobPosting;
-use App\Modules\HR\Domain\Models\OnboardingStep;
-use App\Modules\Payroll\Domain\Models\PayrollRun;
-use App\Modules\Payroll\Domain\Models\PaySlip;
-use App\Modules\Billing\Domain\Models\Subscription;
-use App\Modules\HR\Domain\Models\TrainingCourse;
-use App\Modules\Fleet\Domain\Models\Vehicle;
-use App\Policies\AttendancePolicy;
-use App\Policies\BillingPolicy;
-use App\Policies\EmployeePolicy;
-use App\Policies\EvaluationPolicy;
 use App\Policies\ExportPolicy;
-use App\Policies\FeatureFlagPolicy;
-use App\Policies\OnboardingPolicy;
-use App\Policies\PayrollPolicy;
-use App\Policies\RecruitmentPolicy;
-use App\Policies\TrainingPolicy;
-use App\Policies\VehiclePolicy;
 use App\Core\Tenant\TenantManager;
 use App\Services\TenantManager as LegacyTenantManager;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -78,19 +56,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Gate::policy(Applicant::class, RecruitmentPolicy::class);
-        Gate::policy(AttendanceLog::class, AttendancePolicy::class);
-        Gate::policy(Employee::class, EmployeePolicy::class);
-        Gate::policy(Evaluation::class, EvaluationPolicy::class);
-        Gate::policy(FeaturePlanMatrix::class, FeatureFlagPolicy::class);
-        Gate::policy(Invoice::class, BillingPolicy::class);
-        Gate::policy(JobPosting::class, RecruitmentPolicy::class);
-        Gate::policy(OnboardingStep::class, OnboardingPolicy::class);
-        Gate::policy(PayrollRun::class, PayrollPolicy::class);
-        Gate::policy(PaySlip::class, PayrollPolicy::class);
-        Gate::policy(Subscription::class, BillingPolicy::class);
-        Gate::policy(TrainingCourse::class, TrainingPolicy::class);
-        Gate::policy(Vehicle::class, VehiclePolicy::class);
+        // PA2-ARCH-008 : point d'enregistrement unique. Tous les Gate::policy(...)
+        // vivent desormais exclusivement dans AuthServiceProvider::boot() ; ce
+        // provider ne garde que les Gate::define(...) qui n'y sont pas dupliques.
         Gate::define('export', [ExportPolicy::class, 'export']);
         Gate::define('viewExportHistory', [ExportPolicy::class, 'viewHistory']);
         Gate::define('downloadExport', [ExportPolicy::class, 'download']);

--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -12,11 +12,13 @@ use App\Modules\Billing\Domain\Models\Subscription;
 use App\Modules\Billing\Domain\Models\WebhookEndpoint;
 use App\Modules\Cameras\Domain\Camera;
 use App\Modules\Cameras\Domain\CameraAccessToken;
+use App\Modules\Billing\Domain\Models\FeaturePlanMatrix;
 use App\Modules\Expense\Domain\Models\ExpenseClaim;
 use App\Modules\Fleet\Domain\Models\Vehicle;
 use App\Modules\HR\Domain\Models\Contract;
 use App\Modules\HR\Domain\Models\Department;
 use App\Modules\HR\Domain\Models\Evaluation;
+use App\Modules\HR\Domain\Models\OnboardingStep;
 use App\Modules\HR\Domain\Models\Position;
 use App\Modules\HR\Domain\Models\TrainingCourse;
 use App\Modules\Marketing\Domain\Models\SocialAccount;
@@ -79,11 +81,17 @@ class AuthServiceProvider extends ServiceProvider
 
         // Finance
         Gate::policy(Subscription::class, BillingPolicy::class);
+        // PA2-ARCH-008 : divergence tranchee. AppServiceProvider et AuthServiceProvider
+        // enregistraient chacun une policy differente pour Invoice (BillingPolicy vs
+        // InvoicePolicy). InvoicePolicy est plus fine (scoping company_id + roles
+        // dedies view/create/pay) : c'est la policy retenue, unique point d'enregistrement.
         Gate::policy(Invoice::class, InvoicePolicy::class);
         Gate::policy(EmployeeLoan::class, LoanPolicy::class);
         Gate::policy(ExpenseClaim::class, ExpenseClaimPolicy::class);
         Gate::policy(PayrollRun::class, PayrollPolicy::class);
         Gate::policy(PaySlip::class, PayrollPolicy::class);
+        Gate::policy(FeaturePlanMatrix::class, FeatureFlagPolicy::class);
+        Gate::policy(OnboardingStep::class, OnboardingPolicy::class);
 
         // Recruitment & Training
         Gate::policy(JobPosting::class, RecruitmentPolicy::class);

--- a/api/tests/Unit/Providers/PolicyRegistrationTest.php
+++ b/api/tests/Unit/Providers/PolicyRegistrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Providers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Modules\Billing\Domain\Models\FeaturePlanMatrix;
+use App\Modules\Billing\Domain\Models\Invoice;
+use App\Modules\HR\Domain\Models\OnboardingStep;
+use App\Policies\InvoicePolicy;
+use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Support\Facades\Gate;
+use ReflectionClass;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * PA2-ARCH-008 : point d'enregistrement unique pour les Gate::policy(...).
+ *
+ * Avant ce ticket, `AppServiceProvider::boot()` et `AuthServiceProvider::boot()`
+ * enregistraient chacun leur propre jeu de `Gate::policy(...)`, avec des
+ * doublons (Attendance, Employee, Evaluation, Payroll, Recruitment, Training,
+ * Vehicle, Subscription...) et une vraie divergence sur `Invoice`
+ * (BillingPolicy dans AppServiceProvider vs InvoicePolicy dans
+ * AuthServiceProvider). Ce test garantit :
+ *  1. Qu'un seul des deux providers appelle encore `Gate::policy(...)`.
+ *  2. Que le modele `Invoice` resout explicitement vers `InvoicePolicy`.
+ */
+class PolicyRegistrationTest extends TestCase
+{
+    public function test_only_one_service_provider_registers_gate_policies(): void
+    {
+        $appProviderCallsPolicy = $this->sourceContainsGatePolicyCall(AppServiceProvider::class);
+        $authProviderCallsPolicy = $this->sourceContainsGatePolicyCall(AuthServiceProvider::class);
+
+        $this->assertTrue(
+            $appProviderCallsPolicy xor $authProviderCallsPolicy,
+            'Exactement un seul provider (AppServiceProvider XOR AuthServiceProvider) doit '
+            .'appeler Gate::policy(...). Sinon la dette PA2-ARCH-008 (doublons/divergences '
+            .'d\'enregistrement de policies) est de retour.'
+        );
+    }
+
+    public function test_invoice_policy_is_unambiguously_invoice_policy(): void
+    {
+        $this->assertSame(
+            InvoicePolicy::class,
+            get_class(Gate::getPolicyFor(Invoice::class)),
+            'La divergence Invoice (BillingPolicy vs InvoicePolicy) doit rester tranchee '
+            .'explicitement en faveur de InvoicePolicy (scoping company_id + roles dedies).'
+        );
+    }
+
+    public function test_core_models_still_resolve_a_policy(): void
+    {
+        $this->assertNotNull(Gate::getPolicyFor(Employee::class));
+        $this->assertNotNull(Gate::getPolicyFor(OnboardingStep::class));
+        $this->assertNotNull(Gate::getPolicyFor(FeaturePlanMatrix::class));
+    }
+
+    private function sourceContainsGatePolicyCall(string $providerClass): bool
+    {
+        $reflection = new ReflectionClass($providerClass);
+        $bootMethod = $reflection->getMethod('boot');
+
+        $source = $this->extractMethodSource($bootMethod);
+
+        // Only count real calls, e.g. "Gate::policy(Foo::class, FooPolicy::class);",
+        // not documentation comments that merely mention the pattern.
+        return (bool) preg_match('/Gate::policy\(\s*\S+::class\s*,/', $source);
+    }
+
+    private function extractMethodSource(ReflectionMethod $method): string
+    {
+        $filename = $method->getFileName();
+        $startLine = $method->getStartLine();
+        $endLine = $method->getEndLine();
+
+        $lines = file($filename);
+
+        return implode('', array_slice($lines, $startLine - 1, $endLine - $startLine + 1));
+    }
+}


### PR DESCRIPTION
## Objectif
Ticket `PA2-ARCH-008` de `docs/PLAN_ACTION2/02_BACKLOG_ATOMIQUE.md` : *"Point d'enregistrement unique pour les Gate::policy ; plus qu'un seul provider enregistre chaque policy ; divergence Invoice -> BillingPolicy vs InvoicePolicy tranchee explicitement ; test unitaire verifiant l'absence de double enregistrement"*.

## Constat
`AppServiceProvider::boot()` et `AuthServiceProvider::boot()` enregistraient chacun un jeu de `Gate::policy(...)`, avec :
- des **doublons** (Attendance, Employee, Evaluation, FeaturePlanMatrix, OnboardingStep, Payroll, Recruitment, Subscription, Training, Vehicle) ;
- une **vraie divergence** sur `Invoice` : `AppServiceProvider` -> `BillingPolicy`, `AuthServiceProvider` -> `InvoicePolicy`.

Verifie via `Gate::getPolicyFor(Invoice::class)` en boot reel de l'app : `InvoicePolicy` gagnait deja (dernier provider bootstrappe dans `bootstrap/providers.php`), mais de facon implicite et fragile — un simple reordonnancement des providers aurait bascule silencieusement vers `BillingPolicy` sans qu'aucun test ne le detecte.

## Changements
- Tous les `Gate::policy(...)` vivent desormais **exclusivement dans `AuthServiceProvider::boot()`**.
- `AppServiceProvider::boot()` ne garde que ses `Gate::define(...)` (export) — plus aucun `Gate::policy(...)`.
- La divergence `Invoice` est tranchee **explicitement et documentee en commentaire** en faveur de `InvoicePolicy` (scoping `company_id` + roles dedies view/create/pay, plus fine que `BillingPolicy`).
- Nouveau test `api/tests/Unit/Providers/PolicyRegistrationTest.php` :
  - verifie qu'un seul des deux providers appelle encore `Gate::policy(...)` (garde anti-recidive) ;
  - verifie que `Invoice` resout sans ambiguite vers `InvoicePolicy` ;
  - verifie que les modeles deplaces entre les deux providers (`Employee`, `OnboardingStep`, `FeaturePlanMatrix`) resolvent toujours une policy.

## Verification
- `Gate::getPolicyFor(...)` compare avant/apres pour les 13 modeles concernes : **resolution identique** dans tous les cas (aucun comportement runtime modifie), `Invoice` verifie explicitement -> `InvoicePolicy`.
- `php artisan test tests/Unit/Providers/PolicyRegistrationTest.php` -> 3 passed.
- `php artisan test --filter="Billing|Invoice|Policy|Onboarding|Marketing|Recruitment|Fleet|Vehicle|Attendance|Payroll"` -> **65 failed / 166 passed** apres (65 failed / 163 passed avant, la difference = les 3 nouveaux tests). Les 65 echecs sont **identiques avant/apres** (verifie via `git stash` sur la meme branche) : incompatibilites SQLite pre-existantes (`EXTRACT(MONTH FROM ...)`, `SET search_path`), sans lien avec cette PR.
- `composer dump-autoload` + `php -l` sur les deux providers modifies : OK.

## Risques residuels
Changement de refactoring pur (deplacement d'enregistrement + suppression de doublons) — aucune regle d'autorisation modifiee, la resolution de policy est verifiee identique avant/apres pour chaque modele.