### PR TITLE
chore(ci): PA2-I18N-014 - etend la couverture CI i18n aux surfaces a risque

### DIFF
--- a/.github/workflows/i18n-enterprise.yml
+++ b/.github/workflows/i18n-enterprise.yml
@@ -6,9 +6,18 @@ on:
       - 'shared/i18n/**'
       - 'front/mobile/lib/l10n/**'
       - 'front/mobile_apps/leopardo_core/lib/l10n/**'
+      - 'front/mobile_apps/leopardo_employee/lib/**'
+      - 'front/mobile_apps/leopardo_manager/lib/**'
+      - 'front/mobile_apps/leopardo_platform_admin/lib/**'
       - 'front/admin-dashboard/src/i18n/**'     # chemin réel dans le repo
+      - 'front/admin-dashboard/src/**'
       - 'front/web/src/lib/i18n/**'             # client Next.js
+      - 'front/web/src/app/**'
+      - 'front/web/src/modules/**'
+      - 'front/zkteco-kiosk/**'
       - 'api/lang/**'
+      - 'api/resources/views/pdf/**'
+      - 'api/resources/views/emails/**'
       - '.github/workflows/i18n-enterprise.yml'
   push:
     branches:
@@ -17,9 +26,18 @@ on:
       - 'shared/i18n/**'
       - 'front/mobile/lib/l10n/**'
       - 'front/mobile_apps/leopardo_core/lib/l10n/**'
+      - 'front/mobile_apps/leopardo_employee/lib/**'
+      - 'front/mobile_apps/leopardo_manager/lib/**'
+      - 'front/mobile_apps/leopardo_platform_admin/lib/**'
       - 'front/admin-dashboard/src/i18n/**'
+      - 'front/admin-dashboard/src/**'
       - 'front/web/src/lib/i18n/**'
+      - 'front/web/src/app/**'
+      - 'front/web/src/modules/**'
+      - 'front/zkteco-kiosk/**'
       - 'api/lang/**'
+      - 'api/resources/views/pdf/**'
+      - 'api/resources/views/emails/**'
       - '.github/workflows/i18n-enterprise.yml'
 
 permissions:


### PR DESCRIPTION
Premiere moitie du ticket PA2-I18N-014 (docs/PLAN_ACTION2/10_AUDIT_I18N_MULTILINGUE.md).

Etend les triggers de `.github/workflows/i18n-enterprise.yml` aux zones ou l'audit identifie la dette la plus importante et qui n'etaient pas couvertes du tout :
- `front/mobile_apps/leopardo_{employee,manager,platform_admin}/lib/**`
- `front/zkteco-kiosk/**`
- `front/admin-dashboard/src/**` (au-dela du seul dossier i18n)
- `front/web/src/app/**` et `front/web/src/modules/**`
- `api/resources/views/{pdf,emails}/**`

Ce PR ne change pas la logique du job (validate + sync + `git diff --exit-code`), seulement son declenchement, donc il reste vert.

**Reste a faire pour PA2-I18N-014 (ticket separe)** : un job qui echoue reellement sur une nouvelle chaine en dur introduite dans une PR (pas seulement le rapport informatif actuel). Couple a PA2-I18N-015 (reecriture fiable de l'outil de detection de dette, aujourd'hui en PowerShell et bruite par les classes Tailwind).