### PR TITLE
fix(mobile): unify punch-button design + fix build-breaking bugs across 4 apps

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/services/push_notification_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/services/push_notification_service.dart
@@ -95,7 +95,7 @@ class PushNotificationService {
     );
 
     await _localNotifications.initialize(
-      initSettings,
+      settings: initSettings,
       onDidReceiveNotificationResponse: (response) {
         debugPrint('Local notification tapped: ${response.payload}');
       },
@@ -211,10 +211,10 @@ class PushNotificationService {
     );
 
     await _localNotifications.show(
-      notification.hashCode,
-      notification.title ?? 'Leopardo HR',
-      notification.body ?? '',
-      details,
+      id: notification.hashCode,
+      title: notification.title ?? 'Leopardo HR',
+      body: notification.body ?? '',
+      notificationDetails: details,
       payload: message.data.toString(),
     );
   }

--- a/front/mobile_apps/leopardo_core/lib/core/theme/app_spacing.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/theme/app_spacing.dart
@@ -1,0 +1,38 @@
+/// APV Design v4 — Échelle d'espacement et de rayons partagée.
+///
+/// Objectif : arrêter les valeurs "magiques" (12, 14, 16, 18, 20, 24...)
+/// dispersées dans les écrans mobiles. Chaque nouvel écran doit utiliser
+/// [AppSpacing] et [AppRadius] pour garder une grille cohérente entre
+/// Employee / Manager / HR / Platform Admin — condition nécessaire pour
+/// qu'une démo commerciale paraisse "un seul produit" et pas quatre
+/// prototypes assemblés.
+class AppSpacing {
+  AppSpacing._();
+
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 20;
+  static const double xxl = 24;
+  static const double xxxl = 32;
+}
+
+class AppRadius {
+  AppRadius._();
+
+  /// Chips, pills, badges de statut.
+  static const double pill = 999;
+
+  /// Petits éléments : inputs, boutons secondaires compacts.
+  static const double sm = 12;
+
+  /// Boutons standards, champs de formulaire.
+  static const double md = 16;
+
+  /// Cartes de contenu (liste, module, résumé).
+  static const double lg = 18;
+
+  /// Grandes surfaces héro (en-tête d'accueil, bottom sheets).
+  static const double xl = 24;
+}

--- a/front/mobile_apps/leopardo_core/lib/core/widgets/pulse_button.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/widgets/pulse_button.dart
@@ -4,16 +4,27 @@ import 'package:flutter/services.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
 
+/// Bouton de pointage premium partagé Employee/Manager.
+///
+/// v4 — remplace l'ancien fond plein rouge/vert par un anneau progressif en
+/// glassmorphism sombre : plus lisible en plein soleil, cohérent avec les
+/// anneaux utilisés dans [AttendanceScreen], et sans la brutalité visuelle
+/// d'un disque rouge saturé pour l'action "sortir".
 class PulseButton extends StatefulWidget {
   final bool isCheckedIn;
   final bool isLoading;
   final VoidCallback? onTap;
+
+  /// Taille du diamètre extérieur. Par défaut 184 (parité avec l'ancien
+  /// design), réductible pour les écrans compacts.
+  final double size;
 
   const PulseButton({
     super.key,
     required this.isCheckedIn,
     required this.isLoading,
     this.onTap,
+    this.size = 184,
   });
 
   @override
@@ -64,70 +75,107 @@ class _PulseButtonState extends State<PulseButton>
         child: AnimatedBuilder(
           animation: _animation,
           builder: (context, child) {
+            final accent = widget.isCheckedIn ? AppColors.danger : AppColors.rh;
+            final coreColors =
+                widget.isCheckedIn
+                    ? const [Color(0xFFB91C1C), Color(0xFF7F1D1D)]
+                    : const [Color(0xFF0D5C3A), AppColors.rhDark];
+
             return Transform.scale(
               scale: widget.isLoading ? 1.0 : _animation.value,
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 300),
-                width: 184,
-                height: 184,
+              child: Container(
+                width: widget.size,
+                height: widget.size,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors:
-                        widget.isCheckedIn
-                            ? const [Color(0xFFEF4444), Color(0xFFB91C1C)]
-                            : const [AppColors.rh, Color(0xFF06B6D4)],
+                  color: accent.withValues(alpha: 0.08),
+                  border: Border.all(
+                    color: accent.withValues(alpha: 0.28),
+                    width: widget.size * 0.085,
                   ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: (widget.isCheckedIn
-                              ? AppColors.danger
-                              : AppColors.rh)
-                          .withValues(alpha: 0.32),
-                      blurRadius: 34,
-                      spreadRadius:
-                          widget.isLoading ? 4 : 12 * _animation.value,
-                    ),
-                  ],
                 ),
-                child: Center(
-                  child:
-                      widget.isLoading
-                          ? const CircularProgressIndicator(color: Colors.white)
-                          : Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                widget.isCheckedIn
-                                    ? Icons.logout_rounded
-                                    : Icons.fingerprint_rounded,
-                                color: Colors.white,
-                                size: 38,
-                              ),
-                              const SizedBox(height: 10),
-                              Text(
-                                widget.isCheckedIn ? 'SORTIR' : 'POINTER',
-                                style: AppTypography.subtitle.copyWith(
-                                  color: Colors.white,
-                                  fontSize: 21,
-                                  fontWeight: FontWeight.w800,
-                                  letterSpacing: 0.8,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                widget.isCheckedIn
-                                    ? 'Fin de journee'
-                                    : 'Arrivee',
-                                style: AppTypography.caption.copyWith(
-                                  color: Colors.white.withValues(alpha: 0.82),
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            ],
+                child: Padding(
+                  padding: EdgeInsets.all(widget.size * 0.095),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: accent.withValues(alpha: 0.13),
+                      border: Border.all(
+                        color: accent.withValues(alpha: 0.42),
+                        width: widget.size * 0.053,
+                      ),
+                    ),
+                    child: Padding(
+                      padding: EdgeInsets.all(widget.size * 0.095),
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: LinearGradient(
+                            begin: Alignment.topLeft,
+                            end: Alignment.bottomRight,
+                            colors: coreColors,
                           ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: accent.withValues(alpha: 0.28),
+                              blurRadius: 28,
+                              spreadRadius:
+                                  widget.isLoading ? 4 : 8 * _animation.value,
+                            ),
+                          ],
+                        ),
+                        child: Center(
+                          child:
+                              widget.isLoading
+                                  ? const SizedBox(
+                                    width: 30,
+                                    height: 30,
+                                    child: CircularProgressIndicator(
+                                      color: Colors.white,
+                                      strokeWidth: 2.4,
+                                    ),
+                                  )
+                                  : Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Icon(
+                                        widget.isCheckedIn
+                                            ? Icons.logout_rounded
+                                            : Icons.fingerprint_rounded,
+                                        color: Colors.white,
+                                        size: widget.size * 0.19,
+                                      ),
+                                      const SizedBox(height: 8),
+                                      Text(
+                                        widget.isCheckedIn
+                                            ? 'SORTIR'
+                                            : 'POINTER',
+                                        style: AppTypography.subtitle.copyWith(
+                                          color: Colors.white,
+                                          fontSize: 18,
+                                          fontWeight: FontWeight.w800,
+                                          letterSpacing: 0.8,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 3),
+                                      Text(
+                                        widget.isCheckedIn
+                                            ? 'Fin de journee'
+                                            : 'Arrivee',
+                                        style: AppTypography.caption.copyWith(
+                                          color: Colors.white.withValues(
+                                            alpha: 0.82,
+                                          ),
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                        ),
+                      ),
+                    ),
+                  ),
                 ),
               ),
             );

--- a/front/mobile_apps/leopardo_employee/lib/features/attendance/screens/attendance_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/attendance/screens/attendance_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
+import 'package:leopardo_core/core/widgets/pulse_button.dart';
 import 'package:leopardo_employee/core/providers/core_providers.dart';
 import 'package:leopardo_employee/features/attendance/providers/attendance_provider.dart';
 import 'package:leopardo_employee/features/auth/providers/auth_provider.dart';
@@ -558,60 +559,11 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }) {
     return Column(
       children: [
-        GestureDetector(
-          onTap: isLoading ? null : onTap,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 180),
-            width: 188,
-            height: 188,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.rh.withValues(alpha: 0.08),
-              border: Border.all(
-                color: AppColors.rh.withValues(alpha: 0.28),
-                width: 16,
-              ),
-            ),
-            child: Container(
-              margin: const EdgeInsets.all(18),
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: AppColors.rh.withValues(alpha: 0.13),
-                border: Border.all(
-                  color: AppColors.rh.withValues(alpha: 0.42),
-                  width: 10,
-                ),
-              ),
-              child: Container(
-                margin: const EdgeInsets.all(18),
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color:
-                      isCheckedIn ? AppColors.rhDark : const Color(0xFF0D5C3A),
-                  boxShadow: [
-                    BoxShadow(
-                      color: AppColors.rh.withValues(alpha: 0.28),
-                      blurRadius: 28,
-                      spreadRadius: 4,
-                    ),
-                  ],
-                ),
-                child: Center(
-                  child:
-                      isLoading
-                          ? const SizedBox(
-                            width: 30,
-                            height: 30,
-                            child: CircularProgressIndicator(
-                              color: Colors.white,
-                              strokeWidth: 2.4,
-                            ),
-                          )
-                          : _buildFingerprintIcon(),
-                ),
-              ),
-            ),
-          ),
+        PulseButton(
+          isCheckedIn: isCheckedIn,
+          isLoading: isLoading,
+          onTap: onTap,
+          size: 184,
         ),
         const SizedBox(height: 12),
         Text(
@@ -655,13 +607,6 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
     );
   }
 
-  Widget _buildFingerprintIcon() {
-    return const SizedBox(
-      width: 44,
-      height: 44,
-      child: CustomPaint(painter: _FingerprintPainter(color: AppColors.rh)),
-    );
-  }
 
   Widget _buildTodayCard(AttendanceState state) {
     final log = state.todayLog;
@@ -1238,44 +1183,6 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }
 }
 
-class _FingerprintPainter extends CustomPainter {
-  final Color color;
-  const _FingerprintPainter({required this.color});
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final cx = size.width / 2;
-    final cy = size.height / 2;
-    final paint =
-        Paint()
-          ..color = color
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.8
-          ..strokeCap = StrokeCap.round;
-
-    canvas.drawCircle(Offset(cx, cy), 1.5, paint..style = PaintingStyle.fill);
-    paint.style = PaintingStyle.stroke;
-
-    final radii = [5.0, 9.0, 13.0, 17.0, 21.0];
-    final alphas = [1.0, 0.85, 0.70, 0.55, 0.40];
-    for (var i = 0; i < radii.length; i++) {
-      final r = radii[i];
-      paint.color = color.withValues(alpha: alphas[i]);
-      final sweep = i == radii.length - 1 ? 0.55 : 0.70;
-      canvas.drawArc(
-        Rect.fromCircle(center: Offset(cx, cy), radius: r),
-        -3.14 * sweep,
-        3.14 * sweep * 2,
-        false,
-        paint,
-      );
-    }
-  }
-
-  @override
-  bool shouldRepaint(_FingerprintPainter oldDelegate) =>
-      oldDelegate.color != color;
-}
 
 class _PunchChoice {
   final String workType;

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/providers/smart_attendance_provider.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/providers/smart_attendance_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:leopardo_employee/core/providers/core_providers.dart';
 import 'package:leopardo_employee/features/smart_attendance/data/models/geo_attendance_session.dart';
 import 'package:leopardo_employee/features/smart_attendance/data/models/smart_attendance_config.dart';

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/services/background_location_service.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/services/background_location_service.dart
@@ -125,7 +125,7 @@ class BackgroundLocationService {
       // Récupération de la position courante avec précision équilibrée
       position = await Geolocator.getCurrentPosition(
         locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.balanced,
+          accuracy: LocationAccuracy.medium,
           timeLimit: Duration(seconds: 10),
         ),
       );

--- a/front/mobile_apps/leopardo_employee/linux/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_employee/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/front/mobile_apps/leopardo_employee/linux/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_employee/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
+  sentry_flutter
   url_launcher_linux
 )
 

--- a/front/mobile_apps/leopardo_employee/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/front/mobile_apps/leopardo_employee/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import file_selector_macos
 import firebase_core
 import firebase_messaging
@@ -13,10 +14,13 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import local_auth_darwin
+import package_info_plus
+import sentry_flutter
 import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
@@ -25,6 +29,8 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/front/mobile_apps/leopardo_employee/pubspec.yaml
+++ b/front/mobile_apps/leopardo_employee/pubspec.yaml
@@ -27,9 +27,9 @@ dependencies:
   local_auth: ^3.0.1
   json_annotation: ^4.11.0
   url_launcher: ^6.3.1
-  firebase_core: ^3.13.0
-  firebase_messaging: ^15.2.5
-  flutter_local_notifications: ^19.2.1
+  firebase_core: ^4.12.1
+  firebase_messaging: ^16.4.3
+  flutter_local_notifications: ^22.1.0
   leopardo_core:
     path: ../leopardo_core
 
@@ -38,8 +38,8 @@ dependencies:
   cached_network_image: ^3.4.1
 
   # Module Smart Attendance — Géofencing + Background Location
-  geolocator: ^13.0.1
-  workmanager: ^0.5.7
+  geolocator: ^14.0.3
+  workmanager: ^0.9.0
   permission_handler: ^11.3.1
 
 dev_dependencies:

--- a/front/mobile_apps/leopardo_employee/windows/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_employee/windows/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,19 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <local_auth_windows/local_auth_plugin.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
@@ -24,6 +29,10 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   LocalAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/front/mobile_apps/leopardo_employee/windows/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_employee/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,14 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   firebase_core
   flutter_secure_storage_windows
   geolocator_windows
   local_auth_windows
+  permission_handler_windows
+  sentry_flutter
   url_launcher_windows
 )
 

--- a/front/mobile_apps/leopardo_hr/lib/features/attendance/screens/attendance_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/attendance/screens/attendance_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
+import 'package:leopardo_core/core/widgets/pulse_button.dart';
 import 'package:leopardo_hr/features/attendance/providers/attendance_provider.dart';
 import 'package:leopardo_hr/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_core/models/attendance_log.dart';
@@ -369,60 +370,11 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }) {
     return Column(
       children: [
-        GestureDetector(
-          onTap: isLoading ? null : onTap,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 180),
-            width: 188,
-            height: 188,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.rh.withValues(alpha: 0.08),
-              border: Border.all(
-                color: AppColors.rh.withValues(alpha: 0.28),
-                width: 16,
-              ),
-            ),
-            child: Container(
-              margin: const EdgeInsets.all(18),
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: AppColors.rh.withValues(alpha: 0.13),
-                border: Border.all(
-                  color: AppColors.rh.withValues(alpha: 0.42),
-                  width: 10,
-                ),
-              ),
-              child: Container(
-                margin: const EdgeInsets.all(18),
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color:
-                      isCheckedIn ? AppColors.rhDark : const Color(0xFF0D5C3A),
-                  boxShadow: [
-                    BoxShadow(
-                      color: AppColors.rh.withValues(alpha: 0.28),
-                      blurRadius: 28,
-                      spreadRadius: 4,
-                    ),
-                  ],
-                ),
-                child: Center(
-                  child:
-                      isLoading
-                          ? const SizedBox(
-                            width: 30,
-                            height: 30,
-                            child: CircularProgressIndicator(
-                              color: Colors.white,
-                              strokeWidth: 2.4,
-                            ),
-                          )
-                          : _buildFingerprintIcon(),
-                ),
-              ),
-            ),
-          ),
+        PulseButton(
+          isCheckedIn: isCheckedIn,
+          isLoading: isLoading,
+          onTap: onTap,
+          size: 184,
         ),
         const SizedBox(height: 12),
         Text(
@@ -466,13 +418,6 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
     );
   }
 
-  Widget _buildFingerprintIcon() {
-    return const SizedBox(
-      width: 44,
-      height: 44,
-      child: CustomPaint(painter: _FingerprintPainter(color: AppColors.rh)),
-    );
-  }
 
   Widget _buildTodayCard(AttendanceState state) {
     final log = state.todayLog;
@@ -823,44 +768,6 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }
 }
 
-class _FingerprintPainter extends CustomPainter {
-  final Color color;
-  const _FingerprintPainter({required this.color});
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final cx = size.width / 2;
-    final cy = size.height / 2;
-    final paint =
-        Paint()
-          ..color = color
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.8
-          ..strokeCap = StrokeCap.round;
-
-    canvas.drawCircle(Offset(cx, cy), 1.5, paint..style = PaintingStyle.fill);
-    paint.style = PaintingStyle.stroke;
-
-    final radii = [5.0, 9.0, 13.0, 17.0, 21.0];
-    final alphas = [1.0, 0.85, 0.70, 0.55, 0.40];
-    for (var i = 0; i < radii.length; i++) {
-      final r = radii[i];
-      paint.color = color.withValues(alpha: alphas[i]);
-      final sweep = i == radii.length - 1 ? 0.55 : 0.70;
-      canvas.drawArc(
-        Rect.fromCircle(center: Offset(cx, cy), radius: r),
-        -3.14 * sweep,
-        3.14 * sweep * 2,
-        false,
-        paint,
-      );
-    }
-  }
-
-  @override
-  bool shouldRepaint(_FingerprintPainter oldDelegate) =>
-      oldDelegate.color != color;
-}
 
 class _CorrectionSheet extends ConsumerStatefulWidget {
   final DateTime targetDate;

--- a/front/mobile_apps/leopardo_hr/lib/features/smart_attendance/screens/pending_sessions_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/smart_attendance/screens/pending_sessions_screen.dart
@@ -59,7 +59,7 @@ class _PendingGeoSessionsScreenState
         backgroundColor: const Color(0xFF111B2E),
         title: Text(
           'Motif du rejet',
-          style: AppTypography.titleMedium.copyWith(color: AppColors.textDark),
+          style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         content: TextField(
           controller: _noteController,
@@ -117,7 +117,8 @@ class _PendingGeoSessionsScreenState
   Widget build(BuildContext context) {
     final sessionsAsync = ref.watch(pendingGeoSessionsProvider);
 
-    return MobilePage(
+    return Scaffold(
+      backgroundColor: const Color(0xFF0B1120),
       appBar: MobileTopBar(
         title: 'Sessions à valider',
         subtitle: 'Smart Attendance — GPS',
@@ -132,14 +133,13 @@ class _PendingGeoSessionsScreenState
           ),
         ],
       ),
-      backgroundColor: const Color(0xFF0B1120),
-      child: sessionsAsync.when(
+      body: sessionsAsync.when(
         data: (sessions) {
           if (sessions.isEmpty) {
-            return const EmptyStateWidget(
+            return const EmptyState(
               icon: Icons.check_circle_outline,
               title: 'Tout est à jour',
-              subtitle: 'Aucune session GPS en attente de validation.',
+              description: 'Aucune session GPS en attente de validation.',
             );
           }
           return RefreshIndicator(
@@ -203,7 +203,7 @@ class _SessionCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   session.employeeName.isNotEmpty ? session.employeeName : 'Employé #${session.employeeId}',
-                  style: AppTypography.titleSmall.copyWith(color: AppColors.textDark),
+                  style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
                 ),
               ),
             ],

--- a/front/mobile_apps/leopardo_hr/lib/features/smart_attendance/screens/smart_attendance_dashboard_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/smart_attendance/screens/smart_attendance_dashboard_screen.dart
@@ -23,7 +23,8 @@ class SmartAttendanceDashboardScreen extends ConsumerWidget {
     final dashAsync = ref.watch(smartAttendanceDashboardProvider);
     final pendingAsync = ref.watch(pendingGeoSessionsProvider);
 
-    return MobilePage(
+    return Scaffold(
+      backgroundColor: _bg,
       appBar: MobileTopBar(
         title: 'Smart Attendance',
         subtitle: 'Pointage GPS — tableau de bord équipe',
@@ -42,8 +43,7 @@ class SmartAttendanceDashboardScreen extends ConsumerWidget {
           ),
         ],
       ),
-      backgroundColor: _bg,
-      child: RefreshIndicator(
+      body: RefreshIndicator(
         onRefresh: () async {
           ref.invalidate(smartAttendanceDashboardProvider);
           ref.invalidate(pendingGeoSessionsProvider);
@@ -101,7 +101,7 @@ class _StatsGrid extends StatelessWidget {
       children: [
         Text(
           "Aujourd'hui — ${parsedDate != null ? DateFormat('d MMM yyyy', 'fr_FR').format(parsedDate) : dateLabel}",
-          style: AppTypography.labelMedium.copyWith(color: AppColors.textMutedDark),
+          style: AppTypography.bodySmall.copyWith(color: AppColors.textMutedDark),
         ),
         const SizedBox(height: 12),
         GridView.count(
@@ -112,7 +112,7 @@ class _StatsGrid extends StatelessWidget {
           mainAxisSpacing: 12,
           childAspectRatio: 1.6,
           children: [
-            _StatCard(label: 'Détectées', value: detected, color: AppColors.accent),
+            _StatCard(label: 'Détectées', value: detected, color: AppColors.info),
             _StatCard(label: 'En attente', value: pending, color: Colors.orange),
             _StatCard(label: 'Approuvées', value: approved, color: Colors.green),
             _StatCard(label: 'Rejetées', value: rejected, color: AppColors.danger),
@@ -148,7 +148,7 @@ class _StatCard extends StatelessWidget {
         children: [
           Text(
             '$value',
-            style: AppTypography.headlineMedium.copyWith(color: color),
+            style: AppTypography.title.copyWith(color: color),
           ),
           const SizedBox(height: 4),
           Text(
@@ -181,7 +181,7 @@ class _PendingCard extends StatelessWidget {
             const SizedBox(width: 12),
             Text(
               'Aucune session en attente de validation',
-              style: AppTypography.bodyMedium.copyWith(color: AppColors.textDark),
+              style: AppTypography.bodySmall.copyWith(color: AppColors.textDark),
             ),
           ],
         ),
@@ -207,7 +207,7 @@ class _PendingCard extends StatelessWidget {
                 children: [
                   Text(
                     '$count session${count > 1 ? 's' : ''} en attente',
-                    style: AppTypography.titleSmall.copyWith(color: Colors.orange),
+                    style: AppTypography.subtitle.copyWith(color: Colors.orange),
                   ),
                   Text(
                     'Appuyez pour valider ou rejeter',

--- a/front/mobile_apps/leopardo_hr/linux/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_hr/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/front/mobile_apps/leopardo_hr/linux/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_hr/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
+  sentry_flutter
   url_launcher_linux
 )
 

--- a/front/mobile_apps/leopardo_hr/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/front/mobile_apps/leopardo_hr/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import file_selector_macos
 import firebase_core
 import firebase_messaging
@@ -13,10 +14,13 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import local_auth_darwin
+import package_info_plus
+import sentry_flutter
 import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
@@ -25,6 +29,8 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/front/mobile_apps/leopardo_hr/pubspec.lock
+++ b/front/mobile_apps/leopardo_hr/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: ff0a84a2734d9e1089f8aedd5c0af0061b82fb94e95260d943404e0ef2134b11
+      sha256: "460e9e684edb461d85498fc166ff8416f303f22216838d302d80676b348c6a4c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.59"
+    version: "1.3.75"
   analyzer:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -269,18 +269,18 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "84688491040b0ceb26575709a84d701c84ad4df4d8aff020adf6d85f155fb0dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.2"
   drift_flutter:
     dependency: transitive
     description:
       name: drift_flutter
-      sha256: "0bc2f1dde59e59cedde0df67a4ff7bd8f0d42274f18b50bf7e7dae7ca3d77801"
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.3.1"
   fake_async:
     dependency: transitive
     description:
@@ -349,50 +349,50 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "7be63a3f841fc9663342f7f3a011a42aef6a61066943c90b1c434d79d5c995c5"
+      sha256: "6f22d1c62e0c20976f02cd842c7b7cd3c0f561cc2052586411871045c08860c9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.15.2"
+    version: "4.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "0ecda14c1bfc9ed8cac303dd0f8d04a320811b479362a9a4efb14fd331a473ce"
+      sha256: f74d1d6fabccf7743b0144c2ed363d81049e258e22428ebb6fb0faec2fa7d938
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "8.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "0ed0dc292e8f9ac50992e2394e9d336a0275b6ae400d64163fdf0a8a8b556c37"
+      sha256: ddab99d709b8c27dd47576eb05a1e719e07a2aa45c009a49ae92ac4d2a8ca555
       url: "https://pub.dev"
     source: hosted
-    version: "2.24.1"
+    version: "3.9.1"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "60be38574f8b5658e2f22b7e311ff2064bea835c248424a383783464e8e02fcc"
+      sha256: "30ad2d59bcd86117dc49d278c8998a0fb390c5a3202f6e43e4bd215d3f1d0556"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.10"
+    version: "16.4.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "685e1771b3d1f9c8502771ccc9f91485b376ffe16d553533f335b9183ea99754"
+      sha256: "4d144cb42b9a5a42855596be2d7682d32c50169f42e7df2cb3278ecf935e7d63"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.10"
+    version: "4.9.2"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "0d1be17bc89ed3ff5001789c92df678b2e963a51b6fa2bdb467532cc9dbed390"
+      sha256: fcd25d0b9da55766ef4d28ae05a7460f5189635d6b42607adcd9f08818fd35f0
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.10"
+    version: "4.2.3"
   fixnum:
     dependency: transitive
     description:
@@ -434,34 +434,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: "40c6a69189a622bda89ddcf50a139f4ba0f0eb9c0fef6718845b1f8b95452ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "22.1.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: "4dfbae10debab9ac975d8b01943fed94c0c19dad43f825964b29f3c3f9a8a852"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "12.0.1"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -557,22 +565,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   geolocator:
     dependency: transitive
     description:
       name: geolocator
-      sha256: f62bcd90459e63210bbf9c35deb6a51c521f992a78de19a1fe5c11704f9530e2
+      sha256: e146a6d63776582651e97a79cbe459f8e1211b100101fadcd84db83361fa599f
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.4"
+    version: "14.0.3"
   geolocator_android:
     dependency: transitive
     description:
       name: geolocator_android
-      sha256: fcb1760a50d7500deca37c9a666785c047139b5f9ee15aa5469fae7dbbe3170d
+      sha256: "86ea1654e4f61ff51466848e91c116b422d6010ea269fda0fbe1af7e9e742ce1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.2"
+    version: "5.0.3"
   geolocator_apple:
     dependency: transitive
     description:
@@ -581,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.14"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: "3da7420f11c3496511a5bd3c18fd67b88e5659f12e46b7ce00a788f6996e850a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.6"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -685,6 +709,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   hive:
     dependency: "direct main"
     description:
@@ -972,6 +1004,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.4"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.2"
   nm:
     dependency: transitive
     description:
@@ -1313,22 +1353,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.0"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   stack_trace:
     dependency: transitive
     description:
@@ -1413,10 +1461,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_hr/pubspec.yaml
+++ b/front/mobile_apps/leopardo_hr/pubspec.yaml
@@ -27,9 +27,9 @@ dependencies:
   local_auth: ^3.0.2
   json_annotation: ^4.11.0
   url_launcher: ^6.3.1
-  firebase_core: ^3.13.0
-  firebase_messaging: ^15.2.5
-  flutter_local_notifications: ^19.2.1
+  firebase_core: ^4.12.1
+  firebase_messaging: ^16.4.3
+  flutter_local_notifications: ^22.1.0
   graphview: ^1.2.1
   leopardo_core:
     path: ../leopardo_core

--- a/front/mobile_apps/leopardo_hr/windows/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_hr/windows/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,18 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <local_auth_windows/local_auth_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
@@ -24,6 +28,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   LocalAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/front/mobile_apps/leopardo_hr/windows/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_hr/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,13 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   firebase_core
   flutter_secure_storage_windows
   geolocator_windows
   local_auth_windows
+  sentry_flutter
   url_launcher_windows
 )
 

--- a/front/mobile_apps/leopardo_manager/lib/features/attendance/screens/attendance_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/attendance/screens/attendance_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
+import 'package:leopardo_core/core/widgets/pulse_button.dart';
 import 'package:leopardo_manager/features/attendance/providers/attendance_provider.dart';
 import 'package:leopardo_manager/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_core/models/attendance_log.dart';
@@ -369,60 +370,11 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }) {
     return Column(
       children: [
-        GestureDetector(
-          onTap: isLoading ? null : onTap,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 180),
-            width: 188,
-            height: 188,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.rh.withValues(alpha: 0.08),
-              border: Border.all(
-                color: AppColors.rh.withValues(alpha: 0.28),
-                width: 16,
-              ),
-            ),
-            child: Container(
-              margin: const EdgeInsets.all(18),
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: AppColors.rh.withValues(alpha: 0.13),
-                border: Border.all(
-                  color: AppColors.rh.withValues(alpha: 0.42),
-                  width: 10,
-                ),
-              ),
-              child: Container(
-                margin: const EdgeInsets.all(18),
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color:
-                      isCheckedIn ? AppColors.rhDark : const Color(0xFF0D5C3A),
-                  boxShadow: [
-                    BoxShadow(
-                      color: AppColors.rh.withValues(alpha: 0.28),
-                      blurRadius: 28,
-                      spreadRadius: 4,
-                    ),
-                  ],
-                ),
-                child: Center(
-                  child:
-                      isLoading
-                          ? const SizedBox(
-                            width: 30,
-                            height: 30,
-                            child: CircularProgressIndicator(
-                              color: Colors.white,
-                              strokeWidth: 2.4,
-                            ),
-                          )
-                          : _buildFingerprintIcon(),
-                ),
-              ),
-            ),
-          ),
+        PulseButton(
+          isCheckedIn: isCheckedIn,
+          isLoading: isLoading,
+          onTap: onTap,
+          size: 184,
         ),
         const SizedBox(height: 12),
         Text(
@@ -466,13 +418,6 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
     );
   }
 
-  Widget _buildFingerprintIcon() {
-    return const SizedBox(
-      width: 44,
-      height: 44,
-      child: CustomPaint(painter: _FingerprintPainter(color: AppColors.rh)),
-    );
-  }
 
   Widget _buildTodayCard(AttendanceState state) {
     final log = state.todayLog;
@@ -823,44 +768,6 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
   }
 }
 
-class _FingerprintPainter extends CustomPainter {
-  final Color color;
-  const _FingerprintPainter({required this.color});
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final cx = size.width / 2;
-    final cy = size.height / 2;
-    final paint =
-        Paint()
-          ..color = color
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.8
-          ..strokeCap = StrokeCap.round;
-
-    canvas.drawCircle(Offset(cx, cy), 1.5, paint..style = PaintingStyle.fill);
-    paint.style = PaintingStyle.stroke;
-
-    final radii = [5.0, 9.0, 13.0, 17.0, 21.0];
-    final alphas = [1.0, 0.85, 0.70, 0.55, 0.40];
-    for (var i = 0; i < radii.length; i++) {
-      final r = radii[i];
-      paint.color = color.withValues(alpha: alphas[i]);
-      final sweep = i == radii.length - 1 ? 0.55 : 0.70;
-      canvas.drawArc(
-        Rect.fromCircle(center: Offset(cx, cy), radius: r),
-        -3.14 * sweep,
-        3.14 * sweep * 2,
-        false,
-        paint,
-      );
-    }
-  }
-
-  @override
-  bool shouldRepaint(_FingerprintPainter oldDelegate) =>
-      oldDelegate.color != color;
-}
 
 class _CorrectionSheet extends ConsumerStatefulWidget {
   final DateTime targetDate;

--- a/front/mobile_apps/leopardo_manager/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/onboarding/screens/onboarding_screen.dart
@@ -102,7 +102,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
         ),
       ),
       body: RefreshIndicator(
-        color: AppColors.primary,
+        color: AppColors.rh,
         backgroundColor: AppColors.cardDark,
         onRefresh: () async => await ref.refresh(onboardingChecklistProvider.future),
         child: checklistAsync.when(
@@ -138,8 +138,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                   decoration: BoxDecoration(
                     gradient: LinearGradient(
                       colors: [
-                        AppColors.primary.withValues(alpha: 0.85),
-                        AppColors.primary.withValues(alpha: 0.5),
+                        AppColors.rh.withValues(alpha: 0.85),
+                        AppColors.rh.withValues(alpha: 0.5),
                       ],
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
@@ -147,7 +147,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                     borderRadius: BorderRadius.circular(16),
                     boxShadow: [
                       BoxShadow(
-                        color: AppColors.primary.withValues(alpha: 0.3),
+                        color: AppColors.rh.withValues(alpha: 0.3),
                         blurRadius: 12,
                         offset: const Offset(0, 4),
                       ),
@@ -258,7 +258,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                             : isSkipped
                                 ? AppColors.textMutedDark.withValues(alpha: 0.3)
                                 : step.required
-                                    ? AppColors.primary.withValues(alpha: 0.4)
+                                    ? AppColors.rh.withValues(alpha: 0.4)
                                     : Colors.transparent,
                         width: 1.5,
                       ),
@@ -277,7 +277,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                                   ? AppColors.success.withValues(alpha: 0.15)
                                   : isSkipped
                                       ? AppColors.textMutedDark.withValues(alpha: 0.1)
-                                      : AppColors.primary.withValues(alpha: 0.15),
+                                      : AppColors.rh.withValues(alpha: 0.15),
                               borderRadius: BorderRadius.circular(10),
                             ),
                             child: Icon(
@@ -290,7 +290,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                                   ? AppColors.success
                                   : isSkipped
                                       ? AppColors.textMutedDark
-                                      : AppColors.primary,
+                                      : AppColors.rh,
                               size: 22,
                             ),
                           ),
@@ -325,13 +325,13 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                                           vertical: 2,
                                         ),
                                         decoration: BoxDecoration(
-                                          color: AppColors.primary.withValues(alpha: 0.15),
+                                          color: AppColors.rh.withValues(alpha: 0.15),
                                           borderRadius: BorderRadius.circular(4),
                                         ),
                                         child: Text(
                                           'Requis',
                                           style: AppTypography.bodySmall.copyWith(
-                                            color: AppColors.primary,
+                                            color: AppColors.rh,
                                             fontSize: 10,
                                           ),
                                         ),
@@ -405,7 +405,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
                     onPressed: () => ref.invalidate(onboardingChecklistProvider),
                     child: Text(
                       'Réessayer',
-                      style: AppTypography.subtitle.copyWith(color: AppColors.primary),
+                      style: AppTypography.subtitle.copyWith(color: AppColors.rh),
                     ),
                   ),
                 ],

--- a/front/mobile_apps/leopardo_manager/lib/features/smart_attendance/screens/pending_sessions_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/smart_attendance/screens/pending_sessions_screen.dart
@@ -9,7 +9,7 @@ import 'package:leopardo_core/core/widgets/mobile_surface.dart';
 import 'package:leopardo_manager/features/smart_attendance/data/models/geo_attendance_session.dart';
 import 'package:leopardo_manager/features/smart_attendance/providers/smart_attendance_provider.dart';
 
-/// Ã‰cran liste des sessions GPS en attente de validation â€” Manager
+/// Ã‰cran liste des sessions GPS en attente de validation â€" Manager
 class PendingGeoSessionsScreen extends ConsumerStatefulWidget {
   const PendingGeoSessionsScreen({super.key});
 
@@ -37,7 +37,7 @@ class _PendingGeoSessionsScreenState
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('Session approuvÃ©e âœ“'),
+            content: Text('Session approuvÃ©e âœ"'),
             backgroundColor: Colors.green,
           ),
         );
@@ -59,7 +59,7 @@ class _PendingGeoSessionsScreenState
         backgroundColor: const Color(0xFF111B2E),
         title: Text(
           'Motif du rejet',
-          style: AppTypography.titleMedium.copyWith(color: AppColors.textDark),
+          style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         content: TextField(
           controller: _noteController,
@@ -119,8 +119,8 @@ class _PendingGeoSessionsScreenState
 
     return Scaffold(
       appBar: MobileTopBar(
-        title: 'Sessions Ã  valider',
-        subtitle: 'Smart Attendance â€” GPS',
+        title: 'Sessions Ã  valider',
+        subtitle: 'Smart Attendance â€" GPS',
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_rounded),
           onPressed: () => context.pop(),
@@ -138,8 +138,8 @@ class _PendingGeoSessionsScreenState
           if (sessions.isEmpty) {
             return const EmptyState(
               icon: Icons.check_circle_outline,
-              title: 'Tout est Ã  jour',
-              subtitle: 'Aucune session GPS en attente de validation.',
+              title: 'Tout est Ã  jour',
+              description: 'Aucune session GPS en attente de validation.',
             );
           }
           return RefreshIndicator(

--- a/front/mobile_apps/leopardo_manager/linux/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_manager/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/front/mobile_apps/leopardo_manager/linux/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_manager/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
+  sentry_flutter
   url_launcher_linux
 )
 

--- a/front/mobile_apps/leopardo_manager/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/front/mobile_apps/leopardo_manager/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import file_selector_macos
 import firebase_core
 import firebase_messaging
@@ -13,10 +14,13 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import local_auth_darwin
+import package_info_plus
+import sentry_flutter
 import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
@@ -25,6 +29,8 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/front/mobile_apps/leopardo_manager/pubspec.lock
+++ b/front/mobile_apps/leopardo_manager/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: ff0a84a2734d9e1089f8aedd5c0af0061b82fb94e95260d943404e0ef2134b11
+      sha256: "460e9e684edb461d85498fc166ff8416f303f22216838d302d80676b348c6a4c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.59"
+    version: "1.3.75"
   analyzer:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -269,18 +269,18 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "84688491040b0ceb26575709a84d701c84ad4df4d8aff020adf6d85f155fb0dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.2"
   drift_flutter:
     dependency: transitive
     description:
       name: drift_flutter
-      sha256: "0bc2f1dde59e59cedde0df67a4ff7bd8f0d42274f18b50bf7e7dae7ca3d77801"
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.3.1"
   fake_async:
     dependency: transitive
     description:
@@ -349,50 +349,50 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "7be63a3f841fc9663342f7f3a011a42aef6a61066943c90b1c434d79d5c995c5"
+      sha256: "6f22d1c62e0c20976f02cd842c7b7cd3c0f561cc2052586411871045c08860c9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.15.2"
+    version: "4.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "0ecda14c1bfc9ed8cac303dd0f8d04a320811b479362a9a4efb14fd331a473ce"
+      sha256: f74d1d6fabccf7743b0144c2ed363d81049e258e22428ebb6fb0faec2fa7d938
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "8.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "0ed0dc292e8f9ac50992e2394e9d336a0275b6ae400d64163fdf0a8a8b556c37"
+      sha256: ddab99d709b8c27dd47576eb05a1e719e07a2aa45c009a49ae92ac4d2a8ca555
       url: "https://pub.dev"
     source: hosted
-    version: "2.24.1"
+    version: "3.9.1"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "60be38574f8b5658e2f22b7e311ff2064bea835c248424a383783464e8e02fcc"
+      sha256: "30ad2d59bcd86117dc49d278c8998a0fb390c5a3202f6e43e4bd215d3f1d0556"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.10"
+    version: "16.4.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "685e1771b3d1f9c8502771ccc9f91485b376ffe16d553533f335b9183ea99754"
+      sha256: "4d144cb42b9a5a42855596be2d7682d32c50169f42e7df2cb3278ecf935e7d63"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.10"
+    version: "4.9.2"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "0d1be17bc89ed3ff5001789c92df678b2e963a51b6fa2bdb467532cc9dbed390"
+      sha256: fcd25d0b9da55766ef4d28ae05a7460f5189635d6b42607adcd9f08818fd35f0
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.10"
+    version: "4.2.3"
   fixnum:
     dependency: transitive
     description:
@@ -434,34 +434,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: "40c6a69189a622bda89ddcf50a139f4ba0f0eb9c0fef6718845b1f8b95452ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "22.1.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: "4dfbae10debab9ac975d8b01943fed94c0c19dad43f825964b29f3c3f9a8a852"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "12.0.1"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -557,22 +565,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   geolocator:
     dependency: transitive
     description:
       name: geolocator
-      sha256: f62bcd90459e63210bbf9c35deb6a51c521f992a78de19a1fe5c11704f9530e2
+      sha256: e146a6d63776582651e97a79cbe459f8e1211b100101fadcd84db83361fa599f
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.4"
+    version: "14.0.3"
   geolocator_android:
     dependency: transitive
     description:
       name: geolocator_android
-      sha256: fcb1760a50d7500deca37c9a666785c047139b5f9ee15aa5469fae7dbbe3170d
+      sha256: "86ea1654e4f61ff51466848e91c116b422d6010ea269fda0fbe1af7e9e742ce1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.2"
+    version: "5.0.3"
   geolocator_apple:
     dependency: transitive
     description:
@@ -581,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.14"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: "3da7420f11c3496511a5bd3c18fd67b88e5659f12e46b7ce00a788f6996e850a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.6"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -685,6 +709,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   hive:
     dependency: "direct main"
     description:
@@ -972,6 +1004,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.4"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.2"
   nm:
     dependency: transitive
     description:
@@ -1313,22 +1353,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.0"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   stack_trace:
     dependency: transitive
     description:
@@ -1413,10 +1461,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_manager/pubspec.yaml
+++ b/front/mobile_apps/leopardo_manager/pubspec.yaml
@@ -27,9 +27,9 @@ dependencies:
   local_auth: ^3.0.2
   json_annotation: ^4.11.0
   url_launcher: ^6.3.1
-  firebase_core: ^3.13.0
-  firebase_messaging: ^15.2.5
-  flutter_local_notifications: ^19.2.1
+  firebase_core: ^4.12.1
+  firebase_messaging: ^16.4.3
+  flutter_local_notifications: ^22.1.0
   graphview: ^1.2.1
   leopardo_core:
     path: ../leopardo_core

--- a/front/mobile_apps/leopardo_manager/windows/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_manager/windows/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,18 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <local_auth_windows/local_auth_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
@@ -24,6 +28,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   LocalAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/front/mobile_apps/leopardo_manager/windows/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_manager/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,13 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   firebase_core
   flutter_secure_storage_windows
   geolocator_windows
   local_auth_windows
+  sentry_flutter
   url_launcher_windows
 )
 

--- a/front/mobile_apps/leopardo_platform_admin/linux/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_platform_admin/linux/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
-  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
 }

--- a/front/mobile_apps/leopardo_platform_admin/linux/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_platform_admin/linux/flutter/generated_plugins.cmake
@@ -3,11 +3,12 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  file_selector_linux
   flutter_secure_storage_linux
+  sentry_flutter
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/front/mobile_apps/leopardo_platform_admin/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/front/mobile_apps/leopardo_platform_admin/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,18 +5,24 @@
 import FlutterMacOS
 import Foundation
 
-import file_selector_macos
+import connectivity_plus
+import firebase_core
+import firebase_messaging
+import flutter_local_notifications
 import flutter_secure_storage_darwin
+import geolocator_apple
 import google_sign_in_ios
-import local_auth_darwin
-import path_provider_foundation
-import sqflite_darwin
+import package_info_plus
+import sentry_flutter
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
-  LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
 }

--- a/front/mobile_apps/leopardo_platform_admin/pubspec.lock
+++ b/front/mobile_apps/leopardo_platform_admin/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "99.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "12.1.0"
   args:
     dependency: transitive
     description:
@@ -49,78 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  build:
-    dependency: transitive
-    description:
-      name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.6"
-  build_config:
-    dependency: transitive
-    description:
-      name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
-  build_daemon:
-    dependency: transitive
-    description:
-      name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.1"
-  build_runner:
-    dependency: "direct dev"
-    description:
-      name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.15.0"
-  built_collection:
-    dependency: transitive
-    description:
-      name: built_collection
-      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.1"
-  built_value:
-    dependency: transitive
-    description:
-      name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.12.6"
-  cached_network_image:
-    dependency: "direct main"
-    description:
-      name: cached_network_image
-      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.1"
-  cached_network_image_platform_interface:
-    dependency: transitive
-    description:
-      name: cached_network_image_platform_interface
-      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.1"
-  cached_network_image_web:
-    dependency: transitive
-    description:
-      name: cached_network_image_web
-      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -129,14 +57,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  checked_yaml:
-    dependency: transitive
-    description:
-      name: checked_yaml
-      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.4"
   cli_config:
     dependency: transitive
     description:
@@ -161,14 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -209,14 +121,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.1"
-  cross_file:
-    dependency: transitive
-    description:
-      name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -233,38 +137,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
-  dart_style:
-    dependency: transitive
-    description:
-      name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.14"
+    version: "0.7.13"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.2"
+    version: "5.10.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      sha256: dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   drift:
     dependency: transitive
     description:
@@ -313,38 +209,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  file_selector_linux:
-    dependency: transitive
-    description:
-      name: file_selector_linux
-      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.4"
-  file_selector_macos:
-    dependency: transitive
-    description:
-      name: file_selector_macos
-      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.5"
-  file_selector_platform_interface:
-    dependency: transitive
-    description:
-      name: file_selector_platform_interface
-      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.7.0"
-  file_selector_windows:
-    dependency: transitive
-    description:
-      name: file_selector_windows
-      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.3+5"
   firebase_core:
     dependency: "direct main"
     description:
@@ -406,22 +270,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_animate:
-    dependency: "direct main"
-    description:
-      name: flutter_animate
-      sha256: "7befe2d3252728afb77aecaaea1dec88a89d35b9b1d2eea6d04479e8af9117b5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.5.2"
-  flutter_cache_manager:
-    dependency: transitive
-    description:
-      name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -475,14 +323,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.35"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -539,14 +379,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.2"
-  flutter_shaders:
-    dependency: transitive
-    description:
-      name: flutter_shaders
-      sha256: "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -574,7 +406,7 @@ packages:
     source: hosted
     version: "0.1.1"
   geolocator:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: geolocator
       sha256: e146a6d63776582651e97a79cbe459f8e1211b100101fadcd84db83361fa599f
@@ -665,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: df5c15533814ed20b7d9e1c5a40a73f174e5d5017bd2669b1c72fb6596fde812
+      sha256: a01d4fd5a0e4eb0c1961434a0289a436abf9225b0933963c8e4e5ed88c26e40b
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.11"
+    version: "7.2.15"
   google_sign_in_ios:
     dependency: transitive
     description:
@@ -693,14 +525,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.3"
-  graphs:
-    dependency: transitive
-    description:
-      name: graphs
-      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.2"
   gsettings:
     dependency: transitive
     description:
@@ -757,70 +581,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  image_picker:
-    dependency: "direct main"
-    description:
-      name: image_picker
-      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.2"
-  image_picker_android:
-    dependency: transitive
-    description:
-      name: image_picker_android
-      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.13+17"
-  image_picker_for_web:
-    dependency: transitive
-    description:
-      name: image_picker_for_web
-      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.1"
-  image_picker_ios:
-    dependency: transitive
-    description:
-      name: image_picker_ios
-      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.13+6"
-  image_picker_linux:
-    dependency: transitive
-    description:
-      name: image_picker_linux
-      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.2"
-  image_picker_macos:
-    dependency: transitive
-    description:
-      name: image_picker_macos
-      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.2+1"
-  image_picker_platform_interface:
-    dependency: transitive
-    description:
-      name: image_picker_platform_interface
-      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.11.1"
-  image_picker_windows:
-    dependency: transitive
-    description:
-      name: image_picker_windows
-      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:
@@ -854,21 +614,13 @@ packages:
     source: hosted
     version: "1.0.1"
   json_annotation:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: json_annotation
       sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
     version: "4.12.0"
-  json_serializable:
-    dependency: "direct dev"
-    description:
-      name: json_serializable
-      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.14.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -908,46 +660,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  local_auth:
-    dependency: "direct main"
-    description:
-      name: local_auth
-      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
-  local_auth_android:
-    dependency: transitive
-    description:
-      name: local_auth_android
-      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.8"
-  local_auth_darwin:
-    dependency: transitive
-    description:
-      name: local_auth_darwin
-      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
-  local_auth_platform_interface:
-    dependency: transitive
-    description:
-      name: local_auth_platform_interface
-      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
-  local_auth_windows:
-    dependency: transitive
-    description:
-      name: local_auth_windows
-      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -988,14 +700,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mockito:
-    dependency: "direct dev"
-    description:
-      name: mockito
-      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.6.4"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -1028,14 +732,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.4.1"
-  octo_image:
-    dependency: transitive
-    description:
-      name: octo_image
-      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -1116,54 +812,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  permission_handler:
-    dependency: "direct main"
-    description:
-      name: permission_handler
-      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
-      url: "https://pub.dev"
-    source: hosted
-    version: "11.4.0"
-  permission_handler_android:
-    dependency: transitive
-    description:
-      name: permission_handler_android
-      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
-      url: "https://pub.dev"
-    source: hosted
-    version: "12.1.0"
-  permission_handler_apple:
-    dependency: transitive
-    description:
-      name: permission_handler_apple
-      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.4.10"
-  permission_handler_html:
-    dependency: transitive
-    description:
-      name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3+5"
-  permission_handler_platform_interface:
-    dependency: transitive
-    description:
-      name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.3.0"
-  permission_handler_windows:
-    dependency: transitive
-    description:
-      name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -1204,14 +852,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  pubspec_parse:
-    dependency: transitive
-    description:
-      name: pubspec_parse
-      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.0"
   qr:
     dependency: transitive
     description:
@@ -1244,14 +884,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.28.0"
   sentry:
     dependency: transitive
     description:
@@ -1313,22 +945,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  source_gen:
-    dependency: transitive
-    description:
-      name: source_gen
-      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.3"
-  source_helper:
-    dependency: transitive
-    description:
-      name: source_helper
-      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1353,46 +969,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
-  sqflite:
-    dependency: transitive
-    description:
-      name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2+1"
-  sqflite_android:
-    dependency: transitive
-    description:
-      name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2+3"
-  sqflite_common:
-    dependency: transitive
-    description:
-      name: sqflite_common
-      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.8"
-  sqflite_darwin:
-    dependency: transitive
-    description:
-      name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
-  sqflite_platform_interface:
-    dependency: transitive
-    description:
-      name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
   sqlcipher_flutter_libs:
     dependency: transitive
     description:
@@ -1441,14 +1017,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  stream_transform:
-    dependency: transitive
-    description:
-      name: stream_transform
-      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -1457,14 +1025,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1513,78 +1073,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  url_launcher:
-    dependency: "direct main"
-    description:
-      name: url_launcher
-      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.2"
-  url_launcher_android:
-    dependency: transitive
-    description:
-      name: url_launcher_android
-      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.30"
-  url_launcher_ios:
-    dependency: transitive
-    description:
-      name: url_launcher_ios
-      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.4.1"
-  url_launcher_linux:
-    dependency: transitive
-    description:
-      name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
-  url_launcher_macos:
-    dependency: transitive
-    description:
-      name: url_launcher_macos
-      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.5"
-  url_launcher_platform_interface:
-    dependency: transitive
-    description:
-      name: url_launcher_platform_interface
-      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.2"
-  url_launcher_web:
-    dependency: transitive
-    description:
-      name: url_launcher_web
-      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.3"
-  url_launcher_windows:
-    dependency: transitive
-    description:
-      name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -1649,38 +1145,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.0"
-  workmanager:
-    dependency: "direct main"
-    description:
-      name: workmanager
-      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.0+3"
-  workmanager_android:
-    dependency: transitive
-    description:
-      name: workmanager_android
-      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.0+2"
-  workmanager_apple:
-    dependency: transitive
-    description:
-      name: workmanager_apple
-      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1+2"
-  workmanager_platform_interface:
-    dependency: transitive
-    description:
-      name: workmanager_platform_interface
-      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:
@@ -1693,10 +1157,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -1706,5 +1170,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/front/mobile_apps/leopardo_platform_admin/pubspec.yaml
+++ b/front/mobile_apps/leopardo_platform_admin/pubspec.yaml
@@ -23,9 +23,9 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   path_provider: ^2.1.3
-  firebase_core: ^3.13.0
-  firebase_messaging: ^15.2.5
-  flutter_local_notifications: ^19.2.1
+  firebase_core: ^4.12.1
+  firebase_messaging: ^16.4.3
+  flutter_local_notifications: ^22.1.0
   google_sign_in: ^7.2.0
   leopardo_core:
     path: ../leopardo_core

--- a/front/mobile_apps/leopardo_platform_admin/windows/flutter/generated_plugin_registrant.cc
+++ b/front/mobile_apps/leopardo_platform_admin/windows/flutter/generated_plugin_registrant.cc
@@ -6,15 +6,21 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <file_selector_windows/file_selector_windows.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
-#include <local_auth_windows/local_auth_plugin.h>
+#include <geolocator_windows/geolocator_windows.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  FileSelectorWindowsRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
-  LocalAuthPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("LocalAuthPlugin"));
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
 }

--- a/front/mobile_apps/leopardo_platform_admin/windows/flutter/generated_plugins.cmake
+++ b/front/mobile_apps/leopardo_platform_admin/windows/flutter/generated_plugins.cmake
@@ -3,12 +3,16 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  file_selector_windows
+  connectivity_plus
+  firebase_core
   flutter_secure_storage_windows
-  local_auth_windows
+  geolocator_windows
+  sentry_flutter
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## Contexte

Objectif initial : moderniser le design des 4 apps mobiles Flutter (Employee/Manager/HR/Platform Admin) pour un rendu plus premium et \"vendable\".

Pour éviter un audit purement visuel (screenshots), j'ai installé le SDK Flutter et **compilé réellement chacune des 4 apps depuis un checkout propre** (`flutter pub get` + `flutter run -d web-server`). Ça a révélé des bugs de build préexistants, indépendants du travail de design, sur les 4 apps.

## Bugs de build corrigés (aucun n'est lié au changement de design — toutes ces apps ne compilaient pas depuis un clone propre avant cette branche)

- **leopardo_employee** :
  - `workmanager: ^0.5.7` — version inexistante sur pub.dev → `^0.9.0`
  - `geolocator: ^13.0.1` en conflit avec `leopardo_core` (`^14.0.3`) → aligné
  - `firebase_core`/`firebase_messaging`/`flutter_local_notifications` désalignés vs `leopardo_core` → alignés
  - `smart_attendance_provider.dart` : API Riverpod v2 (`StateNotifier`) sans l'import `flutter_riverpod/legacy.dart` requis en v3
  - `background_location_service.dart` : `LocationAccuracy.balanced` renommé `.medium` dans geolocator 14
  - `push_notification_service.dart` (core) : `FlutterLocalNotificationsPlugin.initialize/.show` avec args positionnels, v22 exige des named params

- **leopardo_manager / leopardo_hr / leopardo_platform_admin** :
  - même désalignement `firebase_core`/`firebase_messaging`/`flutter_local_notifications` vs `leopardo_core` → `flutter pub get` échouait purement et simplement sur les 3 apps
  - écrans Smart Attendance (`pending_sessions_screen.dart`, `smart_attendance_dashboard_screen.dart`) référençant des tokens inexistants : `AppTypography.titleMedium/labelMedium/bodyMedium/titleSmall/headlineMedium`, `AppColors.primary/accent`, `EmptyStateWidget`, et usage incorrect de `MobilePage(backgroundColor:, child:)` (l'API n'accepte que `padding/appBar/bottom/children`) → échec de compilation garanti

## Design

- `PulseButton` (leopardo_core) : remplace le disque à dégradé plat par le même traitement en anneaux superposés (glow externe → anneau intermédiaire → cœur plein) déjà utilisé sur `AttendanceScreen`, paramétrable en taille.
- Unification des boutons de pointage Employee/Manager/HR sur ce widget partagé au lieu de 3 copies quasi-identiques de `_buildPunchButton`/`_buildFingerprintIcon`/`_FingerprintPainter` (~90 lignes × 3 supprimées).
- Ajout de `AppSpacing`/`AppRadius` (leopardo_core) pour commencer à remplacer les valeurs de marge/rayon codées en dur, dispersées entre écrans.

## Vérification

Chacune des 4 apps a été buildée avec succès via `flutter run -d web-server` après ces correctifs (aucun outil de build natif Android/iOS/desktop disponible dans le sandbox — vérification faite via le device web-server).

⚠️ Le token GitHub utilisé pour ce push a été partagé en clair dans une conversation externe — merci de le révoquer/régénérer dès que possible (Settings → Developer settings → Personal access tokens).