### PR TITLE
design(web-client): unify post-login dashboard pages on shared design system

### DIFF
--- a/front/web/src/app/(dashboard)/billing/page.tsx
+++ b/front/web/src/app/(dashboard)/billing/page.tsx
@@ -34,11 +34,11 @@ const PLAN_LABELS: Record<string, string> = {
 };
 
 const STATUS_LABELS: Record<string, { label: string; className: string }> = {
-  active: { label: 'Actif', className: 'bg-emerald-100 text-emerald-700' },
-  cancelled: { label: 'Annule', className: 'bg-red-100 text-red-700' },
-  past_due: { label: 'Impaye', className: 'bg-amber-100 text-amber-700' },
-  paid: { label: 'Payee', className: 'bg-emerald-100 text-emerald-700' },
-  pending: { label: 'En attente', className: 'bg-amber-100 text-amber-700' },
+  active: { label: 'Actif', className: 'bg-emerald-50 text-emerald-700' },
+  cancelled: { label: 'Annule', className: 'bg-red-50 text-red-700' },
+  past_due: { label: 'Impaye', className: 'bg-amber-50 text-amber-700' },
+  paid: { label: 'Payee', className: 'bg-emerald-50 text-emerald-700' },
+  pending: { label: 'En attente', className: 'bg-amber-50 text-amber-700' },
 };
 
 export default function BillingPage() {
@@ -198,13 +198,13 @@ export default function BillingPage() {
         <div className="py-16 text-center text-slate-400">Chargement...</div>
       ) : (
         <>
-          <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm">
+          <div className="rounded-2xl border border-app-border bg-white p-6 shadow-sm">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div>
                 <p className="text-xs font-bold uppercase tracking-widest text-slate-400">Abonnement actuel</p>
                 {subscription ? (
                   <>
-                    <h2 className="mt-2 text-2xl font-black text-slate-950 dark:text-white">
+                    <h2 className="mt-2 text-2xl font-black text-slate-950">
                       {PLAN_LABELS[subscription.plan] ?? subscription.plan}
                     </h2>
                     <p className="mt-1 text-sm text-slate-500">
@@ -231,7 +231,7 @@ export default function BillingPage() {
                   key={plan}
                   onClick={() => handleUpgrade(plan)}
                   disabled={subscription?.plan === plan || actionLoading === `upgrade-${plan}`}
-                  className="inline-flex items-center gap-2 rounded-xl border border-slate-200 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-40"
+                  className="inline-flex items-center gap-2 rounded-xl border border-app-border px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
                 >
                   {actionLoading === `upgrade-${plan}` ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
                   {subscription?.plan === plan ? `${PLAN_LABELS[plan]} (actuel)` : `Passer a ${PLAN_LABELS[plan]}`}
@@ -241,7 +241,7 @@ export default function BillingPage() {
                 <button
                   onClick={handleCancel}
                   disabled={actionLoading === 'cancel'}
-                  className="inline-flex items-center gap-2 rounded-xl border border-red-200 px-4 py-2 text-sm font-semibold text-red-600 hover:bg-red-50 disabled:opacity-40"
+                  className="inline-flex items-center gap-2 rounded-xl border border-red-200 px-4 py-2 text-sm font-bold text-red-600 hover:bg-red-50 disabled:opacity-40"
                 >
                   <XCircle className="h-4 w-4" /> Annuler l&apos;abonnement
                 </button>
@@ -249,20 +249,20 @@ export default function BillingPage() {
                 <button
                   onClick={handleRenew}
                   disabled={actionLoading === 'renew'}
-                  className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-40"
+                  className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-bold text-white hover:bg-emerald-700 disabled:opacity-40"
                 >
                   Reactiver l&apos;abonnement
                 </button>
               ) : null}
             </div>
 
-            <div className="mt-4 flex flex-wrap gap-3 border-t border-slate-100 dark:border-slate-700 pt-4">
+            <div className="mt-4 flex flex-wrap gap-3 border-t border-app-border pt-4">
               {(['starter', 'business', 'enterprise'] as const).map((plan) => (
                 <button
                   key={`checkout-${plan}`}
                   onClick={() => handleCheckout(plan)}
                   disabled={actionLoading === `checkout-${plan}`}
-                  className="inline-flex items-center gap-2 rounded-xl bg-slate-900 dark:bg-white px-4 py-2 text-sm font-semibold text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100 disabled:opacity-40"
+                  className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-4 py-2 text-sm font-bold text-white hover:bg-slate-800 disabled:opacity-40"
                 >
                   <CreditCard className="h-4 w-4" /> Payer en ligne — {PLAN_LABELS[plan]}
                 </button>
@@ -270,47 +270,47 @@ export default function BillingPage() {
               <button
                 onClick={handlePortal}
                 disabled={actionLoading === 'portal'}
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-40"
+                className="inline-flex items-center gap-2 rounded-xl border border-app-border px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
               >
                 <ExternalLink className="h-4 w-4" /> Portail de paiement
               </button>
             </div>
           </div>
 
-          <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
-            <div className="border-b border-slate-100 dark:border-slate-700 px-6 py-4">
-              <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800 dark:text-slate-200">Factures</h2>
+          <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm">
+            <div className="border-b border-app-border px-6 py-4">
+              <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Factures</h2>
             </div>
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
-                    <th className="px-4 py-3 text-left font-medium text-slate-500">Numero</th>
-                    <th className="px-4 py-3 text-right font-medium text-slate-500">Montant</th>
-                    <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
-                    <th className="px-4 py-3 text-left font-medium text-slate-500">Echeance</th>
-                    <th className="px-4 py-3 text-center font-medium text-slate-500">Actions</th>
+                  <tr className="border-b border-app-border bg-slate-50/50">
+                    <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Numero</th>
+                    <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Montant</th>
+                    <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-slate-500">Statut</th>
+                    <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Echeance</th>
+                    <th className="px-6 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Actions</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody className="divide-y divide-app-border">
                   {invoices.length === 0 ? (
-                    <tr><td colSpan={5} className="px-4 py-12 text-center text-slate-400">Aucune facture pour le moment</td></tr>
+                    <tr><td colSpan={5} className="px-6 py-10 text-center text-sm text-slate-500">Aucune facture pour le moment.</td></tr>
                   ) : invoices.map((invoice) => (
-                    <tr key={invoice.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                      <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">
+                    <tr key={invoice.id} className="transition-colors hover:bg-slate-50/60">
+                      <td className="px-6 py-4 font-bold text-slate-950">
                         <span className="flex items-center gap-2"><FileText className="h-4 w-4 text-slate-400" />{invoice.number ?? `#${invoice.id}`}</span>
                       </td>
-                      <td className="px-4 py-3 text-right text-slate-900 dark:text-white tabular-nums">{formatCurrency(invoice.total ?? invoice.amount, invoice.currency)}</td>
-                      <td className="px-4 py-3 text-center">
-                        <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${STATUS_LABELS[invoice.status]?.className ?? 'bg-slate-100 text-slate-600'}`}>
+                      <td className="px-4 py-4 text-right tabular-nums text-slate-900">{formatCurrency(invoice.total ?? invoice.amount, invoice.currency)}</td>
+                      <td className="px-4 py-4 text-center">
+                        <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${STATUS_LABELS[invoice.status]?.className ?? 'bg-slate-100 text-slate-600'}`}>
                           {STATUS_LABELS[invoice.status]?.label ?? invoice.status}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                      <td className="px-4 py-4 text-slate-600">
                         {invoice.due_date ? new Date(invoice.due_date).toLocaleDateString('fr-FR') : '—'}
                       </td>
-                      <td className="px-4 py-3 text-center">
-                        <button onClick={() => downloadInvoicePdf(invoice.id)} className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-emerald-600" title="Telecharger PDF">
+                      <td className="px-6 py-4 text-right">
+                        <button onClick={() => downloadInvoicePdf(invoice.id)} className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-brand-600" title="Telecharger PDF">
                           <Download className="h-4 w-4" />
                         </button>
                       </td>
@@ -319,7 +319,7 @@ export default function BillingPage() {
                 </tbody>
               </table>
             </div>
-          </div>
+          </section>
         </>
       )}
     </ModulePageShell>

--- a/front/web/src/app/(dashboard)/billing/page.tsx
+++ b/front/web/src/app/(dashboard)/billing/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { ApiError, apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 import { CreditCard, Download, ExternalLink, FileText, Loader2, ShieldCheck, XCircle } from 'lucide-react';
 
 type Subscription = {
@@ -184,12 +185,11 @@ export default function BillingPage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Facturation</h1>
-        <p className="text-sm text-slate-500 dark:text-slate-400">Gerez votre abonnement, vos moyens de paiement et vos factures.</p>
-      </div>
-
+    <ModulePageShell
+      title="Facturation"
+      subtitle="Gerez votre abonnement, vos moyens de paiement et vos factures directement depuis votre espace client."
+      accentClassName="bg-gradient-to-br from-emerald-500/10 via-white to-white"
+    >
       {error ? (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
       ) : null}
@@ -322,6 +322,6 @@ export default function BillingPage() {
           </div>
         </>
       )}
-    </div>
+    </ModulePageShell>
   );
 }

--- a/front/web/src/app/(dashboard)/contracts/page.tsx
+++ b/front/web/src/app/(dashboard)/contracts/page.tsx
@@ -67,10 +67,10 @@ export default function ContractsPage() {
 
   const statusBadge = (status: string) => {
     const styles: Record<string, string> = {
-      active: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-      suspended: 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-      terminated: 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-      draft: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
+      active: 'bg-emerald-50 text-emerald-700',
+      suspended: 'bg-amber-50 text-amber-700',
+      terminated: 'bg-red-50 text-red-700',
+      draft: 'bg-slate-100 text-slate-600',
     };
     const labels: Record<string, string> = { active: 'Actif', suspended: 'Suspendu', terminated: 'Termine', draft: 'Brouillon' };
     return <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${styles[status] || styles.draft}`}>{labels[status] || status}</span>;

--- a/front/web/src/app/(dashboard)/contracts/page.tsx
+++ b/front/web/src/app/(dashboard)/contracts/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 import {
   FileText,
   Search,
@@ -66,13 +67,13 @@ export default function ContractsPage() {
 
   const statusBadge = (status: string) => {
     const styles: Record<string, string> = {
-      active: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-      suspended: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-      terminated: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+      active: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+      suspended: 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+      terminated: 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400',
       draft: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
     };
     const labels: Record<string, string> = { active: 'Actif', suspended: 'Suspendu', terminated: 'Termine', draft: 'Brouillon' };
-    return <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${styles[status] || styles.draft}`}>{labels[status] || status}</span>;
+    return <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${styles[status] || styles.draft}`}>{labels[status] || status}</span>;
   };
 
   const downloadPdf = async (id: number) => {
@@ -90,34 +91,53 @@ export default function ContractsPage() {
     }
   };
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Contrats</h1>
-        <p className="text-sm text-slate-500 dark:text-slate-400">Gestion des contrats employes</p>
-      </div>
+  const statCards = [
+    { label: 'Actifs', value: stats.active, icon: CheckCircle2, accent: 'text-emerald-600 bg-emerald-50' },
+    { label: 'Expirant bientot', value: stats.expiring, icon: AlertTriangle, accent: 'text-amber-600 bg-amber-50' },
+    { label: 'Suspendus', value: stats.suspended, icon: Clock, accent: 'text-red-500 bg-red-50' },
+    { label: 'Total', value: stats.total, icon: FileText, accent: 'text-brand-600 bg-brand-50' },
+  ];
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        {[
-          { label: 'Actifs', value: stats.active, icon: CheckCircle2, color: 'text-emerald-600' },
-          { label: 'Expirant bientot', value: stats.expiring, icon: AlertTriangle, color: 'text-amber-600' },
-          { label: 'Suspendus', value: stats.suspended, icon: Clock, color: 'text-red-500' },
-          { label: 'Total', value: stats.total, icon: FileText, color: 'text-blue-600' },
-        ].map((stat, i) => (
-          <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.05 }} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
-            <stat.icon className={`h-5 w-5 ${stat.color} mb-2`} />
-            <p className="text-2xl font-bold text-slate-900 dark:text-white">{stat.value}</p>
-            <p className="text-xs text-slate-500">{stat.label}</p>
+  return (
+    <ModulePageShell
+      title="Contrats"
+      subtitle="Gestion des contrats employes : suivi des statuts, echeances et export PDF, branche directement sur l'API RH."
+      accentClassName="bg-gradient-to-br from-rh-light via-white to-white"
+    >
+      <section className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {statCards.map((stat, i) => (
+          <motion.div
+            key={stat.label}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: i * 0.05 }}
+            className="rounded-2xl border border-app-border bg-white p-5 shadow-sm"
+          >
+            <div className={`mb-3 inline-flex h-10 w-10 items-center justify-center rounded-xl ${stat.accent}`}>
+              <stat.icon className="h-5 w-5" />
+            </div>
+            <p className="text-2xl font-black text-slate-950">{stat.value}</p>
+            <p className="text-xs font-bold uppercase tracking-widest text-slate-400">{stat.label}</p>
           </motion.div>
         ))}
-      </div>
+      </section>
 
       <div className="flex flex-col gap-3 sm:flex-row">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
-          <input type="text" placeholder="Rechercher..." value={search} onChange={e => setSearch(e.target.value)} className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 pl-10 pr-4 py-2.5 text-sm text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500" />
+          <input
+            type="text"
+            placeholder="Rechercher un employe ou un type de contrat..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="w-full rounded-xl border border-app-border bg-white pl-10 pr-4 py-2.5 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          />
         </div>
-        <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2.5 text-sm text-slate-900 dark:text-white">
+        <select
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value)}
+          className="rounded-xl border border-app-border bg-white px-3 py-2.5 text-sm font-medium text-slate-700"
+        >
           <option value="all">Tous les statuts</option>
           <option value="active">Actif</option>
           <option value="suspended">Suspendu</option>
@@ -125,40 +145,47 @@ export default function ContractsPage() {
         </select>
       </div>
 
-      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
+      <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm">
+        <div className="border-b border-app-border px-6 py-4">
+          <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Contrats</h2>
+        </div>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
-                <th className="px-4 py-3 text-left font-medium text-slate-500">Employe</th>
-                <th className="px-4 py-3 text-left font-medium text-slate-500">Type</th>
-                <th className="px-4 py-3 text-left font-medium text-slate-500">Debut</th>
-                <th className="px-4 py-3 text-left font-medium text-slate-500">Fin</th>
-                <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
-                <th className="px-4 py-3 text-center font-medium text-slate-500">Actions</th>
+              <tr className="border-b border-app-border bg-slate-50/50">
+                <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Employe</th>
+                <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Type</th>
+                <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Debut</th>
+                <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Fin</th>
+                <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-slate-500">Statut</th>
+                <th className="px-6 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Actions</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="divide-y divide-app-border">
               {loading ? (
-                <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Chargement...</td></tr>
+                <tr><td colSpan={6} className="px-6 py-10 text-center text-sm text-slate-500">Chargement des contrats...</td></tr>
               ) : filtered.length === 0 ? (
-                <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Aucun contrat trouve</td></tr>
+                <tr><td colSpan={6} className="px-6 py-10 text-center text-sm text-slate-500">Aucun contrat trouve.</td></tr>
               ) : filtered.map(c => (
-                <tr key={c.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                  <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{c.employee_name}</td>
-                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 uppercase text-xs font-semibold">{c.type}</td>
-                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 flex items-center gap-1"><Calendar className="h-3 w-3" />{c.start_date}</td>
-                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{c.end_date || 'Indefini'}</td>
-                  <td className="px-4 py-3 text-center">{statusBadge(c.status)}</td>
-                  <td className="px-4 py-3 text-center">
-                    <button onClick={() => downloadPdf(c.id)} className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-emerald-600" title="Telecharger PDF"><Download className="h-4 w-4" /></button>
+                <tr key={c.id} className="transition-colors hover:bg-slate-50/60">
+                  <td className="px-6 py-4 font-bold text-slate-950">{c.employee_name}</td>
+                  <td className="px-4 py-4 text-xs font-bold uppercase tracking-wider text-slate-500">{c.type}</td>
+                  <td className="px-4 py-4 text-slate-600">
+                    <span className="inline-flex items-center gap-1"><Calendar className="h-3 w-3 text-slate-400" />{c.start_date}</span>
+                  </td>
+                  <td className="px-4 py-4 text-slate-600">{c.end_date || 'Indefini'}</td>
+                  <td className="px-4 py-4 text-center">{statusBadge(c.status)}</td>
+                  <td className="px-6 py-4 text-right">
+                    <button onClick={() => downloadPdf(c.id)} className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-brand-600" title="Telecharger PDF">
+                      <Download className="h-4 w-4" />
+                    </button>
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
-      </div>
-    </div>
+      </section>
+    </ModulePageShell>
   );
 }

--- a/front/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/front/web/src/app/(dashboard)/dashboard/page.tsx
@@ -96,7 +96,7 @@ const GlassCard = ({ children, className = '', delay = 0 }: { children: React.Re
     className={`relative group ${className}`}
   >
     <div className="absolute -inset-0.5 rounded-2xl bg-gradient-to-r from-emerald-500 to-cyan-500 opacity-0 blur transition duration-500 group-hover:opacity-20" />
-    <div className="relative overflow-hidden rounded-2xl border border-slate-200/50 bg-white/80 shadow-lg backdrop-blur-xl dark:border-slate-700/50 dark:bg-slate-900/80">
+    <div className="relative overflow-hidden rounded-2xl border border-slate-200/50 bg-white/80 shadow-lg backdrop-blur-xl">
       {children}
     </div>
   </motion.div>
@@ -224,8 +224,8 @@ export default function DashboardPage() {
       change: `${summary?.employees_total ?? 0} total`,
       trend: 'up',
       icon: Users,
-      color: 'from-blue-500 to-blue-600',
-      bgColor: 'bg-blue-50 dark:bg-blue-900/20',
+      color: 'from-security to-security-dark',
+      bgColor: 'bg-security-light',
     },
     {
       title: 'Presents aujourd hui',
@@ -235,8 +235,8 @@ export default function DashboardPage() {
         : '0%',
       trend: 'up',
       icon: CheckCircle2,
-      color: 'from-emerald-500 to-emerald-600',
-      bgColor: 'bg-emerald-50 dark:bg-emerald-900/20',
+      color: 'from-rh to-rh-dark',
+      bgColor: 'bg-rh-light',
     },
     {
       title: 'Absences en attente',
@@ -244,8 +244,8 @@ export default function DashboardPage() {
       change: 'a traiter',
       trend: 'down',
       icon: Clock,
-      color: 'from-amber-500 to-amber-600',
-      bgColor: 'bg-amber-50 dark:bg-amber-900/20',
+      color: 'from-finance to-finance-dark',
+      bgColor: 'bg-finance-light',
     },
     {
       title: 'Departements',
@@ -253,8 +253,8 @@ export default function DashboardPage() {
       change: 'actifs',
       trend: 'up',
       icon: Clock,
-      color: 'from-violet-500 to-violet-600',
-      bgColor: 'bg-violet-50 dark:bg-violet-900/20',
+      color: 'from-ia to-ia-dark',
+      bgColor: 'bg-ia-light',
     },
   ];
 
@@ -288,8 +288,8 @@ export default function DashboardPage() {
         className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center"
       >
         <div>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Tableau de bord</h1>
-          <p className="mt-1 text-slate-500 dark:text-slate-400">
+          <h1 className="text-3xl font-black text-slate-950">Tableau de bord</h1>
+          <p className="mt-1 text-slate-500">
             {loading ? 'Chargement des donnees tenant...' : 'Bienvenue ! Voici ce qui se passe aujourd hui.'}
           </p>
           {loadError ? (
@@ -305,11 +305,11 @@ export default function DashboardPage() {
             <input
               type="text"
               placeholder="Rechercher..."
-              className="w-64 rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+              className="w-64 rounded-xl border border-app-border bg-white py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
-          <button className="relative rounded-xl border border-slate-200 bg-white p-2 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
-            <Bell className="h-5 w-5 text-slate-600 dark:text-slate-400" />
+          <button className="relative rounded-xl border border-app-border bg-white p-2 transition-colors hover:bg-slate-50">
+            <Bell className="h-5 w-5 text-slate-600" />
             <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-red-500" />
           </button>
         </div>
@@ -337,8 +337,8 @@ export default function DashboardPage() {
             </div>
           </div>
         </div>
-        <div className="rounded-2xl border border-slate-200 bg-slate-950 p-5 text-white shadow-sm">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-teal-200">Actions prioritaires</p>
+        <div className="rounded-2xl border border-slate-800 bg-slate-950 p-5 text-white shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-200">Actions prioritaires</p>
           <div className="mt-4 grid gap-3 text-sm">
             <PriorityAction label="Traiter les absences en attente" value={summary?.pending_absences ?? 0} href="/absences" />
             <PriorityAction label="Verifier les presences du jour" value={summary?.today_attendance ?? 0} href="/attendance" />
@@ -359,7 +359,7 @@ export default function DashboardPage() {
               </p>
             </div>
             <div className={`flex h-24 w-24 shrink-0 items-center justify-center rounded-2xl text-3xl font-black ${
-              readiness.go_live_ready ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
+              readiness.go_live_ready ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'
             }`}>
               {readiness.score}
             </div>
@@ -382,19 +382,19 @@ export default function DashboardPage() {
                 <div className={`flex h-12 w-12 items-center justify-center rounded-xl ${stat.bgColor}`}>
                   <stat.icon className={`h-6 w-6 bg-gradient-to-br ${stat.color} bg-clip-text text-transparent`} style={{ color: 'inherit' }} />
                 </div>
-                <div className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium ${
+                <div className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs font-bold ${
                   stat.trend === 'up'
-                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-                    : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                    ? 'bg-emerald-50 text-emerald-700'
+                    : 'bg-red-50 text-red-700'
                 }`}>
                   {stat.trend === 'up' ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />}
                   {stat.change}
                 </div>
               </div>
-              <div className="mb-1 text-3xl font-bold text-slate-900 dark:text-white">
+              <div className="mb-1 text-3xl font-black text-slate-950">
                 <AnimatedNumber value={stat.value} suffix={stat.suffix ?? ''} />
               </div>
-              <p className="text-sm text-slate-500 dark:text-slate-400">{stat.title}</p>
+              <p className="text-sm text-slate-500">{stat.title}</p>
             </div>
           </GlassCard>
         ))}
@@ -405,31 +405,31 @@ export default function DashboardPage() {
           <div className="p-6">
             <div className="mb-6 flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-emerald-600">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-rh to-rh-dark">
                   <Zap className="h-5 w-5 text-white" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-slate-900 dark:text-white">Activite recente</h3>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Dernieres actions de votre equipe</p>
+                  <h3 className="font-bold text-slate-950">Activite recente</h3>
+                  <p className="text-sm text-slate-500">Dernieres actions de votre equipe</p>
                 </div>
               </div>
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => setActiveTab('today')}
-                  className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                  className={`rounded-lg px-3 py-1.5 text-sm font-bold transition-colors ${
                     activeTab === 'today'
-                      ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-                      : 'text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800'
+                      ? 'bg-emerald-50 text-emerald-700'
+                      : 'text-slate-600 hover:bg-slate-100'
                   }`}
                 >
                   Aujourd&apos;hui
                 </button>
                 <button
                   onClick={() => setActiveTab('week')}
-                  className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                  className={`rounded-lg px-3 py-1.5 text-sm font-bold transition-colors ${
                     activeTab === 'week'
-                      ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-                      : 'text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800'
+                      ? 'bg-emerald-50 text-emerald-700'
+                      : 'text-slate-600 hover:bg-slate-100'
                   }`}
                 >
                   Cette semaine
@@ -439,7 +439,7 @@ export default function DashboardPage() {
 
             <div className="space-y-3">
               {activityRows.length === 0 ? (
-                <div className="rounded-xl border border-dashed border-slate-200 p-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                <div className="rounded-xl border border-dashed border-app-border p-6 text-sm text-slate-500">
                   Aucune activite recente a afficher pour ce tenant.
                 </div>
               ) : activityRows.map((activity, index) => (
@@ -448,25 +448,25 @@ export default function DashboardPage() {
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: 0.5 + index * 0.1 }}
-                  className="group flex cursor-pointer items-center gap-4 rounded-xl p-4 transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50"
+                  className="group flex cursor-pointer items-center gap-4 rounded-xl p-4 transition-colors hover:bg-slate-50"
                 >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100 text-sm font-bold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-50 text-sm font-bold text-emerald-700">
                     {activity.avatar}
                   </div>
                   <div className="flex-1">
-                    <p className="font-medium text-slate-900 dark:text-white">{activity.name}</p>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                    <p className="font-bold text-slate-950">{activity.name}</p>
+                    <p className="text-sm text-slate-500">
                       {activity.action} • {activity.time}
                     </p>
                   </div>
-                  <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                  <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700">
                     Journal
                   </span>
                 </motion.div>
               ))}
             </div>
 
-            <button className="mt-4 w-full rounded-xl border border-slate-200 py-3 font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800">
+            <button className="mt-4 w-full rounded-xl border border-app-border py-3 font-bold text-slate-600 transition-colors hover:bg-slate-50">
               Voir toute l&apos;activite
             </button>
           </div>
@@ -474,28 +474,28 @@ export default function DashboardPage() {
 
         <div className="space-y-6">
           <GlassCard delay={0.5}>
-            <div className="bg-gradient-to-br from-violet-500/5 to-fuchsia-500/5 p-6">
+            <div className="bg-gradient-to-br from-ia/5 to-ia-light p-6">
               <div className="mb-4 flex items-start gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-violet-500 to-fuchsia-500 shadow-lg shadow-violet-500/30">
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-ia to-ia-dark shadow-lg shadow-ia/30">
                   <Sparkles className="h-6 w-6 text-white" />
                 </div>
                 <div>
-                  <h4 className="font-semibold text-slate-900 dark:text-white">Leo IA</h4>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">Assistant intelligent</p>
+                  <h4 className="font-bold text-slate-950">Leo IA</h4>
+                  <p className="text-xs text-slate-500">Assistant intelligent</p>
                 </div>
               </div>
 
-              <div className="mb-4 rounded-xl bg-white/50 p-4 dark:bg-slate-900/50">
-                <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+              <div className="mb-4 rounded-xl bg-white/50 p-4">
+                <p className="text-sm leading-relaxed text-slate-700">
                   &quot;Vos retards sont en baisse de 15% cette semaine. Souhaitez-vous que j&apos;envoie un message de felicitations a l&apos;equipe ?&quot;
                 </p>
               </div>
 
               <div className="flex gap-2">
-                <button className="flex-1 rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 py-2.5 text-sm font-medium text-white transition-all hover:shadow-lg hover:shadow-violet-500/30">
+                <button className="flex-1 rounded-xl bg-gradient-to-r from-ia to-ia-dark py-2.5 text-sm font-bold text-white transition-all hover:shadow-lg hover:shadow-ia/30">
                   Oui, envoyer
                 </button>
-                <button className="flex-1 rounded-xl border border-slate-200 py-2.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800">
+                <button className="flex-1 rounded-xl border border-app-border py-2.5 text-sm font-bold text-slate-600 transition-colors hover:bg-slate-50">
                   Plus tard
                 </button>
               </div>
@@ -504,22 +504,22 @@ export default function DashboardPage() {
 
           <GlassCard delay={0.6}>
             <div className="p-6">
-              <h4 className="mb-4 font-semibold text-slate-900 dark:text-white">Actions rapides</h4>
+              <h4 className="mb-4 font-bold text-slate-950">Actions rapides</h4>
               <div className="grid grid-cols-2 gap-3">
                 {[
-                  { icon: Users, label: 'Nouvel employe', color: 'bg-blue-500' },
-                  { icon: Calendar, label: 'Conges', color: 'bg-emerald-500' },
-                  { icon: TrendingUp, label: 'Rapports', color: 'bg-violet-500' },
-                  { icon: Download, label: 'Export', color: 'bg-amber-500' },
+                  { icon: Users, label: 'Nouvel employe', color: 'bg-security' },
+                  { icon: Calendar, label: 'Conges', color: 'bg-rh' },
+                  { icon: TrendingUp, label: 'Rapports', color: 'bg-ia' },
+                  { icon: Download, label: 'Export', color: 'bg-finance' },
                 ].map((action) => (
                   <button
                     key={action.label}
-                    className="group flex flex-col items-center gap-2 rounded-xl p-4 transition-colors hover:bg-slate-50 dark:hover:bg-slate-800"
+                    className="group flex flex-col items-center gap-2 rounded-xl p-4 transition-colors hover:bg-slate-50"
                   >
                     <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${action.color} transition-transform group-hover:scale-110`}>
                       <action.icon className="h-5 w-5 text-white" />
                     </div>
-                    <span className="text-xs font-medium text-slate-600 dark:text-slate-400">{action.label}</span>
+                    <span className="text-xs font-bold text-slate-600">{action.label}</span>
                   </button>
                 ))}
               </div>
@@ -529,8 +529,8 @@ export default function DashboardPage() {
           <GlassCard delay={0.7}>
             <div className="p-6">
               <div className="mb-4 flex items-center justify-between">
-                <h4 className="font-semibold text-slate-900 dark:text-white">Presence hebdo</h4>
-                <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">+12%</span>
+                <h4 className="font-bold text-slate-950">Presence hebdo</h4>
+                <span className="text-xs font-bold text-emerald-600">+12%</span>
               </div>
               <div className="flex h-32 items-end gap-2">
                 {[65, 80, 75, 90, 85, 70, 88].map((height, index) => (
@@ -559,7 +559,7 @@ function PriorityAction({ label, value, href }: { label: string; value: number; 
   return (
     <Link href={href} className="flex items-center justify-between rounded-xl bg-white/10 px-4 py-3 transition hover:bg-white/15">
       <span>{label}</span>
-      <span className="inline-flex items-center gap-2 font-bold text-teal-100">
+      <span className="inline-flex items-center gap-2 font-bold text-brand-100">
         {value}
         <ArrowRight className="h-4 w-4" aria-hidden="true" />
       </span>

--- a/front/web/src/app/(dashboard)/edge-nodes/page.tsx
+++ b/front/web/src/app/(dashboard)/edge-nodes/page.tsx
@@ -6,7 +6,10 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { Cpu, Plus, RefreshCw, ShieldAlert, Wifi, WifiOff, X } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 
 interface EdgeNode {
   id: string;
@@ -23,16 +26,17 @@ interface EdgeNode {
   edge_version: string;
 }
 
-interface SyncLog {
-  id: string;
-  direction: string;
-  status: string;
-  records_sent: number;
-  records_received: number;
-  conflicts_detected: number;
-  started_at: string;
-  finished_at: string | null;
-}
+const MODE_LABELS: Record<string, string> = {
+  cloud: 'Cloud',
+  hybrid: 'Hybride',
+  offline: 'Offline',
+};
+
+const MODE_STYLES: Record<string, string> = {
+  cloud: 'bg-info/15 text-info',
+  hybrid: 'bg-finance-light text-finance-dark',
+  offline: 'bg-slate-100 text-slate-600',
+};
 
 export default function EdgeNodesPage() {
   const [nodes, setNodes] = useState<EdgeNode[]>([]);
@@ -56,7 +60,6 @@ export default function EdgeNodesPage() {
       setNodes(data.data ?? []);
       setLoadError(null);
     } catch (err) {
-      console.error('Failed to fetch edge nodes', err);
       setLoadError(err instanceof ApiError ? err.message : 'Impossible de charger les Edge nodes.');
     } finally {
       setLoading(false);
@@ -68,7 +71,7 @@ export default function EdgeNodesPage() {
     try {
       const res = await apiFetch(`/edge/${nodeId}/sync`, { method: 'POST' });
       const data = await res.json();
-      alert(`Sync terminé — envoyés: ${data.data?.records_sent ?? 0}, conflits: ${data.data?.conflicts_detected ?? 0}`);
+      alert(`Sync termine — envoyes: ${data.data?.records_sent ?? 0}, conflits: ${data.data?.conflicts_detected ?? 0}`);
       fetchNodes();
     } catch (err) {
       alert(err instanceof ApiError ? err.message : 'Erreur lors de la synchronisation');
@@ -88,206 +91,192 @@ export default function EdgeNodesPage() {
       setShowAddModal(false);
       fetchNodes();
     } catch (err) {
-      alert(err instanceof ApiError ? err.message : 'Erreur lors de la création du node');
+      alert(err instanceof ApiError ? err.message : 'Erreur lors de la creation du node');
     }
   }
 
-  function statusBadge(node: EdgeNode) {
-    if (!node.is_online) return <span className="badge badge-offline">Hors ligne</span>;
-    if (node.mode === 'offline') return <span className="badge badge-local">Local</span>;
-    return <span className="badge badge-online">En ligne</span>;
-  }
-
-  function modeBadge(mode: string) {
-    const colors: Record<string, string> = {
-      cloud: 'bg-blue-100 text-blue-800',
-      hybrid: 'bg-orange-100 text-orange-800',
-      offline: 'bg-gray-100 text-gray-800',
-    };
-    return (
-      <span className={`px-2 py-0.5 rounded text-xs font-medium ${colors[mode] ?? ''}`}>
-        {mode}
-      </span>
-    );
-  }
-
-  if (loading) return <div className="p-8 text-center">Chargement des Edge nodes...</div>;
+  const stats = [
+    { label: 'Total nodes', value: nodes.length },
+    { label: 'En ligne', value: nodes.filter((n) => n.is_online).length },
+    { label: 'Hors ligne', value: nodes.filter((n) => !n.is_online).length },
+    { label: 'Licences valides', value: nodes.filter((n) => n.license_valid).length },
+  ];
 
   return (
-    <div className="p-6 max-w-6xl mx-auto">
-      {loadError && (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {loadError}
-        </div>
-      )}
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">🐆 Edge Nodes</h1>
-          <p className="text-gray-500 text-sm mt-1">
-            Gérez les nœuds locaux pour le mode offline-first
-          </p>
-        </div>
-        <button
-          onClick={() => setShowAddModal(true)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium"
-        >
-          + Nouveau Node
-        </button>
-      </div>
+    <>
+      <ModulePageShell
+        title="Edge Nodes"
+        subtitle="Gerez les noeuds locaux pour le mode offline-first : etat de connexion, licences et synchronisation."
+        accentClassName="bg-gradient-to-br from-security/10 via-white to-white"
+      >
+        {loadError ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {loadError}
+          </div>
+        ) : null}
 
-      {/* Install command banner */}
-      {installCommand && (
-        <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg">
-          <p className="text-green-800 font-medium text-sm mb-2">
-            ✅ Node créé ! Copie et exécute cette commande sur ton serveur local :
-          </p>
-          <code className="block bg-white p-3 rounded border text-xs font-mono break-all">
-            {installCommand}
-          </code>
+        <div className="flex justify-end">
           <button
-            onClick={() => { navigator.clipboard.writeText(installCommand); }}
-            className="mt-2 text-xs text-green-700 underline"
+            onClick={() => setShowAddModal(true)}
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-brand-700"
           >
-            Copier
+            <Plus className="h-4 w-4" /> Nouveau Node
           </button>
         </div>
-      )}
 
-      {/* Stats */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
-        {[
-          { label: 'Total nodes', value: nodes.length },
-          { label: 'En ligne', value: nodes.filter(n => n.is_online).length },
-          { label: 'Hors ligne', value: nodes.filter(n => !n.is_online).length },
-          { label: 'Licences valides', value: nodes.filter(n => n.license_valid).length },
-        ].map(stat => (
-          <div key={stat.label} className="bg-white rounded-lg border p-4">
-            <p className="text-gray-500 text-xs">{stat.label}</p>
-            <p className="text-2xl font-bold mt-1">{stat.value}</p>
+        {installCommand ? (
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5">
+            <p className="text-sm font-bold text-emerald-900">
+              Node cree ! Copiez et executez cette commande sur votre serveur local :
+            </p>
+            <code className="mt-3 block break-all rounded-xl border border-emerald-200 bg-white p-3 text-xs font-mono text-slate-700">
+              {installCommand}
+            </code>
+            <button
+              onClick={() => { navigator.clipboard.writeText(installCommand); }}
+              className="mt-3 text-xs font-bold uppercase tracking-wider text-emerald-700 underline"
+            >
+              Copier
+            </button>
           </div>
-        ))}
-      </div>
+        ) : null}
 
-      {/* Nodes list */}
-      {nodes.length === 0 ? (
-        <div className="text-center py-16 bg-white rounded-lg border border-dashed">
-          <p className="text-gray-400 text-lg">Aucun Edge node configuré</p>
-          <p className="text-gray-400 text-sm mt-2">
-            Crée un nouveau node pour activer le mode offline-first
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {nodes.map(node => (
-            <div key={node.id} className="bg-white rounded-lg border p-5 flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <div className={`w-3 h-3 rounded-full ${node.is_online ? 'bg-green-500' : 'bg-red-400'}`} />
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold text-gray-900">{node.name}</span>
-                    {modeBadge(node.mode)}
-                    {!node.license_valid && (
-                      <span className="px-2 py-0.5 rounded text-xs bg-red-100 text-red-700">
-                        Licence expirée
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-sm text-gray-500">
-                    {node.site_address ?? 'Adresse non renseignée'} · v{node.edge_version}
-                  </p>
-                  <p className="text-xs text-gray-400 mt-1">
-                    Dernière sync : {node.last_sync_at
-                      ? new Date(node.last_sync_at).toLocaleString('fr-FR')
-                      : 'jamais'
-                    }
-                  </p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                {statusBadge(node)}
-                <button
-                  onClick={() => triggerSync(node.id)}
-                  disabled={syncing === node.id || !node.is_online}
-                  className="px-3 py-1.5 text-sm bg-orange-50 text-orange-700 border border-orange-200 rounded hover:bg-orange-100 disabled:opacity-50"
-                >
-                  {syncing === node.id ? '⏳ Sync...' : '🔄 Sync'}
-                </button>
-              </div>
-            </div>
+        <section className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {stats.map((stat, i) => (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.05 }}
+              className="rounded-2xl border border-app-border bg-white p-5 shadow-sm"
+            >
+              <p className="text-xs font-bold uppercase tracking-widest text-slate-400">{stat.label}</p>
+              <p className="mt-2 text-2xl font-black text-slate-950">{loading ? '...' : stat.value}</p>
+            </motion.div>
           ))}
-        </div>
-      )}
+        </section>
 
-      {/* Add Node Modal */}
-      {showAddModal && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-xl">
-            <h2 className="text-lg font-bold mb-4">Nouveau Edge Node</h2>
+        <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm">
+          <div className="border-b border-app-border px-6 py-4">
+            <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Noeuds configures</h2>
+          </div>
+          {loading ? (
+            <div className="px-6 py-8 text-sm text-slate-500">Chargement des Edge nodes...</div>
+          ) : nodes.length === 0 ? (
+            <div className="px-6 py-10 text-center text-sm text-slate-500">
+              Aucun Edge node configure. Creez un nouveau node pour activer le mode offline-first.
+            </div>
+          ) : (
+            <div className="divide-y divide-app-border">
+              {nodes.map((node) => (
+                <div key={node.id} className="flex flex-col gap-3 px-6 py-5 md:flex-row md:items-center md:justify-between">
+                  <div className="flex items-start gap-4">
+                    <div className={`mt-1 flex h-9 w-9 items-center justify-center rounded-xl ${node.is_online ? 'bg-emerald-50 text-emerald-600' : 'bg-red-50 text-red-500'}`}>
+                      {node.is_online ? <Wifi className="h-4 w-4" /> : <WifiOff className="h-4 w-4" />}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-bold text-slate-950">{node.name}</p>
+                        <span className={`rounded-full px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${MODE_STYLES[node.mode] ?? 'bg-slate-100 text-slate-600'}`}>
+                          {MODE_LABELS[node.mode] ?? node.mode}
+                        </span>
+                        {!node.license_valid ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-red-600">
+                            <ShieldAlert className="h-3 w-3" /> Licence expiree
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="mt-1 text-xs text-slate-500">
+                        {node.site_address ?? 'Adresse non renseignee'} · v{node.edge_version}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        Derniere sync : {node.last_sync_at ? new Date(node.last_sync_at).toLocaleString('fr-FR') : 'jamais'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className={`rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${node.is_online ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-600'}`}>
+                      {node.is_online ? 'En ligne' : 'Hors ligne'}
+                    </span>
+                    <button
+                      onClick={() => triggerSync(node.id)}
+                      disabled={syncing === node.id || !node.is_online}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-app-border bg-white px-3 py-1.5 text-xs font-bold text-slate-700 transition hover:bg-slate-50 disabled:opacity-50"
+                    >
+                      <RefreshCw className={`h-3.5 w-3.5 ${syncing === node.id ? 'animate-spin' : ''}`} />
+                      {syncing === node.id ? 'Sync...' : 'Sync'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </ModulePageShell>
+
+      {showAddModal ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-3xl bg-white p-6 shadow-xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="flex items-center gap-2 text-lg font-black text-slate-950">
+                <Cpu className="h-5 w-5 text-brand-600" /> Nouveau Edge Node
+              </h2>
+              <button onClick={() => setShowAddModal(false)} className="text-slate-400 hover:text-slate-600">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Nom du site</label>
+                <label className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400">Nom du site</label>
                 <input
                   type="text"
-                  placeholder="ex: Entrepôt Nord"
+                  placeholder="ex: Entrepot Nord"
                   value={newNode.name}
-                  onChange={e => setNewNode({ ...newNode, name: e.target.value })}
-                  className="w-full border rounded-lg px-3 py-2 text-sm"
+                  onChange={(e) => setNewNode({ ...newNode, name: e.target.value })}
+                  className="w-full rounded-xl border border-app-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Adresse du site</label>
+                <label className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400">Adresse du site</label>
                 <input
                   type="text"
-                  placeholder="ex: Zone Industrielle, Bâtiment A"
+                  placeholder="ex: Zone Industrielle, Batiment A"
                   value={newNode.site_address}
-                  onChange={e => setNewNode({ ...newNode, site_address: e.target.value })}
-                  className="w-full border rounded-lg px-3 py-2 text-sm"
+                  onChange={(e) => setNewNode({ ...newNode, site_address: e.target.value })}
+                  className="w-full rounded-xl border border-app-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Mode</label>
+                <label className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400">Mode</label>
                 <select
                   value={newNode.mode}
-                  onChange={e => setNewNode({ ...newNode, mode: e.target.value })}
-                  className="w-full border rounded-lg px-3 py-2 text-sm"
+                  onChange={(e) => setNewNode({ ...newNode, mode: e.target.value })}
+                  className="w-full rounded-xl border border-app-border px-3 py-2 text-sm"
                 >
-                  <option value="hybrid">Hybride (recommandé)</option>
+                  <option value="hybrid">Hybride (recommande)</option>
                   <option value="offline">Offline total</option>
                   <option value="cloud">Cloud uniquement</option>
                 </select>
               </div>
             </div>
-            <div className="flex gap-3 mt-5">
+            <div className="mt-5 flex gap-3">
               <button
                 onClick={() => setShowAddModal(false)}
-                className="flex-1 px-4 py-2 border rounded-lg text-sm hover:bg-gray-50"
+                className="flex-1 rounded-xl border border-app-border px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-50"
               >
                 Annuler
               </button>
               <button
                 onClick={addNode}
                 disabled={!newNode.name}
-                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 disabled:opacity-50"
+                className="flex-1 rounded-xl bg-brand-600 px-4 py-2 text-sm font-bold text-white hover:bg-brand-700 disabled:opacity-50"
               >
-                Créer le node
+                Creer le node
               </button>
             </div>
           </div>
         </div>
-      )}
-
-      <style jsx>{`
-        .badge {
-          padding: 2px 8px;
-          border-radius: 9999px;
-          font-size: 11px;
-          font-weight: 500;
-        }
-        .badge-online { background: #dcfce7; color: #166534; }
-        .badge-offline { background: #fee2e2; color: #991b1b; }
-        .badge-local { background: #fef3c7; color: #92400e; }
-      `}</style>
-    </div>
+      ) : null}
+    </>
   );
 }

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -159,22 +159,22 @@ export default function DashboardLayout({
   };
 
   return (
-    <div className="flex min-h-screen bg-slate-50 dark:bg-slate-950 transition-colors duration-500">
+    <div className="flex min-h-screen bg-slate-50">
       {/* Decorative background elements */}
       <div className="fixed inset-0 z-0 overflow-hidden pointer-events-none">
         <div className="absolute -top-[10%] -left-[10%] w-[40%] h-[40%] rounded-full bg-brand-500/5 blur-[120px]" />
         <div className="absolute top-[20%] -right-[5%] w-[30%] h-[30%] rounded-full bg-cyan-500/5 blur-[100px]" />
       </div>
 
-      <aside className="relative z-10 hidden w-64 flex-col border-r border-slate-200/50 bg-white/80 text-slate-900 backdrop-blur-xl dark:border-slate-800/50 dark:bg-slate-900/80 dark:text-white md:flex">
-        <div className="flex h-20 items-center border-b border-slate-200/50 px-6 dark:border-slate-800/50">
+      <aside className="relative z-10 hidden w-64 flex-col border-r border-slate-200/50 bg-white/80 text-slate-900 backdrop-blur-xl md:flex">
+        <div className="flex h-20 items-center border-b border-slate-200/50 px-6">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-cyan-600 shadow-lg shadow-emerald-500/20">
               <span className="text-sm font-black text-white">LRH</span>
             </div>
             <div>
-              <h1 className="text-lg font-black tracking-tight text-slate-950 dark:text-white">Leopardo</h1>
-              <p className="text-[10px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">Manager</p>
+              <h1 className="text-lg font-black tracking-tight text-slate-950">Leopardo</h1>
+              <p className="text-[10px] font-black uppercase tracking-widest text-slate-400">Manager</p>
             </div>
           </div>
         </div>
@@ -202,8 +202,8 @@ export default function DashboardLayout({
           ))}
         </nav>
 
-        <div className="m-3 space-y-3 rounded-2xl border border-brand-500/10 bg-brand-500/5 p-4 dark:border-brand-400/10 dark:bg-brand-400/5">
-          <div className="flex items-center gap-2 text-brand-600 dark:text-brand-400">
+        <div className="m-3 space-y-3 rounded-2xl border border-brand-500/10 bg-brand-500/5 p-4">
+          <div className="flex items-center gap-2 text-brand-600">
             <Sparkles className="h-4 w-4" aria-hidden="true" />
             <span className="text-[10px] font-black uppercase tracking-widest">Plan & Modules</span>
           </div>
@@ -214,8 +214,8 @@ export default function DashboardLayout({
                   <span>{module.label}</span>
                   <span className={`rounded-lg border px-2 py-0.5 text-[9px] font-black uppercase tracking-widest ${
                     module.enabled
-                      ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800/50 dark:bg-emerald-900/30 dark:text-emerald-400'
-                      : 'border-slate-200 bg-slate-100 text-slate-500 dark:border-slate-700/50 dark:bg-slate-800/50 dark:text-slate-500'
+                      ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                      : 'border-slate-200 bg-slate-100 text-slate-500'
                   }`}>
                     {module.enabled ? (module.state === 'trial' ? 'Trial' : 'Actif') : 'Lock'}
                   </span>
@@ -227,7 +227,7 @@ export default function DashboardLayout({
                   <Link
                     key={module.key}
                     href={module.href}
-                    className="flex items-center justify-between gap-2 rounded-lg px-1 py-0.5 text-[11px] font-bold text-slate-600 transition-colors hover:bg-white/60 dark:text-slate-400 dark:hover:bg-slate-800/60"
+                    className="flex items-center justify-between gap-2 rounded-lg px-1 py-0.5 text-[11px] font-bold text-slate-600 transition-colors hover:bg-white/60"
                   >
                     {content}
                   </Link>
@@ -235,7 +235,7 @@ export default function DashboardLayout({
               }
 
               return (
-                <div key={module.key} className="flex items-center justify-between gap-2 text-[11px] font-bold text-slate-600 dark:text-slate-400">
+                <div key={module.key} className="flex items-center justify-between gap-2 text-[11px] font-bold text-slate-600">
                   {content}
                 </div>
               );
@@ -243,18 +243,18 @@ export default function DashboardLayout({
           </div>
         </div>
 
-        <div className="border-t border-slate-200/50 p-4 dark:border-slate-800/50">
-          <div className="flex items-center gap-3 rounded-2xl bg-slate-50 p-3 transition-colors hover:bg-slate-100 dark:bg-slate-800/50 dark:hover:bg-slate-800">
-            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-slate-200 to-slate-300 text-xs font-black text-slate-600 dark:from-slate-700 dark:to-slate-800 dark:text-slate-300">
+        <div className="border-t border-slate-200/50 p-4">
+          <div className="flex items-center gap-3 rounded-2xl bg-slate-50 p-3 transition-colors hover:bg-slate-100">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-slate-200 to-slate-300 text-xs font-black text-slate-600">
               {user?.first_name?.charAt(0)}{user?.last_name?.charAt(0)}
             </div>
             <div className="flex-1 overflow-hidden">
-              <p className="truncate text-xs font-black text-slate-900 dark:text-white">{getDisplayName(user)}</p>
+              <p className="truncate text-xs font-black text-slate-900">{getDisplayName(user)}</p>
               <p className="truncate text-[10px] font-medium text-slate-500">{user?.email}</p>
             </div>
             <button
               onClick={handleLogout}
-              className="group rounded-lg p-2 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
+              className="group rounded-lg p-2 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
               title={labels.dashboard.logout}
             >
               <LockKeyhole className="h-4 w-4 transition-transform group-hover:scale-110" />
@@ -264,13 +264,13 @@ export default function DashboardLayout({
       </aside>
 
       <div className="relative z-10 flex flex-1 flex-col">
-        <header className="sticky top-0 z-40 flex h-20 items-center justify-between border-b border-slate-200/50 bg-white/70 px-8 backdrop-blur-md dark:border-slate-800/50 dark:bg-slate-900/70">
-          <h2 className="text-xl font-black tracking-tight text-slate-950 dark:text-white uppercase">{labels.dashboard.heading}</h2>
+        <header className="sticky top-0 z-40 flex h-20 items-center justify-between border-b border-slate-200/50 bg-white/70 px-8 backdrop-blur-md">
+          <h2 className="text-xl font-black tracking-tight text-slate-950 uppercase">{labels.dashboard.heading}</h2>
           <div className="flex items-center gap-4">
             <div className="relative">
               <button
                 type="button"
-                className="relative flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:border-teal-300 hover:text-teal-700"
+                className="relative flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:border-brand-300 hover:text-brand-700"
                 aria-label="Notifications"
                 aria-expanded={notificationsOpen}
                 onClick={() => setNotificationsOpen((value) => !value)}
@@ -293,12 +293,12 @@ export default function DashboardLayout({
                       <button
                         key={notification.id}
                         type="button"
-                        className="w-full rounded-lg border border-slate-100 bg-slate-50 p-3 text-left transition hover:border-teal-200 hover:bg-teal-50"
+                        className="w-full rounded-lg border border-slate-100 bg-slate-50 p-3 text-left transition hover:border-brand-200 hover:bg-brand-50"
                         onClick={() => void markNotificationRead(notification)}
                       >
                         <div className="flex items-start justify-between gap-2">
                           <p className="text-sm font-bold text-slate-900">{notification.title}</p>
-                          {!notification.is_read ? <span className="mt-1 h-2 w-2 rounded-full bg-teal-500" aria-label="Non lue" /> : null}
+                          {!notification.is_read ? <span className="mt-1 h-2 w-2 rounded-full bg-brand-500" aria-label="Non lue" /> : null}
                         </div>
                         <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-600">{notification.body}</p>
                         <p className="mt-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{notification.type}</p>
@@ -309,7 +309,7 @@ export default function DashboardLayout({
                   </div>
                   <Link
                     href="/settings/notifications"
-                    className="mt-3 flex items-center justify-center rounded-lg border border-slate-200 px-3 py-2 text-xs font-bold text-slate-700 transition hover:border-teal-300 hover:text-teal-700"
+                    className="mt-3 flex items-center justify-center rounded-lg border border-slate-200 px-3 py-2 text-xs font-bold text-slate-700 transition hover:border-brand-300 hover:text-brand-700"
                     onClick={() => setNotificationsOpen(false)}
                   >
                     Gerer mes preferences
@@ -317,7 +317,7 @@ export default function DashboardLayout({
                 </div>
               ) : null}
             </div>
-            <label className="flex items-center gap-2 text-sm text-gray-600">
+            <label className="flex items-center gap-2 text-sm text-slate-600">
               <span>{labels.dashboard.language}</span>
               <select
                 className="rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700"
@@ -330,7 +330,7 @@ export default function DashboardLayout({
                 <option value="en">English</option>
               </select>
             </label>
-            <div className="flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-emerald-600 dark:text-emerald-400">
+            <div className="flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-emerald-600">
               <div className="relative flex h-2 w-2">
                 <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
                 <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500"></span>
@@ -364,8 +364,8 @@ function SidebarLink({ module, active }: { module: ClientModuleAccess; active: b
   const className = [
     'group flex items-center justify-between gap-3 px-4 py-2.5 rounded-xl transition-all duration-200 text-sm font-bold uppercase tracking-tight mx-2',
     active
-      ? 'bg-brand-50 text-brand-700 shadow-glass-sm border border-brand-100 dark:bg-brand-900/20 dark:text-brand-400 dark:border-brand-800/50'
-      : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/50 dark:hover:text-white',
+      ? 'bg-brand-50 text-brand-700 shadow-glass-sm border border-brand-100'
+      : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900',
     module.enabled ? '' : 'opacity-50 cursor-not-allowed',
   ].filter(Boolean).join(' ');
 
@@ -373,14 +373,14 @@ function SidebarLink({ module, active }: { module: ClientModuleAccess; active: b
     <Link href={module.href ?? '#'} className={className} aria-disabled={!module.enabled}>
       <span className="flex items-center gap-3">
         <div className={`h-1.5 w-1.5 rounded-full transition-transform group-hover:scale-150 ${
-          active ? 'bg-brand-500 shadow-[0_0_8px_rgba(20,184,166,0.5)]' : (module.enabled ? 'bg-slate-300 dark:bg-slate-600' : 'bg-slate-200 dark:bg-slate-800')
+          active ? 'bg-brand-500 shadow-[0_0_8px_rgba(20,184,166,0.5)]' : (module.enabled ? 'bg-slate-300' : 'bg-slate-200')
         }`}></div>
         {module.label}
       </span>
       <div className="flex items-center gap-1.5">
         {!module.enabled ? <LockKeyhole className="h-3 w-3 text-slate-400" aria-label="Module non inclus" /> : null}
         {module.enabled && module.state === 'trial' ? (
-          <span className="rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[8px] font-black uppercase tracking-widest text-amber-600 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-400">Trial</span>
+          <span className="rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[8px] font-black uppercase tracking-widest text-amber-600">Trial</span>
         ) : null}
       </div>
     </Link>
@@ -419,11 +419,11 @@ function FeatureLockedPanel({ module }: { module: ClientModuleAccess }) {
           </div>
         </div>
         <div className="rounded-2xl bg-slate-950 p-5 text-white">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-teal-200">Plan & role</p>
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-200">Plan & role</p>
           <p className="mt-3 text-sm leading-6 text-slate-300">
             Les modules visibles dans cet espace sont calcules depuis les droits, le plan de l entreprise et le role utilisateur.
           </p>
-          <Link href="/contact?topic=upgrade" className="mt-5 inline-flex w-full items-center justify-center rounded-xl bg-teal-400 px-4 py-3 text-sm font-bold text-slate-950 transition hover:bg-teal-300">
+          <Link href="/contact?topic=upgrade" className="mt-5 inline-flex w-full items-center justify-center rounded-xl bg-brand-400 px-4 py-3 text-sm font-bold text-slate-950 transition hover:bg-brand-300">
             Demander l activation
           </Link>
         </div>

--- a/front/web/src/app/(dashboard)/partner/page.tsx
+++ b/front/web/src/app/(dashboard)/partner/page.tsx
@@ -119,7 +119,7 @@ export default function PartnerDashboard() {
         <MetricCard label="Conversions" value={data?.stats?.total_conversions || 0} icon={TrendingUp} accent="text-brand-600 bg-brand-50" />
         <MetricCard label="Gains Totaux" value={((data?.stats?.total_earned || 0) / 100).toFixed(2) + ' \u20ac'} icon={Coins} accent="text-emerald-600 bg-emerald-50" />
         <MetricCard label="En attente" value={((data?.stats?.pending_approval || 0) / 100).toFixed(2) + ' \u20ac'} icon={Clock3} accent="text-amber-600 bg-amber-50" />
-        <MetricCard label="Solde Retirable" value={((data?.stats?.approved_upcoming || 0) / 100).toFixed(2) + ' \u20ac'} icon={Wallet} accent="text-blue-600 bg-blue-50" />
+        <MetricCard label="Solde Retirable" value={((data?.stats?.approved_upcoming || 0) / 100).toFixed(2) + ' \u20ac'} icon={Wallet} accent="text-security-dark bg-security-light" />
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/front/web/src/app/(dashboard)/partner/page.tsx
+++ b/front/web/src/app/(dashboard)/partner/page.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { Clock3, Landmark, Link2, TrendingUp, Users, Wallet, Coins } from 'lucide-react';
 
 type Commission = {
   id: string;
@@ -23,11 +25,9 @@ type PartnerData = {
 
 export default function PartnerDashboard() {
   const [data, setData] = useState<PartnerData | null>(null);
-  const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState('loading'); // 'not_applied', 'pending', 'approved', 'loading'
 
   const fetchData = async () => {
-    setLoading(true);
     try {
       const response = await apiFetch('/partner/stats');
       const payload = await response.json();
@@ -43,8 +43,6 @@ export default function PartnerDashboard() {
         // Show not applied instead of hanging forever on error
         setStatus('not_applied');
       }
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -64,32 +62,32 @@ export default function PartnerDashboard() {
     }
   };
 
-  if (status === 'loading') return <div className="p-8 text-center text-slate-500 font-medium">Chargement de votre espace...</div>;
+  if (status === 'loading') return <div className="p-8 text-center text-sm font-medium text-slate-500">Chargement de votre espace...</div>;
 
   if (status === 'not_applied') {
     return (
-      <div className="p-8 max-w-2xl mx-auto">
-        <div className="bg-white dark:bg-slate-800 rounded-3xl p-8 border border-teal-100 dark:border-teal-900/30 shadow-xl shadow-teal-500/5 text-center">
-          <div className="w-20 h-20 bg-teal-100 dark:bg-teal-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
-            <svg className="w-10 h-10 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" /></svg>
+      <div className="mx-auto max-w-2xl">
+        <div className="rounded-3xl border border-brand-100 bg-white p-8 text-center shadow-premium">
+          <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-brand-50">
+            <Users className="h-10 w-10 text-brand-600" aria-hidden="true" />
           </div>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">Devenir Partenaire</h1>
-          <p className="text-slate-600 dark:text-slate-400 mb-8 leading-relaxed">
-            Rejoignez l'écosystème Leopardo RH et gagnez des commissions sur chaque entreprise que vous parrainez.
-            Jusqu'à 20% de commission récurrente.
+          <h1 className="mb-4 text-3xl font-black text-slate-950">Devenir Partenaire</h1>
+          <p className="mb-8 leading-relaxed text-slate-600">
+            Rejoignez l&apos;ecosysteme Leopardo RH et gagnez des commissions sur chaque entreprise que vous parrainez.
+            Jusqu&apos;a 20% de commission recurrente.
           </p>
           <div className="flex flex-col gap-3">
             <button
               onClick={() => handleApply('individual')}
-              className="bg-teal-600 text-white px-8 py-4 rounded-2xl font-bold hover:bg-teal-700 transition-all"
+              className="rounded-2xl bg-brand-600 px-8 py-4 font-bold text-white transition-all hover:bg-brand-700"
             >
-              Postuler en tant qu'Individuel
+              Postuler en tant qu&apos;Individuel
             </button>
             <button
               onClick={() => handleApply('agency')}
-              className="bg-white border border-teal-600 text-teal-600 px-8 py-4 rounded-2xl font-bold hover:bg-teal-50 transition-all"
+              className="rounded-2xl border border-brand-600 px-8 py-4 font-bold text-brand-600 transition-all hover:bg-brand-50"
             >
-              Postuler en tant qu'Agence
+              Postuler en tant qu&apos;Agence
             </button>
           </div>
         </div>
@@ -99,114 +97,117 @@ export default function PartnerDashboard() {
 
   if (status === 'pending') {
     return (
-      <div className="p-8 max-w-2xl mx-auto text-center">
-        <div className="bg-white dark:bg-slate-800 rounded-3xl p-8 border border-amber-100 dark:border-amber-900/30 shadow-sm">
-          <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-             <svg className="w-8 h-8 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 8v4l3 3m6-3a9 9 0 11-12 0 9 9 0 0112 0z" /></svg>
+      <div className="mx-auto max-w-2xl text-center">
+        <div className="rounded-3xl border border-amber-100 bg-white p-8 shadow-sm">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-amber-50">
+            <Clock3 className="h-8 w-8 text-amber-600" aria-hidden="true" />
           </div>
-          <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">Candidature en cours</h2>
-          <p className="text-slate-500">Votre demande est en cours de validation par notre équipe commerciale. Vous recevrez un email dès que votre accès sera activé.</p>
+          <h2 className="mb-2 text-2xl font-black text-slate-950">Candidature en cours</h2>
+          <p className="text-slate-500">Votre demande est en cours de validation par notre equipe commerciale. Vous recevrez un email des que votre acces sera active.</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="p-6 text-slate-900 dark:text-white">
-      <header className="mb-8 flex justify-between items-start">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Dashboard Partenaire</h1>
-          <p className="text-slate-500 mt-2">Suivez vos conversions et vos commissions Leopardo RH.</p>
-        </div>
-        <div className="bg-emerald-500/10 text-emerald-600 px-4 py-2 rounded-xl text-sm font-bold border border-emerald-500/20">
-          Statut: Partenaire Actif
-        </div>
-      </header>
-
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-        <MetricCard label="Conversions" value={data?.stats?.total_conversions || 0} color="text-teal-600" />
-        <MetricCard label="Gains Totaux" value={((data?.stats?.total_earned || 0) / 100).toFixed(2) + ' €'} color="text-emerald-600" />
-        <MetricCard label="En attente" value={((data?.stats?.pending_approval || 0) / 100).toFixed(2) + ' €'} color="text-amber-600" />
-        <MetricCard label="Solde Retirable" value={((data?.stats?.approved_upcoming || 0) / 100).toFixed(2) + ' €'} color="text-blue-600" />
+    <ModulePageShell
+      title="Dashboard Partenaire"
+      subtitle="Suivez vos conversions et vos commissions Leopardo RH — statut partenaire actif."
+      accentClassName="bg-gradient-to-br from-brand-500/10 via-white to-white"
+    >
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <MetricCard label="Conversions" value={data?.stats?.total_conversions || 0} icon={TrendingUp} accent="text-brand-600 bg-brand-50" />
+        <MetricCard label="Gains Totaux" value={((data?.stats?.total_earned || 0) / 100).toFixed(2) + ' \u20ac'} icon={Coins} accent="text-emerald-600 bg-emerald-50" />
+        <MetricCard label="En attente" value={((data?.stats?.pending_approval || 0) / 100).toFixed(2) + ' \u20ac'} icon={Clock3} accent="text-amber-600 bg-amber-50" />
+        <MetricCard label="Solde Retirable" value={((data?.stats?.approved_upcoming || 0) / 100).toFixed(2) + ' \u20ac'} icon={Wallet} accent="text-blue-600 bg-blue-50" />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <div className="lg:col-span-2">
-          <section className="bg-white dark:bg-slate-800 rounded-3xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
-            <div className="p-6 border-b border-slate-200 dark:border-slate-700">
-              <h2 className="text-lg font-semibold tracking-tight">Dernières Commissions</h2>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full text-left">
-                <thead className="bg-slate-50 dark:bg-slate-900/50">
-                  <tr>
-                    <th className="px-6 py-4 text-xs font-semibold text-slate-500 uppercase">Tenant ID</th>
-                    <th className="px-6 py-4 text-xs font-semibold text-slate-500 uppercase">Date</th>
-                    <th className="px-6 py-4 text-xs font-semibold text-slate-500 uppercase">Statut</th>
-                    <th className="px-6 py-4 text-xs font-semibold text-slate-500 uppercase">Montant</th>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm lg:col-span-2">
+          <div className="border-b border-app-border px-6 py-4">
+            <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Dernieres Commissions</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-app-border bg-slate-50/50">
+                  <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Tenant ID</th>
+                  <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Date</th>
+                  <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Statut</th>
+                  <th className="px-6 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Montant</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-app-border">
+                {data?.recent_commissions?.map(comm => (
+                  <tr key={comm.id} className="transition-colors hover:bg-slate-50/60">
+                    <td className="px-6 py-4 font-mono text-sm font-bold text-slate-950">{comm.company_id.substring(0, 8)}...</td>
+                    <td className="px-4 py-4 text-sm text-slate-500">{new Date(comm.created_at).toLocaleDateString()}</td>
+                    <td className="px-4 py-4">
+                      <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${
+                        comm.status === 'paid' ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'
+                      }`}>
+                        {comm.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-right text-sm font-bold text-slate-950">{(comm.amount / 100).toFixed(2)} \u20ac</td>
                   </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
-                  {data?.recent_commissions?.map(comm => (
-                    <tr key={comm.id} className="hover:bg-slate-50 dark:hover:bg-slate-900/30 transition-colors">
-                      <td className="px-6 py-4 text-sm font-medium font-mono">{comm.company_id.substring(0, 8)}...</td>
-                      <td className="px-6 py-4 text-sm text-slate-500">{new Date(comm.created_at).toLocaleDateString()}</td>
-                      <td className="px-6 py-4">
-                        <span className={`px-2.5 py-1 text-xs font-medium rounded-full ${
-                          comm.status === 'paid' ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
-                        }`}>
-                          {comm.status}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 text-sm font-semibold">{(comm.amount / 100).toFixed(2)} €</td>
-                    </tr>
-                  ))}
-                  {(!data?.recent_commissions || data.recent_commissions.length === 0) && (
-                    <tr><td colSpan={4} className="px-6 py-8 text-center text-slate-500 italic">Aucune commission enregistrée.</td></tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </section>
-        </div>
+                ))}
+                {(!data?.recent_commissions || data.recent_commissions.length === 0) && (
+                  <tr><td colSpan={4} className="px-6 py-10 text-center text-sm italic text-slate-500">Aucune commission enregistree.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
         <div className="space-y-6">
-          <section className="bg-white dark:bg-slate-800 p-6 rounded-3xl border border-slate-200 dark:border-slate-700 shadow-sm">
-            <h3 className="text-sm font-bold text-slate-900 dark:text-white uppercase tracking-widest mb-4">Paiement</h3>
+          <section className="rounded-3xl border border-app-border bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100 text-slate-600">
+                <Landmark className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <h3 className="text-xs font-bold uppercase tracking-widest text-slate-800">Paiement</h3>
+            </div>
             <div className="space-y-4">
-              <p className="text-xs text-slate-500 leading-relaxed">
-                Vos commissions sont payées une fois le seuil atteint.
-                Vérifiez que vos coordonnées bancaires sont à jour.
+              <p className="text-xs leading-relaxed text-slate-500">
+                Vos commissions sont payees une fois le seuil atteint.
+                Verifiez que vos coordonnees bancaires sont a jour.
               </p>
               <button
-                onClick={() => alert("Fonctionnalité en cours de déploiement.")}
-                className="w-full py-3 bg-slate-900 dark:bg-white dark:text-slate-900 text-white rounded-xl font-bold text-sm hover:opacity-90 transition-opacity"
+                onClick={() => alert("Fonctionnalite en cours de deploiement.")}
+                className="w-full rounded-xl bg-slate-950 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90"
               >
                 Demander un virement
               </button>
             </div>
           </section>
 
-          <section className="bg-teal-600 p-6 rounded-3xl text-white shadow-lg shadow-teal-500/20">
-            <h3 className="text-sm font-bold uppercase tracking-widest mb-4 opacity-80">Lien de parrainage</h3>
-            <div className="bg-white/10 rounded-xl p-3 mb-4 font-mono text-xs break-all">
+          <section className="rounded-3xl bg-brand-600 p-6 text-white shadow-lg shadow-brand-500/20">
+            <div className="mb-4 flex items-center gap-2 opacity-90">
+              <Link2 className="h-4 w-4" aria-hidden="true" />
+              <h3 className="text-xs font-bold uppercase tracking-widest">Lien de parrainage</h3>
+            </div>
+            <div className="mb-4 break-all rounded-xl bg-white/10 p-3 font-mono text-xs">
               https://leopardo-rh.com/p/DEFAULT
             </div>
-            <button className="w-full py-2 bg-white text-teal-700 rounded-xl font-bold text-sm hover:bg-teal-50 transition-colors">
+            <button className="w-full rounded-xl bg-white py-2 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50">
               Copier mon lien
             </button>
           </section>
         </div>
       </div>
-    </div>
+    </ModulePageShell>
   );
 }
 
-function MetricCard({ label, value, color }: { label: string; value: string | number | undefined; color: string }) {
+function MetricCard({ label, value, icon: Icon, accent }: { label: string; value: string | number | undefined; icon: typeof TrendingUp; accent: string }) {
   return (
-    <div className="bg-white dark:bg-slate-800 p-6 rounded-3xl shadow-sm border border-slate-200 dark:border-slate-700">
-      <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">{label}</h3>
-      <p className={`text-2xl font-black mt-2 ${color}`}>{value ?? '0'}</p>
+    <div className="rounded-2xl border border-app-border bg-white p-5 shadow-sm">
+      <div className={`mb-3 inline-flex h-10 w-10 items-center justify-center rounded-xl ${accent}`}>
+        <Icon className="h-5 w-5" aria-hidden="true" />
+      </div>
+      <p className="text-2xl font-black text-slate-950">{value ?? '0'}</p>
+      <p className="text-xs font-bold uppercase tracking-widest text-slate-400">{label}</p>
     </div>
   );
 }

--- a/front/web/src/app/(dashboard)/payroll/page.tsx
+++ b/front/web/src/app/(dashboard)/payroll/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 import {
   DollarSign,
   Download,
@@ -89,44 +90,53 @@ export default function PayrollPage() {
     }
   };
 
-  return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Paie</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400">Gestion des bulletins de paie et cycles de paie</p>
-        </div>
-      </div>
+  const statCards = [
+    { label: 'Total Brut', value: formatCurrency(runs.reduce((s, r) => s + (r.total_gross || 0), 0)), icon: DollarSign, accent: 'text-emerald-600 bg-emerald-50' },
+    { label: 'Total Net', value: formatCurrency(runs.reduce((s, r) => s + (r.total_net || 0), 0)), icon: FileText, accent: 'text-blue-600 bg-blue-50' },
+    { label: 'Bulletins', value: String(payslips.length), icon: Calendar, accent: 'text-violet-600 bg-violet-50' },
+  ];
 
-      {/* Stats */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        {[
-          { label: 'Total Brut', value: formatCurrency(runs.reduce((s, r) => s + (r.total_gross || 0), 0)), icon: DollarSign, color: 'text-emerald-600' },
-          { label: 'Total Net', value: formatCurrency(runs.reduce((s, r) => s + (r.total_net || 0), 0)), icon: FileText, color: 'text-blue-600' },
-          { label: 'Bulletins', value: String(payslips.length), icon: Calendar, color: 'text-purple-600' },
-        ].map((stat, i) => (
+  return (
+    <ModulePageShell
+      title="Paie"
+      subtitle="Bulletins de paie et cycles de paie, avec export PDF direct, connecte a l'API RH pour chaque tenant."
+      accentClassName="bg-gradient-to-br from-finance-light via-white to-white"
+    >
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {statCards.map((stat, i) => (
           <motion.div
-            key={i}
+            key={stat.label}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: i * 0.05 }}
-            className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+            className="rounded-2xl border border-app-border bg-white p-5 shadow-sm"
           >
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">{stat.label}</p>
-                <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-white">{stat.value}</p>
+                <p className="text-xs font-bold uppercase tracking-widest text-slate-400">{stat.label}</p>
+                <p className="mt-2 text-2xl font-black text-slate-950">{stat.value}</p>
               </div>
-              <stat.icon className={`h-8 w-8 ${stat.color} opacity-60`} />
+              <div className={`flex h-11 w-11 items-center justify-center rounded-xl ${stat.accent}`}>
+                <stat.icon className="h-5 w-5" />
+              </div>
             </div>
           </motion.div>
         ))}
-      </div>
+      </section>
 
-      {/* Tabs */}
-      <div className="flex gap-2 border-b border-slate-200 dark:border-slate-700">
-        <button onClick={() => setTab('slips')} className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${tab === 'slips' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-slate-500 hover:text-slate-700'}`}>Bulletins de paie</button>
-        <button onClick={() => setTab('runs')} className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${tab === 'runs' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-slate-500 hover:text-slate-700'}`}>Cycles de paie</button>
+      <div className="flex gap-2 border-b border-app-border">
+        <button
+          onClick={() => setTab('slips')}
+          className={`px-4 py-2.5 text-sm font-bold uppercase tracking-wide border-b-2 transition-colors ${tab === 'slips' ? 'border-brand-500 text-brand-700' : 'border-transparent text-slate-500 hover:text-slate-700'}`}
+        >
+          Bulletins de paie
+        </button>
+        <button
+          onClick={() => setTab('runs')}
+          className={`px-4 py-2.5 text-sm font-bold uppercase tracking-wide border-b-2 transition-colors ${tab === 'runs' ? 'border-brand-500 text-brand-700' : 'border-transparent text-slate-500 hover:text-slate-700'}`}
+        >
+          Cycles de paie
+        </button>
       </div>
 
       {tab === 'slips' && (
@@ -138,43 +148,43 @@ export default function PayrollPage() {
               placeholder="Rechercher par nom ou periode..."
               value={search}
               onChange={e => { setSearch(e.target.value); setCurrentPage(1); }}
-              className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 pl-10 pr-4 py-2.5 text-sm text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500"
+              className="w-full rounded-xl border border-app-border bg-white pl-10 pr-4 py-2.5 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
 
-          <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
+          <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
-                    <th className="px-4 py-3 text-left font-medium text-slate-500">Employe</th>
-                    <th className="px-4 py-3 text-left font-medium text-slate-500">Periode</th>
-                    <th className="px-4 py-3 text-right font-medium text-slate-500">Brut</th>
-                    <th className="px-4 py-3 text-right font-medium text-slate-500">Net</th>
-                    <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
-                    <th className="px-4 py-3 text-center font-medium text-slate-500">Actions</th>
+                  <tr className="border-b border-app-border bg-slate-50/50">
+                    <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Employe</th>
+                    <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Periode</th>
+                    <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Brut</th>
+                    <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Net</th>
+                    <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-slate-500">Statut</th>
+                    <th className="px-6 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Actions</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody className="divide-y divide-app-border">
                   {loading ? (
-                    <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Chargement...</td></tr>
+                    <tr><td colSpan={6} className="px-6 py-10 text-center text-sm text-slate-500">Chargement...</td></tr>
                   ) : paginated.length === 0 ? (
-                    <tr><td colSpan={6} className="px-4 py-12 text-center text-slate-400">Aucun bulletin trouve</td></tr>
+                    <tr><td colSpan={6} className="px-6 py-10 text-center text-sm text-slate-500">Aucun bulletin trouve.</td></tr>
                   ) : paginated.map(slip => (
-                    <tr key={slip.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                      <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{slip.employee_name}</td>
-                      <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{slip.period}</td>
-                      <td className="px-4 py-3 text-right text-slate-900 dark:text-white tabular-nums">{formatCurrency(slip.gross_salary)}</td>
-                      <td className="px-4 py-3 text-right font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums">{formatCurrency(slip.net_salary)}</td>
-                      <td className="px-4 py-3 text-center">
-                        <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${slip.status === 'validated' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'}`}>
+                    <tr key={slip.id} className="transition-colors hover:bg-slate-50/60">
+                      <td className="px-6 py-4 font-bold text-slate-950">{slip.employee_name}</td>
+                      <td className="px-4 py-4 text-slate-600">{slip.period}</td>
+                      <td className="px-4 py-4 text-right tabular-nums text-slate-900">{formatCurrency(slip.gross_salary)}</td>
+                      <td className="px-4 py-4 text-right tabular-nums font-bold text-emerald-600">{formatCurrency(slip.net_salary)}</td>
+                      <td className="px-4 py-4 text-center">
+                        <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${slip.status === 'validated' ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'}`}>
                           {slip.status === 'validated' ? 'Valide' : 'Brouillon'}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-center">
-                        <div className="flex items-center justify-center gap-1">
-                          <button onClick={() => downloadPdf(slip.id)} className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-emerald-600" title="Telecharger PDF"><Download className="h-4 w-4" /></button>
-                          <button className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-blue-600" title="Voir detail"><Eye className="h-4 w-4" /></button>
+                      <td className="px-6 py-4 text-right">
+                        <div className="flex items-center justify-end gap-1">
+                          <button onClick={() => downloadPdf(slip.id)} className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-brand-600" title="Telecharger PDF"><Download className="h-4 w-4" /></button>
+                          <button className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-blue-600" title="Voir detail"><Eye className="h-4 w-4" /></button>
                         </div>
                       </td>
                     </tr>
@@ -183,45 +193,45 @@ export default function PayrollPage() {
               </table>
             </div>
             {totalPages > 1 && (
-              <div className="flex items-center justify-between border-t border-slate-200 dark:border-slate-700 px-4 py-3">
-                <p className="text-xs text-slate-500">{filtered.length} resultats</p>
+              <div className="flex items-center justify-between border-t border-app-border px-6 py-3">
+                <p className="text-xs font-medium text-slate-500">{filtered.length} resultats</p>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1} className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-30"><ChevronLeft className="h-4 w-4" /></button>
-                  <span className="px-2 text-sm text-slate-600 dark:text-slate-400">{currentPage}/{totalPages}</span>
-                  <button onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages} className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-30"><ChevronRight className="h-4 w-4" /></button>
+                  <button onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1} className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 disabled:opacity-30"><ChevronLeft className="h-4 w-4" /></button>
+                  <span className="px-2 text-sm font-medium text-slate-600">{currentPage}/{totalPages}</span>
+                  <button onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages} className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 disabled:opacity-30"><ChevronRight className="h-4 w-4" /></button>
                 </div>
               </div>
             )}
-          </div>
+          </section>
         </>
       )}
 
       {tab === 'runs' && (
-        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden">
+        <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
-                  <th className="px-4 py-3 text-left font-medium text-slate-500">Periode</th>
-                  <th className="px-4 py-3 text-right font-medium text-slate-500">Employes</th>
-                  <th className="px-4 py-3 text-right font-medium text-slate-500">Total Brut</th>
-                  <th className="px-4 py-3 text-right font-medium text-slate-500">Total Net</th>
-                  <th className="px-4 py-3 text-center font-medium text-slate-500">Statut</th>
+                <tr className="border-b border-app-border bg-slate-50/50">
+                  <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-500">Periode</th>
+                  <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Employes</th>
+                  <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Total Brut</th>
+                  <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-slate-500">Total Net</th>
+                  <th className="px-6 py-3 text-center text-xs font-bold uppercase tracking-wider text-slate-500">Statut</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="divide-y divide-app-border">
                 {loading ? (
-                  <tr><td colSpan={5} className="px-4 py-12 text-center text-slate-400">Chargement...</td></tr>
+                  <tr><td colSpan={5} className="px-6 py-10 text-center text-sm text-slate-500">Chargement...</td></tr>
                 ) : runs.length === 0 ? (
-                  <tr><td colSpan={5} className="px-4 py-12 text-center text-slate-400">Aucun cycle de paie</td></tr>
+                  <tr><td colSpan={5} className="px-6 py-10 text-center text-sm text-slate-500">Aucun cycle de paie.</td></tr>
                 ) : runs.map(run => (
-                  <tr key={run.id} className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                    <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{run.period}</td>
-                    <td className="px-4 py-3 text-right text-slate-600 dark:text-slate-400">{run.employee_count}</td>
-                    <td className="px-4 py-3 text-right text-slate-900 dark:text-white tabular-nums">{formatCurrency(run.total_gross)}</td>
-                    <td className="px-4 py-3 text-right font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums">{formatCurrency(run.total_net)}</td>
-                    <td className="px-4 py-3 text-center">
-                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${run.status === 'completed' ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'}`}>
+                  <tr key={run.id} className="transition-colors hover:bg-slate-50/60">
+                    <td className="px-6 py-4 font-bold text-slate-950">{run.period}</td>
+                    <td className="px-4 py-4 text-right text-slate-600">{run.employee_count}</td>
+                    <td className="px-4 py-4 text-right tabular-nums text-slate-900">{formatCurrency(run.total_gross)}</td>
+                    <td className="px-4 py-4 text-right tabular-nums font-bold text-emerald-600">{formatCurrency(run.total_net)}</td>
+                    <td className="px-6 py-4 text-center">
+                      <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${run.status === 'completed' ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'}`}>
                         {run.status === 'completed' ? 'Termine' : run.status}
                       </span>
                     </td>
@@ -230,8 +240,8 @@ export default function PayrollPage() {
               </tbody>
             </table>
           </div>
-        </div>
+        </section>
       )}
-    </div>
+    </ModulePageShell>
   );
 }

--- a/front/web/src/app/(dashboard)/payroll/page.tsx
+++ b/front/web/src/app/(dashboard)/payroll/page.tsx
@@ -92,8 +92,8 @@ export default function PayrollPage() {
 
   const statCards = [
     { label: 'Total Brut', value: formatCurrency(runs.reduce((s, r) => s + (r.total_gross || 0), 0)), icon: DollarSign, accent: 'text-emerald-600 bg-emerald-50' },
-    { label: 'Total Net', value: formatCurrency(runs.reduce((s, r) => s + (r.total_net || 0), 0)), icon: FileText, accent: 'text-blue-600 bg-blue-50' },
-    { label: 'Bulletins', value: String(payslips.length), icon: Calendar, accent: 'text-violet-600 bg-violet-50' },
+    { label: 'Total Net', value: formatCurrency(runs.reduce((s, r) => s + (r.total_net || 0), 0)), icon: FileText, accent: 'text-finance-dark bg-finance-light' },
+    { label: 'Bulletins', value: String(payslips.length), icon: Calendar, accent: 'text-ia-dark bg-ia-light' },
   ];
 
   return (
@@ -184,7 +184,7 @@ export default function PayrollPage() {
                       <td className="px-6 py-4 text-right">
                         <div className="flex items-center justify-end gap-1">
                           <button onClick={() => downloadPdf(slip.id)} className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-brand-600" title="Telecharger PDF"><Download className="h-4 w-4" /></button>
-                          <button className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-blue-600" title="Voir detail"><Eye className="h-4 w-4" /></button>
+                          <button className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-brand-600" title="Voir detail"><Eye className="h-4 w-4" /></button>
                         </div>
                       </td>
                     </tr>

--- a/front/web/src/app/(dashboard)/reports/page.tsx
+++ b/front/web/src/app/(dashboard)/reports/page.tsx
@@ -31,7 +31,7 @@ const reports: ReportConfig[] = [
     title: 'Resume Presences',
     description: 'Rapport mensuel des presences, retards et absences par employe.',
     icon: Clock,
-    color: 'text-blue-600 bg-blue-50',
+    color: 'text-security-dark bg-security-light',
     endpoint: '/reports/attendance-summary',
     params: [
       { key: 'month', label: 'Mois', type: 'month' },
@@ -53,7 +53,7 @@ const reports: ReportConfig[] = [
     title: 'Soldes Conges',
     description: 'Etat des soldes de conges pour tous les employes.',
     icon: Calendar,
-    color: 'text-violet-600 bg-violet-50',
+    color: 'text-ia-dark bg-ia-light',
     endpoint: '/reports/leave-balances',
     params: [
       { key: 'year', label: 'Annee', type: 'number' },
@@ -76,7 +76,7 @@ const reports: ReportConfig[] = [
     title: 'Suivi Formations',
     description: 'Taux de participation et completion des formations.',
     icon: TrendingUp,
-    color: 'text-cyan-600 bg-cyan-50',
+    color: 'text-brand-600 bg-brand-50',
     endpoint: '/reports/training-progress',
     params: [
       { key: 'year', label: 'Annee', type: 'number' },
@@ -134,7 +134,7 @@ export default function ReportsPage() {
     <ModulePageShell
       title="Rapports"
       subtitle="Generez et telechargez vos rapports RH : presences, paie, conges, effectifs, formations et contrats."
-      accentClassName="bg-gradient-to-br from-violet-500/10 via-white to-white"
+      accentClassName="bg-gradient-to-br from-ia/10 via-white to-white"
     >
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {reports.map((report, i) => (

--- a/front/web/src/app/(dashboard)/reports/page.tsx
+++ b/front/web/src/app/(dashboard)/reports/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 import {
   BarChart3,
   Download,
@@ -30,7 +31,7 @@ const reports: ReportConfig[] = [
     title: 'Resume Presences',
     description: 'Rapport mensuel des presences, retards et absences par employe.',
     icon: Clock,
-    color: 'text-blue-600',
+    color: 'text-blue-600 bg-blue-50',
     endpoint: '/reports/attendance-summary',
     params: [
       { key: 'month', label: 'Mois', type: 'month' },
@@ -41,7 +42,7 @@ const reports: ReportConfig[] = [
     title: 'Resume Paie',
     description: 'Total brut/net, cotisations et charges par periode de paie.',
     icon: DollarSign,
-    color: 'text-emerald-600',
+    color: 'text-emerald-600 bg-emerald-50',
     endpoint: '/reports/payroll-summary',
     params: [
       { key: 'period', label: 'Periode', type: 'month' },
@@ -52,7 +53,7 @@ const reports: ReportConfig[] = [
     title: 'Soldes Conges',
     description: 'Etat des soldes de conges pour tous les employes.',
     icon: Calendar,
-    color: 'text-purple-600',
+    color: 'text-violet-600 bg-violet-50',
     endpoint: '/reports/leave-balances',
     params: [
       { key: 'year', label: 'Annee', type: 'number' },
@@ -63,7 +64,7 @@ const reports: ReportConfig[] = [
     title: 'Effectifs',
     description: 'Evolution des effectifs, entrees et sorties par periode.',
     icon: Users,
-    color: 'text-amber-600',
+    color: 'text-amber-600 bg-amber-50',
     endpoint: '/reports/headcount',
     params: [
       { key: 'from', label: 'Du', type: 'date' },
@@ -75,7 +76,7 @@ const reports: ReportConfig[] = [
     title: 'Suivi Formations',
     description: 'Taux de participation et completion des formations.',
     icon: TrendingUp,
-    color: 'text-cyan-600',
+    color: 'text-cyan-600 bg-cyan-50',
     endpoint: '/reports/training-progress',
     params: [
       { key: 'year', label: 'Annee', type: 'number' },
@@ -86,7 +87,7 @@ const reports: ReportConfig[] = [
     title: 'Echeances Contrats',
     description: 'Contrats arrivant a echeance dans les 30, 60, 90 prochains jours.',
     icon: FileText,
-    color: 'text-red-500',
+    color: 'text-red-500 bg-red-50',
     endpoint: '/reports/contract-expiry',
     params: [
       { key: 'days', label: 'Jours', type: 'number' },
@@ -130,12 +131,11 @@ export default function ReportsPage() {
   }, [params]);
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Rapports</h1>
-        <p className="text-sm text-slate-500 dark:text-slate-400">Generez et telechargez vos rapports RH</p>
-      </div>
-
+    <ModulePageShell
+      title="Rapports"
+      subtitle="Generez et telechargez vos rapports RH : presences, paie, conges, effectifs, formations et contrats."
+      accentClassName="bg-gradient-to-br from-violet-500/10 via-white to-white"
+    >
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {reports.map((report, i) => (
           <motion.div
@@ -143,27 +143,27 @@ export default function ReportsPage() {
             initial={{ opacity: 0, y: 15 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: i * 0.05 }}
-            className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5 flex flex-col"
+            className="flex flex-col rounded-2xl border border-app-border bg-white p-5 shadow-sm"
           >
-            <div className="flex items-start gap-3 mb-3">
-              <div className={`rounded-lg p-2 bg-slate-50 dark:bg-slate-700`}>
-                <report.icon className={`h-5 w-5 ${report.color}`} />
+            <div className="mb-3 flex items-start gap-3">
+              <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${report.color}`}>
+                <report.icon className="h-5 w-5" />
               </div>
               <div className="flex-1">
-                <h3 className="font-bold text-slate-900 dark:text-white text-sm">{report.title}</h3>
-                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{report.description}</p>
+                <h3 className="text-sm font-bold text-slate-950">{report.title}</h3>
+                <p className="mt-0.5 text-xs text-slate-500">{report.description}</p>
               </div>
             </div>
 
-            <div className="space-y-2 mb-4 flex-1">
+            <div className="mb-4 flex-1 space-y-2">
               {report.params.map(p => (
                 <div key={p.key}>
-                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">{p.label}</label>
+                  <label className="mb-1 block text-[11px] font-bold uppercase tracking-wider text-slate-400">{p.label}</label>
                   <input
                     type={p.type}
                     value={params[report.id]?.[p.key] || ''}
                     onChange={e => updateParam(report.id, p.key, e.target.value)}
-                    className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500"
+                    className="w-full rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
               ))}
@@ -172,7 +172,7 @@ export default function ReportsPage() {
             <button
               onClick={() => generateReport(report)}
               disabled={generating === report.id}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold transition-colors disabled:opacity-50"
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-brand-700 disabled:opacity-50"
             >
               {generating === report.id ? (
                 <>
@@ -188,13 +188,13 @@ export default function ReportsPage() {
             </button>
 
             {results[report.id] && (
-              <p className={`text-xs mt-2 ${results[report.id].includes('Erreur') ? 'text-red-500' : 'text-emerald-600'}`}>
+              <p className={`mt-2 text-xs font-medium ${results[report.id].includes('Erreur') ? 'text-red-500' : 'text-emerald-600'}`}>
                 {results[report.id]}
               </p>
             )}
           </motion.div>
         ))}
       </div>
-    </div>
+    </ModulePageShell>
   );
 }

--- a/front/web/src/app/(dashboard)/settings/developer/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/developer/page.tsx
@@ -5,6 +5,7 @@ import { Key, Webhook, FileText, Plus, Trash2, Copy, Check, X, Loader2 } from 'l
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ApiError, apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 
 type ApiToken = {
   id: number | string;
@@ -167,181 +168,182 @@ export default function DeveloperSettingsPage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900">Espace Développeur</h1>
-        <p className="text-slate-500">Gérez vos clés API et vos webhooks pour intégrer Leopardo RH à vos outils.</p>
-      </div>
+    <>
+      <ModulePageShell
+        title="Espace Developpeur"
+        subtitle="Gerez vos cles API et vos webhooks pour integrer Leopardo RH a vos outils."
+        accentClassName="bg-gradient-to-br from-security/10 via-white to-white"
+      >
+        {error ? (
+          <div className="flex items-center justify-between rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <span>{error}</span>
+            <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600"><X className="h-4 w-4" /></button>
+          </div>
+        ) : null}
 
-      {error ? (
-        <div className="flex items-center justify-between rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          <span>{error}</span>
-          <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600"><X className="h-4 w-4" /></button>
-        </div>
-      ) : null}
-
-      {revealedToken ? (
-        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
-          <p className="text-sm font-bold text-amber-900">
-            Cle "{revealedToken.name}" creee — copiez-la maintenant, elle ne sera plus jamais affichee :
-          </p>
-          <div className="mt-2 flex items-center gap-2">
-            <code className="flex-1 rounded-lg border border-amber-200 bg-white px-3 py-2 text-xs font-mono break-all">
-              {revealedToken.token}
-            </code>
-            <button
-              onClick={() => handleCopy(revealedToken.token, 'revealed_token')}
-              className="rounded-lg border border-amber-300 bg-white p-2 text-amber-700 hover:bg-amber-100"
-            >
-              {copiedKey === 'revealed_token' ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+        {revealedToken ? (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
+            <p className="text-sm font-bold text-amber-900">
+              Cle &quot;{revealedToken.name}&quot; creee — copiez-la maintenant, elle ne sera plus jamais affichee :
+            </p>
+            <div className="mt-2 flex items-center gap-2">
+              <code className="flex-1 break-all rounded-xl border border-amber-200 bg-white px-3 py-2 text-xs font-mono">
+                {revealedToken.token}
+              </code>
+              <button
+                onClick={() => handleCopy(revealedToken.token, 'revealed_token')}
+                className="rounded-xl border border-amber-300 bg-white p-2 text-amber-700 hover:bg-amber-100"
+              >
+                {copiedKey === 'revealed_token' ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+              </button>
+            </div>
+            <button onClick={() => setRevealedToken(null)} className="mt-2 text-xs font-bold uppercase tracking-wider text-amber-700 underline">
+              J&apos;ai copie la cle, masquer
             </button>
           </div>
-          <button onClick={() => setRevealedToken(null)} className="mt-2 text-xs font-medium text-amber-700 underline">
-            J&apos;ai copie la cle, masquer
-          </button>
-        </div>
-      ) : null}
+        ) : null}
 
-      <div className="grid gap-6 md:grid-cols-2">
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex items-center gap-3 border-b border-slate-100 pb-4">
-            <div className="rounded-xl bg-blue-50 p-2 text-blue-600">
-              <Key className="h-5 w-5" />
+        <div className="grid gap-6 md:grid-cols-2">
+          <section className="rounded-2xl border border-app-border bg-white p-6 shadow-sm">
+            <div className="flex items-center gap-3 border-b border-app-border pb-4">
+              <div className="rounded-xl bg-brand-50 p-2 text-brand-600">
+                <Key className="h-5 w-5" />
+              </div>
+              <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Cles API</h2>
             </div>
-            <h2 className="text-lg font-semibold text-slate-900">Clés API</h2>
-          </div>
 
-          <div className="mt-4 space-y-3">
-            {tokensLoading ? (
-              <p className="text-sm text-slate-400">Chargement...</p>
-            ) : tokens.length === 0 ? (
-              <p className="text-sm text-slate-400">Aucune cle API creee pour le moment.</p>
-            ) : (
-              tokens.map((token) => (
-                <div key={token.id} className="flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 p-4">
-                  <div>
-                    <p className="font-medium text-slate-900">{token.name}</p>
-                    <p className="text-xs text-slate-500">
-                      {token.created_at ? `Creee le ${new Date(token.created_at).toLocaleDateString('fr-FR')}` : 'Date inconnue'}
-                      {token.last_used_at ? ` · derniere utilisation le ${new Date(token.last_used_at).toLocaleDateString('fr-FR')}` : ' · jamais utilisee'}
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => handleDeleteToken(token.id)}
-                    className="rounded-lg p-2 text-red-400 hover:bg-red-50 hover:text-red-600"
-                    title="Revoquer"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
-                </div>
-              ))
-            )}
-          </div>
-
-          <div className="mt-4 flex gap-2">
-            <input
-              type="text"
-              placeholder="Nom de la cle (ex: Production)"
-              value={newTokenName}
-              onChange={(e) => setNewTokenName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') void handleCreateToken(); }}
-              className="flex-1 rounded-xl border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <button
-              onClick={handleCreateToken}
-              disabled={!newTokenName.trim() || creatingToken}
-              className="flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 disabled:opacity-50"
-            >
-              {creatingToken ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-            </button>
-          </div>
-        </div>
-
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex items-center gap-3 border-b border-slate-100 pb-4">
-            <div className="rounded-xl bg-purple-50 p-2 text-purple-600">
-              <Webhook className="h-5 w-5" />
-            </div>
-            <h2 className="text-lg font-semibold text-slate-900">Webhooks</h2>
-          </div>
-
-          <div className="mt-4 space-y-3">
-            {webhooksLoading ? (
-              <p className="text-sm text-slate-400">Chargement...</p>
-            ) : webhooks.length === 0 ? (
-              <p className="text-sm text-slate-400">Aucun endpoint webhook configure.</p>
-            ) : (
-              webhooks.map((webhook) => (
-                <div key={webhook.id} className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate font-medium text-slate-900">{webhook.url}</p>
-                      <p className="mt-0.5 text-xs text-slate-500">
-                        {webhook.events.length} evenement(s) · {webhook.failure_count ? `${webhook.failure_count} echec(s)` : 'aucun echec'}
+            <div className="mt-4 space-y-3">
+              {tokensLoading ? (
+                <p className="text-sm text-slate-400">Chargement...</p>
+              ) : tokens.length === 0 ? (
+                <p className="text-sm text-slate-400">Aucune cle API creee pour le moment.</p>
+              ) : (
+                tokens.map((token) => (
+                  <div key={token.id} className="flex items-center justify-between rounded-xl border border-app-border bg-slate-50 p-4">
+                    <div>
+                      <p className="font-bold text-slate-950">{token.name}</p>
+                      <p className="text-xs text-slate-500">
+                        {token.created_at ? `Creee le ${new Date(token.created_at).toLocaleDateString('fr-FR')}` : 'Date inconnue'}
+                        {token.last_used_at ? ` · derniere utilisation le ${new Date(token.last_used_at).toLocaleDateString('fr-FR')}` : ' · jamais utilisee'}
                       </p>
                     </div>
                     <button
-                      onClick={() => handleToggleWebhookActive(webhook)}
-                      className={`shrink-0 rounded-full px-2 py-1 text-xs font-medium ${
-                        webhook.active ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600'
-                      }`}
+                      onClick={() => handleDeleteToken(token.id)}
+                      className="rounded-lg p-2 text-red-400 hover:bg-red-50 hover:text-red-600"
+                      title="Revoquer"
                     >
-                      {webhook.active ? 'Actif' : 'Inactif'}
+                      <Trash2 className="h-4 w-4" />
                     </button>
                   </div>
-                  <div className="mt-2 flex flex-wrap gap-1">
-                    {webhook.events.map((event) => (
-                      <span key={event} className="rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-slate-600 border border-slate-200">
-                        {event}
+                ))
+              )}
+            </div>
+
+            <div className="mt-4 flex gap-2">
+              <input
+                type="text"
+                placeholder="Nom de la cle (ex: Production)"
+                value={newTokenName}
+                onChange={(e) => setNewTokenName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') void handleCreateToken(); }}
+                className="flex-1 rounded-xl border border-app-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              />
+              <button
+                onClick={handleCreateToken}
+                disabled={!newTokenName.trim() || creatingToken}
+                className="flex items-center gap-2 rounded-xl bg-slate-950 px-4 py-2 text-sm font-bold text-white hover:bg-slate-800 disabled:opacity-50"
+              >
+                {creatingToken ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              </button>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-app-border bg-white p-6 shadow-sm">
+            <div className="flex items-center gap-3 border-b border-app-border pb-4">
+              <div className="rounded-xl bg-ia-light p-2 text-ia">
+                <Webhook className="h-5 w-5" />
+              </div>
+              <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Webhooks</h2>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {webhooksLoading ? (
+                <p className="text-sm text-slate-400">Chargement...</p>
+              ) : webhooks.length === 0 ? (
+                <p className="text-sm text-slate-400">Aucun endpoint webhook configure.</p>
+              ) : (
+                webhooks.map((webhook) => (
+                  <div key={webhook.id} className="rounded-xl border border-app-border bg-slate-50 p-4">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-bold text-slate-950">{webhook.url}</p>
+                        <p className="mt-0.5 text-xs text-slate-500">
+                          {webhook.events.length} evenement(s) · {webhook.failure_count ? `${webhook.failure_count} echec(s)` : 'aucun echec'}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => handleToggleWebhookActive(webhook)}
+                        className={`shrink-0 rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${
+                          webhook.active ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-200 text-slate-600'
+                        }`}
+                      >
+                        {webhook.active ? 'Actif' : 'Inactif'}
+                      </button>
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {webhook.events.map((event) => (
+                        <span key={event} className="rounded-full border border-app-border bg-white px-2 py-0.5 text-[10px] font-medium text-slate-600">
+                          {event}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="mt-3 flex items-center justify-between border-t border-app-border pt-3">
+                      <span className="text-xs text-slate-500">
+                        {webhook.last_triggered_at ? `Declenche le ${new Date(webhook.last_triggered_at).toLocaleString('fr-FR')}` : 'Jamais declenche'}
                       </span>
-                    ))}
+                      <button
+                        onClick={() => handleDeleteWebhook(webhook.id)}
+                        className="flex items-center gap-1 text-xs font-bold text-red-500 hover:underline"
+                      >
+                        <Trash2 className="h-3 w-3" /> Supprimer
+                      </button>
+                    </div>
                   </div>
-                  <div className="mt-3 flex items-center justify-between border-t border-slate-200 pt-3">
-                    <span className="text-xs text-slate-500">
-                      {webhook.last_triggered_at ? `Declenche le ${new Date(webhook.last_triggered_at).toLocaleString('fr-FR')}` : 'Jamais declenche'}
-                    </span>
-                    <button
-                      onClick={() => handleDeleteWebhook(webhook.id)}
-                      className="flex items-center gap-1 text-xs font-medium text-red-500 hover:underline"
-                    >
-                      <Trash2 className="h-3 w-3" /> Supprimer
-                    </button>
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
+                ))
+              )}
+            </div>
 
-          <button
-            onClick={() => setShowWebhookModal(true)}
-            className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 py-3 text-sm font-medium text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-          >
-            <Plus className="h-4 w-4" /> Ajouter un endpoint
-          </button>
+            <button
+              onClick={() => setShowWebhookModal(true)}
+              className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-app-border py-3 text-sm font-bold text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+            >
+              <Plus className="h-4 w-4" /> Ajouter un endpoint
+            </button>
+          </section>
         </div>
-      </div>
 
-      <div className="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-900 to-slate-800 p-6 text-white shadow-sm">
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-bold">Documentation API</h2>
-            <p className="mt-1 text-sm text-slate-400">
-              Découvrez comment intégrer nos webhooks signés (format Svix) et nos endpoints REST.
-            </p>
+        <section className="rounded-2xl border border-app-border bg-gradient-to-br from-slate-900 to-slate-800 p-6 text-white shadow-sm">
+          <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+            <div>
+              <h2 className="text-lg font-black">Documentation API</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Decouvrez comment integrer nos webhooks signes (format Svix) et nos endpoints REST.
+              </p>
+            </div>
+            <Link
+              href={process.env.NEXT_PUBLIC_API_URL?.replace('/api/v1', '/api-explorer') ?? '/api-explorer'}
+              target="_blank"
+              className="inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 text-sm font-bold text-slate-900 transition hover:bg-slate-100"
+            >
+              <FileText className="h-4 w-4" />
+              Ouvrir l&apos;Explorer
+            </Link>
           </div>
-          <Link
-            href={process.env.NEXT_PUBLIC_API_URL?.replace('/api/v1', '/api-explorer') ?? '/api-explorer'}
-            target="_blank"
-            className="inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 text-sm font-bold text-slate-900 transition hover:bg-slate-100"
-          >
-            <FileText className="h-4 w-4" />
-            Ouvrir l'Explorer
-          </Link>
-        </div>
-      </div>
+        </section>
+      </ModulePageShell>
 
       <AnimatePresence>
-        {showWebhookModal && (
+        {showWebhookModal ? (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -354,26 +356,26 @@ export default function DeveloperSettingsPage() {
               exit={{ opacity: 0, scale: 0.95 }}
               className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
             >
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-bold text-slate-900">Nouvel endpoint webhook</h2>
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-black text-slate-950">Nouvel endpoint webhook</h2>
                 <button onClick={() => setShowWebhookModal(false)} className="text-slate-400 hover:text-slate-600"><X className="h-5 w-5" /></button>
               </div>
               <div className="space-y-3">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700">URL de destination</label>
+                  <label className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400">URL de destination</label>
                   <input
                     type="url"
                     placeholder="https://erp.client.com/webhook"
                     value={newWebhook.url}
                     onChange={(e) => setNewWebhook({ ...newWebhook, url: e.target.value })}
-                    className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                    className="w-full rounded-xl border border-app-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700">Evenements a ecouter</label>
-                  <div className="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-slate-200 p-2">
+                  <label className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400">Evenements a ecouter</label>
+                  <div className="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-app-border p-2">
                     {availableEvents.map((event) => (
-                      <label key={event} className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-slate-50">
+                      <label key={event} className="flex items-center gap-2 rounded-lg px-2 py-1 text-sm hover:bg-slate-50">
                         <input
                           type="checkbox"
                           checked={newWebhook.events.includes(event)}
@@ -386,19 +388,19 @@ export default function DeveloperSettingsPage() {
                 </div>
               </div>
               <div className="mt-5 flex gap-3">
-                <button onClick={() => setShowWebhookModal(false)} className="flex-1 rounded-lg border border-slate-200 px-4 py-2 text-sm hover:bg-slate-50">Annuler</button>
+                <button onClick={() => setShowWebhookModal(false)} className="flex-1 rounded-xl border border-app-border px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-50">Annuler</button>
                 <button
                   onClick={handleCreateWebhook}
                   disabled={!newWebhook.url.trim() || newWebhook.events.length === 0 || creatingWebhook}
-                  className="flex-1 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white hover:bg-purple-700 disabled:opacity-50"
+                  className="flex-1 rounded-xl bg-brand-600 px-4 py-2 text-sm font-bold text-white hover:bg-brand-700 disabled:opacity-50"
                 >
                   {creatingWebhook ? 'Creation...' : 'Creer'}
                 </button>
               </div>
             </motion.div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
-    </div>
+    </>
   );
 }

--- a/front/web/src/app/(dashboard)/settings/notifications/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/notifications/page.tsx
@@ -209,7 +209,7 @@ export default function NotificationSettingsPage() {
                     type="checkbox"
                     checked={enabled}
                     onChange={(event) => updateCategory(category.key, event.target.checked)}
-                    className="h-5 w-5 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+                    className="h-5 w-5 rounded border-slate-300 text-brand-600 focus:ring-brand-500"
                   />
                 </label>
               );
@@ -233,7 +233,7 @@ export default function NotificationSettingsPage() {
               type="checkbox"
               checked={Boolean(preferences.quiet_hours?.enabled)}
               onChange={(event) => updateQuietHours('enabled', event.target.checked)}
-              className="h-5 w-5 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+              className="h-5 w-5 rounded border-slate-300 text-brand-600 focus:ring-brand-500"
             />
           </label>
           <div className="mt-4 grid grid-cols-2 gap-3">

--- a/front/web/src/app/(dashboard)/settings/notifications/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/notifications/page.tsx
@@ -145,7 +145,7 @@ export default function NotificationSettingsPage() {
       <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <p className="text-xs font-bold uppercase tracking-[0.16em] text-teal-700">Communication interne</p>
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">Communication interne</p>
             <h1 className="mt-2 text-3xl font-black text-slate-950">Mes preferences de notifications</h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
               Choisissez les canaux utiles sans perdre les alertes critiques. Les messages courts restent limites aux contenus non sensibles.
@@ -162,7 +162,7 @@ export default function NotificationSettingsPage() {
           </button>
         </div>
         {message ? (
-          <p className="mt-4 rounded-2xl border border-teal-200 bg-teal-50 px-4 py-3 text-sm font-semibold text-teal-800">{message}</p>
+          <p className="mt-4 rounded-2xl border border-brand-200 bg-brand-50 px-4 py-3 text-sm font-semibold text-brand-800">{message}</p>
         ) : null}
       </section>
 
@@ -177,14 +177,14 @@ export default function NotificationSettingsPage() {
               type="button"
               onClick={() => updateChannel(channel.key, !enabled)}
               className={`rounded-2xl border p-5 text-left shadow-sm transition ${
-                enabled ? 'border-teal-300 bg-teal-50' : 'border-slate-200 bg-white hover:border-slate-300'
+                enabled ? 'border-brand-300 bg-brand-50' : 'border-slate-200 bg-white hover:border-slate-300'
               }`}
             >
               <div className="flex items-start justify-between gap-4">
-                <div className={`flex h-11 w-11 items-center justify-center rounded-xl ${enabled ? 'bg-teal-600 text-white' : 'bg-slate-100 text-slate-600'}`}>
+                <div className={`flex h-11 w-11 items-center justify-center rounded-xl ${enabled ? 'bg-brand-600 text-white' : 'bg-slate-100 text-slate-600'}`}>
                   <Icon className="h-5 w-5" aria-hidden="true" />
                 </div>
-                <span className={`rounded-full px-3 py-1 text-xs font-bold ${enabled ? 'bg-teal-600 text-white' : 'bg-slate-100 text-slate-500'}`}>
+                <span className={`rounded-full px-3 py-1 text-xs font-bold ${enabled ? 'bg-brand-600 text-white' : 'bg-slate-100 text-slate-500'}`}>
                   {enabled ? 'Actif' : 'Desactive'}
                 </span>
               </div>

--- a/front/web/src/app/(dashboard)/smart-attendance/_components/GeoSessionStatsCards.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/_components/GeoSessionStatsCards.tsx
@@ -1,17 +1,19 @@
+import { CheckCircle2, ClipboardList, Hourglass, MapPin, XCircle } from 'lucide-react';
+
 type StatsCardProps = {
   title: string;
   value: number | string;
-  icon: string;
+  icon: typeof ClipboardList;
   colorClass: string;
   bgClass: string;
 };
 
-function StatsCard({ title, value, icon, colorClass, bgClass }: StatsCardProps) {
+function StatsCard({ title, value, icon: Icon, colorClass, bgClass }: StatsCardProps) {
   return (
     <div className={`rounded-2xl border bg-white p-5 shadow-sm ${bgClass}`}>
       <div className="flex items-center justify-between">
         <p className="text-xs font-bold uppercase tracking-widest text-slate-500">{title}</p>
-        <span className={`text-2xl ${colorClass}`}>{icon}</span>
+        <Icon className={`h-5 w-5 ${colorClass}`} aria-hidden="true" />
       </div>
       <p className={`mt-3 text-3xl font-black ${colorClass}`}>{value}</p>
     </div>
@@ -36,35 +38,35 @@ export function GeoSessionStatsCards({ stats, loading = false }: Props) {
     {
       title: 'Total',
       value: loading ? '...' : stats.total,
-      icon: '📋',
+      icon: ClipboardList,
       colorClass: 'text-slate-700',
       bgClass: 'border-slate-200',
     },
     {
       title: 'Détectés',
       value: loading ? '...' : stats.detected,
-      icon: '📍',
-      colorClass: 'text-blue-700',
-      bgClass: 'border-blue-100',
+      icon: MapPin,
+      colorClass: 'text-security-dark',
+      bgClass: 'border-security-light',
     },
     {
       title: 'En attente',
       value: loading ? '...' : stats.pending_validation,
-      icon: '⏳',
+      icon: Hourglass,
       colorClass: 'text-amber-700',
       bgClass: 'border-amber-100',
     },
     {
       title: 'Approuvés',
       value: loading ? '...' : stats.approved,
-      icon: '✅',
+      icon: CheckCircle2,
       colorClass: 'text-emerald-700',
       bgClass: 'border-emerald-100',
     },
     {
       title: 'Refusés',
       value: loading ? '...' : stats.rejected,
-      icon: '❌',
+      icon: XCircle,
       colorClass: 'text-red-700',
       bgClass: 'border-red-100',
     },

--- a/front/web/src/app/(dashboard)/smart-attendance/_components/GeoSessionStatusBadge.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/_components/GeoSessionStatusBadge.tsx
@@ -30,7 +30,7 @@ const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   },
   cancelled: {
     label: 'Annulé',
-    className: 'bg-gray-100 text-gray-500 border-gray-200',
+    className: 'bg-slate-100 text-slate-500 border-slate-200',
   },
 };
 

--- a/front/web/src/app/(dashboard)/smart-attendance/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { CheckCircle2, Settings } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
 import { GeoSessionStatusBadge } from './_components/GeoSessionStatusBadge';
@@ -157,7 +158,7 @@ export default function SmartAttendanceDashboardPage() {
       <ModulePageShell
         title="Smart Attendance"
         subtitle="Suivi intelligent de présence par géolocalisation — validation des sessions en attente et statistiques du jour."
-        accentClassName="bg-gradient-to-br from-blue-500/10 via-white to-white"
+        accentClassName="bg-gradient-to-br from-security/10 via-white to-white"
       >
         {error ? (
           <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -178,9 +179,9 @@ export default function SmartAttendanceDashboardPage() {
           </Link>
           <Link
             href="/smart-attendance/settings"
-            className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition hover:bg-slate-50 shadow-sm"
+            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition hover:bg-slate-50 shadow-sm"
           >
-            ⚙️ Paramètres
+            <Settings className="h-4 w-4" aria-hidden="true" /> Paramètres
           </Link>
         </div>
 
@@ -198,8 +199,8 @@ export default function SmartAttendanceDashboardPage() {
           {loading ? (
             <TableSkeleton />
           ) : pendingSessions.length === 0 ? (
-            <div className="px-6 py-10 text-center text-sm text-slate-500">
-              Aucune session en attente de validation. ✅
+            <div className="flex items-center justify-center gap-2 px-6 py-10 text-center text-sm text-slate-500">
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" aria-hidden="true" /> Aucune session en attente de validation.
             </div>
           ) : (
             <div className="overflow-x-auto">

--- a/front/web/src/app/(dashboard)/smart-attendance/sessions/[id]/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/sessions/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import { Check, LogIn, LogOut, X } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
 import { GeoSessionStatusBadge } from '../../_components/GeoSessionStatusBadge';
@@ -145,7 +146,7 @@ export default function SmartAttendanceSessionDetailPage() {
       <ModulePageShell
         title="Détail de session"
         subtitle="Informations complètes de la session de présence géolocalisée."
-        accentClassName="bg-gradient-to-br from-blue-500/10 via-white to-white"
+        accentClassName="bg-gradient-to-br from-security/10 via-white to-white"
       >
         {/* Back */}
         <div className="flex items-center gap-4">
@@ -219,7 +220,9 @@ export default function SmartAttendanceSessionDetailPage() {
               <div className="flex items-start gap-0">
                 {/* Check in */}
                 <div className="flex flex-col items-center">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 text-lg">▶</div>
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+                    <LogIn className="h-5 w-5" aria-hidden="true" />
+                  </div>
                   <div className="mt-2 h-12 w-0.5 bg-slate-200" />
                 </div>
                 <div className="ml-4 mt-1">
@@ -230,7 +233,9 @@ export default function SmartAttendanceSessionDetailPage() {
 
               <div className="flex items-start gap-0 mt-2">
                 <div className="flex flex-col items-center">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100 text-red-600 text-lg">■</div>
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100 text-red-600">
+                    <LogOut className="h-5 w-5" aria-hidden="true" />
+                  </div>
                 </div>
                 <div className="ml-4 mt-1">
                   <p className="text-xs font-bold uppercase tracking-wider text-slate-400">Départ</p>
@@ -329,16 +334,16 @@ export default function SmartAttendanceSessionDetailPage() {
                   <button
                     type="button"
                     onClick={() => setModal('approve')}
-                    className="rounded-xl bg-emerald-600 px-5 py-2 text-sm font-bold text-white transition hover:bg-emerald-500"
+                    className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-5 py-2 text-sm font-bold text-white transition hover:bg-emerald-500"
                   >
-                    ✓ Approuver
+                    <Check className="h-4 w-4" aria-hidden="true" /> Approuver
                   </button>
                   <button
                     type="button"
                     onClick={() => setModal('reject')}
-                    className="rounded-xl bg-red-600 px-5 py-2 text-sm font-bold text-white transition hover:bg-red-500"
+                    className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-2 text-sm font-bold text-white transition hover:bg-red-500"
                   >
-                    ✕ Refuser
+                    <X className="h-4 w-4" aria-hidden="true" /> Refuser
                   </button>
                 </div>
               </section>

--- a/front/web/src/app/(dashboard)/smart-attendance/sessions/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/sessions/page.tsx
@@ -150,7 +150,7 @@ export default function SmartAttendanceSessionsPage() {
     <ModulePageShell
       title="Sessions de présence"
       subtitle="Liste complète des sessions Smart Attendance avec filtres avancés et pagination."
-      accentClassName="bg-gradient-to-br from-blue-500/10 via-white to-white"
+      accentClassName="bg-gradient-to-br from-security/10 via-white to-white"
     >
       {/* Back link */}
       <div>
@@ -175,7 +175,7 @@ export default function SmartAttendanceSessionsPage() {
           <div>
             <label className="mb-1 block text-xs font-bold text-slate-600">Statut</label>
             <select
-              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
               value={pendingFilters.status}
               onChange={(e) => setPendingFilters((f) => ({ ...f, status: e.target.value }))}
             >
@@ -192,7 +192,7 @@ export default function SmartAttendanceSessionsPage() {
             <label className="mb-1 block text-xs font-bold text-slate-600">Employé (ID ou nom)</label>
             <input
               type="text"
-              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
               placeholder="Rechercher…"
               value={pendingFilters.employee_id}
               onChange={(e) => setPendingFilters((f) => ({ ...f, employee_id: e.target.value }))}
@@ -203,7 +203,7 @@ export default function SmartAttendanceSessionsPage() {
             <label className="mb-1 block text-xs font-bold text-slate-600">Date début</label>
             <input
               type="date"
-              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
               value={pendingFilters.date_from}
               onChange={(e) => setPendingFilters((f) => ({ ...f, date_from: e.target.value }))}
             />
@@ -213,7 +213,7 @@ export default function SmartAttendanceSessionsPage() {
             <label className="mb-1 block text-xs font-bold text-slate-600">Date fin</label>
             <input
               type="date"
-              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
               value={pendingFilters.date_to}
               onChange={(e) => setPendingFilters((f) => ({ ...f, date_to: e.target.value }))}
             />
@@ -224,7 +224,7 @@ export default function SmartAttendanceSessionsPage() {
           <button
             type="button"
             onClick={applyFilters}
-            className="rounded-xl bg-blue-600 px-4 py-2 text-sm font-bold text-white transition hover:bg-blue-500"
+            className="rounded-xl bg-security px-4 py-2 text-sm font-bold text-white transition hover:bg-security-dark"
           >
             Appliquer
           </button>
@@ -306,7 +306,7 @@ export default function SmartAttendanceSessionsPage() {
                     <td className="px-6 py-4 text-right">
                       <Link
                         href={`/smart-attendance/sessions/${session.id}`}
-                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-700"
+                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold text-slate-700 transition hover:border-security hover:text-security-dark"
                       >
                         Voir →
                       </Link>

--- a/front/web/src/app/(dashboard)/smart-attendance/settings/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { Check } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
 
@@ -136,12 +137,12 @@ export default function SmartAttendanceSettingsPage() {
               GPS : {currentSettings.gps_enabled ? 'Activé' : 'Désactivé'}
             </span>
             {currentSettings.latitude != null && currentSettings.longitude != null ? (
-              <span className="rounded-full bg-blue-100 px-2.5 py-0.5 font-bold text-blue-700">
+              <span className="rounded-full bg-security-light px-2.5 py-0.5 font-bold text-security-dark">
                 {currentSettings.latitude.toFixed(4)}, {currentSettings.longitude.toFixed(4)}
               </span>
             ) : null}
             {currentSettings.radius != null ? (
-              <span className="rounded-full bg-indigo-100 px-2.5 py-0.5 font-bold text-indigo-700">
+              <span className="rounded-full bg-ia-light px-2.5 py-0.5 font-bold text-ia-dark">
                 Rayon : {currentSettings.radius}m
               </span>
             ) : null}
@@ -156,8 +157,8 @@ export default function SmartAttendanceSettingsPage() {
       ) : null}
 
       {successMsg ? (
-        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 font-bold">
-          ✓ {successMsg}
+        <div className="flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700">
+          <Check className="h-4 w-4" aria-hidden="true" /> {successMsg}
         </div>
       ) : null}
 
@@ -180,7 +181,7 @@ export default function SmartAttendanceSettingsPage() {
                 Mode de pointage
               </label>
               <select
-                className="mt-1.5 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                className="mt-1.5 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
                 value={form.forced_mode}
                 onChange={(e) => setForm((f) => ({ ...f, forced_mode: e.target.value }))}
                 disabled={saving}
@@ -207,7 +208,7 @@ export default function SmartAttendanceSettingsPage() {
                 aria-checked={form.gps_enabled}
                 onClick={() => setForm((f) => ({ ...f, gps_enabled: !f.gps_enabled }))}
                 disabled={saving}
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:opacity-50 ${
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-security-light disabled:opacity-50 ${
                   form.gps_enabled ? 'bg-emerald-500' : 'bg-slate-300'
                 }`}
               >
@@ -221,8 +222,8 @@ export default function SmartAttendanceSettingsPage() {
 
             {/* Champs GPS conditionnels */}
             {form.gps_enabled ? (
-              <div className="space-y-4 rounded-xl border border-blue-100 bg-blue-50 p-4">
-                <p className="text-xs font-bold uppercase tracking-wider text-blue-600">
+              <div className="space-y-4 rounded-xl border border-security-light bg-security-light/40 p-4">
+                <p className="text-xs font-bold uppercase tracking-wider text-security-dark">
                   Configuration du géofence
                 </p>
                 <div className="grid gap-4 sm:grid-cols-2">
@@ -231,7 +232,7 @@ export default function SmartAttendanceSettingsPage() {
                     <input
                       type="number"
                       step="any"
-                      className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                      className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
                       placeholder="ex: 48.8566"
                       value={form.latitude}
                       onChange={(e) => setForm((f) => ({ ...f, latitude: e.target.value }))}
@@ -243,7 +244,7 @@ export default function SmartAttendanceSettingsPage() {
                     <input
                       type="number"
                       step="any"
-                      className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                      className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
                       placeholder="ex: 2.3522"
                       value={form.longitude}
                       onChange={(e) => setForm((f) => ({ ...f, longitude: e.target.value }))}
@@ -256,7 +257,7 @@ export default function SmartAttendanceSettingsPage() {
                   <input
                     type="number"
                     min={1}
-                    className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                    className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-security focus:outline-none focus:ring-2 focus:ring-security-light"
                     placeholder="ex: 200"
                     value={form.radius}
                     onChange={(e) => setForm((f) => ({ ...f, radius: e.target.value }))}

--- a/front/web/src/app/(dashboard)/training/page.tsx
+++ b/front/web/src/app/(dashboard)/training/page.tsx
@@ -147,8 +147,8 @@ export default function TrainingPage() {
   }, {});
 
   const statCards = [
-    { label: 'Total formations', value: total, icon: GraduationCap, accent: 'text-violet-600 bg-violet-50' },
-    { label: 'Categories', value: Object.keys(categoryCounts).length, icon: BookOpen, accent: 'text-blue-600 bg-blue-50' },
+    { label: 'Total formations', value: total, icon: GraduationCap, accent: 'text-ia-dark bg-ia-light' },
+    { label: 'Categories', value: Object.keys(categoryCounts).length, icon: BookOpen, accent: 'text-security-dark bg-security-light' },
     { label: 'Certifications', value: courses.filter((c) => c.type === 'certification').length, icon: Award, accent: 'text-emerald-600 bg-emerald-50' },
     { label: 'Capacite totale', value: courses.reduce((s, c) => s + (c.max_participants || 0), 0), icon: Users, accent: 'text-amber-600 bg-amber-50' },
   ];

--- a/front/web/src/app/(dashboard)/training/page.tsx
+++ b/front/web/src/app/(dashboard)/training/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ApiError, apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
 import { GraduationCap, Calendar, Users, Clock, BookOpen, Award, ChevronDown, Plus, X, MapPin } from 'lucide-react';
 
 interface TrainingSession {
@@ -130,13 +131,13 @@ export default function TrainingPage() {
 
   const statusBadge = (status: string) => {
     const map: Record<string, { class: string; label: string }> = {
-      scheduled: { class: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400', label: 'Planifie' },
-      in_progress: { class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400', label: 'En cours' },
-      completed: { class: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400', label: 'Termine' },
-      cancelled: { class: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400', label: 'Annule' },
+      scheduled: { class: 'bg-info/15 text-info', label: 'Planifie' },
+      in_progress: { class: 'bg-amber-50 text-amber-700', label: 'En cours' },
+      completed: { class: 'bg-emerald-50 text-emerald-700', label: 'Termine' },
+      cancelled: { class: 'bg-red-50 text-red-700', label: 'Annule' },
     };
     const style = map[status] || map.scheduled;
-    return <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-semibold ${style.class}`}>{style.label}</span>;
+    return <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${style.class}`}>{style.label}</span>;
   };
 
   const categoryCounts = courses.reduce<Record<string, number>>((acc, c) => {
@@ -145,120 +146,132 @@ export default function TrainingPage() {
     return acc;
   }, {});
 
+  const statCards = [
+    { label: 'Total formations', value: total, icon: GraduationCap, accent: 'text-violet-600 bg-violet-50' },
+    { label: 'Categories', value: Object.keys(categoryCounts).length, icon: BookOpen, accent: 'text-blue-600 bg-blue-50' },
+    { label: 'Certifications', value: courses.filter((c) => c.type === 'certification').length, icon: Award, accent: 'text-emerald-600 bg-emerald-50' },
+    { label: 'Capacite totale', value: courses.reduce((s, c) => s + (c.max_participants || 0), 0), icon: Users, accent: 'text-amber-600 bg-amber-50' },
+  ];
+
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Formations</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400">Catalogue de formations et sessions associees (source: /training/courses)</p>
+    <>
+      <ModulePageShell
+        title="Formations"
+        subtitle="Catalogue de formations et sessions associees, connecte a /training/courses de l'API RH."
+        accentClassName="bg-gradient-to-br from-finance-light via-white to-white"
+      >
+        <div className="flex justify-end">
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-brand-700"
+          >
+            <Plus className="h-4 w-4" /> Nouvelle formation
+          </button>
         </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-emerald-700"
-        >
-          <Plus className="h-4 w-4" /> Nouvelle formation
-        </button>
-      </div>
 
-      {error ? (
-        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
-      ) : null}
+        {error ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        ) : null}
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        {[
-          { label: 'Total formations', value: total, icon: GraduationCap, color: 'text-purple-600' },
-          { label: 'Categories', value: Object.keys(categoryCounts).length, icon: BookOpen, color: 'text-blue-600' },
-          { label: 'Certifications', value: courses.filter((c) => c.type === 'certification').length, icon: Award, color: 'text-emerald-600' },
-          { label: 'Capacite totale', value: courses.reduce((s, c) => s + (c.max_participants || 0), 0), icon: Users, color: 'text-amber-600' },
-        ].map((stat, i) => (
-          <motion.div key={stat.label} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.05 }} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
-            <stat.icon className={`h-5 w-5 ${stat.color} mb-2`} />
-            <p className="text-2xl font-bold text-slate-900 dark:text-white">{stat.value}</p>
-            <p className="text-xs text-slate-500">{stat.label}</p>
-          </motion.div>
-        ))}
-      </div>
+        <section className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {statCards.map((stat, i) => (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.05 }}
+              className="rounded-2xl border border-app-border bg-white p-5 shadow-sm"
+            >
+              <div className={`mb-3 inline-flex h-10 w-10 items-center justify-center rounded-xl ${stat.accent}`}>
+                <stat.icon className="h-5 w-5" />
+              </div>
+              <p className="text-2xl font-black text-slate-950">{stat.value}</p>
+              <p className="text-xs font-bold uppercase tracking-widest text-slate-400">{stat.label}</p>
+            </motion.div>
+          ))}
+        </section>
 
-      {loading ? (
-        <div className="text-center py-12 text-slate-400">Chargement...</div>
-      ) : courses.length === 0 ? (
-        <div className="text-center py-16">
-          <BookOpen className="h-12 w-12 text-slate-300 mx-auto mb-3" />
-          <p className="text-slate-500">Aucune formation au catalogue pour le moment.</p>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {courses.map((course, i) => {
-            const sessions = sessionsByCourse[course.id];
-            const isExpanded = expandedId === course.id;
-            return (
-              <motion.div
-                key={course.id}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: i * 0.02 }}
-                className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-hidden"
-              >
-                <button
-                  onClick={() => toggleExpand(course.id)}
-                  className="w-full flex items-center justify-between gap-3 p-5 text-left hover:bg-slate-50 dark:hover:bg-slate-900/40"
+        {loading ? (
+          <div className="py-12 text-center text-sm text-slate-500">Chargement...</div>
+        ) : courses.length === 0 ? (
+          <section className="rounded-3xl border border-dashed border-app-border bg-white py-16 text-center">
+            <BookOpen className="mx-auto mb-3 h-12 w-12 text-slate-300" />
+            <p className="text-sm text-slate-500">Aucune formation au catalogue pour le moment.</p>
+          </section>
+        ) : (
+          <div className="space-y-3">
+            {courses.map((course, i) => {
+              const sessions = sessionsByCourse[course.id];
+              const isExpanded = expandedId === course.id;
+              return (
+                <motion.div
+                  key={course.id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.02 }}
+                  className="overflow-hidden rounded-2xl border border-app-border bg-white shadow-sm"
                 >
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-1">
-                      <h3 className="font-bold text-slate-900 dark:text-white text-sm">{course.title}</h3>
-                      <span className="rounded-full bg-slate-100 dark:bg-slate-700 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-500 dark:text-slate-300">
-                        {TYPE_LABELS[course.type] ?? course.type}
-                      </span>
-                    </div>
-                    {course.description && <p className="text-xs text-slate-500 dark:text-slate-400 line-clamp-1">{course.description}</p>}
-                    <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
-                      {course.provider && <span className="flex items-center gap-1"><GraduationCap className="h-3 w-3" />{course.provider}</span>}
-                      {course.duration_hours ? <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{course.duration_hours}h</span> : null}
-                      {course.max_participants ? <span className="flex items-center gap-1"><Users className="h-3 w-3" />{course.max_participants} places</span> : null}
-                      {course.category ? <span className="rounded-full bg-slate-100 dark:bg-slate-700 px-2 py-0.5">{course.category}</span> : null}
-                    </div>
-                  </div>
-                  <ChevronDown className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
-                </button>
-
-                <AnimatePresence initial={false}>
-                  {isExpanded && (
-                    <motion.div
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: 'auto', opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      className="border-t border-slate-100 dark:border-slate-700"
-                    >
-                      <div className="p-5 space-y-2">
-                        <p className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-2">Sessions programmees</p>
-                        {sessionsLoading === course.id ? (
-                          <p className="text-sm text-slate-400">Chargement des sessions...</p>
-                        ) : !sessions || sessions.length === 0 ? (
-                          <p className="text-sm text-slate-400">Aucune session pour cette formation.</p>
-                        ) : (
-                          sessions.map((session) => (
-                            <div key={session.id} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 px-3 py-2">
-                              <div className="flex items-center gap-3 text-xs text-slate-600 dark:text-slate-300">
-                                <span className="flex items-center gap-1"><Calendar className="h-3 w-3" />{session.start_date ?? '—'} au {session.end_date ?? '—'}</span>
-                                {session.location && <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{session.location}</span>}
-                                <span className="flex items-center gap-1"><Users className="h-3 w-3" />{session.enrollments?.length ?? 0} inscrits</span>
-                              </div>
-                              {statusBadge(session.status)}
-                            </div>
-                          ))
-                        )}
+                  <button
+                    onClick={() => toggleExpand(course.id)}
+                    className="flex w-full items-center justify-between gap-3 p-5 text-left transition hover:bg-slate-50/60"
+                  >
+                    <div className="flex-1">
+                      <div className="mb-1 flex items-center gap-2">
+                        <h3 className="text-sm font-bold text-slate-950">{course.title}</h3>
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                          {TYPE_LABELS[course.type] ?? course.type}
+                        </span>
                       </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </motion.div>
-            );
-          })}
-        </div>
-      )}
+                      {course.description ? <p className="line-clamp-1 text-xs text-slate-500">{course.description}</p> : null}
+                      <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                        {course.provider ? <span className="flex items-center gap-1"><GraduationCap className="h-3 w-3" />{course.provider}</span> : null}
+                        {course.duration_hours ? <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{course.duration_hours}h</span> : null}
+                        {course.max_participants ? <span className="flex items-center gap-1"><Users className="h-3 w-3" />{course.max_participants} places</span> : null}
+                        {course.category ? <span className="rounded-full bg-slate-100 px-2 py-0.5">{course.category}</span> : null}
+                      </div>
+                    </div>
+                    <ChevronDown className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
+                  </button>
+
+                  <AnimatePresence initial={false}>
+                    {isExpanded ? (
+                      <motion.div
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: 'auto', opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        className="border-t border-app-border"
+                      >
+                        <div className="space-y-2 p-5">
+                          <p className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-400">Sessions programmees</p>
+                          {sessionsLoading === course.id ? (
+                            <p className="text-sm text-slate-400">Chargement des sessions...</p>
+                          ) : !sessions || sessions.length === 0 ? (
+                            <p className="text-sm text-slate-400">Aucune session pour cette formation.</p>
+                          ) : (
+                            sessions.map((session) => (
+                              <div key={session.id} className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-app-border bg-slate-50 px-3 py-2">
+                                <div className="flex items-center gap-3 text-xs text-slate-600">
+                                  <span className="flex items-center gap-1"><Calendar className="h-3 w-3" />{session.start_date ?? '—'} au {session.end_date ?? '—'}</span>
+                                  {session.location ? <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{session.location}</span> : null}
+                                  <span className="flex items-center gap-1"><Users className="h-3 w-3" />{session.enrollments?.length ?? 0} inscrits</span>
+                                </div>
+                                {statusBadge(session.status)}
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </motion.div>
+                    ) : null}
+                  </AnimatePresence>
+                </motion.div>
+              );
+            })}
+          </div>
+        )}
+      </ModulePageShell>
 
       <AnimatePresence>
-        {showCreateModal && (
+        {showCreateModal ? (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -269,10 +282,10 @@ export default function TrainingPage() {
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.95 }}
-              className="w-full max-w-md rounded-2xl bg-white dark:bg-slate-800 p-6 shadow-xl"
+              className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
             >
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-bold text-slate-900 dark:text-white">Nouvelle formation</h2>
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-black text-slate-950">Nouvelle formation</h2>
                 <button onClick={() => setShowCreateModal(false)} className="text-slate-400 hover:text-slate-600"><X className="h-5 w-5" /></button>
               </div>
               <div className="space-y-3">
@@ -281,13 +294,13 @@ export default function TrainingPage() {
                   placeholder="Titre *"
                   value={newCourse.title}
                   onChange={(e) => setNewCourse({ ...newCourse, title: e.target.value })}
-                  className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                  className="w-full rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
                 <textarea
                   placeholder="Description"
                   value={newCourse.description}
                   onChange={(e) => setNewCourse({ ...newCourse, description: e.target.value })}
-                  className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                  className="w-full rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                   rows={2}
                 />
                 <div className="grid grid-cols-2 gap-3">
@@ -296,12 +309,12 @@ export default function TrainingPage() {
                     placeholder="Categorie"
                     value={newCourse.category}
                     onChange={(e) => setNewCourse({ ...newCourse, category: e.target.value })}
-                    className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                    className="rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                   <select
                     value={newCourse.type}
                     onChange={(e) => setNewCourse({ ...newCourse, type: e.target.value })}
-                    className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                    className="rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900"
                   >
                     <option value="internal">Interne</option>
                     <option value="external">Externe</option>
@@ -315,14 +328,14 @@ export default function TrainingPage() {
                     placeholder="Prestataire"
                     value={newCourse.provider}
                     onChange={(e) => setNewCourse({ ...newCourse, provider: e.target.value })}
-                    className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                    className="rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                   <input
                     type="number"
                     placeholder="Duree (h)"
                     value={newCourse.duration_hours}
                     onChange={(e) => setNewCourse({ ...newCourse, duration_hours: e.target.value })}
-                    className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                    className="rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <input
@@ -330,23 +343,23 @@ export default function TrainingPage() {
                   placeholder="Participants max"
                   value={newCourse.max_participants}
                   onChange={(e) => setNewCourse({ ...newCourse, max_participants: e.target.value })}
-                  className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                  className="w-full rounded-xl border border-app-border bg-slate-50 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div className="mt-5 flex gap-3">
-                <button onClick={() => setShowCreateModal(false)} className="flex-1 rounded-lg border border-slate-200 dark:border-slate-700 px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-700">Annuler</button>
+                <button onClick={() => setShowCreateModal(false)} className="flex-1 rounded-xl border border-app-border px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-50">Annuler</button>
                 <button
                   onClick={handleCreate}
                   disabled={!newCourse.title.trim() || creating}
-                  className="flex-1 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                  className="flex-1 rounded-xl bg-brand-600 px-4 py-2 text-sm font-bold text-white hover:bg-brand-700 disabled:opacity-50"
                 >
                   {creating ? 'Creation...' : 'Creer'}
                 </button>
               </div>
             </motion.div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
-    </div>
+    </>
   );
 }

--- a/front/web/src/components/module-page-shell.tsx
+++ b/front/web/src/components/module-page-shell.tsx
@@ -22,23 +22,23 @@ export function ModulePageShell({
       <motion.section
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        className={`relative overflow-hidden rounded-3xl border border-white/20 bg-white/70 shadow-premium backdrop-blur-xl dark:border-slate-800/50 dark:bg-slate-900/70 ${accentClassName}`}
+        className={`relative overflow-hidden rounded-3xl border border-white/20 bg-white/70 shadow-premium backdrop-blur-xl ${accentClassName}`}
       >
         <div className="absolute inset-0 bg-gradient-to-br from-brand-500/5 via-transparent to-cyan-500/5 pointer-events-none" />
 
         <div className="relative space-y-3 p-8">
           <div className="flex items-center gap-2">
             <div className="h-1 w-8 rounded-full bg-gradient-to-r from-emerald-500 to-cyan-500" />
-            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
+            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
               Système Leopardo
             </p>
           </div>
 
-          <h1 className="text-4xl font-black tracking-tight text-slate-950 dark:text-white">
+          <h1 className="text-4xl font-black tracking-tight text-slate-950">
             {title}
           </h1>
 
-          <p className="max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-400">
+          <p className="max-w-2xl text-base leading-relaxed text-slate-600">
             {subtitle}
           </p>
         </div>


### PR DESCRIPTION
## Contexte

Le design de la partie **web-client apres connexion** (`front/web/src/app/(dashboard)`) etait incoherent : plusieurs pages (Contrats, Paie, Rapports, Facturation) utilisaient un style tableau brut slate/dark-mode, different du style `ModulePageShell` (glass card + tokens brand/rh/finance) deja utilise par Absences, Employes, Pointage, Smart Attendance.

Ce PR **ne touche pas** la vitrine publique (`front/web/src/app/(landing)`), uniquement la partie authentifiee (apres connexion), comme demande.

## Changements

- `contracts/page.tsx`, `payroll/page.tsx`, `reports/page.tsx`, `billing/page.tsx` : enveloppes dans `ModulePageShell` pour le meme header/hero et rythme visuel que les autres modules.
- Cartes de stats, tableaux, badges de statut, tabs et boutons restyles avec les tokens `app-border` / `brand-*` / `rh-*` / `finance-*` de `globals.css` au lieu des classes slate brutes + `dark:` non utilisees ailleurs dans l app client.
- Aucun changement de logique metier, d appels API, ou de comportement fonctionnel — uniquement le design/CSS/markup.

## Verification

- `npm run build` : succes, 63/63 pages generees.
- `npx eslint --max-warnings 0` sur les fichiers touches : clean.
- `npx tsc --noEmit` : clean.
