### PR TITLE
fix(vitrine): correct OTP signup success screen + restore vitrine tests

### DIFF
--- a/front/web/jest.config.ts
+++ b/front/web/jest.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'jest';
-import nextJest from 'next/jest';
+import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
@@ -21,7 +21,25 @@ const config: Config = {
   ],
   testPathIgnorePatterns: [
     '<rootDir>/e2e/',
-    '<rootDir>/src/modules/vitrine/components/.*/__tests__/',
+    // NOTE: these suites predate a visual/design-token rework of the shared
+    // vitrine UI kit (Badge/Card colors+spacing, Pricing/Hero/Feature cards)
+    // and assert the old class names, so they fail against current markup.
+    // They were previously hidden wholesale (including unrelated, currently
+    // passing-when-fixed suites like SignupForm/ContactForm) via a single
+    // catch-all glob — that masked real regressions from CI. Keeping only
+    // these specific stale suites ignored until they are rewritten against
+    // the current design tokens; do not widen this pattern back to a glob.
+    '<rootDir>/src/modules/vitrine/components/common/__tests__/Badge.test.tsx',
+    '<rootDir>/src/modules/vitrine/components/common/__tests__/Card.test.tsx',
+    '<rootDir>/src/modules/vitrine/components/common/__tests__/Button.test.tsx',
+    '<rootDir>/src/modules/vitrine/components/common/__tests__/Input.test.tsx',
+    '<rootDir>/src/modules/vitrine/components/sections/__tests__/PricingCard.test.tsx',
+    '<rootDir>/src/modules/vitrine/components/sections/__tests__/HeroSection.test.tsx',
+    '<rootDir>/src/modules/vitrine/components/sections/__tests__/FeatureCard.test.tsx',
+    // ContactForm predates this cleanup too: its labels are French
+    // ("Nom complet") but the test queries English accessible names
+    // (/name/i). Unrelated to the OTP signup work; needs its own fix pass.
+    '<rootDir>/src/modules/vitrine/components/forms/__tests__/ContactForm.test.tsx',
   ],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
@@ -350,7 +350,7 @@ export function SignupForm({
 
               <p className="text-center text-sm text-slate-600 dark:text-slate-400">
                 Vous avez deja un compte?{' '}
-                <a href="/login" className="font-semibold text-emerald-600 hover:text-emerald-700">
+                <a href="/auth/login" className="font-semibold text-emerald-600 hover:text-emerald-700">
                   Se connecter
                 </a>
               </p>
@@ -462,29 +462,91 @@ export function SignupForm({
               <div className="flex items-center gap-3 bg-emerald-500/10 px-5 py-3 dark:bg-emerald-500/5">
                 <Rocket className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                 <h3 className="text-lg font-black text-emerald-900 dark:text-emerald-100">
-                  Votre demande est confirmée !
+                  Votre espace est pret !
                 </h3>
               </div>
 
               <div className="space-y-4 p-5">
-                <div className="rounded-xl bg-white p-4 shadow-sm ring-1 ring-slate-100 text-center dark:bg-slate-800/60 dark:ring-slate-700">
-                  <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                    Votre adresse email a bien été vérifiée.
-                  </p>
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                    Un conseiller Leopardo vous contactera sous 24h pour activer votre espace de test personnalisé.
-                  </p>
+                <div className="rounded-xl bg-white p-4 shadow-sm ring-1 ring-slate-100 dark:bg-slate-800/60 dark:ring-slate-700">
+                  <div className="flex items-center gap-2 text-center justify-center mb-3">
+                    <CheckCircle className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                    <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                      Votre adresse email a bien été vérifiée.
+                    </p>
+                  </div>
+                  {provisionedData?.manager ? (
+                    <>
+                      <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+                        Identifiants de connexion
+                      </p>
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-slate-600 dark:text-slate-300">Email</span>
+                          <span className="font-mono text-sm font-bold text-slate-900 dark:text-white">
+                            {provisionedData.manager.email}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-sm text-slate-600 dark:text-slate-300">Mot de passe</span>
+                          <div className="flex items-center gap-2">
+                            <span className="rounded-lg bg-slate-100 px-3 py-1 font-mono text-sm font-bold text-slate-900 dark:bg-slate-700 dark:text-white">
+                              {provisionedData.manager.temp_password}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => copyPassword(provisionedData.manager!.temp_password)}
+                              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-200"
+                              title="Copier le mot de passe"
+                            >
+                              <ClipboardCopy className="h-4 w-4" />
+                            </button>
+                          </div>
+                        </div>
+                        {copied && (
+                          <p className="text-right text-xs font-medium text-emerald-600">Copie !</p>
+                        )}
+                      </div>
+                      <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+                        Ces identifiants ont aussi ete envoyes par email a {provisionedData.manager.email}.
+                      </p>
+                    </>
+                  ) : (
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Vos identifiants de connexion viennent de vous etre envoyes par email.
+                    </p>
+                  )}
                 </div>
 
-                <div className="flex flex-col gap-2 sm:flex-row mt-4">
+                {provisionedData?.trial && (
+                  <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+                    Essai gratuit de{' '}
+                    <span className="font-bold text-emerald-600">
+                      {provisionedData.trial.days} jours
+                    </span>{' '}
+                    — aucune carte bancaire requise.
+                  </p>
+                )}
+
+                <div className="flex flex-col gap-2 sm:flex-row">
                   <a
-                    href="/download"
+                    href="/auth/login"
                     className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-3 text-sm font-bold text-white shadow-lg shadow-emerald-500/25 transition hover:bg-emerald-700"
                   >
+                    <LogIn className="h-4 w-4" />
+                    Se connecter
+                  </a>
+                  <a
+                    href="/download"
+                    className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                  >
                     <Download className="h-4 w-4" />
-                    Découvrir l'app mobile
+                    Telecharger l'app
                   </a>
                 </div>
+
+                <p className="text-center text-xs text-slate-400 dark:text-slate-500">
+                  Changez votre mot de passe des la premiere connexion.
+                </p>
               </div>
             </div>
           </motion.div>

--- a/front/web/src/modules/vitrine/components/forms/__tests__/SignupForm.test.tsx
+++ b/front/web/src/modules/vitrine/components/forms/__tests__/SignupForm.test.tsx
@@ -46,7 +46,7 @@ describe('SignupForm Component', () => {
 
     it('should render submit button', () => {
       render(<SignupForm />);
-      expect(screen.getByRole('button', { name: /recevoir mon acces/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /recevoir mon code de verification/i })).toBeInTheDocument();
     });
   });
 
@@ -55,7 +55,7 @@ describe('SignupForm Component', () => {
       render(<SignupForm />);
       const emailInput = screen.getByRole('textbox', { name: /email/i });
       await userEvent.type(emailInput, 'invalid-email');
-      await userEvent.click(screen.getByRole('button', { name: /recevoir mon acces/i }));
+      await userEvent.click(screen.getByRole('button', { name: /recevoir mon code de verification/i }));
       
       await waitFor(() => {
         expect(screen.getByText(/email invalide|valid email/i)).toBeInTheDocument();
@@ -64,11 +64,11 @@ describe('SignupForm Component', () => {
 
     it('should show error for empty email', async () => {
       render(<SignupForm />);
-      const submitButton = screen.getByRole('button', { name: /recevoir mon acces/i });
+      const submitButton = screen.getByRole('button', { name: /recevoir mon code de verification/i });
       await userEvent.click(submitButton);
       
       await waitFor(() => {
-        expect(screen.getByText(/required|email/i)).toBeInTheDocument();
+        expect(screen.getByText(/email (invalide|trop court)/i)).toBeInTheDocument();
       });
     });
 
@@ -76,11 +76,11 @@ describe('SignupForm Component', () => {
       render(<SignupForm />);
       const emailInput = screen.getByRole('textbox', { name: /email/i });
       await userEvent.type(emailInput, 'test@example.com');
-      const submitButton = screen.getByRole('button', { name: /recevoir mon acces/i });
+      const submitButton = screen.getByRole('button', { name: /recevoir mon code de verification/i });
       await userEvent.click(submitButton);
       
       await waitFor(() => {
-        expect(screen.getByText(/entreprise|company/i)).toBeInTheDocument();
+        expect(screen.getByText(/entreprise doit contenir/i)).toBeInTheDocument();
       });
     });
 
@@ -91,11 +91,11 @@ describe('SignupForm Component', () => {
       await userEvent.type(screen.getByRole('textbox', { name: /entreprise/i }), 'Acme Corp');
       await userEvent.type(screen.getByRole('textbox', { name: /telephone/i }), 'not-a-phone');
 
-      const submitButton = screen.getByRole('button', { name: /recevoir mon acces/i });
+      const submitButton = screen.getByRole('button', { name: /recevoir mon code de verification/i });
       await userEvent.click(submitButton);
       
       await waitFor(() => {
-        expect(screen.getByText(/telephone|phone/i)).toBeInTheDocument();
+        expect(screen.getByText(/numero de telephone invalide/i)).toBeInTheDocument();
       });
     });
   });
@@ -107,7 +107,7 @@ describe('SignupForm Component', () => {
       await userEvent.type(emailInput, 'test@example.com');
       await userEvent.type(screen.getByRole('textbox', { name: /entreprise/i }), 'Acme Corp');
 
-      const submitButton = screen.getByRole('button', { name: /recevoir mon acces/i });
+      const submitButton = screen.getByRole('button', { name: /recevoir mon code de verification/i });
       expect(submitButton).not.toBeDisabled();
     });
   });
@@ -147,7 +147,7 @@ describe('SignupForm Component', () => {
 
     it('should show loading state during submission', async () => {
       render(<SignupForm />);
-      const submitButton = screen.getByRole('button', { name: /recevoir mon acces/i });
+      const submitButton = screen.getByRole('button', { name: /recevoir mon code de verification/i });
       
       expect(submitButton).not.toHaveAttribute('disabled');
     });


### PR DESCRIPTION
## Contexte

Revue de la partie vitrine (public site) suite aux travaux recents sur le signup avec verification OTP (`ca69a675`, `78773398`). Correctifs trouves et appliques :

### 1. Ecran de succes incoherent avec le flux self-service instantane
Apres verification du code OTP, le backend (`SelfServiceTrialController::verify`) provisionne **immediatement** le tenant et retourne des identifiants de connexion valides (`data.manager.email` / `data.manager.temp_password`). Pourtant l'ecran de succes affichait encore un message obsolete : *"Un conseiller Leopardo vous contactera sous 24h pour activer votre espace de test personnalise"* — copie residuelle du flux "guide" d'avant l'OTP. L'utilisateur ne voyait ni ses identifiants ni de bouton pour se connecter.

**Fix** : restaure la carte identifiants (email + mot de passe + bouton copier) et un CTA "Se connecter" fonctionnel, coherents avec ce que le backend fait reellement.

### 2. Lien de connexion casse
`Vous avez deja un compte? Se connecter` pointait vers `/login`, route inexistante dans l'app (la vraie route est `/auth/login`, utilisee correctement ailleurs dans `Navbar.tsx` et dans le fallback `EMAIL_ALREADY_REGISTERED` de `api/forms/signup/route.ts`).

### 3. Tests vitrine casses au niveau infra (aucun test ne tournait)
`jest.config.ts` importait `next/jest`, qui ne se resout plus avec la version de Next installee (`ERR_MODULE_NOT_FOUND`). Corrige en `next/jest.js`.

### 4. Regression masquee par un fix CI precedent
Un commit `fix(ci)` anterieur (`02ac5ce2`) avait desactive silencieusement **tous** les tests de composants vitrine sous `components/**/__tests__` via un glob generique dans `testPathIgnorePatterns`, au lieu de corriger les echecs reels. Cela cachait de vraies regressions (dont les points 1 et 2 ci-dessus) a la CI.

**Fix** : le glob est remplace par une liste explicite et commentee des suites reellement obsoletes (design-tokens UI kit changes pour Badge/Card/Button/Input/PricingCard/HeroSection/FeatureCard, et un mismatch de libelles FR/EN dans ContactForm) — a corriger dans un lot separe. Tout le reste, y compris la suite `SignupForm`, est reactive.

### 5. Assertions de test obsoletes dans SignupForm.test.tsx
Les assertions verifiaient un texte de bouton (`recevoir mon acces`) et des messages d'erreur qui ne correspondent plus a la copie introduite par la fonctionnalite OTP. Mis a jour pour matcher le comportement actuel.

## Verification
- `npm run lint` : OK
- `npx tsc --noEmit` : OK
- `npm run build` : OK (63 routes generees)
- `npx jest` : 235/235 tests passent (7 suites)

## Hors scope (documente mais non corrige ici)
- Tests Badge/Card/Button/Input/PricingCard/HeroSection/FeatureCard : assertions de classes CSS obsoletes suite a un rework visuel du design system partage, sans rapport avec le travail OTP.
- ContactForm.test.tsx : le composant est en francais ("Nom complet") mais le test interroge des noms accessibles en anglais (`/name/i`).
