### PR TITLE
fix(api): PA2-I18N-007 - localise les messages GeoSessionController

### DIFF
--- a/api/app/Modules/SmartAttendance/Interfaces/Api/V1/GeoSessionController.php
+++ b/api/app/Modules/SmartAttendance/Interfaces/Api/V1/GeoSessionController.php
@@ -142,7 +142,7 @@ class GeoSessionController extends Controller
         );
 
         return response()->json([
-            'message' => 'Session approuvée. Le pointage a été créé.',
+            'message' => __('attendance.geo_session_approved'),
             'data'    => $this->formatSession($session),
         ]);
     }
@@ -172,7 +172,7 @@ class GeoSessionController extends Controller
         );
 
         return response()->json([
-            'message' => 'Session refusée.',
+            'message' => __('attendance.geo_session_rejected'),
             'data'    => $this->formatSession($session),
         ]);
     }

--- a/api/lang/ar/attendance.php
+++ b/api/lang/ar/attendance.php
@@ -25,4 +25,8 @@ return [
     'daily_summary' => 'الملخص اليومي',
     'monthly_summary' => 'الملخص الشهري',
     'history' => 'السجل',
+
+    // جلسات الموقع (SmartAttendance)
+    'geo_session_approved' => 'تمت الموافقة على الجلسة. تم إنشاء سجل الحضور.',
+    'geo_session_rejected' => 'تم رفض الجلسة.',
 ];

--- a/api/lang/en/attendance.php
+++ b/api/lang/en/attendance.php
@@ -25,4 +25,8 @@ return [
     'daily_summary' => 'Daily summary',
     'monthly_summary' => 'Monthly summary',
     'history' => 'History',
+
+    // Geo sessions (SmartAttendance)
+    'geo_session_approved' => 'Session approved. The attendance record has been created.',
+    'geo_session_rejected' => 'Session rejected.',
 ];

--- a/api/lang/fr/attendance.php
+++ b/api/lang/fr/attendance.php
@@ -25,4 +25,8 @@ return [
     'daily_summary' => 'Résumé journalier',
     'monthly_summary' => 'Résumé mensuel',
     'history' => 'Historique',
+
+    // Sessions geo (SmartAttendance)
+    'geo_session_approved' => 'Session approuvée. Le pointage a été créé.',
+    'geo_session_rejected' => 'Session refusée.',
 ];

--- a/api/lang/tr/attendance.php
+++ b/api/lang/tr/attendance.php
@@ -25,4 +25,8 @@ return [
     'daily_summary' => 'Günlük özet',
     'monthly_summary' => 'Aylık özet',
     'history' => 'Geçmiş',
+
+    // Konum oturumları (SmartAttendance)
+    'geo_session_approved' => 'Oturum onaylandi. Devam kaydi olusturuldu.',
+    'geo_session_rejected' => 'Oturum reddedildi.',
 ];


### PR DESCRIPTION
Corrige le dernier message API en dur identifie par l'audit i18n (docs/PLAN_ACTION2/10_AUDIT_I18N_MULTILINGUE.md, ticket PA2-I18N-007).

- `approve()` et `reject()` de `GeoSessionController` (SmartAttendance) renvoyaient un texte francais fixe, ignorant la langue active de l'utilisateur.
- Ajoute `attendance.geo_session_approved` / `attendance.geo_session_rejected` dans `api/lang/{fr,en,ar,tr}/attendance.php`.
- Remplace les chaines en dur par `__('attendance.geo_session_approved')` / `__('attendance.geo_session_rejected')`.
- `node shared/i18n/validators/validate.js` -> `I18N_VALIDATION_OK (4 locales)`.

Suite du plan i18n dans docs/PLAN_ACTION2/10_AUDIT_I18N_MULTILINGUE.md (tickets PA2-I18N-005 a 015). D'autres tickets (008 a 015) seront traites separement (volume plus important : mobile, web, admin, kiosk, CI, emails, dates/devises).