### PR TITLE
Fixes #925: i18n AiChatScreen FR/EN/AR/TR dans les 3 apps mobiles

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "مرحبا :name،",
   "emailsAbsenceRejectedBody": "تم رفض طلب الغياب للفترة :period.",
   "emailsAbsenceRejectedAction": "عرض الطلب",
-  "emailsAbsenceRejectedFooter": "تواصل مع مديرك اذا كنت تحتاج تفاصيل اضافية."
+  "emailsAbsenceRejectedFooter": "تواصل مع مديرك اذا كنت تحتاج تفاصيل اضافية.",
+  "aiChatAppBarTitle": "المساعد الذكي",
+  "aiChatBackTooltip": "رجوع",
+  "aiChatSendTooltip": "ارسال",
+  "aiChatPlaceholder": "اكتب رسالتك...",
+  "aiChatEmptyStateHint": "اطرح اسئلتك المتعلقة بالموارد البشرية",
+  "aiChatErrorMessage": "خطا: تعذر الاتصال بالمساعد."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "Hello :name,",
   "emailsAbsenceRejectedBody": "Your leave request for :period has been rejected.",
   "emailsAbsenceRejectedAction": "View request",
-  "emailsAbsenceRejectedFooter": "Please contact your manager if you need more details."
+  "emailsAbsenceRejectedFooter": "Please contact your manager if you need more details.",
+  "aiChatAppBarTitle": "AI Assistant",
+  "aiChatBackTooltip": "Back",
+  "aiChatSendTooltip": "Send",
+  "aiChatPlaceholder": "Type your message...",
+  "aiChatEmptyStateHint": "Ask your HR questions",
+  "aiChatErrorMessage": "Error: unable to reach the assistant."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "Bonjour :name,",
   "emailsAbsenceRejectedBody": "Votre demande d absence pour :period a ete refusee.",
   "emailsAbsenceRejectedAction": "Voir la demande",
-  "emailsAbsenceRejectedFooter": "Consultez votre manager si vous avez besoin d un complement."
+  "emailsAbsenceRejectedFooter": "Consultez votre manager si vous avez besoin d un complement.",
+  "aiChatAppBarTitle": "Assistant IA",
+  "aiChatBackTooltip": "Retour",
+  "aiChatSendTooltip": "Envoyer",
+  "aiChatPlaceholder": "Tapez votre message...",
+  "aiChatEmptyStateHint": "Posez vos questions RH",
+  "aiChatErrorMessage": "Erreur : impossible de contacter l assistant."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "Merhaba :name,",
   "emailsAbsenceRejectedBody": ":period donemi icin izin talebiniz reddedildi.",
   "emailsAbsenceRejectedAction": "Talebi gor",
-  "emailsAbsenceRejectedFooter": "Ek bilgiye ihtiyaciniz varsa yoneticinizle gorusun."
+  "emailsAbsenceRejectedFooter": "Ek bilgiye ihtiyaciniz varsa yoneticinizle gorusun.",
+  "aiChatAppBarTitle": "Yapay Zeka Asistani",
+  "aiChatBackTooltip": "Geri",
+  "aiChatSendTooltip": "Gonder",
+  "aiChatPlaceholder": "Mesajinizi yazin...",
+  "aiChatEmptyStateHint": "IK sorularinizi sorun",
+  "aiChatErrorMessage": "Hata: asistana ulasilamiyor."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -419,6 +419,42 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'Consultez votre manager si vous avez besoin d un complement.'**
   String get emailsAbsenceRejectedFooter;
+
+  /// No description provided for @aiChatAppBarTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Assistant IA'**
+  String get aiChatAppBarTitle;
+
+  /// No description provided for @aiChatBackTooltip.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retour'**
+  String get aiChatBackTooltip;
+
+  /// No description provided for @aiChatSendTooltip.
+  ///
+  /// In fr, this message translates to:
+  /// **'Envoyer'**
+  String get aiChatSendTooltip;
+
+  /// No description provided for @aiChatPlaceholder.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tapez votre message...'**
+  String get aiChatPlaceholder;
+
+  /// No description provided for @aiChatEmptyStateHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Posez vos questions RH'**
+  String get aiChatEmptyStateHint;
+
+  /// No description provided for @aiChatErrorMessage.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur : impossible de contacter l assistant.'**
+  String get aiChatErrorMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -181,4 +181,22 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'تواصل مع مديرك اذا كنت تحتاج تفاصيل اضافية.';
+
+  @override
+  String get aiChatAppBarTitle => 'المساعد الذكي';
+
+  @override
+  String get aiChatBackTooltip => 'رجوع';
+
+  @override
+  String get aiChatSendTooltip => 'ارسال';
+
+  @override
+  String get aiChatPlaceholder => 'اكتب رسالتك...';
+
+  @override
+  String get aiChatEmptyStateHint => 'اطرح اسئلتك المتعلقة بالموارد البشرية';
+
+  @override
+  String get aiChatErrorMessage => 'خطا: تعذر الاتصال بالمساعد.';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -186,4 +186,22 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'Please contact your manager if you need more details.';
+
+  @override
+  String get aiChatAppBarTitle => 'AI Assistant';
+
+  @override
+  String get aiChatBackTooltip => 'Back';
+
+  @override
+  String get aiChatSendTooltip => 'Send';
+
+  @override
+  String get aiChatPlaceholder => 'Type your message...';
+
+  @override
+  String get aiChatEmptyStateHint => 'Ask your HR questions';
+
+  @override
+  String get aiChatErrorMessage => 'Error: unable to reach the assistant.';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -188,4 +188,23 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'Consultez votre manager si vous avez besoin d un complement.';
+
+  @override
+  String get aiChatAppBarTitle => 'Assistant IA';
+
+  @override
+  String get aiChatBackTooltip => 'Retour';
+
+  @override
+  String get aiChatSendTooltip => 'Envoyer';
+
+  @override
+  String get aiChatPlaceholder => 'Tapez votre message...';
+
+  @override
+  String get aiChatEmptyStateHint => 'Posez vos questions RH';
+
+  @override
+  String get aiChatErrorMessage =>
+      'Erreur : impossible de contacter l assistant.';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -182,4 +182,22 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'Ek bilgiye ihtiyaciniz varsa yoneticinizle gorusun.';
+
+  @override
+  String get aiChatAppBarTitle => 'Yapay Zeka Asistani';
+
+  @override
+  String get aiChatBackTooltip => 'Geri';
+
+  @override
+  String get aiChatSendTooltip => 'Gonder';
+
+  @override
+  String get aiChatPlaceholder => 'Mesajinizi yazin...';
+
+  @override
+  String get aiChatEmptyStateHint => 'IK sorularinizi sorun';
+
+  @override
+  String get aiChatErrorMessage => 'Hata: asistana ulasilamiyor.';
 }

--- a/front/mobile_apps/leopardo_employee/lib/features/ai_chat/screens/ai_chat_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/ai_chat/screens/ai_chat_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_employee/core/providers/core_providers.dart';
 
 class _ChatMessage {
@@ -72,7 +73,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           _messages.add(
             _ChatMessage(
               role: 'assistant',
-              content: 'Erreur : impossible de contacter l\'assistant.',
+              content: context.l10n.aiChatErrorMessage,
             ),
           );
         });
@@ -84,18 +85,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       backgroundColor: AppColors.bgDark,
       appBar: AppBar(
         backgroundColor: AppColors.bgDark,
         elevation: 0,
         title: Text(
-          'Assistant IA',
+          l10n.aiChatAppBarTitle,
           style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          tooltip: 'Retour',
+          tooltip: l10n.aiChatBackTooltip,
           onPressed: () => context.pop(),
         ),
       ),
@@ -114,7 +116,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Posez vos questions RH',
+                          l10n.aiChatEmptyStateHint,
                           style: AppTypography.bodySmall.copyWith(
                             color: AppColors.textMutedDark,
                           ),
@@ -179,7 +181,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                       controller: _controller,
                       style: const TextStyle(color: AppColors.textDark),
                       decoration: InputDecoration(
-                        hintText: 'Tapez votre message...',
+                        hintText: l10n.aiChatPlaceholder,
                         hintStyle: const TextStyle(
                           color: AppColors.textMutedDark,
                         ),
@@ -207,7 +209,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                   IconButton(
                     onPressed: _loading ? null : _send,
                     icon: const Icon(Icons.send, color: AppColors.ia),
-                    tooltip: 'Envoyer',
+                    tooltip: l10n.aiChatSendTooltip,
                   ),
                 ],
               ),

--- a/front/mobile_apps/leopardo_hr/lib/features/ai_chat/screens/ai_chat_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/ai_chat/screens/ai_chat_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_hr/core/providers/core_providers.dart';
 
 class _ChatMessage {
@@ -72,7 +73,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           _messages.add(
             _ChatMessage(
               role: 'assistant',
-              content: 'Erreur : impossible de contacter l\'assistant.',
+              content: context.l10n.aiChatErrorMessage,
             ),
           );
         });
@@ -84,18 +85,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       backgroundColor: AppColors.bgDark,
       appBar: AppBar(
         backgroundColor: AppColors.bgDark,
         elevation: 0,
         title: Text(
-          'Assistant IA',
+          l10n.aiChatAppBarTitle,
           style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          tooltip: 'Retour',
+          tooltip: l10n.aiChatBackTooltip,
           onPressed: () => context.pop(),
         ),
       ),
@@ -114,7 +116,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Posez vos questions RH',
+                          l10n.aiChatEmptyStateHint,
                           style: AppTypography.bodySmall.copyWith(
                             color: AppColors.textMutedDark,
                           ),
@@ -179,7 +181,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                       controller: _controller,
                       style: const TextStyle(color: AppColors.textDark),
                       decoration: InputDecoration(
-                        hintText: 'Tapez votre message...',
+                        hintText: l10n.aiChatPlaceholder,
                         hintStyle: const TextStyle(
                           color: AppColors.textMutedDark,
                         ),
@@ -207,7 +209,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                   IconButton(
                     onPressed: _loading ? null : _send,
                     icon: const Icon(Icons.send, color: AppColors.ia),
-                    tooltip: 'Envoyer',
+                    tooltip: l10n.aiChatSendTooltip,
                   ),
                 ],
               ),

--- a/front/mobile_apps/leopardo_manager/lib/features/ai_chat/screens/ai_chat_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/ai_chat/screens/ai_chat_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_manager/core/providers/core_providers.dart';
 
 class _ChatMessage {
@@ -72,7 +73,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           _messages.add(
             _ChatMessage(
               role: 'assistant',
-              content: 'Erreur : impossible de contacter l\'assistant.',
+              content: context.l10n.aiChatErrorMessage,
             ),
           );
         });
@@ -84,18 +85,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       backgroundColor: AppColors.bgDark,
       appBar: AppBar(
         backgroundColor: AppColors.bgDark,
         elevation: 0,
         title: Text(
-          'Assistant IA',
+          l10n.aiChatAppBarTitle,
           style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          tooltip: 'Retour',
+          tooltip: l10n.aiChatBackTooltip,
           onPressed: () => context.pop(),
         ),
       ),
@@ -114,7 +116,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Posez vos questions RH',
+                          l10n.aiChatEmptyStateHint,
                           style: AppTypography.bodySmall.copyWith(
                             color: AppColors.textMutedDark,
                           ),
@@ -179,7 +181,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                       controller: _controller,
                       style: const TextStyle(color: AppColors.textDark),
                       decoration: InputDecoration(
-                        hintText: 'Tapez votre message...',
+                        hintText: l10n.aiChatPlaceholder,
                         hintStyle: const TextStyle(
                           color: AppColors.textMutedDark,
                         ),
@@ -207,7 +209,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                   IconButton(
                     onPressed: _loading ? null : _send,
                     icon: const Icon(Icons.send, color: AppColors.ia),
-                    tooltip: 'Envoyer',
+                    tooltip: l10n.aiChatSendTooltip,
                   ),
                 ],
               ),


### PR DESCRIPTION
Implémente l'i18n de AiChatScreen (leopardo_employee, leopardo_hr, leopardo_manager) : ajout des clés aiChat* dans les 4 langues (fr/en/ar/tr) et remplacement des chaînes en dur par context.l10n.

Closes #925