### PR TITLE
feat(attendance): page web manager pour approuver/refuser les corrections de pointage

### DIFF
--- a/api/app/Http/Controllers/Web/AttendanceCorrectionAdminController.php
+++ b/api/app/Http/Controllers/Web/AttendanceCorrectionAdminController.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Web;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Http\Controllers\Controller;
+use App\Modules\Attendance\Domain\Models\AttendanceCorrectionRequest;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
+use App\Modules\Attendance\Infrastructure\Services\AttendanceService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class AttendanceCorrectionAdminController extends Controller
+{
+    public function __construct(private readonly AttendanceService $attendanceService) {}
+
+    public function index(Request $request): View
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $this->authorize('update', new AttendanceLog(['company_id' => $actor->company_id]));
+
+        $status = $request->query('status', 'pending');
+
+        $corrections = AttendanceCorrectionRequest::query()
+            ->with(['employee:id,company_id,first_name,last_name,matricule', 'attendanceLog:id,employee_id,date,session_number,status'])
+            ->where('company_id', $actor->company_id)
+            ->when($status !== 'all', fn ($builder) => $builder->where('status', $status))
+            ->orderByDesc('date')
+            ->orderByDesc('id')
+            ->paginate(20)
+            ->withQueryString();
+
+        return view('attendance-corrections.index', [
+            'corrections' => $corrections,
+            'status' => $status,
+        ]);
+    }
+
+    public function approve(Request $request, AttendanceCorrectionRequest $correction): RedirectResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $this->authorize('update', new AttendanceLog(['company_id' => $correction->company_id]));
+        $this->ensureCorrectionBelongsToActorCompany($correction, $actor);
+
+        if ($correction->status !== 'pending') {
+            throw ValidationException::withMessages([
+                'status' => [__('attendance.correction_already_processed')],
+            ]);
+        }
+
+        $employee = Employee::query()
+            ->where('company_id', $actor->company_id)
+            ->findOrFail($correction->employee_id);
+
+        $log = $correction->attendanceLog;
+        if (! $log) {
+            $sessionNumber = ((int) AttendanceLog::query()
+                ->where('employee_id', $employee->id)
+                ->whereDate('date', $correction->date)
+                ->max('session_number')) + 1;
+
+            $log = new AttendanceLog([
+                'company_id' => $actor->company_id,
+                'employee_id' => $employee->id,
+                'schedule_id' => $employee->schedule_id,
+                'date' => $correction->date,
+                'session_number' => $sessionNumber,
+                'method' => 'manual',
+                'work_type' => 'normal',
+            ]);
+        }
+
+        $log->fill([
+            'check_in' => $correction->requested_check_in,
+            'check_out' => $correction->requested_check_out,
+            'method' => 'manual',
+            'corrected_by' => $actor->id,
+            'correction_note' => $correction->reason,
+        ]);
+
+        $log = $this->attendanceService->recalculateLog($log);
+
+        $correction->forceFill([
+            'attendance_log_id' => $log->id,
+            'status' => 'applied',
+            'reviewed_by' => $actor->id,
+            'reviewed_at' => now(),
+        ])->save();
+
+        return redirect()
+            ->route('attendance-corrections.index')
+            ->with('status', __('attendance.correction_applied'));
+    }
+
+    public function reject(Request $request, AttendanceCorrectionRequest $correction): RedirectResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $this->authorize('update', new AttendanceLog(['company_id' => $correction->company_id]));
+        $this->ensureCorrectionBelongsToActorCompany($correction, $actor);
+
+        if ($correction->status !== 'pending') {
+            throw ValidationException::withMessages([
+                'status' => [__('attendance.correction_already_processed')],
+            ]);
+        }
+
+        $correction->forceFill([
+            'status' => 'rejected',
+            'reviewed_by' => $actor->id,
+            'reviewed_at' => now(),
+        ])->save();
+
+        return redirect()
+            ->route('attendance-corrections.index')
+            ->with('status', __('attendance.correction_rejected'));
+    }
+
+    private function ensureCorrectionBelongsToActorCompany(AttendanceCorrectionRequest $correction, Employee $actor): void
+    {
+        if ($correction->company_id !== $actor->company_id) {
+            abort(404);
+        }
+    }
+}

--- a/api/lang/ar/attendance.php
+++ b/api/lang/ar/attendance.php
@@ -29,4 +29,24 @@ return [
     // جلسات الموقع (SmartAttendance)
     'geo_session_approved' => 'تمت الموافقة على الجلسة. تم إنشاء سجل الحضور.',
     'geo_session_rejected' => 'تم رفض الجلسة.',
+
+    // تصحيحات الحضور (مراجعة المدير/الموارد البشرية)
+    'corrections_title' => 'تصحيحات الحضور',
+    'corrections_subtitle' => 'قم بالموافقة أو الرفض لطلبات التصحيح المقدمة من الموظفين.',
+    'corrections_empty' => 'لا يوجد طلب تصحيح حالياً.',
+    'correction_reason_label' => 'سبب الموظف',
+    'correction_requested_check_in' => 'الحضور المطلوب',
+    'correction_requested_check_out' => 'الانصراف المطلوب',
+    'correction_status_pending' => 'قيد الانتظار',
+    'correction_status_applied' => 'مطبقة',
+    'correction_status_rejected' => 'مرفوضة',
+    'correction_approve' => 'موافقة',
+    'correction_reject' => 'رفض',
+    'correction_applied' => 'تم تطبيق التصحيح على سجل الحضور.',
+    'correction_rejected' => 'تم رفض التصحيح.',
+    'correction_already_processed' => 'تم معالجة طلب التصحيح هذا مسبقاً.',
+    'correction_filter_pending' => 'قيد الانتظار',
+    'correction_filter_applied' => 'مطبقة',
+    'correction_filter_rejected' => 'مرفوضة',
+    'correction_filter_all' => 'الكل',
 ];

--- a/api/lang/en/attendance.php
+++ b/api/lang/en/attendance.php
@@ -29,4 +29,24 @@ return [
     // Geo sessions (SmartAttendance)
     'geo_session_approved' => 'Session approved. The attendance record has been created.',
     'geo_session_rejected' => 'Session rejected.',
+
+    // Attendance corrections (manager/HR review)
+    'corrections_title' => 'Attendance corrections',
+    'corrections_subtitle' => 'Approve or reject correction requests submitted by employees.',
+    'corrections_empty' => 'No correction request at the moment.',
+    'correction_reason_label' => 'Employee reason',
+    'correction_requested_check_in' => 'Requested check-in',
+    'correction_requested_check_out' => 'Requested check-out',
+    'correction_status_pending' => 'Pending',
+    'correction_status_applied' => 'Applied',
+    'correction_status_rejected' => 'Rejected',
+    'correction_approve' => 'Approve',
+    'correction_reject' => 'Reject',
+    'correction_applied' => 'Correction applied to the attendance record.',
+    'correction_rejected' => 'Correction rejected.',
+    'correction_already_processed' => 'This correction request has already been processed.',
+    'correction_filter_pending' => 'Pending',
+    'correction_filter_applied' => 'Applied',
+    'correction_filter_rejected' => 'Rejected',
+    'correction_filter_all' => 'All',
 ];

--- a/api/lang/fr/attendance.php
+++ b/api/lang/fr/attendance.php
@@ -29,4 +29,24 @@ return [
     // Sessions geo (SmartAttendance)
     'geo_session_approved' => 'Session approuvée. Le pointage a été créé.',
     'geo_session_rejected' => 'Session refusée.',
+
+    // Corrections de pointage (validation manager/RH)
+    'corrections_title' => 'Corrections de pointage',
+    'corrections_subtitle' => 'Validez ou refusez les demandes de correction envoyees par les collaborateurs.',
+    'corrections_empty' => 'Aucune demande de correction pour le moment.',
+    'correction_reason_label' => 'Motif du collaborateur',
+    'correction_requested_check_in' => 'Arrivee demandee',
+    'correction_requested_check_out' => 'Depart demande',
+    'correction_status_pending' => 'En attente',
+    'correction_status_applied' => 'Appliquee',
+    'correction_status_rejected' => 'Refusee',
+    'correction_approve' => 'Approuver',
+    'correction_reject' => 'Refuser',
+    'correction_applied' => 'Correction appliquee au pointage.',
+    'correction_rejected' => 'Correction refusee.',
+    'correction_already_processed' => 'Cette demande de correction a deja ete traitee.',
+    'correction_filter_pending' => 'En attente',
+    'correction_filter_applied' => 'Appliquees',
+    'correction_filter_rejected' => 'Refusees',
+    'correction_filter_all' => 'Toutes',
 ];

--- a/api/lang/tr/attendance.php
+++ b/api/lang/tr/attendance.php
@@ -29,4 +29,24 @@ return [
     // Konum oturumları (SmartAttendance)
     'geo_session_approved' => 'Oturum onaylandi. Devam kaydi olusturuldu.',
     'geo_session_rejected' => 'Oturum reddedildi.',
+
+    // Devam duzeltmeleri (yonetici/IK incelemesi)
+    'corrections_title' => 'Devam duzeltmeleri',
+    'corrections_subtitle' => 'Calisanlar tarafindan gonderilen duzeltme taleplerini onaylayin veya reddedin.',
+    'corrections_empty' => 'Su anda duzeltme talebi yok.',
+    'correction_reason_label' => 'Calisan gerekcesi',
+    'correction_requested_check_in' => 'Talep edilen giris',
+    'correction_requested_check_out' => 'Talep edilen cikis',
+    'correction_status_pending' => 'Beklemede',
+    'correction_status_applied' => 'Uygulandi',
+    'correction_status_rejected' => 'Reddedildi',
+    'correction_approve' => 'Onayla',
+    'correction_reject' => 'Reddet',
+    'correction_applied' => 'Duzeltme devam kaydina uygulandi.',
+    'correction_rejected' => 'Duzeltme reddedildi.',
+    'correction_already_processed' => 'Bu duzeltme talebi zaten islendi.',
+    'correction_filter_pending' => 'Beklemede',
+    'correction_filter_applied' => 'Uygulandi',
+    'correction_filter_rejected' => 'Reddedildi',
+    'correction_filter_all' => 'Tumu',
 ];

--- a/api/resources/views/attendance-corrections/index.blade.php
+++ b/api/resources/views/attendance-corrections/index.blade.php
@@ -1,0 +1,78 @@
+@extends('layouts.app')
+
+@section('title', __('attendance.corrections_title'))
+
+@section('content')
+    <div class="space-y-6">
+        <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold tracking-tight">{{ __('attendance.corrections_title') }}</h1>
+                <p class="mt-1 text-sm text-slate-400">{{ __('attendance.corrections_subtitle') }}</p>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+                @foreach (['pending' => __('attendance.correction_filter_pending'), 'applied' => __('attendance.correction_filter_applied'), 'rejected' => __('attendance.correction_filter_rejected'), 'all' => __('attendance.correction_filter_all')] as $value => $label)
+                    <a
+                        href="{{ route('attendance-corrections.index', ['status' => $value]) }}"
+                        class="rounded-md px-3 py-1.5 text-sm font-medium {{ $status === $value ? 'bg-emerald-500 text-slate-950' : 'bg-slate-800 text-slate-200 hover:bg-slate-700' }}"
+                    >
+                        {{ $label }}
+                    </a>
+                @endforeach
+            </div>
+        </div>
+
+        <div class="rounded-2xl border border-slate-800 bg-slate-900 p-6">
+            <div class="space-y-4">
+                @forelse ($corrections as $correction)
+                    <div class="rounded-xl border border-slate-800 bg-slate-950/50 p-4">
+                        <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                            <div>
+                                <div class="font-medium">
+                                    {{ $correction->employee?->first_name }} {{ $correction->employee?->last_name }}
+                                    @if ($correction->employee?->matricule)
+                                        <span class="text-slate-500">({{ $correction->employee->matricule }})</span>
+                                    @endif
+                                    <x-attendance-badge :status="$correction->status === 'applied' ? 'accepted' : ($correction->status === 'rejected' ? 'expired' : 'pending')" :label="match($correction->status) { 'applied' => __('attendance.correction_status_applied'), 'rejected' => __('attendance.correction_status_rejected'), default => __('attendance.correction_status_pending') }" />
+                                </div>
+                                <div class="mt-1 text-sm text-slate-400">{{ $correction->date?->format('Y-m-d') }}</div>
+                                <div class="mt-2 text-sm text-slate-300">
+                                    {{ __('attendance.correction_requested_check_in') }}: {{ $correction->requested_check_in?->format('H:i') }}
+                                    @if ($correction->requested_check_out)
+                                        &middot; {{ __('attendance.correction_requested_check_out') }}: {{ $correction->requested_check_out->format('H:i') }}
+                                    @endif
+                                </div>
+                                <div class="mt-1 text-sm text-slate-400">{{ __('attendance.correction_reason_label') }}: {{ $correction->reason }}</div>
+                            </div>
+
+                            @if ($correction->status === 'pending')
+                                <div class="flex min-w-48 flex-col gap-2">
+                                    <form method="POST" action="{{ route('attendance-corrections.approve', $correction) }}">
+                                        @csrf
+                                        <button type="submit" class="w-full rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-slate-950">
+                                            {{ __('attendance.correction_approve') }}
+                                        </button>
+                                    </form>
+                                    <form method="POST" action="{{ route('attendance-corrections.reject', $correction) }}">
+                                        @csrf
+                                        <button type="submit" class="w-full rounded-lg bg-rose-500 px-4 py-2 text-sm font-medium text-white">
+                                            {{ __('attendance.correction_reject') }}
+                                        </button>
+                                    </form>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+                @empty
+                    <div class="rounded-xl border border-dashed border-slate-800 px-4 py-8 text-center text-slate-400">
+                        {{ __('attendance.corrections_empty') }}
+                    </div>
+                @endforelse
+            </div>
+
+            <div class="mt-6">
+                {{ $corrections->links() }}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/api/resources/views/layouts/app.blade.php
+++ b/api/resources/views/layouts/app.blade.php
@@ -43,6 +43,9 @@
                                 <a href="{{ route('hr.invitations.index') }}" class="rounded-md bg-slate-800 px-3 py-2 text-sm font-medium text-slate-100 hover:bg-slate-700">
                                     Invitations
                                 </a>
+                                <a href="{{ route('attendance-corrections.index') }}" class="rounded-md bg-slate-800 px-3 py-2 text-sm font-medium text-slate-100 hover:bg-slate-700">
+                                    {{ __('attendance.corrections_title') }}
+                                </a>
                             @endif
                             @if ($me->hasManagerRole('principal', 'superviseur'))
                                 <a href="{{ route('biometrics.index') }}" class="rounded-md bg-slate-800 px-3 py-2 text-sm font-medium text-slate-100 hover:bg-slate-700">

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Web\AttendanceCorrectionAdminController;
 use App\Http\Controllers\Web\BiometricAdminController;
 use App\Http\Controllers\Web\DashboardController;
 use App\Http\Controllers\Web\InvitationController;
@@ -106,6 +107,14 @@ Route::middleware(['auth:web', 'tenant', 'manager_role:principal,rh'])->group(fu
         Route::get('/invitations', [InvitationManagementController::class, 'index'])->name('invitations.index');
         Route::post('/invitations/{invitation}/resend', [InvitationManagementController::class, 'resend'])->name('invitations.resend');
     });
+
+    Route::get('/attendance-corrections', [AttendanceCorrectionAdminController::class, 'index'])->name('attendance-corrections.index');
+    Route::post('/attendance-corrections/{correction}/approve', [AttendanceCorrectionAdminController::class, 'approve'])
+        ->whereNumber('correction')
+        ->name('attendance-corrections.approve');
+    Route::post('/attendance-corrections/{correction}/reject', [AttendanceCorrectionAdminController::class, 'reject'])
+        ->whereNumber('correction')
+        ->name('attendance-corrections.reject');
 });
 
 // Biometrie / bornes : Principal et Superviseur.

--- a/api/tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php
+++ b/api/tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Modules\Attendance\Domain\Models\AttendanceCorrectionRequest;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Auth\Domain\Models\Employee;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+class AttendanceCorrectionAdminPagesTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_manager_can_list_and_approve_pending_correction_from_web(): void
+    {
+        [$company, $manager, $employee] = $this->makeCompanyWithUsers();
+
+        $correction = AttendanceCorrectionRequest::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-27',
+            'requested_check_in' => Carbon::parse('2026-05-27 08:12:00', 'UTC'),
+            'requested_check_out' => Carbon::parse('2026-05-27 17:20:00', 'UTC'),
+            'reason' => 'Oubli du pointage mobile',
+            'status' => 'pending',
+        ]);
+
+        $index = $this->actingAs($manager, 'web')->get('/attendance-corrections');
+        $index->assertOk();
+        $index->assertSee($employee->last_name);
+        $index->assertSee('Oubli du pointage mobile');
+
+        $approve = $this->actingAs($manager, 'web')
+            ->post("/attendance-corrections/{$correction->id}/approve");
+
+        $approve->assertRedirect('/attendance-corrections');
+
+        $this->assertDatabaseHas('attendance_correction_requests', [
+            'id' => $correction->id,
+            'status' => 'applied',
+            'reviewed_by' => $manager->id,
+        ]);
+
+        $this->assertDatabaseHas('attendance_logs', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-27',
+            'method' => 'manual',
+            'corrected_by' => $manager->id,
+        ]);
+    }
+
+    public function test_manager_can_reject_pending_correction_from_web(): void
+    {
+        [, $manager, $employee] = $this->makeCompanyWithUsers();
+
+        $correction = AttendanceCorrectionRequest::query()->create([
+            'company_id' => $manager->company_id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-27',
+            'requested_check_in' => Carbon::parse('2026-05-27 08:12:00', 'UTC'),
+            'reason' => 'Test rejet',
+            'status' => 'pending',
+        ]);
+
+        $reject = $this->actingAs($manager, 'web')
+            ->post("/attendance-corrections/{$correction->id}/reject");
+
+        $reject->assertRedirect('/attendance-corrections');
+
+        $this->assertDatabaseHas('attendance_correction_requests', [
+            'id' => $correction->id,
+            'status' => 'rejected',
+            'reviewed_by' => $manager->id,
+        ]);
+    }
+
+    public function test_employee_is_forbidden_from_attendance_corrections_page(): void
+    {
+        [, , $employee] = $this->makeCompanyWithUsers();
+
+        $response = $this->actingAs($employee, 'web')->get('/attendance-corrections');
+
+        $response->assertForbidden();
+    }
+
+    public function test_manager_cannot_approve_correction_from_other_company(): void
+    {
+        [, $manager] = $this->makeCompanyWithUsers();
+        [$otherCompany, , $otherEmployee] = $this->makeCompanyWithUsers('company-b', 'b.test');
+
+        $correction = AttendanceCorrectionRequest::query()->create([
+            'company_id' => $otherCompany->id,
+            'employee_id' => $otherEmployee->id,
+            'date' => '2026-05-27',
+            'requested_check_in' => Carbon::parse('2026-05-27 08:00:00', 'UTC'),
+            'reason' => 'Tenant etranger',
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($manager, 'web')
+            ->post("/attendance-corrections/{$correction->id}/approve");
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * @return array{Company, Employee, Employee}
+     */
+    private function makeCompanyWithUsers(string $slug = 'company-a', string $domain = 'company.test'): array
+    {
+        $company = Company::query()->create([
+            'name' => 'Company '.$slug,
+            'slug' => $slug,
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'contact@'.$domain,
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'currency' => 'DZD',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Nadia',
+            'last_name' => 'Manager',
+            'email' => 'manager@'.$domain,
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+            'salary_type' => 'daily',
+            'salary_base' => 800,
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Ahmed',
+            'last_name' => 'Benali',
+            'email' => 'employee@'.$domain,
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+            'salary_type' => 'daily',
+            'salary_base' => 800,
+        ]);
+
+        return [$company, $manager, $employee];
+    }
+}


### PR DESCRIPTION
## Probleme

Le systeme de correction de pointage (`AttendanceCorrectionRequest`, endpoints `/api/v1/attendance/corrections*`) n'etait expose que via l'API Sanctum consommee par l'app mobile. Un manager/RH n'avait **aucun moyen sur le web** de lister ou traiter les demandes de correction envoyees par les collaborateurs, alors que toute la logique metier (approbation, refus, recalcul du pointage) existait deja cote backend et etait testee.

Correspond au retour client **K1** documente dans `docs/GESTION_PROJET/RETOURS_CLIENTS_PILOTE_2026_04_22.md` :
> "Je peux pas corriger un pointage oublie le soir..." (Karim B., DRH BTP)

## Changements

- **`AttendanceCorrectionAdminController`** (nouveau) : `index` (liste paginee, filtrable par statut), `approve`, `reject`. Reutilise `AttendanceService::recalculateLog` et suit exactement la meme logique metier que `AttendanceController::approveCorrection`/`rejectCorrection` cote API mobile, pour rester coherent entre les deux surfaces.
- **Routes web** `/attendance-corrections` (index/approve/reject), placees dans le groupe `manager_role:principal,rh` — coherent avec `AttendancePolicy::update` qui restreint deja l'API aux memes roles.
- **Vue** `attendance-corrections/index.blade.php` : reprend le pattern deja utilise par `biometrics/index.blade.php` (liste de cartes + formulaires approve/reject), avec filtres par statut (en attente / appliquees / refusees / toutes) et pagination.
- **Lien de navigation** ajoute dans `layouts/app.blade.php`, visible uniquement pour les managers `principal`/`rh` (meme emplacement que "Invitations").
- **Traductions** : nouvelles cles dans `attendance.php` pour les 4 locales (fr/en/ar/tr).

## Tests

Nouveau fichier `tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php` (4 tests) :
- Un manager peut lister les demandes et voir le motif du collaborateur.
- Un manager peut approuver une demande en attente → le pointage est cree/mis a jour et la demande passe a `applied`.
- Un manager peut refuser une demande en attente.
- Un simple employe recoit un 403.
- Un manager ne peut pas approuver une demande d'un autre tenant (404).

### Verification effectuee localement

- Installation complete des dependances (`composer install`), PostgreSQL 17 local, migrations appliquees.
- `php artisan test tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php` → **4/4 passent**.
- Suite de regression executee en plus (pas de changement de comportement existant) :
  - `WebManagerPagesTest` + `Attendance/CorrectionWorkflowTest` (API mobile existante) → **9/9 passent**.
  - Toutes les suites liees au dashboard (`DashboardControllerTest`, `HrAppRoutesTest`, `SmartAttendance/*`, `WebAuthPagesTest`, etc.) → **27/27 passent**.

Fixes #1110
