### PR TITLE
fix(mobile): i18n AiChatScreen (FR/EN/AR/TR) across employee/hr/manager apps

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "مرحبا :name،",
   "emailsAbsenceRejectedBody": "تم رفض طلب الغياب للفترة :period.",
   "emailsAbsenceRejectedAction": "عرض الطلب",
-  "emailsAbsenceRejectedFooter": "تواصل مع مديرك اذا كنت تحتاج تفاصيل اضافية."
+  "emailsAbsenceRejectedFooter": "تواصل مع مديرك اذا كنت تحتاج تفاصيل اضافية.",
+  "aiChatScreenTitle": "المساعد الذكي",
+  "aiChatBackTooltip": "رجوع",
+  "aiChatSendTooltip": "إرسال",
+  "aiChatEmptyStateTitle": "اطرح أسئلتك المتعلقة بالموارد البشرية",
+  "aiChatInputHint": "اكتب رسالتك...",
+  "aiChatErrorMessage": "خطأ: تعذر الاتصال بالمساعد."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "Hello :name,",
   "emailsAbsenceRejectedBody": "Your leave request for :period has been rejected.",
   "emailsAbsenceRejectedAction": "View request",
-  "emailsAbsenceRejectedFooter": "Please contact your manager if you need more details."
+  "emailsAbsenceRejectedFooter": "Please contact your manager if you need more details.",
+  "aiChatScreenTitle": "AI Assistant",
+  "aiChatBackTooltip": "Back",
+  "aiChatSendTooltip": "Send",
+  "aiChatEmptyStateTitle": "Ask your HR questions",
+  "aiChatInputHint": "Type your message...",
+  "aiChatErrorMessage": "Error: unable to reach the assistant."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "Bonjour :name,",
   "emailsAbsenceRejectedBody": "Votre demande d absence pour :period a ete refusee.",
   "emailsAbsenceRejectedAction": "Voir la demande",
-  "emailsAbsenceRejectedFooter": "Consultez votre manager si vous avez besoin d un complement."
+  "emailsAbsenceRejectedFooter": "Consultez votre manager si vous avez besoin d un complement.",
+  "aiChatScreenTitle": "Assistant IA",
+  "aiChatBackTooltip": "Retour",
+  "aiChatSendTooltip": "Envoyer",
+  "aiChatEmptyStateTitle": "Posez vos questions RH",
+  "aiChatInputHint": "Tapez votre message...",
+  "aiChatErrorMessage": "Erreur : impossible de contacter l assistant."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
@@ -52,5 +52,11 @@
   "emailsAbsenceRejectedGreeting": "Merhaba :name,",
   "emailsAbsenceRejectedBody": ":period donemi icin izin talebiniz reddedildi.",
   "emailsAbsenceRejectedAction": "Talebi gor",
-  "emailsAbsenceRejectedFooter": "Ek bilgiye ihtiyaciniz varsa yoneticinizle gorusun."
+  "emailsAbsenceRejectedFooter": "Ek bilgiye ihtiyaciniz varsa yoneticinizle gorusun.",
+  "aiChatScreenTitle": "Yapay Zeka Asistani",
+  "aiChatBackTooltip": "Geri",
+  "aiChatSendTooltip": "Gonder",
+  "aiChatEmptyStateTitle": "IK sorularinizi sorun",
+  "aiChatInputHint": "Mesajinizi yazin...",
+  "aiChatErrorMessage": "Hata: asistana ulasilamadi."
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -419,6 +419,42 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'Consultez votre manager si vous avez besoin d un complement.'**
   String get emailsAbsenceRejectedFooter;
+
+  /// No description provided for @aiChatScreenTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Assistant IA'**
+  String get aiChatScreenTitle;
+
+  /// No description provided for @aiChatBackTooltip.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retour'**
+  String get aiChatBackTooltip;
+
+  /// No description provided for @aiChatSendTooltip.
+  ///
+  /// In fr, this message translates to:
+  /// **'Envoyer'**
+  String get aiChatSendTooltip;
+
+  /// No description provided for @aiChatEmptyStateTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Posez vos questions RH'**
+  String get aiChatEmptyStateTitle;
+
+  /// No description provided for @aiChatInputHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tapez votre message...'**
+  String get aiChatInputHint;
+
+  /// No description provided for @aiChatErrorMessage.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur : impossible de contacter l assistant.'**
+  String get aiChatErrorMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -181,4 +181,22 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'تواصل مع مديرك اذا كنت تحتاج تفاصيل اضافية.';
+
+  @override
+  String get aiChatScreenTitle => 'المساعد الذكي';
+
+  @override
+  String get aiChatBackTooltip => 'رجوع';
+
+  @override
+  String get aiChatSendTooltip => 'إرسال';
+
+  @override
+  String get aiChatEmptyStateTitle => 'اطرح أسئلتك المتعلقة بالموارد البشرية';
+
+  @override
+  String get aiChatInputHint => 'اكتب رسالتك...';
+
+  @override
+  String get aiChatErrorMessage => 'خطأ: تعذر الاتصال بالمساعد.';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -186,4 +186,22 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'Please contact your manager if you need more details.';
+
+  @override
+  String get aiChatScreenTitle => 'AI Assistant';
+
+  @override
+  String get aiChatBackTooltip => 'Back';
+
+  @override
+  String get aiChatSendTooltip => 'Send';
+
+  @override
+  String get aiChatEmptyStateTitle => 'Ask your HR questions';
+
+  @override
+  String get aiChatInputHint => 'Type your message...';
+
+  @override
+  String get aiChatErrorMessage => 'Error: unable to reach the assistant.';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -188,4 +188,23 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'Consultez votre manager si vous avez besoin d un complement.';
+
+  @override
+  String get aiChatScreenTitle => 'Assistant IA';
+
+  @override
+  String get aiChatBackTooltip => 'Retour';
+
+  @override
+  String get aiChatSendTooltip => 'Envoyer';
+
+  @override
+  String get aiChatEmptyStateTitle => 'Posez vos questions RH';
+
+  @override
+  String get aiChatInputHint => 'Tapez votre message...';
+
+  @override
+  String get aiChatErrorMessage =>
+      'Erreur : impossible de contacter l assistant.';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -182,4 +182,22 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get emailsAbsenceRejectedFooter =>
       'Ek bilgiye ihtiyaciniz varsa yoneticinizle gorusun.';
+
+  @override
+  String get aiChatScreenTitle => 'Yapay Zeka Asistani';
+
+  @override
+  String get aiChatBackTooltip => 'Geri';
+
+  @override
+  String get aiChatSendTooltip => 'Gonder';
+
+  @override
+  String get aiChatEmptyStateTitle => 'IK sorularinizi sorun';
+
+  @override
+  String get aiChatInputHint => 'Mesajinizi yazin...';
+
+  @override
+  String get aiChatErrorMessage => 'Hata: asistana ulasilamadi.';
 }

--- a/front/mobile_apps/leopardo_employee/lib/features/ai_chat/screens/ai_chat_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/ai_chat/screens/ai_chat_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_employee/core/providers/core_providers.dart';
 
 class _ChatMessage {
@@ -72,7 +73,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           _messages.add(
             _ChatMessage(
               role: 'assistant',
-              content: 'Erreur : impossible de contacter l\'assistant.',
+              content: context.l10n.aiChatErrorMessage,
             ),
           );
         });
@@ -84,18 +85,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       backgroundColor: AppColors.bgDark,
       appBar: AppBar(
         backgroundColor: AppColors.bgDark,
         elevation: 0,
         title: Text(
-          'Assistant IA',
+          l10n.aiChatScreenTitle,
           style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          tooltip: 'Retour',
+          tooltip: l10n.aiChatBackTooltip,
           onPressed: () => context.pop(),
         ),
       ),
@@ -114,7 +116,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Posez vos questions RH',
+                          l10n.aiChatEmptyStateTitle,
                           style: AppTypography.bodySmall.copyWith(
                             color: AppColors.textMutedDark,
                           ),
@@ -179,7 +181,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                       controller: _controller,
                       style: const TextStyle(color: AppColors.textDark),
                       decoration: InputDecoration(
-                        hintText: 'Tapez votre message...',
+                        hintText: l10n.aiChatInputHint,
                         hintStyle: const TextStyle(
                           color: AppColors.textMutedDark,
                         ),
@@ -207,7 +209,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                   IconButton(
                     onPressed: _loading ? null : _send,
                     icon: const Icon(Icons.send, color: AppColors.ia),
-                    tooltip: 'Envoyer',
+                    tooltip: l10n.aiChatSendTooltip,
                   ),
                 ],
               ),

--- a/front/mobile_apps/leopardo_hr/lib/features/ai_chat/screens/ai_chat_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/ai_chat/screens/ai_chat_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_hr/core/providers/core_providers.dart';
 
 class _ChatMessage {
@@ -72,7 +73,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           _messages.add(
             _ChatMessage(
               role: 'assistant',
-              content: 'Erreur : impossible de contacter l\'assistant.',
+              content: context.l10n.aiChatErrorMessage,
             ),
           );
         });
@@ -84,18 +85,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       backgroundColor: AppColors.bgDark,
       appBar: AppBar(
         backgroundColor: AppColors.bgDark,
         elevation: 0,
         title: Text(
-          'Assistant IA',
+          l10n.aiChatScreenTitle,
           style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          tooltip: 'Retour',
+          tooltip: l10n.aiChatBackTooltip,
           onPressed: () => context.pop(),
         ),
       ),
@@ -114,7 +116,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Posez vos questions RH',
+                          l10n.aiChatEmptyStateTitle,
                           style: AppTypography.bodySmall.copyWith(
                             color: AppColors.textMutedDark,
                           ),
@@ -179,7 +181,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                       controller: _controller,
                       style: const TextStyle(color: AppColors.textDark),
                       decoration: InputDecoration(
-                        hintText: 'Tapez votre message...',
+                        hintText: l10n.aiChatInputHint,
                         hintStyle: const TextStyle(
                           color: AppColors.textMutedDark,
                         ),
@@ -207,7 +209,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                   IconButton(
                     onPressed: _loading ? null : _send,
                     icon: const Icon(Icons.send, color: AppColors.ia),
-                    tooltip: 'Envoyer',
+                    tooltip: l10n.aiChatSendTooltip,
                   ),
                 ],
               ),

--- a/front/mobile_apps/leopardo_manager/lib/features/ai_chat/screens/ai_chat_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/ai_chat/screens/ai_chat_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_manager/core/providers/core_providers.dart';
 
 class _ChatMessage {
@@ -72,7 +73,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           _messages.add(
             _ChatMessage(
               role: 'assistant',
-              content: 'Erreur : impossible de contacter l\'assistant.',
+              content: context.l10n.aiChatErrorMessage,
             ),
           );
         });
@@ -84,18 +85,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       backgroundColor: AppColors.bgDark,
       appBar: AppBar(
         backgroundColor: AppColors.bgDark,
         elevation: 0,
         title: Text(
-          'Assistant IA',
+          l10n.aiChatScreenTitle,
           style: AppTypography.subtitle.copyWith(color: AppColors.textDark),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textDark),
-          tooltip: 'Retour',
+          tooltip: l10n.aiChatBackTooltip,
           onPressed: () => context.pop(),
         ),
       ),
@@ -114,7 +116,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                         ),
                         const SizedBox(height: 12),
                         Text(
-                          'Posez vos questions RH',
+                          l10n.aiChatEmptyStateTitle,
                           style: AppTypography.bodySmall.copyWith(
                             color: AppColors.textMutedDark,
                           ),
@@ -179,7 +181,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                       controller: _controller,
                       style: const TextStyle(color: AppColors.textDark),
                       decoration: InputDecoration(
-                        hintText: 'Tapez votre message...',
+                        hintText: l10n.aiChatInputHint,
                         hintStyle: const TextStyle(
                           color: AppColors.textMutedDark,
                         ),
@@ -207,7 +209,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                   IconButton(
                     onPressed: _loading ? null : _send,
                     icon: const Icon(Icons.send, color: AppColors.ia),
-                    tooltip: 'Envoyer',
+                    tooltip: l10n.aiChatSendTooltip,
                   ),
                 ],
               ),


### PR DESCRIPTION
## What Problem This Solves
`ai_chat_screen.dart` had several hardcoded French strings (tooltip "Retour"/"Envoyer", placeholder "Tapez votre message...", title "Assistant IA", empty-state "Posez vos questions RH", and the error message "Erreur : impossible de contacter l'assistant.") with no `AppLocalizations` keys. This is duplicated identically across the 3 mobile apps that embed this screen (`leopardo_employee`, `leopardo_hr`, `leopardo_manager`), so EN/AR/TR users always saw French text on this screen regardless of their selected app language.

## Why This Change Was Made
Added the missing translation keys (`aiChatScreenTitle`, `aiChatBackTooltip`, `aiChatSendTooltip`, `aiChatEmptyStateTitle`, `aiChatInputHint`, `aiChatErrorMessage`) to the shared `leopardo_core` ARB files (FR/EN/AR/TR) and to the generated `AppLocalizations` classes, then replaced every hardcoded string in the 3 identical `ai_chat_screen.dart` files with `context.l10n.xxx` lookups, following the existing pattern already used elsewhere in the app (e.g. `welcome_screen.dart`).

## User Impact
- The AI chat screen now renders fully in the user's selected language (FR/EN/AR/TR) instead of always showing French UI strings.
- No behavior change for French users; other locales gain a translated screen.
- Applied consistently to all 3 apps that share this file (employee, HR/manager, manager).

## Evidence
- `git diff --stat`: 12 files changed (4 ARB files + 5 generated localization files + 3 `ai_chat_screen.dart` files).
- Verified all 4 ARB files remain valid JSON after edits (`python3 -c "import json; json.load(...)"` passed for all).
- `grep` confirms zero remaining hardcoded occurrences of `'Assistant IA'`, `'Retour'`, `'Envoyer'`, `'Posez vos questions RH'`, `'Tapez votre message...'`, or the old error string in the 3 screen files.
- No Flutter/Dart toolchain is available in this sandbox to run `flutter analyze`/`flutter test`, so changes were made by hand-editing the generated `AppLocalizations` classes to match the exact style/pattern of the existing generated code (same as `flutter gen-l10n` output would produce for these new keys).

Fixes kitokoh/leopardo-hr#925