### PR TITLE
feat(hr): add GET /me/contract endpoint for the active contract

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ContractController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ContractController.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\ContractAmendmentResource;
 use App\Http\Resources\Api\V1\ContractResource;
+use App\Modules\Cabinet\Infrastructure\Services\ContractPdfGenerator;
 use App\Modules\HR\Domain\Models\Contract;
 use App\Modules\HR\Domain\Models\ContractAmendment;
-use App\Core\Auth\Domain\Models\Employee;
-use App\Modules\Cabinet\Infrastructure\Services\ContractPdfGenerator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -352,6 +352,47 @@ class ContractController extends Controller
         return ContractResource::collection($contracts)->response();
     }
 
+    /**
+     * Return the authenticated employee's active contract, i.e. the one
+     * whose period covers today (status active/suspended, start_date <= now
+     * and end_date null or >= now). Falls back to the most recently started
+     * contract when none is currently active, so the endpoint still returns
+     * something useful for employees between contracts.
+     */
+    public function myActiveContract(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $baseQuery = Contract::query()
+            ->where('company_id', $actor->company_id)
+            ->where('employee_id', $actor->id)
+            ->with(['department:id,name', 'position:id,name']);
+
+        $today = now()->toDateString();
+
+        $contract = (clone $baseQuery)
+            ->whereIn('status', ['active', 'suspended'])
+            ->where('start_date', '<=', $today)
+            ->where(function ($query) use ($today) {
+                $query->whereNull('end_date')->orWhere('end_date', '>=', $today);
+            })
+            ->orderByDesc('start_date')
+            ->first();
+
+        if ($contract === null) {
+            $contract = (clone $baseQuery)
+                ->orderByDesc('start_date')
+                ->first();
+        }
+
+        if ($contract === null) {
+            return response()->json(['message' => 'No contract found for this employee.'], 404);
+        }
+
+        return (new ContractResource($contract))->response();
+    }
+
     public function generatePdf(Request $request, Contract $contract, ContractPdfGenerator $generator)
     {
         /** @var Employee $actor */
@@ -371,4 +412,3 @@ class ContractController extends Controller
         ]);
     }
 }
-

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -39,6 +39,7 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
     // ── Self-Service (all employees) ─────────────────────────────────────
     Route::get('/me/leave-balances', [LeavePolicyController::class, 'myBalances']);
     Route::get('/me/contracts', [ContractController::class, 'myContracts']);
+    Route::get('/me/contract', [ContractController::class, 'myActiveContract']);
     Route::get('/me/career', [SelfServiceController::class, 'myCareer']);
     Route::get('/me/trainings', [SelfServiceController::class, 'myTrainings']);
     Route::post('/me/trainings/{sessionId}/enroll', [SelfServiceController::class, 'selfEnroll'])->whereNumber('sessionId');

--- a/api/tests/Feature/Contracts/ContractWorkflowTest.php
+++ b/api/tests/Feature/Contracts/ContractWorkflowTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Contracts;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\HR\Domain\Models\Contract;
 use App\Modules\HR\Domain\Models\ContractAmendment;
-use App\Core\Auth\Domain\Models\Employee;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Sanctum\Sanctum;
@@ -350,6 +350,111 @@ class ContractWorkflowTest extends TestCase
         $response->assertJsonCount(1, 'data');
     }
 
+    public function test_self_service_my_active_contract_returns_the_currently_active_one(): void
+    {
+        [$company, $manager, $employee] = $this->makeManagerAndCompany();
+        Sanctum::actingAs($employee);
+
+        Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'contract_type' => 'cdd',
+            'start_date' => now()->subYears(2)->toDateString(),
+            'end_date' => now()->subYear()->toDateString(),
+            'base_salary' => 40000,
+            'status' => 'expired',
+            'created_by' => $manager->id,
+        ]);
+        $activeContract = Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'contract_type' => 'cdi',
+            'start_date' => now()->subMonths(3)->toDateString(),
+            'end_date' => null,
+            'base_salary' => 60000,
+            'status' => 'active',
+            'created_by' => $manager->id,
+        ]);
+
+        $response = $this->getJson('/api/v1/me/contract');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $activeContract->id);
+        $response->assertJsonPath('data.status', 'active');
+    }
+
+    public function test_self_service_my_active_contract_falls_back_to_most_recent_when_none_active(): void
+    {
+        [$company, $manager, $employee] = $this->makeManagerAndCompany();
+        Sanctum::actingAs($employee);
+
+        Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'contract_type' => 'cdd',
+            'start_date' => now()->subYears(2)->toDateString(),
+            'end_date' => now()->subYears(1)->toDateString(),
+            'base_salary' => 40000,
+            'status' => 'expired',
+            'created_by' => $manager->id,
+        ]);
+        $mostRecent = Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'contract_type' => 'cdd',
+            'start_date' => now()->subMonths(6)->toDateString(),
+            'end_date' => now()->subMonths(1)->toDateString(),
+            'base_salary' => 45000,
+            'status' => 'expired',
+            'created_by' => $manager->id,
+        ]);
+
+        $response = $this->getJson('/api/v1/me/contract');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $mostRecent->id);
+    }
+
+    public function test_self_service_my_active_contract_returns_404_when_none_exist(): void
+    {
+        [, , $employee] = $this->makeManagerAndCompany();
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson('/api/v1/me/contract');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_self_service_my_active_contract_is_scoped_to_the_actor(): void
+    {
+        [$company, $manager, $employee] = $this->makeManagerAndCompany();
+        $coworker = Employee::query()->create([
+            'company_id' => $company->id,
+            'matricule' => 'EMP-C04',
+            'first_name' => 'Coworker',
+            'last_name' => 'Two',
+            'email' => 'coworker2@contract-co.test',
+            'password_hash' => Hash::make('password'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        Contract::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $coworker->id,
+            'contract_type' => 'cdi',
+            'start_date' => now()->subMonths(1)->toDateString(),
+            'base_salary' => 55000,
+            'status' => 'active',
+            'created_by' => $manager->id,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson('/api/v1/me/contract');
+
+        $response->assertStatus(404);
+    }
+
     public function test_expiring_contracts_are_tenant_scoped(): void
     {
         [$company, $manager, $employee] = $this->makeManagerAndCompany();
@@ -420,4 +525,3 @@ class ContractWorkflowTest extends TestCase
         $this->getJson("/api/v1/contracts/{$contract->id}/amendments")->assertForbidden();
     }
 }
-


### PR DESCRIPTION
Closes #924

## Summary

`GET /me/contracts` (plural, `ContractController::myContracts`) already returns every contract the authenticated employee has ever had. There was no dedicated endpoint returning just the one that's currently active, forcing every frontend caller to re-implement that filtering logic.

## What changed

- New `ContractController::myActiveContract()`, exposed at `GET /api/v1/me/contract` (singular).
- Selection logic: contract with `status` in `active|suspended` whose `start_date <= today` and (`end_date` is null or `>= today`). Falls back to the most recently started contract when none is currently active (useful for an employee between contracts), and returns a clean 404 when the employee has no contract at all.
- Scoped to `company_id` + `employee_id` of the authenticated actor, same pattern as `myContracts()` — verified with a test that a coworker's contract is never visible.

## Testing

Added to `tests/Feature/Contracts/ContractWorkflowTest.php`:
- active contract is returned when one exists
- falls back to the most recent contract when none is active
- 404 when the employee has no contract
- scoped to the actor (coworker's contract returns 404, not someone else's data)

```
php artisan test --filter=ContractWorkflowTest
Tests:    14 passed (42 assertions)
```

`./vendor/bin/pint` run on touched files (kept the route-file diff to a single added line, reverted an unrelated import-reordering auto-fix).

`./vendor/bin/phpstan analyse app/Modules/HR/Interfaces/Api/V1/Controllers/ContractController.php`: 15 pre-existing errors, confirmed identical count on `main` via `git stash` before/after — no new PHPStan findings introduced by this change.