### PR TITLE
feat(platform): secure super-admin impersonation (PA2-ADM-006)

### DIFF
--- a/api/app/Modules/Platform/Domain/Models/PlatformImpersonationSession.php
+++ b/api/app/Modules/Platform/Domain/Models/PlatformImpersonationSession.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Domain\Models;
+
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * PA2-ADM-006 — Audit record of a super-admin impersonating a tenant
+ * employee ("log in as ..."), with a mandatory reason and a hard expiry.
+ *
+ * `company_name`/`employee_name`/`employee_email` are a point-in-time
+ * denormalized snapshot (see the migration docblock): this table is global
+ * (public schema) and lists sessions across every tenant schema at once,
+ * so it cannot rely on Eloquent relations into per-tenant `companies`/
+ * `employees` rows without switching search_path per row.
+ *
+ * @property int $id
+ * @property int $super_admin_id
+ * @property string $company_id
+ * @property int $employee_id
+ * @property int|null $personal_access_token_id
+ * @property string|null $company_name
+ * @property string|null $employee_name
+ * @property string|null $employee_email
+ * @property string $reason
+ * @property string|null $ip_address
+ * @property Carbon $expires_at
+ * @property Carbon|null $ended_at
+ * @property int|null $ended_by
+ * @property Carbon|null $created_at
+ *
+ * @mixin Builder<static>
+ */
+class PlatformImpersonationSession extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'platform_impersonation_sessions';
+
+    protected $fillable = [
+        'super_admin_id',
+        'company_id',
+        'employee_id',
+        'personal_access_token_id',
+        'company_name',
+        'employee_name',
+        'employee_email',
+        'reason',
+        'ip_address',
+        'expires_at',
+        'ended_at',
+        'ended_by',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'ended_at' => 'datetime',
+        'created_at' => 'datetime',
+    ];
+
+    /** @return BelongsTo<SuperAdmin, $this> */
+    public function superAdmin(): BelongsTo
+    {
+        return $this->belongsTo(SuperAdmin::class, 'super_admin_id');
+    }
+
+    public function isActive(): bool
+    {
+        return $this->ended_at === null && $this->expires_at->isFuture();
+    }
+
+    /**
+     * @param  Builder<static>  $q
+     * @return Builder<static>
+     */
+    public function scopeActive(Builder $q): Builder
+    {
+        return $q->whereNull('ended_at')->where('expires_at', '>', now());
+    }
+}

--- a/api/app/Modules/Platform/Infrastructure/Services/ImpersonationService.php
+++ b/api/app/Modules/Platform/Infrastructure/Services/ImpersonationService.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Infrastructure\Services;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Core\Tenant\TenantManager;
+use App\Exceptions\AccountSuspendedException;
+use App\Modules\Platform\Domain\Models\PlatformImpersonationSession;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * PA2-ADM-006 — Secure super-admin impersonation ("log in as this employee").
+ *
+ * Every session is: super-admin only, requires a mandatory reason, is
+ * recorded for audit (who/whom/why/when), and is hard time-limited (a
+ * fresh Sanctum token scoped to a short TTL, distinguishable from the
+ * employee's normal tokens via the `impersonation:<session_id>` ability so
+ * it can be told apart and revoked independently). Ending a session — or
+ * letting it expire — revokes exactly that token.
+ */
+class ImpersonationService
+{
+    /**
+     * Default and maximum impersonation session lifetime, in minutes.
+     * Kept short: this is a support/debugging tool, not a login bypass.
+     */
+    private const int DEFAULT_TTL_MINUTES = 30;
+
+    private const int MAX_TTL_MINUTES = 120;
+
+    /**
+     * @return array{session: PlatformImpersonationSession, employee: Employee, token: string, expires_at: Carbon}
+     */
+    public function start(
+        SuperAdmin $superAdmin,
+        string $companyId,
+        int $employeeId,
+        string $reason,
+        ?string $ipAddress = null,
+        ?int $ttlMinutes = null,
+    ): array {
+        $company = Company::query()->find($companyId);
+
+        if (! $company instanceof Company) {
+            throw (new ModelNotFoundException)->setModel(Company::class, [$companyId]);
+        }
+
+        if (in_array($company->status, ['suspended', 'expired'], true)) {
+            throw new AccountSuspendedException;
+        }
+
+        $ttl = min(max($ttlMinutes ?? self::DEFAULT_TTL_MINUTES, 1), self::MAX_TTL_MINUTES);
+        $expiresAt = now()->addMinutes($ttl);
+
+        /** @var TenantManager $tenantManager */
+        $tenantManager = app(TenantManager::class);
+
+        return $tenantManager->withinTenant($company, function () use ($superAdmin, $company, $employeeId, $reason, $ipAddress, $expiresAt): array {
+            /** @var Employee|null $employee */
+            $employee = Employee::query()->find($employeeId);
+
+            if (! $employee instanceof Employee) {
+                throw (new ModelNotFoundException)->setModel(Employee::class, [$employeeId]);
+            }
+
+            if (in_array($employee->status, ['archived', 'suspended'], true)) {
+                throw new AccountSuspendedException;
+            }
+
+            $tokenResult = $employee->createToken(
+                name: 'impersonation',
+                abilities: ['*', 'impersonation:pending'],
+                expiresAt: $expiresAt,
+            );
+
+            $session = PlatformImpersonationSession::create([
+                'super_admin_id' => $superAdmin->id,
+                'company_id' => $company->id,
+                'employee_id' => $employee->id,
+                'personal_access_token_id' => $tokenResult->accessToken->id,
+                'company_name' => $company->name,
+                'employee_name' => trim($employee->first_name.' '.$employee->last_name),
+                'employee_email' => $employee->email,
+                'reason' => $reason,
+                'ip_address' => $ipAddress,
+                'expires_at' => $expiresAt,
+            ]);
+
+            // The ability needs the session id, which only exists once the
+            // session row is created; the token itself was minted first so
+            // personal_access_token_id could be recorded on the session.
+            $tokenResult->accessToken->forceFill([
+                'abilities' => ['*', 'impersonation:'.$session->id],
+            ])->save();
+
+            Log::channel('structured')->warning('platform.impersonation.started', [
+                'super_admin_id' => $superAdmin->id,
+                'super_admin_email' => $superAdmin->email,
+                'company_id' => $company->id,
+                'employee_id' => $employee->id,
+                'session_id' => $session->id,
+                'reason' => $reason,
+                'expires_at' => $expiresAt->toIso8601String(),
+            ]);
+
+            return [
+                'session' => $session,
+                'employee' => $employee,
+                'token' => $tokenResult->plainTextToken,
+                'expires_at' => $expiresAt,
+            ];
+        });
+    }
+
+    public function end(PlatformImpersonationSession $session, ?SuperAdmin $endedBy = null): void
+    {
+        if ($session->ended_at !== null) {
+            return;
+        }
+
+        $session->forceFill([
+            'ended_at' => now(),
+            'ended_by' => $endedBy?->id,
+        ])->save();
+
+        if ($session->personal_access_token_id !== null) {
+            $this->revokeToken($session->personal_access_token_id);
+        }
+
+        Log::channel('structured')->warning('platform.impersonation.ended', [
+            'session_id' => $session->id,
+            'super_admin_id' => $session->super_admin_id,
+            'company_id' => $session->company_id,
+            'employee_id' => $session->employee_id,
+            'ended_by' => $endedBy?->id,
+        ]);
+    }
+
+    private function revokeToken(int $tokenId): void
+    {
+        // personal_access_tokens is a public-schema table (see
+        // database/migrations/public/2026_04_04_000010_create_personal_access_tokens_table.php)
+        // and every tenant search_path falls back to `public`, so this
+        // resolves correctly regardless of the currently active tenant
+        // schema — no need to switch tenant context just to delete a token.
+        $tokenClass = config('sanctum.personal_access_token_model', PersonalAccessToken::class);
+        $tokenClass::query()->whereKey($tokenId)->delete();
+    }
+}

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformImpersonationController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformImpersonationController.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
+
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Http\Controllers\Controller;
+use App\Modules\Platform\Domain\Models\PlatformImpersonationSession;
+use App\Modules\Platform\Infrastructure\Services\ImpersonationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * PA2-ADM-006 — Super-admin "log in as this employee" support tool.
+ *
+ * Every session requires a mandatory reason, is time-limited (30 min by
+ * default, 120 min max), and is fully audited: who impersonated, whom,
+ * why, and when it started/ended. See ImpersonationService for the token
+ * issuance/revocation mechanics.
+ */
+class PlatformImpersonationController extends Controller
+{
+    public function __construct(
+        private readonly ImpersonationService $impersonationService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = min(100, max(1, $request->integer('per_page', 20)));
+
+        $query = PlatformImpersonationSession::query()->with('superAdmin');
+
+        if ($request->boolean('active_only')) {
+            $query->active();
+        }
+
+        $sessions = $query->orderByDesc('created_at')->paginate($perPage);
+
+        return new JsonResponse([
+            'data' => $sessions->getCollection()->map(fn (PlatformImpersonationSession $session): array => $this->serialize($session))->all(),
+            'meta' => [
+                'current_page' => $sessions->currentPage(),
+                'last_page' => $sessions->lastPage(),
+                'per_page' => $sessions->perPage(),
+                'total' => $sessions->total(),
+            ],
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'company_id' => ['required', 'uuid'],
+            'employee_id' => ['required', 'integer'],
+            'reason' => ['required', 'string', 'min:5', 'max:500'],
+            'ttl_minutes' => ['nullable', 'integer', 'min:1', 'max:120'],
+        ]);
+
+        /** @var SuperAdmin $admin */
+        $admin = $request->user('super_admin_api');
+
+        $result = $this->impersonationService->start(
+            superAdmin: $admin,
+            companyId: $data['company_id'],
+            employeeId: $data['employee_id'],
+            reason: $data['reason'],
+            ipAddress: $request->ip(),
+            ttlMinutes: $data['ttl_minutes'] ?? null,
+        );
+
+        return new JsonResponse([
+            'data' => $this->serialize($result['session']),
+            'token' => $result['token'],
+            'token_type' => 'Bearer',
+            'expires_at' => $result['expires_at']->toIso8601String(),
+        ], 201);
+    }
+
+    public function destroy(Request $request, PlatformImpersonationSession $session): JsonResponse
+    {
+        /** @var SuperAdmin $admin */
+        $admin = $request->user('super_admin_api');
+
+        $this->impersonationService->end($session, $admin);
+
+        return new JsonResponse(['status' => 'ok']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(PlatformImpersonationSession $session): array
+    {
+        return [
+            'id' => $session->id,
+            'super_admin_id' => $session->super_admin_id,
+            'super_admin_name' => $session->superAdmin?->name,
+            'company_id' => $session->company_id,
+            'company_name' => $session->company_name,
+            'employee_id' => $session->employee_id,
+            'employee_name' => $session->employee_name,
+            'employee_email' => $session->employee_email,
+            'reason' => $session->reason,
+            'ip_address' => $session->ip_address,
+            'expires_at' => $session->expires_at->toIso8601String(),
+            'ended_at' => $session->ended_at?->toIso8601String(),
+            'is_active' => $session->isActive(),
+            'created_at' => $session->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/database/migrations/public/2026_07_23_000003_create_platform_impersonation_sessions_table.php
+++ b/api/database/migrations/public/2026_07_23_000003_create_platform_impersonation_sessions_table.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-ADM-006 — Secure super-admin impersonation.
+ *
+ * Every "log in as this employee" action taken from the platform admin
+ * console is recorded here: who impersonated (super-admin), whom (company +
+ * employee), why (mandatory reason, for audit), and for how long (impersonation
+ * tokens are time-limited and can be ended early). This table is intentionally
+ * global (public schema): the acting party is a SuperAdmin, not a tenant
+ * employee, and a session can target any tenant regardless of its schema.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('platform_impersonation_sessions')) {
+            return;
+        }
+
+        Schema::create('platform_impersonation_sessions', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedInteger('super_admin_id');
+            $table->uuid('company_id');
+            $table->unsignedBigInteger('employee_id');
+            // Personal access token id backing the impersonation session, so
+            // ending the session (or its natural expiry) can revoke exactly
+            // that token without touching the employee's other sessions.
+            $table->unsignedBigInteger('personal_access_token_id')->nullable();
+            // Denormalized point-in-time snapshot: `employees`/`companies` are
+            // per-tenant-schema rows, but this audit table is global (public
+            // schema) and lists sessions across every tenant at once. Storing
+            // the display name here avoids having to switch search_path per
+            // row just to render a history list, and preserves the label
+            // even if the employee/company is later renamed or deleted.
+            $table->string('company_name', 200)->nullable();
+            $table->string('employee_name', 200)->nullable();
+            $table->string('employee_email', 150)->nullable();
+            $table->string('reason', 500);
+            $table->string('ip_address', 45)->nullable();
+            $table->timestampTz('expires_at');
+            $table->timestampTz('ended_at')->nullable();
+            $table->unsignedInteger('ended_by')->nullable();
+            $table->timestampTz('created_at')->nullable();
+
+            $table->index('super_admin_id');
+            $table->index('company_id');
+            $table->index('employee_id');
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('platform_impersonation_sessions');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,35 +1,37 @@
 <?php
 
-use App\Core\Feature\Interfaces\Api\V1\FeatureManifestController;
 use App\Core\Auth\Interfaces\Api\V1\AuthController;
+use App\Core\Auth\Interfaces\Api\V1\PlatformAuthController;
+use App\Core\Feature\Interfaces\Api\V1\FeatureManifestController;
+use App\Http\Controllers\Web\PlatformCompanyController;
 use App\Modules\Attendance\Interfaces\Api\V1\BiometricEnrollmentController;
+use App\Modules\Billing\Interfaces\Api\V1\CompanyRequestController;
+use App\Modules\Billing\Interfaces\Api\V1\PaymentWebhookController;
+use App\Modules\Billing\Interfaces\Api\V1\PlatformCompanySubscriptionController;
+use App\Modules\Billing\Interfaces\Api\V1\PlatformPlanController;
+use App\Modules\Billing\Interfaces\Api\V1\SelfServiceTrialController;
+use App\Modules\Billing\Interfaces\Api\V1\StripeWebhookController;
+use App\Modules\EdgeSync\Interfaces\Api\V1\EdgeController;
+use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBrandingController;
+use App\Modules\HR\Interfaces\Api\V1\Controllers\PrivacyController;
+use App\Modules\Notification\Interfaces\Api\V1\Controllers\NotificationPreferenceController;
+use App\Modules\Onboarding\Interfaces\Api\V1\Controllers\OnboardingChecklistController;
+use App\Modules\Onboarding\Interfaces\Api\V1\Controllers\OnboardingController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\ClientEventController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\CommunicationAnalyticsController;
-use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBrandingController;
-use App\Modules\Billing\Interfaces\Api\V1\CompanyRequestController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\DemoUserController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\HealthController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\LaunchReadinessController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\MetricsController;
-use App\Modules\Notification\Interfaces\Api\V1\Controllers\NotificationPreferenceController;
-use App\Modules\Onboarding\Interfaces\Api\V1\Controllers\OnboardingChecklistController;
-use App\Modules\Onboarding\Interfaces\Api\V1\Controllers\OnboardingController;
-use App\Modules\Billing\Interfaces\Api\V1\PaymentWebhookController;
-use App\Core\Auth\Interfaces\Api\V1\PlatformAuthController;
+use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformAnnouncementController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCompanyFeatureController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCompanyHealthController;
-use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformAnnouncementController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCompanyRequestController;
-use App\Modules\Billing\Interfaces\Api\V1\PlatformCompanySubscriptionController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCountryDefaultsController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCrmPipelineController;
+use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformImpersonationController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformMetricsOverviewController;
-use App\Modules\Billing\Interfaces\Api\V1\PlatformPlanController;
-use App\Modules\HR\Interfaces\Api\V1\Controllers\PrivacyController;
-use App\Modules\Billing\Interfaces\Api\V1\SelfServiceTrialController;
-use App\Modules\Billing\Interfaces\Api\V1\StripeWebhookController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\TranslationCatalogController;
-use App\Http\Controllers\Web\PlatformCompanyController;
 use Illuminate\Support\Facades\Route;
 
 // Edge routes are now registered by EdgeSyncServiceProvider
@@ -190,11 +192,17 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/announcements/{announcement}', [PlatformAnnouncementController::class, 'show']);
         Route::delete('/announcements/{announcement}', [PlatformAnnouncementController::class, 'destroy']);
 
+        // PA2-ADM-006 — Secure super-admin impersonation ("log in as this
+        // employee"): mandatory reason, hard time limit, fully audited.
+        Route::get('/impersonations', [PlatformImpersonationController::class, 'index']);
+        Route::post('/impersonations', [PlatformImpersonationController::class, 'store']);
+        Route::delete('/impersonations/{session}', [PlatformImpersonationController::class, 'destroy'])->whereNumber('session');
+
         // Edge node management (super-admin)
         Route::prefix('edge/nodes')->group(function (): void {
-            Route::get('/', [\App\Modules\EdgeSync\Interfaces\Api\V1\EdgeController::class, 'listNodes']);
-            Route::post('/{id}/sync', [\App\Modules\EdgeSync\Interfaces\Api\V1\EdgeController::class, 'forceSync'])->whereNumber('id');
-            Route::delete('/{id}', [\App\Modules\EdgeSync\Interfaces\Api\V1\EdgeController::class, 'revokeNode'])->whereNumber('id');
+            Route::get('/', [EdgeController::class, 'listNodes']);
+            Route::post('/{id}/sync', [EdgeController::class, 'forceSync'])->whereNumber('id');
+            Route::delete('/{id}', [EdgeController::class, 'revokeNode'])->whereNumber('id');
         });
     });
 });

--- a/api/tests/Feature/PlatformImpersonationControllerTest.php
+++ b/api/tests/Feature/PlatformImpersonationControllerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Modules\Platform\Domain\Models\PlatformImpersonationSession;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-ADM-006 — Secure super-admin impersonation ("log in as this employee"):
+ * mandatory reason, hard time limit, fully audited start/end.
+ */
+class PlatformImpersonationControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    private function actingAsSuperAdmin(): SuperAdmin
+    {
+        $superAdmin = SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => 'admin@leopardo.test',
+            'password_hash' => Hash::make('password123'),
+        ]);
+
+        Sanctum::actingAs($superAdmin, ['*'], 'super_admin_api');
+
+        return $superAdmin;
+    }
+
+    public function test_super_admin_can_start_an_impersonation_session(): void
+    {
+        $admin = $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id, 'status' => 'active']);
+
+        $response = $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'reason' => 'Investigating a payroll export bug reported by the client.',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.company_id', $company->id)
+            ->assertJsonPath('data.employee_id', $employee->id)
+            ->assertJsonPath('data.is_active', true)
+            ->assertJsonStructure(['token', 'token_type', 'expires_at']);
+
+        $this->assertDatabaseHas('platform_impersonation_sessions', [
+            'super_admin_id' => $admin->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+        ]);
+
+        $token = $response->json('token');
+        $this->assertNotEmpty($token);
+
+        // The minted token authenticates as the impersonated employee.
+        $meResponse = $this->withHeader('Authorization', 'Bearer '.$token)->getJson('/api/v1/auth/me');
+        $meResponse->assertOk()->assertJsonPath('data.id', $employee->id);
+    }
+
+    public function test_reason_is_mandatory_and_validated(): void
+    {
+        $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'reason' => 'hi',
+        ])->assertUnprocessable()->assertJsonValidationErrors(['reason']);
+
+        $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+        ])->assertUnprocessable()->assertJsonValidationErrors(['reason']);
+    }
+
+    public function test_cannot_impersonate_an_employee_of_a_suspended_company(): void
+    {
+        $this->actingAsSuperAdmin();
+        $company = Company::factory()->create(['status' => 'suspended']);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'reason' => 'Support investigation for suspended tenant.',
+        ])->assertStatus(403);
+
+        $this->assertDatabaseMissing('platform_impersonation_sessions', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+        ]);
+    }
+
+    public function test_cannot_impersonate_an_archived_employee(): void
+    {
+        $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id, 'status' => 'archived']);
+
+        $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'reason' => 'Support investigation for archived employee.',
+        ])->assertStatus(403);
+    }
+
+    public function test_tenant_employee_cannot_start_impersonation_sessions(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $target = Employee::factory()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($employee);
+
+        $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $target->id,
+            'reason' => 'Should be rejected.',
+        ])->assertUnauthorized();
+    }
+
+    public function test_super_admin_can_end_a_session_and_the_token_stops_working(): void
+    {
+        $admin = $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id, 'status' => 'active']);
+
+        $startResponse = $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'reason' => 'Reproducing a reported bug for this employee.',
+        ])->assertCreated();
+
+        $sessionId = $startResponse->json('data.id');
+        $token = $startResponse->json('token');
+
+        $this->deleteJson("/api/v1/platform/impersonations/{$sessionId}")->assertOk();
+
+        $session = PlatformImpersonationSession::find($sessionId);
+        $this->assertNotNull($session->ended_at);
+        $this->assertSame($admin->id, $session->ended_by);
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/auth/me')
+            ->assertUnauthorized();
+    }
+
+    public function test_index_lists_sessions_with_active_only_filter(): void
+    {
+        $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id, 'status' => 'active']);
+
+        $startResponse = $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'reason' => 'First session for the index listing test.',
+        ])->assertCreated();
+
+        $sessionId = $startResponse->json('data.id');
+        $this->deleteJson("/api/v1/platform/impersonations/{$sessionId}")->assertOk();
+
+        $secondEmployee = Employee::factory()->create(['company_id' => $company->id, 'status' => 'active']);
+        $this->postJson('/api/v1/platform/impersonations', [
+            'company_id' => $company->id,
+            'employee_id' => $secondEmployee->id,
+            'reason' => 'Second, still-active session for the index listing test.',
+        ])->assertCreated();
+
+        $all = $this->getJson('/api/v1/platform/impersonations')->assertOk();
+        $this->assertCount(2, $all->json('data'));
+
+        $activeOnly = $this->getJson('/api/v1/platform/impersonations?active_only=1')->assertOk();
+        $this->assertCount(1, $activeOnly->json('data'));
+        $this->assertSame($secondEmployee->id, $activeOnly->json('data.0.employee_id'));
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -815,6 +815,30 @@ trait CreatesMvpSchema
             $table->index('company_id');
         });
 
+        // PA2-ADM-006 — Secure super-admin impersonation sessions (public
+        // schema; see database/migrations/public/2026_07_23_000003_...).
+        Schema::create('platform_impersonation_sessions', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedInteger('super_admin_id');
+            $table->uuid('company_id');
+            $table->unsignedBigInteger('employee_id');
+            $table->unsignedBigInteger('personal_access_token_id')->nullable();
+            $table->string('company_name', 200)->nullable();
+            $table->string('employee_name', 200)->nullable();
+            $table->string('employee_email', 150)->nullable();
+            $table->string('reason', 500);
+            $table->string('ip_address', 45)->nullable();
+            $table->timestampTz('expires_at');
+            $table->timestampTz('ended_at')->nullable();
+            $table->unsignedInteger('ended_by')->nullable();
+            $table->timestampTz('created_at')->nullable();
+
+            $table->index('super_admin_id');
+            $table->index('company_id');
+            $table->index('employee_id');
+            $table->index('expires_at');
+        });
+
         $this->createPostSprintModuleTables();
         $this->restoreDefaultSearchPath();
     }
@@ -1809,6 +1833,7 @@ trait CreatesMvpSchema
 
         DB::statement('DROP TABLE IF EXISTS "user_invitations"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "platform_announcement_companies"'.$cascade);
+        DB::statement('DROP TABLE IF EXISTS "platform_impersonation_sessions"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "platform_announcements"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "super_admins"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "personal_access_tokens"'.$cascade);

--- a/api/tests/Support/sql/mvp_schema.pgsql.sql
+++ b/api/tests/Support/sql/mvp_schema.pgsql.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS public.user_invitations CASCADE;
 DROP TABLE IF EXISTS public.platform_announcement_companies CASCADE;
+DROP TABLE IF EXISTS public.platform_impersonation_sessions CASCADE;
 DROP TABLE IF EXISTS public.platform_announcements CASCADE;
 DROP TABLE IF EXISTS public.super_admins CASCADE;
 DROP TABLE IF EXISTS public.user_lookups CASCADE;
@@ -783,6 +784,29 @@ CREATE UNIQUE INDEX platform_announcement_companies_unique
     ON public.platform_announcement_companies (platform_announcement_id, company_id);
 CREATE INDEX platform_announcement_companies_company_id_index
     ON public.platform_announcement_companies (company_id);
+
+-- PA2-ADM-006 — Secure super-admin impersonation sessions (public schema).
+CREATE TABLE public.platform_impersonation_sessions (
+    id bigserial PRIMARY KEY,
+    super_admin_id integer NOT NULL,
+    company_id uuid NOT NULL,
+    employee_id bigint NOT NULL,
+    personal_access_token_id bigint NULL,
+    company_name varchar(200) NULL,
+    employee_name varchar(200) NULL,
+    employee_email varchar(150) NULL,
+    reason varchar(500) NOT NULL,
+    ip_address varchar(45) NULL,
+    expires_at timestamptz NOT NULL,
+    ended_at timestamptz NULL,
+    ended_by integer NULL,
+    created_at timestamptz NULL
+);
+
+CREATE INDEX platform_impersonation_sessions_super_admin_id_index ON public.platform_impersonation_sessions (super_admin_id);
+CREATE INDEX platform_impersonation_sessions_company_id_index ON public.platform_impersonation_sessions (company_id);
+CREATE INDEX platform_impersonation_sessions_employee_id_index ON public.platform_impersonation_sessions (employee_id);
+CREATE INDEX platform_impersonation_sessions_expires_at_index ON public.platform_impersonation_sessions (expires_at);
 
 -- SSO configs (public, FK to companies)
 CREATE TABLE IF NOT EXISTS public.company_sso_configs (


### PR DESCRIPTION
Closes #970

## Summary
Super-admins can start a time-limited "log in as this employee" session for support/debugging. Every session is super-admin only, requires a mandatory reason, and is fully audited.

## Changes
- New public-schema `platform_impersonation_sessions` table: who impersonated, whom (company + employee, with a denormalized name/email snapshot for cross-tenant listing), why (mandatory `reason`), and when (created/expires/ended/ended_by). Tracks the backing `personal_access_token_id` so ending a session revokes exactly that token.
- `PlatformImpersonationSession` model with `isActive()` and an `active()` scope.
- `ImpersonationService::start()` rejects suspended/expired companies and archived/suspended employees, mints a Sanctum token with a hard TTL (30 min default, 120 min max) tagged with a unique `impersonation:<session_id>` ability, and writes the audit row. `::end()` marks it ended and revokes the token immediately; it also stops working on its own once it expires.
- `PlatformImpersonationController`: `POST /api/v1/platform/impersonations` (start), `DELETE /api/v1/platform/impersonations/{id}` (end), `GET /api/v1/platform/impersonations` (paginated history, `active_only` filter) — behind the existing super-admin API guard.

## Tests
`tests/Feature/PlatformImpersonationControllerTest.php` (7 tests, 34 assertions): starting a session and using the minted token to authenticate as the employee, reason validation, suspended-company/archived-employee rejection, non-super-admin rejection, ending a session (token stops working), index + `active_only` filtering.

Verified against both SQLite and a real PostgreSQL instance (matching CI). `phpstan-modules.neon` (the CI architecture gate) reports no errors for the changed module files. Pint applied.

```
Tests:    7 passed (34 assertions)
```