### PR TITLE
feat(payroll): add month/year filter to PayrollView runs tab

### DIFF
--- a/front/admin-dashboard/src/views/payroll/PayrollView.vue
+++ b/front/admin-dashboard/src/views/payroll/PayrollView.vue
@@ -124,7 +124,7 @@
     <DataTable
       v-else-if="activeTab === 'runs'"
       :columns="runColumns"
-      :rows="runs"
+      :rows="filteredRuns"
       :loading="loading"
       :error="error"
       :search-keys="['reference', 'period']"
@@ -134,6 +134,36 @@
       exportable
       @export="exportRuns"
     >
+      <template #filters>
+        <div class="flex items-center gap-2">
+          <label for="payroll-run-month" class="sr-only">Mois</label>
+          <select
+            id="payroll-run-month"
+            v-model="runFilterMonth"
+            class="rounded-xl border-slate-200/50 dark:border-slate-700/50 bg-slate-50/50 dark:bg-slate-800/50 py-2 pl-3 pr-8 text-sm text-slate-900 dark:text-white focus:border-brand-500 focus:ring-brand-500"
+          >
+            <option value="">Tous les mois</option>
+            <option v-for="(label, idx) in monthLabels" :key="idx" :value="idx">{{ label }}</option>
+          </select>
+          <label for="payroll-run-year" class="sr-only">Année</label>
+          <select
+            id="payroll-run-year"
+            v-model="runFilterYear"
+            class="rounded-xl border-slate-200/50 dark:border-slate-700/50 bg-slate-50/50 dark:bg-slate-800/50 py-2 pl-3 pr-8 text-sm text-slate-900 dark:text-white focus:border-brand-500 focus:ring-brand-500"
+          >
+            <option value="">Toutes les années</option>
+            <option v-for="y in availableYears" :key="y" :value="y">{{ y }}</option>
+          </select>
+          <button
+            v-if="runFilterMonth !== '' || runFilterYear !== ''"
+            type="button"
+            class="text-sm font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+            @click="runFilterMonth = ''; runFilterYear = ''"
+          >
+            Réinitialiser
+          </button>
+        </div>
+      </template>
       <template #cell-status="{ value }">
         <StatusBadge :status="value" :map="runStatusMap" />
       </template>
@@ -198,6 +228,15 @@ const stats = ref({ runs_this_month: 0, slips_generated: 0, total_net: 0, pendin
 
 const structures = ref([])
 
+const monthLabels = [
+  'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
+  'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre',
+]
+
+const initialDate = new Date()
+const runFilterMonth = ref(initialDate.getMonth())
+const runFilterYear = ref(initialDate.getFullYear())
+
 const tabs = [
   { key: 'structures', label: 'Structures salariales' },
   { key: 'runs', label: 'Runs de paie' },
@@ -241,6 +280,24 @@ const runStatusMap = {
   paid: { label: 'Paye', color: 'green' },
   cancelled: { label: 'Annule', color: 'red' },
 }
+
+const availableYears = computed(() => {
+  const years = new Set(runs.value
+    .map(r => (r.period_start ? new Date(r.period_start).getFullYear() : null))
+    .filter(y => y !== null && !Number.isNaN(y)))
+  years.add(runFilterYear.value)
+  return [...years].sort((a, b) => b - a)
+})
+
+const filteredRuns = computed(() => {
+  return runs.value.filter(run => {
+    if (!run.period_start) return runFilterMonth.value === '' && runFilterYear.value === ''
+    const d = new Date(run.period_start)
+    const monthMatches = runFilterMonth.value === '' || d.getMonth() === Number(runFilterMonth.value)
+    const yearMatches = runFilterYear.value === '' || d.getFullYear() === Number(runFilterYear.value)
+    return monthMatches && yearMatches
+  })
+})
 
 const formattedMasse = computed(() => formatCurrency(stats.value.total_net))
 
@@ -410,7 +467,7 @@ function downloadCsv(filename, headerRow, lines) {
 
 function exportRuns() {
   const header = ['reference', 'periode', 'employes', 'net_total', 'statut']
-  const lines = runs.value.map(r =>
+  const lines = filteredRuns.value.map(r =>
     [r.reference, r.period, r.employees_count, r.total_net, r.status].map(escapeCsvCell).join(';'),
   )
   downloadCsv('payroll-runs.csv', header, lines)


### PR DESCRIPTION
Closes #923

## Summary

`front/admin-dashboard/src/views/payroll/PayrollView.vue` listed every payroll run with no time filter — only a client-side "runs this month" stat counter existed (`runStartsThisMonth`), no way to actually filter the visible list.

## What changed

- Added a month + year `<select>` filter above the runs `DataTable` (via its existing `#filters` slot), defaulting to the current month/year.
- `filteredRuns` computed filters `runs` by `period_start` matching the selected month/year (client-side, since `fetchAllPayrollRuns` already loads all runs in memory across pages).
- Year options are derived from the actual run data (plus the currently selected year, so it never disappears from the list).
- A "Réinitialiser" button clears both filters back to showing all runs.
- `exportRuns()` now exports the filtered set instead of the full list, so the CSV matches what's on screen.

## Testing

- `npx eslint src/views/payroll/PayrollView.vue`: clean, no warnings.
- `npm run build`: succeeds.
- Filter-matching logic (month-only / year-only / both / cleared / null `period_start`) verified against a standalone reproduction of the exact date-comparison code used in the computed (no existing unit test harness for this dashboard's Vue components, so this mirrors the logic 1:1 rather than adding new test infra out of scope for this ticket).