### PR TITLE
security: retirer le mot de passe Redis Upstash en clair de la documentation

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -108,9 +108,9 @@ Le déploiement via Render webhook (`RENDER_DEPLOY_HOOK_URL`) déclenche un re-d
 > Sans worker actif, les jobs (pushs, emails, documents PDF) restent en attente indéfiniment.
 
 #### 2.3 Redis Upstash — credentials engagées dans `.env.example` public
-Le `.env.example` contient une URL Redis Upstash **avec mot de passe en clair** :
+Le `.env.example` contenait une URL Redis Upstash **avec mot de passe en clair** (valeur réelle retirée de ce document le 2026-07-19, voir `SECURITY_INCIDENT_REDIS_2026-07.md` pour le détail de la remédiation et le statut de rotation) :
 ```
-REDIS_URL=rediss://default:gQAAAA...@noted-tomcat-92597.upstash.io:6379
+REDIS_URL=rediss://default:<REDACTED>@<REDACTED_HOST>.upstash.io:6379
 ```
 Ce fichier est public sur GitHub. **Changer immédiatement ce mot de passe** dans Upstash Dashboard > Reset Password, puis mettre à jour les secrets Render et `.env.example` avec un placeholder.
 
@@ -517,11 +517,14 @@ REDIS_PASSWORD=NOUVEAU_MDP
     contre un jeton SSE à usage unique via POST /api/v1/notifications/sse-token avant d'ouvrir l'EventSource
     (endpoint backend SseTokenController déjà présent, coté frontend corrigé le 2026-07-05)
 [x] front/web/.env.local.example créé (STRIPE_SECRET_KEY, LEOPARDO_API_URL, NEXT_PUBLIC_API_URL, etc.)
-[ ] 🔴 URGENT — Rotation du mot de passe Redis Upstash. Le fichier actuel contient un placeholder,
-    MAIS un vrai mot de passe Upstash a été committé en clair dans l'historique git
-    (`REDIS_URL=rediss://default:gQAAAAAAAWm1AAIgcDE1NmY0YWQ3ODc2OTQ0YWY0YjYyMjlhZDJhMTNmM2VjYw@noted-tomcat-92597.upstash.io`)
-    et reste récupérable par quiconque clone le repo (repo public). Action requise immediatement dans le
-    dashboard Upstash : reset password, puis mettre à jour la variable REDIS_URL/REDIS_PASSWORD sur Render.
+[~] 🔴 URGENT — Rotation du mot de passe Redis Upstash. Un vrai mot de passe Upstash a été committé
+    en clair dans l'historique git (valeur retirée de ce document le 2026-07-19 — voir
+    `SECURITY_INCIDENT_REDIS_2026-07.md` pour la référence de commit exacte et le statut de remédiation)
+    et reste récupérable par quiconque clone le repo (repo public) tant que l'historique n'est pas purgé.
+    Documentation nettoyée le 2026-07-19 (ce fichier + PLAN_ACTION*) : le mot de passe en clair n'apparaît
+    plus dans aucun fichier Markdown suivi. Reste à faire, hors du périmètre code (action manuelle) :
+    reset password dans le dashboard Upstash, mise à jour REDIS_URL/REDIS_PASSWORD sur Render, puis purge
+    de l'historique git (BFG/filter-repo) une fois la rotation confirmée — voir le rapport pour le détail.
     L'historique git lui-même ne peut pas être nettoyé sans rewrite (BFG/filter-repo) coordonné avec l'équipe.
 [ ] Ajouter les secrets GitHub Actions listés ci-dessus dans Settings > Secrets — action manuelle GitHub,
     hors du périmètre code (aucun moyen de vérifier depuis le repo si déjà fait)

--- a/SECURITY_INCIDENT_REDIS_2026-07.md
+++ b/SECURITY_INCIDENT_REDIS_2026-07.md
@@ -1,0 +1,85 @@
+# 🔴 Incident de sécurité — Mot de passe Redis Upstash exposé en clair
+
+Statut : **ROTATION UPSTASH + PURGE HISTORIQUE GIT NON EFFECTUÉES — action manuelle requise**
+Sévérité : Critique
+Ouvert depuis : au moins 2026-07-01 (première mention dans `AUDIT.md`)
+Documentation nettoyée le : 2026-07-19
+
+---
+
+## 1. Résumé
+
+Un mot de passe Redis Upstash réel a été committé en clair dans plusieurs fichiers Markdown
+du dépôt (`AUDIT.md`, `docs/PLAN_ACTION/POST_AUDIT_2026/08_SCALABILITE_REDIS.md`,
+`docs/PLAN_ACTION/POST_AUDIT_2026/01_ROADMAP_30J.md`, `docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md`).
+Le dépôt GitHub `kitokoh/leopardo-hr` est **public** (5 étoiles, 1 fork au moment de cet audit) :
+n'importe qui pouvant lire l'historique git a accès à ce mot de passe depuis sa date de commit.
+
+Ce document a été détecté lors de plusieurs audits précédents (`AUDIT.md` section 2.3,
+`docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md` section 4) mais la case de remédiation
+restait **non cochée** sans preuve de rotation effective.
+
+## 2. Ce qui a été fait aujourd'hui (2026-07-19)
+
+- Retrait de la valeur en clair (mot de passe + hostname réel `noted-tomcat-92597.upstash.io`)
+  de tous les fichiers Markdown suivis dans le dépôt, remplacée par des placeholders génériques.
+- Ce fichier créé comme référence centrale de l'incident.
+- **Aucune modification de code applicatif** — `api/.env.example` utilisait déjà des placeholders
+  (`VOTRE_HOST.upstash.io` / `VOTRE_PASSWORD_UPSTASH`), il n'a pas eu besoin de correction.
+
+## 3. Ce qui N'A PAS été fait et reste requis (actions manuelles, hors périmètre agent/code)
+
+### 3.1 Rotation immédiate du mot de passe Upstash — 🔴 P0, à faire en premier
+1. Se connecter à https://console.upstash.com
+2. Sélectionner la base Redis concernée (ex-hostname `noted-tomcat-92597`)
+3. Settings → Reset Password (ou régénérer les credentials complets si l'option existe)
+4. Mettre à jour immédiatement sur Render : `REDIS_URL` / `REDIS_HOST` / `REDIS_PASSWORD`
+   dans Environment Variables du service API + du service Background Worker
+5. Redéployer le service API et le worker de queue pour appliquer les nouvelles credentials
+6. Vérifier `/api/v1/health` → `checks.redis.ok == true` après redéploiement
+
+**Tant que cette rotation n'est pas faite, le nettoyage de la documentation ci-dessus est
+cosmétique : l'ancien secret reste valide et exploitable via l'historique git.**
+
+### 3.2 Purge de l'historique git — 🔴 P0, après la rotation
+Nettoyer la doc actuelle (fait aujourd'hui) ne supprime PAS le secret des commits passés.
+Il reste récupérable via `git log -p` ou `git clone` par quiconque.
+
+Deux options, à faire **après** confirmation de la rotation (sinon le nouveau secret risque
+d'être exposé au même titre si mal manipulé) :
+
+```bash
+# Option BFG Repo-Cleaner (plus simple)
+bfg --replace-text redis-secrets.txt leopardo-hr.git
+cd leopardo-hr.git
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+git push --force
+
+# Option git filter-repo (recommandée par GitHub)
+git filter-repo --replace-text redis-secrets.txt
+git push --force --all
+git push --force --tags
+```
+`redis-secrets.txt` doit contenir le mot de passe réel (récupérable via `git log -p -- AUDIT.md`
+sur une copie locale) à remplacer par `***REMOVED***`.
+
+⚠️ Un `push --force` sur `main` réécrit l'historique partagé : **coordonner avec toute l'équipe/
+les autres agents actifs sur le repo avant de l'exécuter** (rebase requis pour toutes les branches
+ouvertes, y compris les PRs #888-#897 actuellement ouvertes). Prévenir tous les contributeurs
+de re-cloner après la purge.
+
+### 3.3 Vérification post-incident
+- [ ] Confirmer sur Upstash que l'ancien mot de passe est bien révoqué (test de connexion avec
+      l'ancienne valeur → doit échouer)
+- [ ] Confirmer que `secret-scan.yml` (TruffleHog) ne référence plus l'ancien secret comme "connu"
+- [ ] Vérifier qu'aucun autre fichier (logs Render, configuration locale de dev, `.env` non commité
+      de contributeurs) ne contient encore l'ancienne valeur
+- [ ] Cocher définitivement ce point dans `AUDIT.md` avec la date et la preuve de rotation
+
+## 4. Pourquoi ce n'a pas été fait automatiquement dans ce même passage
+
+La rotation du mot de passe nécessite un accès au dashboard Upstash et à Render (comptes tiers,
+hors périmètre du dépôt git et des credentials disponibles ici). La purge d'historique nécessite
+un `push --force` destructif sur la branche par défaut d'un repo partagé actif — décision qui doit
+rester **entre les mains du/de la propriétaire du repo**, coordonnée avec l'équipe, et non exécutée
+unilatéralement par un agent d'audit.

--- a/docs/PLAN_ACTION/POST_AUDIT_2026/01_ROADMAP_30J.md
+++ b/docs/PLAN_ACTION/POST_AUDIT_2026/01_ROADMAP_30J.md
@@ -46,7 +46,7 @@
 ```
 QUEUE_CONNECTION=redis
 REDIS_CLIENT=predis
-REDIS_HOST=noted-tomcat-92597.upstash.io
+REDIS_HOST=<votre_host>.upstash.io  # voir dashboard Upstash — ne pas committer le hostname reel, cf. SECURITY_INCIDENT_REDIS_2026-07.md
 REDIS_PORT=6379
 REDIS_PASSWORD=<upstash_password>
 REDIS_CACHE_DB=1

--- a/docs/PLAN_ACTION/POST_AUDIT_2026/08_SCALABILITE_REDIS.md
+++ b/docs/PLAN_ACTION/POST_AUDIT_2026/08_SCALABILITE_REDIS.md
@@ -219,7 +219,7 @@ Schema::table('notifications', function (Blueprint $table) {
 | Variable | Valeur | Description |
 |---|---|---|
 | `REDIS_CLIENT` | `predis` | **CRITIQUE** — Upstash nécessite predis, pas phpredis |
-| `REDIS_HOST` | `noted-tomcat-92597.upstash.io` | Host Upstash Redis |
+| `REDIS_HOST` | `<votre_host>.upstash.io` (voir dashboard Upstash — ne pas committer le hostname reel, cf. `SECURITY_INCIDENT_REDIS_2026-07.md`) | Host Upstash Redis |
 | `REDIS_PORT` | `6379` | Port Redis (TLS) |
 | `REDIS_PASSWORD` | `<upstash_password>` | Mot de passe Upstash (dans les credentials Upstash console) |
 | `REDIS_DB` | `0` | Database par défaut |

--- a/docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md
+++ b/docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md
@@ -81,7 +81,7 @@ Un chef de departement (`manager_role = 'dept'`) ou un superviseur (`manager_rol
 
 ## 4. Secret Redis en clair — rappel de criticite (deja documente, toujours ouvert)
 
-Confirme a nouveau lors de cet audit : `AUDIT.md` reference lui-meme un mot de passe Upstash reel commite dans l'historique git public (`noted-tomcat-92597.upstash.io`), et la case correspondante dans sa propre checklist finale reste **non cochee** (`[ ]`). Aucune preuve dans le code ou les commits recents d'une rotation effectuee. Ce point est repris ici en P0 dans le backlog ci-dessous parce qu'il n'a pas de ticket PA2 dedie a ce jour — seulement une note dans un fichier d'audit que personne n'est oblige de relire.
+Confirme a nouveau lors de cet audit : `AUDIT.md` reference lui-meme un mot de passe Upstash reel commite dans l'historique git public (hostname et mot de passe retires de la documentation le 2026-07-19, voir `SECURITY_INCIDENT_REDIS_2026-07.md`), et la case correspondante dans sa propre checklist finale restait **non cochee** avant cette meme date. Aucune preuve dans le code ou les commits recents d'une rotation Upstash effectuee — cette action reste a faire manuellement (hors perimetre code). Ce point est repris ici en P0 dans le backlog ci-dessous parce qu'il n'a pas de ticket PA2 dedie a ce jour — seulement une note dans un fichier d'audit que personne n'est oblige de relire.
 
 ---
 

--- a/docs/PLAN_ACTION2/11_AUDIT_CONSOLIDE_TECHCOMMERCIAL_2026-07-19.md
+++ b/docs/PLAN_ACTION2/11_AUDIT_CONSOLIDE_TECHCOMMERCIAL_2026-07-19.md
@@ -1,0 +1,119 @@
+# Audit consolidé technico-commercial — 2026-07-19 (revue Aria)
+
+Statut : complet pour publication
+Auteur : audit externe KiloClaw (agent Aria), à la demande de kitokoh — angle "qu'est-ce qui a échappé aux audits précédents / qu'est-ce qui est réellement encore ouvert"
+Périmètre : vérification croisée de tous les audits internes existants (`AUDIT.md`, `AUDIT_CICD_2026-07-19.md`, `docs/PLAN_ACTION2/08_*`, `09_*`, `10_*`, `docs/security/*`) contre l'état réel du code sur `main` au 2026-07-19, plus vérifications live (endpoints prod, GitHub API, git log).
+
+Ce document ne répète pas ce que les audits précédents documentent déjà correctement. Il fait trois choses :
+1. Confirme, avec preuve dans le code actuel, quels points signalés comme "ouverts" dans les audits précédents sont **réellement encore ouverts** aujourd'hui (beaucoup ont déjà été corrigés depuis leur publication — attention à ne pas re-traiter du travail déjà fait).
+2. Signale ce qui n'était pas dans les audits précédents (fuite du secret Redis dans la doc versionnée, positionnement produit vs traction commerciale réelle).
+3. Priorise l'ensemble en un seul plan d'action exécutable, sans doublon avec `02_BACKLOG_ATOMIQUE.md`.
+
+---
+
+## 1. Sécurité — traité aujourd'hui (2026-07-19, PR #898)
+
+Le mot de passe Redis Upstash réel, documenté comme fuite depuis le 2026-07-01 dans `AUDIT.md` (case `[ ]` jamais cochée malgré 3 revues successives qui le confirmaient), a été retiré de tous les fichiers Markdown suivis dans ce même passage :
+
+- `AUDIT.md`, `docs/PLAN_ACTION/POST_AUDIT_2026/08_SCALABILITE_REDIS.md`, `docs/PLAN_ACTION/POST_AUDIT_2026/01_ROADMAP_30J.md`, `docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md` : hostname + mot de passe réel remplacés par des placeholders génériques.
+- Nouveau fichier `SECURITY_INCIDENT_REDIS_2026-07.md` : suivi centralisé, procédure exacte de rotation Upstash + purge d'historique git (`BFG`/`git filter-repo`), et explication de pourquoi ces deux actions restent manuelles (accès dashboard tiers + `push --force` destructif sur branche partagée active, décision qui doit rester humaine).
+- PR ouverte : `security/redis-secret-redaction` → **#898**.
+
+**Important : le nettoyage de la doc ne corrige PAS le risque réel.** Le secret reste valide et récupérable dans l'historique git tant que la rotation Upstash + la purge d'historique ne sont pas faites. C'est la seule action **vraiment P0-P0** de tout ce document — tout le reste peut attendre quelques jours, celle-ci ne devrait pas.
+
+→ **PA2-SEC-001 est déjà dans le backlog existant** (`02_BACKLOG_ATOMIQUE.md`) mais reste non fait ; ce document ne le duplique pas.
+
+---
+
+## 2. Vérification croisée : qu'est-ce qui est VRAIMENT encore ouvert dans les audits existants
+
+Beaucoup de points listés comme "ouverts" dans `AUDIT.md`/`08_*`/`09_*`/`docs/security/AUDIT_API_2026-07-19.md` ont déjà été corrigés par des commits/PR postérieurs à la publication de ces audits. Vérification directe dans le code de `main` :
+
+| Ticket / finding | Statut réel vérifié dans le code | Preuve |
+|---|---|---|
+| `/api/v1/demo-users` public en clair (🔴 critique, `docs/security/AUDIT_API_2026-07-19.md`) | ✅ **Corrigé** | `DemoUserController::index()` fait `abort(404)` si `demo_mode_enabled` est faux ; vérifié en direct sur `gestionemployerbackend.onrender.com/api/v1/demo-users` → `404 RESOURCE_NOT_FOUND` |
+| SSRF webhooks sortants (🟠) | ✅ **Corrigé** | `app/Rules/NotPrivateUrl.php` appliqué sur `StoreWebhookEndpointRequest`, re-vérification DNS dans `DispatchWebhook::handle()` |
+| Pas de révocation token Sanctum au changement de mot de passe (🟠) | ✅ **Corrigé** | `ChangePasswordAction::execute()` fait `$employee->tokens()->delete()` puis émet un nouveau token |
+| CORS `allowed_headers: '*'` (🟡) | ✅ **Corrigé** | Restreint à la liste explicite (`Authorization, Content-Type, Accept, ...`) |
+| `trustProxies` non déclaré (🟡) | ✅ **Corrigé** | `bootstrap/app.php` déclare `trustProxies(at: '*', ...)` |
+| PA2-ARCH-006 (garde CI 16/19 modules) | ✅ **Corrigé** | `architecture-check.yml` découvre les modules dynamiquement (`find api/app/Modules -maxdepth 1 -mindepth 1 -type d`) |
+| PA2-ARCH-007 (controllers dupliqués jamais routés) | ✅ **Corrigé** | Garde CI `check-unrouted-controllers.sh` en place, 7 orphelins supprimés |
+| PA2-ARCH-002 (doublon Absence/Planning) | ✅ **Corrigé** | `Modules/Absence` ne garde que sa façade HTTP, `Planning` est propriétaire canonique |
+| **PA2-ARCH-008 (double enregistrement `Gate::policy`, divergence `Invoice`)** | ✅ **Corrigé** | `AppServiceProvider::boot()` ne fait plus que des `Gate::define()` ; `AuthServiceProvider::boot()` seul point d'enregistrement, `Invoice` résolu explicitement vers `InvoicePolicy` |
+| **PA2-ARCH-001 (TaxSlab jamais branché dans PayrollCalculator)** | ❌ **Toujours ouvert** | `grep -rn "TaxSlab::" api/app/Modules/Payroll/Infrastructure/` → 0 résultat. Le modèle `TaxSlab` (DB) et `XxxPayrollRules` (code) restent complètement déconnectés. Un changement de barème via `TaxSlabController` (API existante) n'a **aucun effet** sur le calcul réel de paie. |
+| **PA2-SEC-002 (scope département `manager_role=dept`)** | ✅ **Corrigé** | `Employee::isDepartmentScoped()`/`managesDepartmentOf()` existent et sont utilisés dans `EmployeePolicy`, `AttendancePolicy`, `EvaluationPolicy`, `DepartmentPolicy`, `EmployeeController::index()` |
+| **PA2-SEC-003 (scope superviseur "assigned-only")** | ❌ **Toujours ouvert, confirmé par lecture directe** | Aucune occurrence de logique de scoping pour `manager_role = 'superviseur'` dans `api/app/Policies/*.php` ni dans `Employee.php`. Le rôle existe dans l'enum DB et dans les Requests de validation, mais se comporte exactement comme un manager company-wide (`isManager()` plat) — alors que `RBAC_SYSTEM.md` promet explicitement "Assigned-only". Un compte "superviseur" voit donc aujourd'hui tout le périmètre RH/attendance de l'entreprise, comme un `principal`. |
+| PA2-I18N-005 (PDF légaux non localisés) | ✅ **Corrigé** | `payslip.blade.php` : `<html lang="{{ app()->getLocale() }}" dir="...isRtl(...)">`, `PaySlipPdfGenerator.php` appelle `App::setLocale(...)` avant rendu |
+| **PA2-I18N-006 (emails transactionnels non localisés)** | ⚠️ **Partiellement corrigé** | Seul `cabinet-share.blade.php` (5 occurrences `__(`) utilise le catalogue. Les 16 autres templates vérifiés (`welcome-employee`, `password-reset`, `subscription-confirmed`, `trial-welcome`, `trial-verification`, `trial-expiring`, `invitation`, `user-invitation`, `role-assignment`, `payment-failed`, `invoice-sent`, `license-expiring`, `newsletter-welcome`, `demo-confirmation`, `welcome-onboarding`, `welcome`) ont chacun **0 occurrence** de `__(`. Le ticket original visait "16+ templates" — 1 seul est traité, 16 restent en français codé en dur. |
+| **PA2-I18N-011 (mélange de langues figé dans les données vitrine)** | ❌ **Toujours ouvert, mais moins grave que documenté** | `pricing.ts` a en réalité une structure `Record<AppLocale, PricingPlan[]>` propre avec un bloc `tr:` dédié séparé du bloc `fr:` — donc pas un vrai "mélange dans le même objet" comme décrit dans `10_AUDIT_I18N_MULTILINGUE.md`. En revanche, une régression réelle et différente a été trouvée : `MarketingReadinessSection.tsx` contient une entrée `tr:` avec le texte `'Kucuk baslayin, ekip buyudukce gelismis modulleri acin.'` — turc **sans caractères diacritiques ni accents**, mélangé au reste du fichier qui a un vrai bloc `fr:`/`en:`/`ar:` à côté. Le contenu proprement dit est bien scindé par langue (pas un vrai "mélange visible à un utilisateur fr"), mais la qualité de la traduction turque de ce composant spécifique est dégradée (accents manquants : `baslayin` au lieu de `başlayın`), signe d'un contenu généré rapidement sans passage par le glossaire verrouillé mentionné dans l'audit i18n. Le ticket `PA2-I18N-011` doit être reformulé : le vrai problème n'est pas un mélange de langues dans le même objet de données (semble déjà résolu), mais une qualité de traduction turque incohérente sur au moins ce composant, à vérifier plus largement. |
+| `dependabot.yml` chemin `pub`/mobile inexistant (`AUDIT_CICD_2026-07-19.md`) | ✅ **Corrigé** | 5 entrées `pub` pointent vers les vrais dossiers `front/mobile_apps/leopardo_{core,employee,manager,hr,platform_admin}` ; `npm` étendu à `front/web` |
+| `release.yml` référence `front/mobile` supprimé | ✅ **Corrigé** | Commentaire confirmant le retrait, plus de référence au dossier supprimé |
+| `tests.yml` fragment de script orphelin (`steps.mobile_*`) | ✅ **Corrigé** | Aucune occurrence de `mobile_smoke_build`/`mobile_analyze`/`mobile_coverage_gate` dans `tests.yml` |
+
+**Conclusion de cette section** : le rythme de correction de ce repo est réellement très élevé (la quasi-totalité des findings critiques/élevés des 3 derniers audits sont déjà réglés en quelques jours). Les points encore ouverts sont concentrés sur 3 sujets précis, détaillés ci-dessous, pas sur une longue liste diffuse.
+
+---
+
+## 3. Ce qui reste réellement ouvert — priorisé
+
+### 🔴 P0 — Sécurité/conformité produit
+
+**AUDIT-P0-1 — Rotation Redis Upstash + purge historique git (déjà `PA2-SEC-003`... non, `PA2-SEC-001` dans le backlog existant)**
+Voir section 1. Seule action non-code de ce document, mais la plus urgente. Sans elle, tout le reste de ce rapport est secondaire.
+
+**AUDIT-P0-2 — Scope RBAC "superviseur = assigned-only" toujours non implémenté (confirme `PA2-SEC-003` déjà dans le backlog, avec preuve à jour)**
+- **Constat** : `manager_role = 'superviseur'` se comporte identiquement à `principal`/`rh` sur toutes les policies testées (`EmployeePolicy`, `AttendancePolicy`, `EvaluationPolicy`, `SchedulePolicy`) — aucune notion d'assignation explicite (liste d'employés/départements assignés) n'existe dans le schéma DB ni dans le code.
+- **Impact commercial** : `RBAC_SYSTEM.md` documente ce rôle comme argument de vente ("Supervisor : View-only access for reporting and monitoring, scope Assigned-only") — probablement utile pour le secteur "Sécurité privée" ciblé en priorité #1 par `LEOPARDO_STRATEGIC_ANALYSIS.md` (superviseurs de site qui ne doivent voir que leur périmètre). Vendre une fonctionnalité RBAC qui n'existe pas dans le code à un premier client pilote est un risque de confiance et de conformité (CNIL/RGPD si le superviseur accède à des données RH hors de son périmètre légitime).
+- **Action recommandée** : soit implémenter un scoping réel (table de pivot `supervisor_assignments` ou réutiliser `department_id` en mode restreint), soit **retirer ce rôle de la doc commerciale et du RBAC vendu tant qu'il n'est pas implémenté** — la seconde option est plus rapide et évite une promesse non tenue en pilote client.
+- Déjà dans le backlog comme `PA2-SEC-003`/`PA2-SEC-004` (tests de régression RBAC) — ce document confirme juste que c'est encore et bien ouvert, avec preuve de code à date.
+
+**AUDIT-P0-3 — TaxSlab (DB) jamais branché dans PayrollCalculator (confirme `PA2-ARCH-001`, toujours ouvert)**
+- **Constat** : le calcul de paie utilise exclusivement des barèmes PHP statiques (`XxxPayrollRules::taxSlabs()`), jamais le modèle `TaxSlab` malgré une API `TaxSlabController` permettant de le gérer.
+- **Impact commercial direct** : c'est la fonctionnalité qui casse la promesse "conformité multi-pays" vendue dans le README ("multi-country regulatory compliance DZ/MA/FR/TR") et dans `PILOTAGE.md` (Maghreb prioritaire #1). Si un client Platform Admin met à jour un barème IR/CNAS via l'interface (fonctionnalité existante, visible, qui donne l'impression de fonctionner), **le calcul de paie réel n'en tient aucun compte** — bug silencieux avec impact financier direct sur le premier client payant.
+- **Priorité réelle** : ce ticket devrait être P0 (bloquant avant tout onboarding payant sur le module Paie), pas P1 comme actuellement classé dans `08_AUDIT_ARCHITECTURE_TECH.md`. Recommandation : soit brancher `TaxSlab` réellement, soit **désactiver/masquer `TaxSlabController` dans l'UI admin** jusqu'à ce que ce soit fait, pour ne pas donner une fausse impression de configurabilité.
+
+### 🟠 P1 — Cohérence produit/documentation
+
+**AUDIT-P1-1 — Emails transactionnels : 1 template sur 17 réellement localisé (révision de `PA2-I18N-006`)**
+- Le ticket existant liste "16+ templates" à corriger ; la vérification directe confirme précisément **16 templates sur 17** encore intégralement en français codé en dur (`welcome-employee`, `password-reset`, `subscription-confirmed`, `trial-welcome`, `trial-verification`, `trial-expiring`, `invitation`, `user-invitation`, `role-assignment`, `payment-failed`, `invoice-sent`, `license-expiring`, `newsletter-welcome`, `demo-confirmation`, `welcome-onboarding`, `welcome`). Seul `cabinet-share` est fait.
+- Impact direct : un employé qui choisit `en` ou `ar` dans son profil continue de recevoir tous ses emails transactionnels (bienvenue, réinitialisation mot de passe, confirmation d'abonnement, trial) en français — sur un produit dont le marché prioritaire inclut explicitement le Maghreb (`ar` pertinent) et la Turquie (`tr`).
+- Pas de nouveau ticket nécessaire — `PA2-I18N-006` existant couvre déjà ce périmètre exact, priorité P0 déjà correcte dans le backlog. Ce document confirme juste l'ampleur réelle (1/17, pas "en cours").
+
+**AUDIT-P1-2 — Qualité de traduction turque incohérente (reformulation de `PA2-I18N-011`)**
+- Le vrai problème n'est pas un "mélange figé dans le même objet de données" (la structure `pricing.ts` par locale est propre) mais une **traduction turque de moindre qualité sur au moins un composant** (`MarketingReadinessSection.tsx` : accents manquants, tournures approximatives) qui contraste avec la traduction plus soignée du fichier `pricing.ts`.
+- Recommandation : élargir la vérification qualité turque (et arabe) à l'ensemble des composants `front/web/src/modules/vitrine/**` avant tout lancement commercial ciblant la Turquie (`PILOTAGE.md` marché prioritaire #3), pas seulement `pricing.ts`.
+
+### 🟡 P2 — Suivi / discipline d'exécution
+
+**AUDIT-P2-1 — Documentation RBAC désynchronisée du code réel (confirme `PA2-SEC-005`)**
+`RBAC_SYSTEM.md` documente 6 rôles avec des scopes qui ne correspondent que partiellement au code (Department = correct maintenant, Supervisor = toujours faux). Tant que `AUDIT-P0-2` n'est pas tranché (implémenter ou retirer), ne pas corriger la doc en cosmétique — corriger la doc pour refléter la vraie décision produit une fois prise.
+
+**AUDIT-P2-2 — Vigilance sur le rythme de fix vs. rythme d'audit**
+Constat transverse, pas un ticket : ce repo produit nettement plus d'audits/plans d'action (72 plans historiques + PLAN_ACTION2 en cours + 4 audits dédiés en une seule semaine) que de clients réels (0 payant à ce jour selon `PILOTAGE.md`). Le taux de correction des findings est excellent une fois qu'un audit existe, mais le volume de nouveaux audits internes continue de croître plus vite que la traction commerciale. Recommandation produit, pas technique : geler la production de nouveaux documents d'audit tant qu'AUDIT-P0-2 et AUDIT-P0-3 ne sont pas tranchés et qu'aucun client pilote payant n'est signé — cohérent avec la règle déjà écrite dans `PILOTAGE.md` ("Pas de nouveau module tant que P0 n'est pas atteint"), à appliquer aussi à la production de documentation d'audit elle-même.
+
+---
+
+## 4. Tickets à ajouter/mettre à jour dans `02_BACKLOG_ATOMIQUE.md`
+
+Pas de nouveaux IDs pour les points déjà couverts par `PA2-SEC-001/003/004/005` et `PA2-ARCH-001` et `PA2-I18N-006/011` — ce document confirme leur statut réel plutôt que de dupliquer le backlog. Une seule reformulation de ticket recommandée :
+
+| ID existant | Changement recommandé |
+|---|---|
+| `PA2-ARCH-001` | Reclasser de P1 à **P0** — impact financier direct sur le premier client payant du module Paie, pas une dette technique différable |
+| `PA2-SEC-003` | Ajouter au Definition of Done : décision explicite écrite (implémenter le scoping réel OU retirer "Supervisor" de `RBAC_SYSTEM.md` et de toute doc commerciale) avant tout client pilote sur un secteur avec hiérarchie superviseur (sécurité privée, priorité #1 du GTM) |
+| `PA2-I18N-011` | Reformuler le titre : "Vérifier la qualité de traduction turque/arabe des composants vitrine (accents, glossaire)" au lieu de "corriger le mélange de langues figé" — la structure par locale est déjà correcte, c'est la qualité de contenu qui est en cause |
+
+---
+
+## 5. Récapitulatif exécutif
+
+| Domaine | État réel au 2026-07-19 (fin de journée) | Sévérité |
+|---|---|---|
+| Secret Redis exposé dans la doc versionnée | Documentation nettoyée aujourd'hui (PR #898) ; rotation Upstash + purge historique **toujours à faire manuellement** | 🔴 Critique — non résolu tant que la rotation n'est pas faite |
+| RBAC "superviseur" assigned-only | Toujours non implémenté, comportement = manager company-wide | 🔴 P0 — écart doc/code vendable |
+| TaxSlab DB déconnecté du calcul de paie réel | Toujours non branché | 🔴 P0 — bug silencieux à impact financier direct |
+| Findings sécurité API (demo-users, SSRF, tokens, CORS, trustProxies) | Tous corrigés, vérifiés en direct sur la prod | ✅ Résolu |
+| Findings architecture (policies dupliquées, controllers orphelins, module CI 16/19) | Tous corrigés | ✅ Résolu |
+| Emails transactionnels multilingues | 1/17 templates traités | 🟠 P1 — déjà dans le backlog, priorité confirmée correcte |
+| Qualité traduction turque vitrine | Incohérente sur au moins 1 composant vérifié | 🟠 P1 |
+| Rythme audits vs traction commerciale | 0 client payant, volume de documentation d'audit élevé et croissant | 🟡 P2 — recommandation de gel, pas un bug |


### PR DESCRIPTION
## Contexte

`AUDIT.md` documentait depuis le 2026-07-01 qu'un vrai mot de passe Upstash Redis avait été committé en clair dans plusieurs fichiers Markdown de ce dépôt **public**. Plusieurs audits successifs (`docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md` notamment) confirmaient le problème sans que la rotation soit faite.

## Ce que cette PR fait

- Retire le hostname réel (`noted-tomcat-92597.upstash.io`) et le mot de passe en clair de :
  - `AUDIT.md`
  - `docs/PLAN_ACTION/POST_AUDIT_2026/08_SCALABILITE_REDIS.md`
  - `docs/PLAN_ACTION/POST_AUDIT_2026/01_ROADMAP_30J.md`
  - `docs/PLAN_ACTION2/08_AUDIT_ARCHITECTURE_TECH.md`
- Ajoute `SECURITY_INCIDENT_REDIS_2026-07.md` : suivi centralisé de l'incident + procédure exacte pour les 2 actions manuelles restantes.

## ⚠️ Ce que cette PR NE fait PAS (actions manuelles hors périmètre, à faire par l'équipe)

1. **Rotation du mot de passe Upstash** (dashboard Upstash + mise à jour Render) — je n'ai pas accès à ces comptes tiers.
2. **Purge de l'historique git** (BFG/git filter-repo + push --force) — décision destructive sur une branche partagée active, à coordonner avec l'équipe (PRs #888-#897 actuellement ouvertes seraient impactées par un rewrite d'historique).

Tant que ces deux points ne sont pas faits, le secret réel reste valide et récupérable via l'historique git. Voir `SECURITY_INCIDENT_REDIS_2026-07.md` pour la procédure détaillée.