### PR TITLE
docs: fix stale Next.js 15 version claims and dead Discord/social links

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Leopardo HR est un monorepo multi-stack couvrant :
 leopardo-hr/
 ├── api/                    # Backend Laravel (PHP 8.4) — cœur métier HRMS
 ├── front/
-│   ├── web/                # Next.js 15 — landing page + dashboard SaaS (déployé sur Vercel)
+│   ├── web/                # Next.js 16 — landing page + dashboard SaaS (déployé sur Vercel)
 │   ├── web-offline/        # Next.js — PWA offline-first pour le bridge Edge (http://leopardo.local)
 │   ├── admin-dashboard/    # Vue.js 3 — interface super-admin plateforme
 │   ├── mobile_apps/        # Flutter — 5 applications mobiles (voir melos.yaml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ First off, thank you for considering contributing to Leopardo RH! It's people li
 Leopardo RH is an **Enterprise-Grade** platform. We maintain high standards for code quality, security, and documentation.
 
 -   **Backend:** PHP 8.4, Laravel 12 (^12.60), PSR-12, Pest PHP for testing.
--   **Frontend:** Next.js 15, TypeScript, Tailwind CSS.
+-   **Frontend:** Next.js 16, TypeScript, Tailwind CSS.
 -   **Mobile:** Flutter 3.x, Riverpod for state management.
 -   **Architecture:** Modular Monolith & Domain-Driven Design (DDD).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/kitokoh/leopardo-hr?style=for-the-badge&label=License" alt="License"></a>
   <img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4">
   <img src="https://img.shields.io/badge/Flutter-3.x-02569B?style=for-the-badge&logo=flutter" alt="Flutter 3.x">
-  <img src="https://img.shields.io/badge/Next.js-15-black?style=for-the-badge&logo=next.js" alt="Next.js 15">
+  <img src="https://img.shields.io/badge/Next.js-16-black?style=for-the-badge&logo=next.js" alt="Next.js 16">
 </p>
 
 ---
@@ -60,7 +60,7 @@ Leopardo RH is engineered for 99.9% uptime and extreme data integrity.
 ```mermaid
 graph TB
     subgraph "Omnichannel Layer"
-        Web[Next.js 15 Dashboard]
+        Web[Next.js 16 Dashboard]
         Mobile[Flutter Native Suite]
         Kiosk[ZKTeco Cloud Bridge]
     end
@@ -96,7 +96,7 @@ graph TB
 | Module | Access Point | Technology Stack |
 | :--- | :--- | :--- |
 | **API Backend** | [Gateway](https://gestionemployerbackend.onrender.com) | Laravel 12, PostgreSQL |
-| **Corporate Web** | [Live Preview](https://gestionemployer-backend.vercel.app) | Next.js 15, Tailwind CSS |
+| **Corporate Web** | [Live Preview](https://gestionemployer-backend.vercel.app) | Next.js 16, Tailwind CSS |
 | **Admin Panel** | [Dashboard](https://leo-admin.pages.dev) | Cloudflare Pages |
 | **Mobile Suite** | [Employee / Manager / HR / Platform Admin](docs/mobile/README.md) | Flutter 3.x, Riverpod |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,11 @@
 # Support Guide — Leopardo RH
 
+> ⚠️ **The `leopardo-rh.com` domain, `@leopardo-rh.com` addresses, Discord invite, and X/Twitter
+> handle below are not live yet** — `leopardo-rh.com` is a recommended future domain, not yet
+> purchased (see `docs/GUIDES/GUIDE_LIENS_PLATEFORME_ET_COMMUNICATION.md`); the Discord invite
+> code returns "Unknown Invite" and `@LeopardoRH` on X returns 404 (both verified). For real
+> support today, use GitHub Issues below.
+
 We are committed to providing the best support for developers, enterprises, and contributors using the Leopardo RH platform.
 
 ## 🛠 Technical Support

--- a/dev-hub/CONTRIBUTING.md
+++ b/dev-hub/CONTRIBUTING.md
@@ -83,4 +83,4 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 
-Need help? Join our [Community Discord](https://discord.gg/leopardo-rh) or check [../SUPPORT.md](../SUPPORT.md).
+Need help? Check [../SUPPORT.md](../SUPPORT.md) (the Discord invite there is not live yet, see the notice at the top of that file).

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -120,7 +120,7 @@ For detailed implementation, see [Multi-Tenancy Documentation](MULTITENANCY.md).
 - **Laravel 11 / PHP 8.4:** Robust ecosystem for rapid enterprise development.
 - **PostgreSQL 16:** Advanced JSONB support and schema-based multi-tenancy.
 - **Redis:** High-speed queue and cache management.
-- **Next.js 15:** Server-side rendering for optimal dashboard performance (`front/web`, deployed on Vercel).
+- **Next.js 16:** Server-side rendering for optimal dashboard performance (`front/web`, deployed on Vercel).
 - **Vue 3 / Vite:** Platform admin dashboard (`front/admin-dashboard`).
 - **Flutter:** Single codebase for native-performance mobile apps (`front/mobile_apps/*`).
 

--- a/docs/contributing/GUIDELINES.md
+++ b/docs/contributing/GUIDELINES.md
@@ -81,7 +81,7 @@ api/                    # Backend Laravel 12 (PHP 8.4)
 
 front/                  # Frontends
 ├── admin-dashboard/    # Dashboard super-admin plateforme (Vue.js 3)
-├── web/                # Vitrine + dashboard SaaS public (Next.js 15)
+├── web/                # Vitrine + dashboard SaaS public (Next.js 16)
 ├── web-offline/        # PWA offline-first bridge Edge (Next.js)
 ├── mobile_apps/        # Apps Flutter : leopardo_core, leopardo_employee, leopardo_manager, leopardo_hr, leopardo_platform_admin
 └── zkteco-kiosk/       # Kiosque pointage biometrique (HTML/JS)

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -20,4 +20,4 @@ Le mobile historique (`front/mobile/`) a ete retire du depot.
 
 ---
 
-For technical support, join our [Discord Community](https://discord.gg/leopardo-rh).
+For technical support, see [SUPPORT.md](../../SUPPORT.md) (the Discord invite is not live yet).


### PR DESCRIPTION
## Summary

Fourth docs-audit batch (separate from #916, #930, #933, no file overlap).

1. **Next.js version drift** — `README.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`, `docs/architecture/ARCHITECTURE.md`, `docs/contributing/GUIDELINES.md` all said "Next.js 15" (badge, mermaid diagram, tech-stack table, tree comments), but `front/web/package.json` has been on Next.js `16.2.10` since the Dependabot bump commit `a7061cd`. Corrected all 6 occurrences across 5 files to Next.js 16.

2. **Dead Discord invite + non-existent social links** — `SUPPORT.md`, `dev-hub/CONTRIBUTING.md`, `docs/mobile/README.md` all linked a Discord invite (`discord.gg/leopardo-rh`) and/or `*@leopardo-rh.com` support addresses as if live. Verified via Discord's own invite API that the invite code returns `"Unknown Invite"` (code 10006), the X/Twitter handle `@LeopardoRH` returns 404, and `leopardo-rh.com` does not resolve. `docs/GUIDES/GUIDE_LIENS_PLATEFORME_ET_COMMUNICATION.md` already documents `leopardo-rh.com` as a *recommended future domain, not yet purchased* — these support-channel docs just hadn't caught up with that reality. Added a warning banner to `SUPPORT.md` (the canonical support doc) and pointed the two secondary references (`dev-hub/CONTRIBUTING.md`, `docs/mobile/README.md`) at it instead of repeating a dead Discord link.

All changes are doc-only; no code/behavior changes. Every version/link claim was verified against the actual filesystem (`package.json`) or a live HTTP/API check (Discord invite API, X profile, domain resolution) before editing, not just cross-referenced against other docs.
