### PR TITLE
fix(mobile): resolve flutter analyze warnings breaking main CI

### DIFF
--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/attendance_mode_picker_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/attendance_mode_picker_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:leopardo_employee/features/smart_attendance/data/smart_attendance_repository.dart';
 import 'package:leopardo_employee/features/smart_attendance/providers/smart_attendance_provider.dart';
 
 /// Écran de sélection du mode de pointage préféré pour l'employé.
@@ -26,7 +25,6 @@ class _AttendanceModePickerScreenState
     extends ConsumerState<AttendanceModePickerScreen> {
   // Couleurs de l'app (cohérentes avec AttendanceScreen)
   static const Color _bg = Color(0xFF0B1120);
-  static const Color _card = Color(0xFF111B2E);
   static const Color _text = Color(0xFFE2EAF6);
   static const Color _muted = Color(0xFF7A9CC0);
   static const Color _border = Color(0xFF1A2B44);

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
@@ -29,7 +29,6 @@ class _SmartAttendanceScreenState extends ConsumerState<SmartAttendanceScreen> {
   static const Color _card = Color(0xFF111B2E);
   static const Color _text = Color(0xFFE2EAF6);
   static const Color _muted = Color(0xFF7A9CC0);
-  static const Color _border = Color(0xFF1A2B44);
   static const Color _accent = Color(0xFF2196F3);
 
   @override
@@ -204,7 +203,6 @@ class _ModeStatusCard extends StatelessWidget {
   final VoidCallback onChangeTap;
 
   static const Color _card = Color(0xFF111B2E);
-  static const Color _text = Color(0xFFE2EAF6);
   static const Color _muted = Color(0xFF7A9CC0);
   static const Color _border = Color(0xFF1A2B44);
   static const Color _accent = Color(0xFF2196F3);

--- a/front/mobile_apps/leopardo_employee/lib/features/user_auth/data/user_auth_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/user_auth/data/user_auth_repository.dart
@@ -179,7 +179,7 @@ class UserAuthRepository {
     if (preferredLanguage != null) {
       final lang = user.preferredLanguage.isNotEmpty
           ? user.preferredLanguage
-          : preferredLanguage!;
+          : preferredLanguage;
       final isRtl = lang == 'ar';
       await preferences.saveLocaleSettings(
         preferredLanguage: lang,

--- a/front/mobile_apps/leopardo_hr/lib/features/smart_attendance/screens/smart_attendance_dashboard_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/smart_attendance/screens/smart_attendance_dashboard_screen.dart
@@ -15,9 +15,6 @@ import 'package:leopardo_hr/features/smart_attendance/providers/smart_attendance
 class SmartAttendanceDashboardScreen extends ConsumerWidget {
   const SmartAttendanceDashboardScreen({super.key});
 
-  static const Color _bg = Color(0xFF0B1120);
-  static const Color _card = Color(0xFF111B2E);
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dashAsync = ref.watch(smartAttendanceDashboardProvider);

--- a/front/mobile_apps/leopardo_hr/lib/features/user_auth/data/user_auth_repository.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/user_auth/data/user_auth_repository.dart
@@ -179,7 +179,7 @@ class UserAuthRepository {
     if (preferredLanguage != null) {
       final lang = user.preferredLanguage.isNotEmpty
           ? user.preferredLanguage
-          : preferredLanguage!;
+          : preferredLanguage;
       final isRtl = lang == 'ar';
       await preferences.saveLocaleSettings(
         preferredLanguage: lang,

--- a/front/mobile_apps/leopardo_manager/lib/features/user_auth/data/user_auth_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/user_auth/data/user_auth_repository.dart
@@ -179,7 +179,7 @@ class UserAuthRepository {
     if (preferredLanguage != null) {
       final lang = user.preferredLanguage.isNotEmpty
           ? user.preferredLanguage
-          : preferredLanguage!;
+          : preferredLanguage;
       final isRtl = lang == 'ar';
       await preferences.saveLocaleSettings(
         preferredLanguage: lang,


### PR DESCRIPTION
## Contexte

Suite au commit `a7061cde` (fix CI Dependabot large), `main` a encore 2 workflows rouges :
- **Mobile Apps CI - Flutter** (jobs `Analyze leopardo_hr`, `Analyze leopardo_manager`, `Analyze leopardo_employee`)
- **Mobile - Build and Firebase Distribution** (jobs employee/hr/manager, échec sur l'étape `Flutter analyze`)

`flutter analyze` traite tout warning comme un échec dur (exit 1), et 3 warnings préexistants (non liés à ce fix ni au précédent) sont ressortis dès que l'analyse a recommencé à s'exécuter normalement.

## Fixes (0 changement de comportement)

- `leopardo_hr`, `leopardo_manager`, `leopardo_employee` — `user_auth_repository.dart:182`: `!` inutile sur `preferredLanguage` juste après un `if (preferredLanguage != null)` (`unnecessary_non_null_assertion`).
- `leopardo_hr` — `smart_attendance_dashboard_screen.dart`: constantes `_bg`/`_card` mortes (reliquat d'un thème custom remplacé par `MobilePage`/`AppColors`).
- `leopardo_employee` — `attendance_mode_picker_screen.dart`: import inutilisé de `smart_attendance_repository.dart` + constante `_card` dupliquée et jamais utilisée sur `_AttendanceModePickerScreenState` (une classe `_ModeCard` séparée plus bas a sa propre copie, utilisée elle).
- `leopardo_employee` — `smart_attendance_screen.dart`: constantes `_text`/`_border` mortes sur `_ModeStatusCard` (n'utilise que `_card`/`_muted`/`_accent`).

## Vérification

Chaque identifiant supprimé a été confirmé mort via le message exact de `flutter analyze` en CI + un grep manuel du fichier pour toute référence restante. Pas de SDK Flutter local disponible pour ré-exécuter l'analyse ; la CI de cette PR fera foi.