### PR TITLE
feat(payroll): add timestamped consent hash to payment confirmations

### DIFF
--- a/api/app/Modules/Payroll/Domain/Models/PaymentConfirmation.php
+++ b/api/app/Modules/Payroll/Domain/Models/PaymentConfirmation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Payroll\Domain\Models;
 
 use App\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -21,8 +22,10 @@ use Illuminate\Support\Carbon;
  * @property string|null $ip_address
  * @property string|null $user_agent
  * @property string $document_version
+ * @property string|null $document_hash
  * @property array<string, mixed>|null $metadata
- * @mixin \Illuminate\Database\Eloquent\Builder<static>
+ *
+ * @mixin Builder<static>
  */
 class PaymentConfirmation extends Model
 {
@@ -39,6 +42,7 @@ class PaymentConfirmation extends Model
         'ip_address',
         'user_agent',
         'document_version',
+        'document_hash',
         'metadata',
     ];
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/PaymentConsentSignatureService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PaymentConsentSignatureService.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Payroll\Infrastructure\Services;
+
+use App\Modules\Payroll\Domain\Models\PaymentItem;
+use Carbon\CarbonInterface;
+
+/**
+ * PA2-PAY-016 - Simple digital signature.
+ *
+ * Produces a timestamped, verifiable consent hash for payment confirmations
+ * without introducing a premature PKI/certificate infrastructure. The hash
+ * binds the confirmation to the exact payment item, amount, currency and
+ * confirmation instant, so any tampering with those facts after the fact is
+ * detectable by recomputing the hash and comparing it.
+ */
+class PaymentConsentSignatureService
+{
+    /**
+     * Builds the canonical payload used to compute the document hash.
+     *
+     * @return array<string, mixed>
+     */
+    public function buildPayload(PaymentItem $item, CarbonInterface $confirmedAt, string $documentVersion): array
+    {
+        return [
+            'payment_item_id' => $item->id,
+            'payment_batch_id' => $item->payment_batch_id,
+            'employee_id' => $item->employee_id,
+            'company_id' => $item->company_id,
+            'amount' => number_format((float) $item->amount, 2, '.', ''),
+            'currency' => $item->currency,
+            'document_version' => $documentVersion,
+            'confirmed_at' => $confirmedAt->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Computes a stable SHA-256 hash for the given consent payload.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function hash(array $payload): string
+    {
+        ksort($payload);
+
+        return hash('sha256', (string) json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * Recomputes the expected hash for a payment item/confirmation instant
+     * and returns whether it matches the stored hash (tamper detection).
+     */
+    public function verify(PaymentItem $item, CarbonInterface $confirmedAt, string $documentVersion, ?string $storedHash): bool
+    {
+        if ($storedHash === null || $storedHash === '') {
+            return false;
+        }
+
+        return hash_equals($this->hash($this->buildPayload($item, $confirmedAt, $documentVersion)), $storedHash);
+    }
+}

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PaymentBatchController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PaymentBatchController.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Jobs\GeneratePaymentDocumentJob;
-use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Payroll\Domain\Models\PaymentBatch;
 use App\Modules\Payroll\Domain\Models\PaymentConfirmation;
 use App\Modules\Payroll\Domain\Models\PaymentItem;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
+use App\Modules\Payroll\Infrastructure\Services\PaymentConsentSignatureService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -19,6 +20,8 @@ use Illuminate\Validation\ValidationException;
 
 class PaymentBatchController extends Controller
 {
+    public function __construct(private readonly PaymentConsentSignatureService $consentSignatureService) {}
+
     public function index(Request $request): JsonResponse
     {
         /** @var Employee $actor */
@@ -182,21 +185,36 @@ class PaymentBatchController extends Controller
         ]);
 
         $confirmation = DB::transaction(function () use ($request, $paymentItem, $actor, $validated): PaymentConfirmation {
-            $confirmation = PaymentConfirmation::query()->firstOrCreate(
-                ['payment_item_id' => $paymentItem->id],
-                [
-                    'company_id' => $actor->company_id,
-                    'payment_batch_id' => $paymentItem->payment_batch_id,
-                    'employee_id' => $actor->id,
-                    'status' => 'confirmed',
-                    'confirmed_at' => now(),
-                    'device_signature' => $validated['device_signature'] ?? null,
-                    'ip_address' => $request->ip(),
-                    'user_agent' => substr((string) $request->userAgent(), 0, 500),
-                    'document_version' => $validated['document_version'] ?? 'v1',
-                    'metadata' => $validated['metadata'] ?? null,
-                ],
+            $existing = PaymentConfirmation::query()->where('payment_item_id', $paymentItem->id)->first();
+
+            if ($existing !== null) {
+                return $existing;
+            }
+
+            $confirmedAt = now();
+            $documentVersion = (string) ($validated['document_version'] ?? 'v1');
+
+            // PA2-PAY-016 - Timestamped consent hash binding this confirmation
+            // to the payment item, amount, currency and instant, without a
+            // premature PKI/certificate stack.
+            $documentHash = $this->consentSignatureService->hash(
+                $this->consentSignatureService->buildPayload($paymentItem, $confirmedAt, $documentVersion)
             );
+
+            $confirmation = PaymentConfirmation::query()->create([
+                'company_id' => $actor->company_id,
+                'payment_batch_id' => $paymentItem->payment_batch_id,
+                'payment_item_id' => $paymentItem->id,
+                'employee_id' => $actor->id,
+                'status' => 'confirmed',
+                'confirmed_at' => $confirmedAt,
+                'device_signature' => $validated['device_signature'] ?? null,
+                'ip_address' => $request->ip(),
+                'user_agent' => substr((string) $request->userAgent(), 0, 500),
+                'document_version' => $documentVersion,
+                'document_hash' => $documentHash,
+                'metadata' => $validated['metadata'] ?? null,
+            ]);
 
             $paymentItem->forceFill([
                 'status' => PaymentItem::STATUS_CONFIRMED,
@@ -215,6 +233,7 @@ class PaymentBatchController extends Controller
                 'status' => $confirmation->status,
                 'confirmed_at' => $confirmation->confirmed_at?->toIso8601String(),
                 'document_version' => $confirmation->document_version,
+                'document_hash' => $confirmation->document_hash,
             ],
             'message' => 'Reception du paiement confirmee.',
         ]);
@@ -284,4 +303,3 @@ class PaymentBatchController extends Controller
         return $payload;
     }
 }
-

--- a/api/database/migrations/tenant/2026_07_23_000001_add_document_hash_to_payment_confirmations.php
+++ b/api/database/migrations/tenant/2026_07_23_000001_add_document_hash_to_payment_confirmations.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * PA2-PAY-016 - Simple digital signature: timestamped consent + document
+     * hash, without introducing a premature PKI/certificate stack.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('payment_confirmations') && ! Schema::hasColumn('payment_confirmations', 'document_hash')) {
+            Schema::table('payment_confirmations', function (Blueprint $table): void {
+                $table->string('document_hash', 64)->nullable()->after('document_version');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('payment_confirmations') && Schema::hasColumn('payment_confirmations', 'document_hash')) {
+            Schema::table('payment_confirmations', function (Blueprint $table): void {
+                $table->dropColumn('document_hash');
+            });
+        }
+    }
+};

--- a/api/tests/Feature/PaymentBatchControllerTest.php
+++ b/api/tests/Feature/PaymentBatchControllerTest.php
@@ -2,14 +2,15 @@
 
 namespace Tests\Feature;
 
-use App\Jobs\GeneratePaymentDocumentJob;
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\GeneratePaymentDocumentJob;
 use App\Modules\Payroll\Domain\Models\PaymentBatch;
 use App\Modules\Payroll\Domain\Models\PaymentConfirmation;
 use App\Modules\Payroll\Domain\Models\PaymentItem;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
+use App\Modules\Payroll\Infrastructure\Services\PaymentConsentSignatureService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Queue;
@@ -71,14 +72,30 @@ class PaymentBatchControllerTest extends TestCase
             ->assertJsonPath('data.status', 'confirmed')
             ->assertJsonPath('data.payment_item_id', $item->id);
 
+        $documentHash = $confirm->json('data.document_hash');
+        $this->assertNotEmpty($documentHash);
+        $this->assertSame(64, strlen($documentHash));
+
         $this->assertDatabaseHas('payment_confirmations', [
             'company_id' => $company->id,
             'employee_id' => $employee->id,
             'payment_item_id' => $item->id,
             'device_signature' => 'employee-mobile-v1',
+            'document_hash' => $documentHash,
         ]);
         $this->assertSame(PaymentBatch::STATUS_CONFIRMED, PaymentBatch::query()->findOrFail($batchId)->status);
         $this->assertSame(PaymentItem::STATUS_CONFIRMED, $item->fresh()->status);
+
+        // PA2-PAY-016 - The stored hash must match what an independent
+        // recomputation from the confirmation facts would produce.
+        $confirmation = PaymentConfirmation::query()->where('payment_item_id', $item->id)->firstOrFail();
+        $signatureService = app(PaymentConsentSignatureService::class);
+        $this->assertTrue($signatureService->verify(
+            $item->fresh(),
+            $confirmation->confirmed_at,
+            $confirmation->document_version,
+            $confirmation->document_hash,
+        ));
 
         $again = $this->postJson("/api/v1/payment-confirmations/{$item->id}/confirm");
         $again->assertOk();
@@ -184,4 +201,3 @@ class PaymentBatchControllerTest extends TestCase
         return [$company, $manager, $employee, $run, $slip];
     }
 }
-

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -1290,6 +1290,7 @@ trait CreatesMvpSchema
                 $table->string('ip_address', 64)->nullable();
                 $table->string('user_agent', 500)->nullable();
                 $table->string('document_version', 40)->default('v1');
+                $table->string('document_hash', 64)->nullable();
                 $table->json('metadata')->nullable();
                 $table->timestamps();
             });

--- a/api/tests/Unit/PaymentConsentSignatureServiceTest.php
+++ b/api/tests/Unit/PaymentConsentSignatureServiceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Modules\Payroll\Domain\Models\PaymentItem;
+use App\Modules\Payroll\Infrastructure\Services\PaymentConsentSignatureService;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-016 - Simple digital signature (timestamped consent + document
+ * hash), covered independently of the HTTP layer.
+ */
+class PaymentConsentSignatureServiceTest extends TestCase
+{
+    public function test_hash_is_deterministic_for_identical_payloads(): void
+    {
+        $service = new PaymentConsentSignatureService;
+        $item = $this->makeItem();
+        $confirmedAt = Carbon::parse('2026-07-23T10:15:00Z');
+
+        $hashA = $service->hash($service->buildPayload($item, $confirmedAt, 'v1'));
+        $hashB = $service->hash($service->buildPayload($item, $confirmedAt, 'v1'));
+
+        $this->assertSame($hashA, $hashB);
+        $this->assertSame(64, strlen($hashA));
+    }
+
+    public function test_hash_changes_when_amount_is_tampered_with(): void
+    {
+        $service = new PaymentConsentSignatureService;
+        $confirmedAt = Carbon::parse('2026-07-23T10:15:00Z');
+
+        $original = $this->makeItem(['amount' => 1000.00]);
+        $tampered = $this->makeItem(['amount' => 1000.01]);
+
+        $originalHash = $service->hash($service->buildPayload($original, $confirmedAt, 'v1'));
+        $tamperedHash = $service->hash($service->buildPayload($tampered, $confirmedAt, 'v1'));
+
+        $this->assertNotSame($originalHash, $tamperedHash);
+    }
+
+    public function test_verify_detects_hash_mismatch(): void
+    {
+        $service = new PaymentConsentSignatureService;
+        $item = $this->makeItem();
+        $confirmedAt = Carbon::parse('2026-07-23T10:15:00Z');
+
+        $this->assertFalse($service->verify($item, $confirmedAt, 'v1', null));
+        $this->assertFalse($service->verify($item, $confirmedAt, 'v1', 'not-a-valid-hash'));
+
+        $validHash = $service->hash($service->buildPayload($item, $confirmedAt, 'v1'));
+        $this->assertTrue($service->verify($item, $confirmedAt, 'v1', $validHash));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeItem(array $overrides = []): PaymentItem
+    {
+        $item = new PaymentItem(array_merge([
+            'company_id' => 'company-uuid',
+            'payment_batch_id' => 1,
+            'employee_id' => 42,
+            'amount' => 1000.00,
+            'currency' => 'DZD',
+        ], $overrides));
+
+        $item->id = 7;
+
+        return $item;
+    }
+}


### PR DESCRIPTION
Closes #1049

## Summary
PA2-PAY-016 - Simple digital signature: payment confirmations now carry a timestamped consent hash (`document_hash`) alongside the existing `device_signature`/`document_version`, so employee payment consent is verifiable without introducing a premature PKI/certificate stack.

## Changes
- New `PaymentConsentSignatureService`: builds a canonical payload (payment item id/batch, employee, amount, currency, document version, confirmation instant) and computes/verifies a SHA-256 hash from it.
- New migration adding `document_hash` to `payment_confirmations` (+ test schema helper update).
- `PaymentBatchController::confirm()` computes and persists the hash, returning it in the API response.
- Unit tests for the signature service (determinism, tamper detection).
- Extended feature test asserting the hash is present in the response, persisted, and independently re-verifiable.

## Testing
- `php artisan test tests/Unit/PaymentConsentSignatureServiceTest.php tests/Feature/PaymentBatchControllerTest.php` — all passing.
- Full `--filter=Payment` suite (34 tests) — all passing, no regressions.
- `vendor/bin/pint` applied to touched files.
- `vendor/bin/phpstan` on touched files shows no new error categories vs. baseline (pre-existing `mixed`-array warnings in this controller are unchanged).