### PR TITLE
fix(i18n): use active locale for date/currency formatting in web and admin dashboard

### DIFF
--- a/front/admin-dashboard/src/components/analytics/InsightCard.vue
+++ b/front/admin-dashboard/src/components/analytics/InsightCard.vue
@@ -103,6 +103,10 @@ import {
   InformationCircleIcon,
   ArrowRightIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   insight: {
@@ -216,7 +220,7 @@ const confidenceColor = computed(() => {
 
 // Methods
 function formatDate(date) {
-  return new Date(date).toLocaleDateString('fr-FR', {
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), {
     day: 'numeric',
     month: 'short',
     hour: '2-digit',

--- a/front/admin-dashboard/src/components/analytics/MetricCard.vue
+++ b/front/admin-dashboard/src/components/analytics/MetricCard.vue
@@ -87,6 +87,10 @@ import {
   UserPlusIcon,
   UsersIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   title: {
@@ -227,6 +231,6 @@ const formattedValue = computed(() => {
     return props.value.toFixed(1)
   }
 
-  return props.value.toLocaleString('fr-FR')
+  return props.value.toLocaleString(toIntlLocale(localeStore.current))
 })
 </script>

--- a/front/admin-dashboard/src/components/analytics/RevenueForecastWidget.vue
+++ b/front/admin-dashboard/src/components/analytics/RevenueForecastWidget.vue
@@ -97,6 +97,10 @@ import {
   ArrowTrendingDownIcon as TrendingDownIcon,
   ArrowRightIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   data: {
@@ -116,7 +120,7 @@ const chartCanvas = ref(null)
 
 // Computed properties
 const formattedRevenue = computed(() => {
-  return new Intl.NumberFormat('fr-FR', {
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), {
     style: 'currency',
     currency: 'EUR',
     minimumFractionDigits: 0
@@ -156,7 +160,7 @@ const trendLabel = computed(() => {
 
 // Methods
 function formatCurrency(amount) {
-  return new Intl.NumberFormat('fr-FR', {
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), {
     style: 'currency',
     currency: 'EUR',
     minimumFractionDigits: 0

--- a/front/admin-dashboard/src/components/charts/RevenueChart.vue
+++ b/front/admin-dashboard/src/components/charts/RevenueChart.vue
@@ -18,7 +18,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import * as echarts from 'echarts'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const chartContainer = ref(null)
 const chart = ref(null)
 const isLoading = ref(true)
@@ -95,7 +98,7 @@ function initChart() {
         params.forEach(param => {
           let value = param.value
           if (param.seriesName === 'Revenus') {
-            value = new Intl.NumberFormat('fr-FR', {
+            value = new Intl.NumberFormat(toIntlLocale(localeStore.current), {
               style: 'currency',
               currency: 'EUR'
             }).format(value)

--- a/front/admin-dashboard/src/components/charts/UserGrowthChart.vue
+++ b/front/admin-dashboard/src/components/charts/UserGrowthChart.vue
@@ -18,7 +18,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import * as echarts from 'echarts'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const chartContainer = ref(null)
 const chart = ref(null)
 const isLoading = ref(true)
@@ -60,7 +63,7 @@ async function loadData() {
   for (let i = 29; i >= 0; i--) {
     const date = new Date()
     date.setDate(date.getDate() - i)
-    dates.push(date.toLocaleDateString('fr-FR', { month: 'short', day: 'numeric' }))
+    dates.push(date.toLocaleDateString(toIntlLocale(localeStore.current), { month: 'short', day: 'numeric' }))
 
     // Random new users between 5-50
     const newUsersCount = Math.floor(Math.random() * 45) + 5
@@ -92,7 +95,7 @@ function initChart() {
         let result = `<div class="font-medium">${params[0].axisValue}</div>`
         params.forEach(param => {
           const value = param.seriesName === 'Total Utilisateurs'
-            ? param.value.toLocaleString('fr-FR')
+            ? param.value.toLocaleString(toIntlLocale(localeStore.current))
             : param.value
           result += `
             <div class="flex items-center mt-1">

--- a/front/admin-dashboard/src/components/common/MetricCard.vue
+++ b/front/admin-dashboard/src/components/common/MetricCard.vue
@@ -26,6 +26,10 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   title: { type: String, required: true },
@@ -40,12 +44,13 @@ const trendUp = computed(() => (props.trend ?? 0) >= 0)
 
 const formattedValue = computed(() => {
   const v = Number(props.value) || 0
+  const intlLocale = toIntlLocale(localeStore.current)
   if (props.format === 'currency') {
-    return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: props.currency }).format(v)
+    return new Intl.NumberFormat(intlLocale, { style: 'currency', currency: props.currency }).format(v)
   }
   if (props.format === 'percent') {
     return `${v}%`
   }
-  return new Intl.NumberFormat('fr-FR').format(v)
+  return new Intl.NumberFormat(intlLocale).format(v)
 })
 </script>

--- a/front/admin-dashboard/src/components/dashboard/QuickActionsCard.vue
+++ b/front/admin-dashboard/src/components/dashboard/QuickActionsCard.vue
@@ -135,9 +135,12 @@ import {
 } from '@heroicons/vue/24/outline'
 import { useToast } from 'vue-toastification'
 import ActionModal from '@/components/modals/ActionModal.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const router = useRouter()
 const toast = useToast()
+const localeStore = useLocaleStore()
 
 const showModal = ref(false)
 const selectedAction = ref(null)
@@ -334,6 +337,6 @@ function formatTime(timestamp) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 </script>

--- a/front/admin-dashboard/src/components/dashboard/RecentActivityList.vue
+++ b/front/admin-dashboard/src/components/dashboard/RecentActivityList.vue
@@ -106,8 +106,11 @@ import {
   CogIcon
 } from '@heroicons/vue/24/outline'
 import { useDashboardStore } from '@/stores/dashboard'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const dashboardStore = useDashboardStore()
+const localeStore = useLocaleStore()
 const isLoading = ref(false)
 
 // Get activities from store
@@ -153,7 +156,7 @@ function formatTime(timestamp) {
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
   if (diff < 604800000) return `${Math.floor(diff / 86400000)}j`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 
 async function loadMore() {

--- a/front/admin-dashboard/src/components/dashboard/StatsCard.vue
+++ b/front/admin-dashboard/src/components/dashboard/StatsCard.vue
@@ -70,6 +70,10 @@ import {
   ArrowUpIcon,
   ArrowDownIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   title: {
@@ -171,6 +175,6 @@ const formattedValue = computed(() => {
     return (props.value / 1000).toFixed(1) + 'K'
   }
 
-  return props.value.toLocaleString('fr-FR')
+  return props.value.toLocaleString(toIntlLocale(localeStore.current))
 })
 </script>

--- a/front/admin-dashboard/src/components/dashboard/SupportTicketsList.vue
+++ b/front/admin-dashboard/src/components/dashboard/SupportTicketsList.vue
@@ -134,9 +134,12 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { ChatBubbleLeftRightIcon } from '@heroicons/vue/24/outline'
 import { useToast } from 'vue-toastification'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const router = useRouter()
 const toast = useToast()
+const localeStore = useLocaleStore()
 
 // Mock tickets data (in real app, this would come from an API)
 const tickets = ref([
@@ -237,7 +240,7 @@ function formatTime(timestamp) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 
 function viewTicket(ticketId) {

--- a/front/admin-dashboard/src/components/dashboard/SystemHealthCard.vue
+++ b/front/admin-dashboard/src/components/dashboard/SystemHealthCard.vue
@@ -135,9 +135,12 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/vue/24/outline'
 import { useDashboardStore } from '@/stores/dashboard'
 import { useRealtimeStore } from '@/stores/realtime'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const dashboardStore = useDashboardStore()
 const realtimeStore = useRealtimeStore()
+const localeStore = useLocaleStore()
 
 // Mock system metrics (in real app, these would come from monitoring APIs)
 const apiResponseTime = ref(45)
@@ -185,6 +188,6 @@ function formatTime(timestamp) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 </script>

--- a/front/admin-dashboard/src/components/edge/EdgeNodeModal.vue
+++ b/front/admin-dashboard/src/components/edge/EdgeNodeModal.vue
@@ -71,6 +71,11 @@
 </template>
 
 <script setup>
+import { useLocaleStore } from '@/stores/locale';
+import { toIntlLocale } from '@/i18n/index.js';
+
+const localeStore = useLocaleStore();
+
 const props = defineProps({
   node: { type: Object, required: true },
 });
@@ -78,7 +83,7 @@ const props = defineProps({
 defineEmits(['close', 'sync']);
 
 function formatDate(iso) {
-  return new Date(iso).toLocaleString('fr-FR', {
+  return new Date(iso).toLocaleString(toIntlLocale(localeStore.current), {
     day: '2-digit', month: 'short', year: 'numeric',
     hour: '2-digit', minute: '2-digit',
   });

--- a/front/admin-dashboard/src/components/layout/Header.vue
+++ b/front/admin-dashboard/src/components/layout/Header.vue
@@ -200,12 +200,15 @@ import {
 import { useDashboardStore } from '@/stores/dashboard'
 import { useRealtimeStore } from '@/stores/realtime'
 import { useThemeStore } from '@/stores/theme'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 defineEmits(['toggle-sidebar'])
 
 const dashboardStore = useDashboardStore()
 const realtimeStore = useRealtimeStore()
 const themeStore = useThemeStore()
+const localeStore = useLocaleStore()
 
 const searchQuery = ref('')
 const showNotifications = ref(false)
@@ -261,7 +264,7 @@ function formatTime(timestamp) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 
 async function refreshData() {

--- a/front/admin-dashboard/src/components/system/AutomatedTasksList.vue
+++ b/front/admin-dashboard/src/components/system/AutomatedTasksList.vue
@@ -66,6 +66,10 @@
 
 <script setup>
 import { PencilIcon, TrashIcon, CogIcon } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 defineProps({
   tasks: {
@@ -87,7 +91,7 @@ function getStatusLabel(status) {
 }
 
 function formatDate(date) {
-  return new Date(date).toLocaleDateString('fr-FR', {
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), {
     day: '2-digit',
     month: '2-digit',
     hour: '2-digit',

--- a/front/admin-dashboard/src/components/system/BackupManagement.vue
+++ b/front/admin-dashboard/src/components/system/BackupManagement.vue
@@ -74,6 +74,10 @@ import {
   ArrowDownTrayIcon,
   TrashIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 defineProps({
   backups: {
@@ -95,7 +99,7 @@ function getStatusLabel(status) {
 }
 
 function formatDate(date) {
-  return new Date(date).toLocaleDateString('fr-FR', {
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), {
     day: '2-digit',
     month: '2-digit',
     year: '2-digit',

--- a/front/admin-dashboard/src/components/system/SecurityMonitoring.vue
+++ b/front/admin-dashboard/src/components/system/SecurityMonitoring.vue
@@ -127,6 +127,10 @@ import {
   ShieldCheckIcon,
   LightBulbIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   alerts: {
@@ -178,6 +182,6 @@ function formatTime(timestamp) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 </script>

--- a/front/admin-dashboard/src/components/system/SystemStatusCard.vue
+++ b/front/admin-dashboard/src/components/system/SystemStatusCard.vue
@@ -77,6 +77,10 @@ import {
   ExclamationTriangleIcon,
   XCircleIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   title: {
@@ -189,6 +193,6 @@ function formatTime(date) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return date.toLocaleDateString('fr-FR')
+  return date.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 </script>

--- a/front/admin-dashboard/src/components/users/EditUserModal.vue
+++ b/front/admin-dashboard/src/components/users/EditUserModal.vue
@@ -211,6 +211,8 @@
 import { ref, reactive, onMounted, watch } from 'vue'
 import { PencilIcon } from '@heroicons/vue/24/outline'
 import { useToast } from 'vue-toastification'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const props = defineProps({
   user: {
@@ -221,6 +223,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'updated'])
 const toast = useToast()
+const localeStore = useLocaleStore()
 
 const isLoading = ref(false)
 const companies = ref([])
@@ -331,7 +334,7 @@ async function forceLogout() {
 
 function formatDate(date) {
   if (!date) return 'Jamais'
-  return new Date(date).toLocaleDateString('fr-FR', {
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',

--- a/front/admin-dashboard/src/components/users/UserDetailModal.vue
+++ b/front/admin-dashboard/src/components/users/UserDetailModal.vue
@@ -280,6 +280,10 @@ import {
   ExclamationTriangleIcon
 } from '@heroicons/vue/24/outline'
 import { useToast } from 'vue-toastification'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   user: {
@@ -435,7 +439,7 @@ function getActivityIcon(type) {
 
 function formatDate(date) {
   if (!date) return 'Jamais'
-  return new Date(date).toLocaleDateString('fr-FR', {
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
@@ -456,7 +460,7 @@ function formatLastLogin(date) {
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
   if (diff < 604800000) return `${Math.floor(diff / 86400000)}j`
 
-  return loginDate.toLocaleDateString('fr-FR')
+  return loginDate.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 
 function formatTime(timestamp) {
@@ -467,7 +471,7 @@ function formatTime(timestamp) {
   if (diff < 60000) return 'À l\'instant'
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
-  return time.toLocaleDateString('fr-FR')
+  return time.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 
 // Action methods

--- a/front/admin-dashboard/src/components/users/UserTable.vue
+++ b/front/admin-dashboard/src/components/users/UserTable.vue
@@ -192,6 +192,10 @@ import {
   TrashIcon,
   UsersIcon
 } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
 
 const props = defineProps({
   users: {
@@ -349,11 +353,11 @@ function formatLastLogin(date) {
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
   if (diff < 604800000) return `${Math.floor(diff / 86400000)}j`
 
-  return loginDate.toLocaleDateString('fr-FR')
+  return loginDate.toLocaleDateString(toIntlLocale(localeStore.current))
 }
 
 function formatDate(date) {
-  return new Date(date).toLocaleDateString('fr-FR', {
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric'

--- a/front/admin-dashboard/src/stores/dashboard.js
+++ b/front/admin-dashboard/src/stores/dashboard.js
@@ -1,8 +1,12 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import api from '@/services/api'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 export const useDashboardStore = defineStore('dashboard', () => {
+  const localeStore = useLocaleStore()
+
   // State
   const stats = ref({
     totalUsers: 0,
@@ -22,7 +26,7 @@ export const useDashboardStore = defineStore('dashboard', () => {
 
   // Getters
   const formattedRevenue = computed(() => {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(toIntlLocale(localeStore.current), {
       style: 'currency',
       currency: 'EUR'
     }).format(stats.value.monthlyRevenue)

--- a/front/admin-dashboard/src/views/DashboardView.vue
+++ b/front/admin-dashboard/src/views/DashboardView.vue
@@ -220,7 +220,10 @@ import {
 } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const isLoading = ref(false)
 const errorMessage = ref('')
 const summary = ref({
@@ -362,15 +365,16 @@ async function loadDashboard() {
 
 function formatCurrency(value, currency = 'EUR') {
   const amount = Number(value || 0)
+  const intlLocale = toIntlLocale(localeStore.current)
 
   try {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(intlLocale, {
       style: 'currency',
       currency: currency || 'EUR',
       maximumFractionDigits: 0,
     }).format(amount)
   } catch {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(intlLocale, {
       style: 'currency',
       currency: 'EUR',
       maximumFractionDigits: 0,
@@ -394,7 +398,7 @@ function riskLabel(risk) {
 
 function formatDate(value) {
   if (!value) return 'Non renseigné'
-  return new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium' }).format(new Date(value))
+  return new Intl.DateTimeFormat(toIntlLocale(localeStore.current), { dateStyle: 'medium' }).format(new Date(value))
 }
 
 onMounted(loadDashboard)

--- a/front/admin-dashboard/src/views/audit/AuditLogsView.vue
+++ b/front/admin-dashboard/src/views/audit/AuditLogsView.vue
@@ -146,7 +146,10 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import api, { downloadApiFile } from '@/services/api'
 import DataTable from '@/components/common/DataTable.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const loading = ref(false)
 const error = ref('')
 const auditLogs = ref([])
@@ -211,7 +214,7 @@ function formatType(type) {
 
 function formatDate(date) {
   if (!date) return '-'
-  return new Date(date).toLocaleString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+  return new Date(date).toLocaleString(toIntlLocale(localeStore.current), { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
 }
 
 function formatJson(data) {

--- a/front/admin-dashboard/src/views/chat/ChatView.vue
+++ b/front/admin-dashboard/src/views/chat/ChatView.vue
@@ -95,7 +95,10 @@
 import { ref, onMounted, nextTick } from 'vue'
 import { ChatBubbleLeftRightIcon } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const conversations = ref([])
 const activeConversation = ref(null)
 const messages = ref([])
@@ -105,12 +108,12 @@ const messagesContainer = ref(null)
 
 function formatDate(date) {
   if (!date) return ''
-  return new Date(date).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' })
+  return new Date(date).toLocaleDateString(toIntlLocale(localeStore.current), { day: '2-digit', month: '2-digit' })
 }
 
 function formatTime(date) {
   if (!date) return ''
-  return new Date(date).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+  return new Date(date).toLocaleTimeString(toIntlLocale(localeStore.current), { hour: '2-digit', minute: '2-digit' })
 }
 
 function scrollToBottom() {

--- a/front/admin-dashboard/src/views/companies/CompaniesView.vue
+++ b/front/admin-dashboard/src/views/companies/CompaniesView.vue
@@ -254,9 +254,12 @@ import {
 } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const router = useRouter()
 const toast = useToast()
+const localeStore = useLocaleStore()
 const isLoading = ref(false)
 const errorMessage = ref('')
 const showCreateModal = ref(false)
@@ -377,7 +380,7 @@ async function submitCreateClient() {
 }
 
 function formatCurrency(value, currency = 'EUR') {
-  return new Intl.NumberFormat('fr-FR', {
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), {
     style: 'currency',
     currency: currency || 'EUR',
     maximumFractionDigits: 0,

--- a/front/admin-dashboard/src/views/companies/CompanyDetailView.vue
+++ b/front/admin-dashboard/src/views/companies/CompanyDetailView.vue
@@ -305,9 +305,12 @@ import {
 } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const route = useRoute()
 const toast = useToast()
+const localeStore = useLocaleStore()
 
 const isLoading = ref(false)
 const errorMessage = ref('')
@@ -423,15 +426,16 @@ function fillSubscriptionForm(subscription) {
 
 function formatCurrency(value, currency = 'EUR') {
   const amount = Number(value || 0)
+  const intlLocale = toIntlLocale(localeStore.current)
 
   try {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(intlLocale, {
       style: 'currency',
       currency: currency || 'EUR',
       maximumFractionDigits: 0,
     }).format(amount)
   } catch {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(intlLocale, {
       style: 'currency',
       currency: 'EUR',
       maximumFractionDigits: 0,
@@ -441,12 +445,12 @@ function formatCurrency(value, currency = 'EUR') {
 
 function formatDate(value) {
   if (!value) return 'Non renseigné'
-  return new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium' }).format(new Date(value))
+  return new Intl.DateTimeFormat(toIntlLocale(localeStore.current), { dateStyle: 'medium' }).format(new Date(value))
 }
 
 function formatDateTime(value) {
   if (!value) return 'Aucun pointage'
-  return new Intl.DateTimeFormat('fr-FR', {
+  return new Intl.DateTimeFormat(toIntlLocale(localeStore.current), {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(new Date(value))

--- a/front/admin-dashboard/src/views/contracts/ContractsView.vue
+++ b/front/admin-dashboard/src/views/contracts/ContractsView.vue
@@ -151,7 +151,10 @@ import api, { downloadApiFile } from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const loading = ref(false)
 const error = ref('')
 const allContracts = ref([])
@@ -194,7 +197,7 @@ const contractAlerts = computed(() => {
 })
 
 function formatCurrency(value, currency = 'EUR') {
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: currency || 'EUR' }).format(value || 0)
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), { style: 'currency', currency: currency || 'EUR' }).format(value || 0)
 }
 
 function isExpiringSoon(endDate) {

--- a/front/admin-dashboard/src/views/crm/CrmPipelineView.vue
+++ b/front/admin-dashboard/src/views/crm/CrmPipelineView.vue
@@ -126,8 +126,11 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import api from '@/services/api'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const router = useRouter()
+const localeStore = useLocaleStore()
 const isLoading = ref(false)
 const errorMessage = ref('')
 const pipeline = ref({
@@ -162,7 +165,7 @@ function openCompany(companyId) {
 
 function formatDate(value) {
   if (!value) return ''
-  return new Intl.DateTimeFormat('fr-FR', {
+  return new Intl.DateTimeFormat(toIntlLocale(localeStore.current), {
     dateStyle: 'short',
     timeStyle: 'short',
   }).format(new Date(value))

--- a/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
+++ b/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
@@ -132,8 +132,11 @@ import { ref, computed, onMounted, onUnmounted } from 'vue';
 import EdgeStatCard from '@/components/edge/EdgeStatCard.vue';
 import EdgeNodeModal from '@/components/edge/EdgeNodeModal.vue';
 import { useEdgeNodesStore } from '@/stores/edgeNodes';
+import { useLocaleStore } from '@/stores/locale';
+import { toIntlLocale } from '@/i18n/index.js';
 
 const store = useEdgeNodesStore();
+const localeStore = useLocaleStore();
 const loading = ref(false);
 const syncingNodeId = ref(null);
 const selectedNode = ref(null);
@@ -191,7 +194,7 @@ function licenseLabel(status) {
 }
 
 function formatDate(iso) {
-  return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' });
+  return new Date(iso).toLocaleDateString(toIntlLocale(localeStore.current), { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
 function formatRelative(iso) {

--- a/front/admin-dashboard/src/views/payroll/PayrollView.vue
+++ b/front/admin-dashboard/src/views/payroll/PayrollView.vue
@@ -216,7 +216,10 @@ import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const loading = ref(false)
 const error = ref('')
 const runs = ref([])
@@ -302,7 +305,7 @@ const filteredRuns = computed(() => {
 const formattedMasse = computed(() => formatCurrency(stats.value.total_net))
 
 function formatCurrency(value) {
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(Number(value) || 0)
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), { style: 'currency', currency: 'EUR' }).format(Number(value) || 0)
 }
 
 function formatPeriod(start, end) {

--- a/front/admin-dashboard/src/views/subscriptions/SubscriptionsView.vue
+++ b/front/admin-dashboard/src/views/subscriptions/SubscriptionsView.vue
@@ -147,7 +147,10 @@ import {
 } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const isLoading = ref(false)
 const plans = ref([])
 const portfolioItems = ref([])
@@ -226,15 +229,16 @@ function formatFeatureLabel(feature) {
 
 function formatCurrency(value, currency = 'EUR') {
   const amount = Number(value || 0)
+  const intlLocale = toIntlLocale(localeStore.current)
 
   try {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(intlLocale, {
       style: 'currency',
       currency: currency || 'EUR',
       maximumFractionDigits: 0,
     }).format(amount)
   } catch {
-    return new Intl.NumberFormat('fr-FR', {
+    return new Intl.NumberFormat(intlLocale, {
       style: 'currency',
       currency: 'EUR',
       maximumFractionDigits: 0,

--- a/front/admin-dashboard/src/views/support/SupportView.vue
+++ b/front/admin-dashboard/src/views/support/SupportView.vue
@@ -210,8 +210,11 @@ import {
 } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
 const toast = useToast()
+const localeStore = useLocaleStore()
 const isLoading = ref(false)
 const errorMessage = ref('')
 const savingId = ref(null)
@@ -314,7 +317,7 @@ function statusLabel(status) {
 function formatDate(value) {
   if (!value) return 'Non renseigné'
 
-  return new Intl.DateTimeFormat('fr-FR', {
+  return new Intl.DateTimeFormat(toIntlLocale(localeStore.current), {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(new Date(value))

--- a/front/admin-dashboard/src/views/training/TrainingView.vue
+++ b/front/admin-dashboard/src/views/training/TrainingView.vue
@@ -169,7 +169,10 @@ import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
 
+const localeStore = useLocaleStore()
 const loading = ref(false)
 const error = ref('')
 const courses = ref([])
@@ -225,7 +228,7 @@ const courseSessions = computed(() => {
 
 function formatCurrency(value, currency = 'EUR') {
   if (!value && value !== 0) return '-'
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: currency || 'EUR' }).format(value)
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), { style: 'currency', currency: currency || 'EUR' }).format(value)
 }
 
 function viewCourse(course) {

--- a/front/web/src/app/(dashboard)/billing/page.tsx
+++ b/front/web/src/app/(dashboard)/billing/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { motion } from 'framer-motion';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale, toIntlLocale, type AppLocale } from '@/lib/i18n';
 import { CreditCard, Download, ExternalLink, FileText, Loader2, ShieldCheck, XCircle } from 'lucide-react';
+
+const emptySubscribe = () => () => {};
 
 type Subscription = {
   id: number | string;
@@ -42,6 +45,7 @@ const STATUS_LABELS: Record<string, { label: string; className: string }> = {
 };
 
 export default function BillingPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [subscription, setSubscription] = useState<Subscription | null>(null);
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
@@ -79,7 +83,7 @@ export default function BillingPage() {
   useEffect(() => { void load(); }, [load]);
 
   const formatCurrency = (val: number, currency = 'EUR') =>
-    new Intl.NumberFormat('fr-FR', { style: 'currency', currency }).format(val || 0);
+    new Intl.NumberFormat(toIntlLocale(locale), { style: 'currency', currency }).format(val || 0);
 
   const handleUpgrade = async (plan: 'starter' | 'business' | 'enterprise') => {
     setActionLoading(`upgrade-${plan}`);
@@ -209,7 +213,7 @@ export default function BillingPage() {
                     </h2>
                     <p className="mt-1 text-sm text-slate-500">
                       {subscription.current_period_start && subscription.current_period_end
-                        ? `Periode: ${new Date(subscription.current_period_start).toLocaleDateString('fr-FR')} au ${new Date(subscription.current_period_end).toLocaleDateString('fr-FR')}`
+                        ? `Periode: ${new Date(subscription.current_period_start).toLocaleDateString(toIntlLocale(locale))} au ${new Date(subscription.current_period_end).toLocaleDateString(toIntlLocale(locale))}`
                         : 'Aucune periode active'}
                     </p>
                   </>
@@ -307,7 +311,7 @@ export default function BillingPage() {
                         </span>
                       </td>
                       <td className="px-4 py-4 text-slate-600">
-                        {invoice.due_date ? new Date(invoice.due_date).toLocaleDateString('fr-FR') : '—'}
+                        {invoice.due_date ? new Date(invoice.due_date).toLocaleDateString(toIntlLocale(locale)) : '—'}
                       </td>
                       <td className="px-6 py-4 text-right">
                         <button onClick={() => downloadInvoicePdf(invoice.id)} className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-brand-600" title="Telecharger PDF">

--- a/front/web/src/app/(dashboard)/edge-nodes/page.tsx
+++ b/front/web/src/app/(dashboard)/edge-nodes/page.tsx
@@ -5,11 +5,14 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useSyncExternalStore } from 'react';
 import { motion } from 'framer-motion';
 import { Cpu, Plus, RefreshCw, ShieldAlert, Wifi, WifiOff, X } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale, toIntlLocale, type AppLocale } from '@/lib/i18n';
+
+const emptySubscribe = () => () => {};
 
 interface EdgeNode {
   id: string;
@@ -39,6 +42,7 @@ const MODE_STYLES: Record<string, string> = {
 };
 
 export default function EdgeNodesPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [nodes, setNodes] = useState<EdgeNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState<string | null>(null);
@@ -190,7 +194,7 @@ export default function EdgeNodesPage() {
                         {node.site_address ?? 'Adresse non renseignee'} · v{node.edge_version}
                       </p>
                       <p className="mt-1 text-xs text-slate-400">
-                        Derniere sync : {node.last_sync_at ? new Date(node.last_sync_at).toLocaleString('fr-FR') : 'jamais'}
+                        Derniere sync : {node.last_sync_at ? new Date(node.last_sync_at).toLocaleString(toIntlLocale(locale)) : 'jamais'}
                       </p>
                     </div>
                   </div>

--- a/front/web/src/app/(dashboard)/settings/developer/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/developer/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { Key, Webhook, FileText, Plus, Trash2, Copy, Check, X, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale, toIntlLocale, type AppLocale } from '@/lib/i18n';
+
+const emptySubscribe = () => () => {};
 
 type ApiToken = {
   id: number | string;
@@ -26,6 +29,7 @@ type WebhookEndpoint = {
 };
 
 export default function DeveloperSettingsPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -223,8 +227,8 @@ export default function DeveloperSettingsPage() {
                     <div>
                       <p className="font-bold text-slate-950">{token.name}</p>
                       <p className="text-xs text-slate-500">
-                        {token.created_at ? `Creee le ${new Date(token.created_at).toLocaleDateString('fr-FR')}` : 'Date inconnue'}
-                        {token.last_used_at ? ` · derniere utilisation le ${new Date(token.last_used_at).toLocaleDateString('fr-FR')}` : ' · jamais utilisee'}
+                        {token.created_at ? `Creee le ${new Date(token.created_at).toLocaleDateString(toIntlLocale(locale))}` : 'Date inconnue'}
+                        {token.last_used_at ? ` · derniere utilisation le ${new Date(token.last_used_at).toLocaleDateString(toIntlLocale(locale))}` : ' · jamais utilisee'}
                       </p>
                     </div>
                     <button
@@ -299,7 +303,7 @@ export default function DeveloperSettingsPage() {
                     </div>
                     <div className="mt-3 flex items-center justify-between border-t border-app-border pt-3">
                       <span className="text-xs text-slate-500">
-                        {webhook.last_triggered_at ? `Declenche le ${new Date(webhook.last_triggered_at).toLocaleString('fr-FR')}` : 'Jamais declenche'}
+                        {webhook.last_triggered_at ? `Declenche le ${new Date(webhook.last_triggered_at).toLocaleString(toIntlLocale(locale))}` : 'Jamais declenche'}
                       </span>
                       <button
                         onClick={() => handleDeleteWebhook(webhook.id)}

--- a/front/web/src/app/(dashboard)/smart-attendance/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/page.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { CheckCircle2, Settings } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale, toIntlLocale, type AppLocale } from '@/lib/i18n';
 import { GeoSessionStatusBadge } from './_components/GeoSessionStatusBadge';
 import { GeoSessionStatsCards, type DashboardStats } from './_components/GeoSessionStatsCards';
 import { ApproveSessionModal } from './_components/ApproveSessionModal';
 import { RejectSessionModal } from './_components/RejectSessionModal';
+
+const emptySubscribe = () => () => {};
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -33,10 +36,10 @@ type DashboardPayload = {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatTime(iso?: string | null): string {
+function formatTime(iso: string | null | undefined, locale: AppLocale): string {
   if (!iso) return '—';
   const d = new Date(iso);
-  return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  return d.toLocaleTimeString(toIntlLocale(locale), { hour: '2-digit', minute: '2-digit' });
 }
 
 function formatDuration(minutes?: number | null): string {
@@ -77,6 +80,7 @@ type ModalState =
   | null;
 
 export default function SmartAttendanceDashboardPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [stats, setStats] = useState<DashboardStats>({
     total: 0,
     detected: 0,
@@ -226,8 +230,8 @@ export default function SmartAttendanceDashboardPage() {
                           ) : null}
                         </Link>
                       </td>
-                      <td className="px-4 py-4 text-slate-700">{formatTime(session.check_in_time)}</td>
-                      <td className="px-4 py-4 text-slate-700">{formatTime(session.check_out_time)}</td>
+                      <td className="px-4 py-4 text-slate-700">{formatTime(session.check_in_time, locale)}</td>
+                      <td className="px-4 py-4 text-slate-700">{formatTime(session.check_out_time, locale)}</td>
                       <td className="px-4 py-4 text-slate-700">{formatDuration(session.duration_minutes)}</td>
                       <td className="px-4 py-4">
                         <GeoSessionStatusBadge status={session.status} />

--- a/front/web/src/app/(dashboard)/smart-attendance/sessions/[id]/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/sessions/[id]/page.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Check, LogIn, LogOut, X } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale, toIntlLocale, type AppLocale } from '@/lib/i18n';
 import { GeoSessionStatusBadge } from '../../_components/GeoSessionStatusBadge';
 import { ApproveSessionModal } from '../../_components/ApproveSessionModal';
 import { RejectSessionModal } from '../../_components/RejectSessionModal';
+
+const emptySubscribe = () => () => {};
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -46,9 +49,9 @@ type SessionPayload = {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatDateTime(iso?: string | null): string {
+function formatDateTime(iso: string | null | undefined, locale: AppLocale): string {
   if (!iso) return '—';
-  return new Date(iso).toLocaleString('fr-FR', {
+  return new Date(iso).toLocaleString(toIntlLocale(locale), {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
@@ -80,6 +83,7 @@ function mapsLink(lat?: number | null, lng?: number | null): string | null {
 type ModalType = 'approve' | 'reject' | null;
 
 export default function SmartAttendanceSessionDetailPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const { id } = useParams<{ id: string }>();
   const [session, setSession] = useState<GeoSessionDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -227,7 +231,7 @@ export default function SmartAttendanceSessionDetailPage() {
                 </div>
                 <div className="ml-4 mt-1">
                   <p className="text-xs font-bold uppercase tracking-wider text-slate-400">Arrivée détectée</p>
-                  <p className="text-lg font-black text-slate-900">{formatDateTime(session.check_in_time)}</p>
+                  <p className="text-lg font-black text-slate-900">{formatDateTime(session.check_in_time, locale)}</p>
                 </div>
               </div>
 
@@ -239,7 +243,7 @@ export default function SmartAttendanceSessionDetailPage() {
                 </div>
                 <div className="ml-4 mt-1">
                   <p className="text-xs font-bold uppercase tracking-wider text-slate-400">Départ</p>
-                  <p className="text-lg font-black text-slate-900">{formatDateTime(session.check_out_time)}</p>
+                  <p className="text-lg font-black text-slate-900">{formatDateTime(session.check_out_time, locale)}</p>
                   {session.duration_minutes != null ? (
                     <p className="text-sm text-slate-500">Durée : {formatDuration(session.duration_minutes)}</p>
                   ) : null}
@@ -314,7 +318,7 @@ export default function SmartAttendanceSessionDetailPage() {
                               {ev.event_type}
                             </span>
                           </td>
-                          <td className="px-4 py-3 text-slate-700">{formatDateTime(ev.recorded_at)}</td>
+                          <td className="px-4 py-3 text-slate-700">{formatDateTime(ev.recorded_at, locale)}</td>
                           <td className="px-4 py-3 font-mono text-slate-700">{ev.latitude?.toFixed(6) ?? '—'}</td>
                           <td className="px-4 py-3 font-mono text-slate-700">{ev.longitude?.toFixed(6) ?? '—'}</td>
                           <td className="px-4 py-3 text-slate-700">{ev.accuracy?.toFixed(1) ?? '—'}</td>

--- a/front/web/src/app/(dashboard)/smart-attendance/sessions/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/sessions/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale, toIntlLocale, type AppLocale } from '@/lib/i18n';
 import { GeoSessionStatusBadge } from '../_components/GeoSessionStatusBadge';
+
+const emptySubscribe = () => () => {};
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -40,10 +43,10 @@ type Filters = {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatDateTime(iso?: string | null): string {
+function formatDateTime(iso: string | null | undefined, locale: AppLocale): string {
   if (!iso) return '—';
   const d = new Date(iso);
-  return d.toLocaleString('fr-FR', {
+  return d.toLocaleString(toIntlLocale(locale), {
     day: '2-digit',
     month: '2-digit',
     hour: '2-digit',
@@ -85,6 +88,7 @@ function sessionsToCSV(sessions: GeoSession[]): string {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function SmartAttendanceSessionsPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const [sessions, setSessions] = useState<GeoSession[]>([]);
   const [meta, setMeta] = useState<Meta | null>(null);
   const [loading, setLoading] = useState(true);
@@ -297,8 +301,8 @@ export default function SmartAttendanceSessionsPage() {
                         <p className="text-xs text-slate-500">{session.employee_matricule}</p>
                       ) : null}
                     </td>
-                    <td className="px-4 py-4 text-slate-700">{formatDateTime(session.check_in_time)}</td>
-                    <td className="px-4 py-4 text-slate-700">{formatDateTime(session.check_out_time)}</td>
+                    <td className="px-4 py-4 text-slate-700">{formatDateTime(session.check_in_time, locale)}</td>
+                    <td className="px-4 py-4 text-slate-700">{formatDateTime(session.check_out_time, locale)}</td>
                     <td className="px-4 py-4 text-slate-700">{formatDuration(session.duration_minutes)}</td>
                     <td className="px-4 py-4">
                       <GeoSessionStatusBadge status={session.status} />

--- a/front/web/src/modules/vitrine/components/forms/DemoForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/DemoForm.tsx
@@ -12,6 +12,8 @@ import { Card } from '@/modules/vitrine/components/common/Card';
 import { demoFormSchema, DemoFormData } from '@/modules/vitrine/lib/validation';
 import { submitDemoForm, createFormReducer, initialFormState } from '@/modules/vitrine/lib/forms';
 import { useAnalyticsForm } from '@/modules/vitrine/hooks/useAnalytics';
+import { useVitrineLocale } from '@/modules/vitrine/lib/vitrine-locale';
+import { toIntlLocale } from '@/lib/i18n';
 
 interface DemoFormProps {
   page?: string;
@@ -38,6 +40,7 @@ export function DemoForm({
 
   const [formState, dispatch] = useReducer(createFormReducer(), initialFormState);
   const { trackDemoRequest } = useAnalyticsForm();
+  const { locale } = useVitrineLocale();
 
   // Generate available dates (next 30 days, excluding weekends)
   const getAvailableDates = () => {
@@ -246,7 +249,7 @@ export function DemoForm({
                 <option value="">Choisir une date</option>
                 {availableDates.map((date) => (
                   <option key={date.toISOString()} value={date.toISOString().split('T')[0]}>
-                    {date.toLocaleDateString('fr-FR', {
+                    {date.toLocaleDateString(toIntlLocale(locale), {
                       weekday: 'long',
                       year: 'numeric',
                       month: 'long',


### PR DESCRIPTION
## What Problem This Solves
Several pages and shared components in `front/web` (Next.js) and `front/admin-dashboard` (Vue) hardcoded the `fr-FR` locale for `Intl.NumberFormat`/`Intl.DateTimeFormat`/`toLocaleDateString`/`toLocaleString` calls, ignoring the user's actual active language (FR/EN/AR/TR). Dates, times, and currency amounts always rendered in French formatting even for EN/AR/TR users.

## Why This Change Was Made
Both apps already ship the infrastructure to resolve the active app locale to a BCP-47 Intl tag (`toIntlLocale()` in `front/web/src/lib/i18n.ts` and `front/admin-dashboard/src/i18n/index.js`), and one page (`front/web`'s payroll page) already used this pattern correctly. This PR extends the same established pattern to every remaining call site that had a hardcoded `fr-FR`.

## User Impact
- `front/web`: billing, edge-nodes, smart-attendance (dashboard/sessions list/session detail), settings/developer, and the vitrine demo form now format dates/currency using the user's active locale instead of always French.
- `front/admin-dashboard`: audit logs, payroll, contracts, companies, company detail, edge nodes, training, CRM pipeline, subscriptions, support, chat, and the main dashboard view now use the active locale from the existing `useLocaleStore` Pinia store. Shared components (StatsCard, MetricCard x2, RevenueForecastWidget, InsightCard, RevenueChart, UserGrowthChart, EdgeNodeModal, RecentActivityList, SystemHealthCard, SupportTicketsList, QuickActionsCard, BackupManagement, SystemStatusCard, AutomatedTasksList, SecurityMonitoring, Header, EditUserModal, UserDetailModal, UserTable) and the `dashboard` Pinia store were updated the same way, so every view that reuses them benefits automatically.
- No visual/behavioral change for FR users (still defaults to `fr-FR`); EN/AR/TR users now see correctly localized date and currency formatting.

## Evidence
- `front/web`: `npm run build` (Next.js/Turbopack) completes successfully, including `tsc` type-checking, with no new errors.
- `front/admin-dashboard`: `npm run build` (Vite) completes successfully with no new errors.
- Verified no remaining hardcoded `fr-FR` outside legitimate default-locale fallbacks/mapping tables already parameterized by the active locale (checked via repo-wide grep).

Fixes kitokoh/leopardo-hr#1099