### PR TITLE
feat(webhooks): dead-letter handling for outbound partner webhooks (PA2-API-006)

### DIFF
--- a/api/app/Http/Resources/Api/V1/WebhookDeliveryResource.php
+++ b/api/app/Http/Resources/Api/V1/WebhookDeliveryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Modules\Billing\Domain\Models\WebhookDelivery;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin WebhookDelivery */
+class WebhookDeliveryResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'webhook_endpoint_id' => $this->webhook_endpoint_id,
+            'event' => $this->event,
+            'response_code' => $this->response_code,
+            'response_body' => $this->response_body,
+            'duration_ms' => $this->duration_ms,
+            'dead_lettered_at' => $this->dead_lettered_at?->toIso8601String(),
+            'delivered_at' => $this->delivered_at?->toIso8601String(),
+        ];
+    }
+}

--- a/api/app/Jobs/DispatchWebhook.php
+++ b/api/app/Jobs/DispatchWebhook.php
@@ -38,6 +38,38 @@ class DispatchWebhook implements ShouldQueue, TenantScopedJob
         $this->queue = 'webhooks';
     }
 
+    /**
+     * Called by the queue worker once every retry attempt (see `$tries`)
+     * has been exhausted for this job.
+     *
+     * Records a dedicated dead-letter `WebhookDelivery` row — distinct from
+     * the generic `failed_jobs` entry Laravel already writes — so partner
+     * admins can see and replay it from `GET /webhooks/{id}/dead-letters`
+     * without needing shell/DB access. See PA2-API-006.
+     */
+    public function failed(Throwable $exception): void
+    {
+        WebhookDelivery::create([
+            'webhook_endpoint_id' => $this->endpoint->id,
+            'event' => $this->event,
+            'payload' => [
+                'event' => $this->event,
+                'timestamp' => now()->toIso8601String(),
+                'data' => $this->payload,
+            ],
+            'response_code' => 0,
+            'response_body' => mb_substr('All retries exhausted: '.$exception->getMessage(), 0, 2000),
+            'duration_ms' => 0,
+            'dead_lettered_at' => now(),
+        ]);
+
+        Log::error('Webhook delivery dead-lettered after exhausting all retries', [
+            'endpoint_id' => $this->endpoint->id,
+            'event' => $this->event,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+
     public function tenantCompanyId(): ?string
     {
         // `SerializesModels` re-hydrates `$endpoint` from the DB when the job
@@ -55,7 +87,7 @@ class DispatchWebhook implements ShouldQueue, TenantScopedJob
      */
     public function middleware(): array
     {
-        return [new EnsureTenantContext()];
+        return [new EnsureTenantContext];
     }
 
     public function handle(): void
@@ -150,4 +182,3 @@ class DispatchWebhook implements ShouldQueue, TenantScopedJob
         }
     }
 }
-

--- a/api/app/Modules/Billing/Domain/Models/WebhookDelivery.php
+++ b/api/app/Modules/Billing/Domain/Models/WebhookDelivery.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Modules\Billing\Domain\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
@@ -15,7 +17,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $response_code
  * @property string|null $response_body
  * @property int $duration_ms
- * @mixin \Illuminate\Database\Eloquent\Builder<static>
+ * @property Carbon|null $dead_lettered_at
+ *
+ * @mixin Builder<static>
  */
 class WebhookDelivery extends Model
 {
@@ -30,16 +34,27 @@ class WebhookDelivery extends Model
         'response_code',
         'response_body',
         'duration_ms',
+        'dead_lettered_at',
     ];
 
     protected $casts = [
         'payload' => 'array',
         'delivered_at' => 'datetime',
+        'dead_lettered_at' => 'datetime',
     ];
 
     /** @return BelongsTo<WebhookEndpoint, $this> */
     public function endpoint(): BelongsTo
     {
         return $this->belongsTo(WebhookEndpoint::class, 'webhook_endpoint_id');
+    }
+
+    /**
+     * @param  Builder<static>  $q
+     * @return Builder<static>
+     */
+    public function scopeDeadLettered(Builder $q): Builder
+    {
+        return $q->whereNotNull('dead_lettered_at');
     }
 }

--- a/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Modules\Billing\Interfaces\Api\V1;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\WebhookDeliveryResource;
+use App\Http\Resources\Api\V1\WebhookEndpointResource;
+use App\Jobs\DispatchWebhook;
+use App\Modules\Billing\Domain\Models\WebhookDelivery;
+use App\Modules\Billing\Domain\Models\WebhookEndpoint;
 use App\Modules\Billing\Interfaces\Api\V1\Requests\StoreWebhookEndpointRequest;
 use App\Modules\Billing\Interfaces\Api\V1\Requests\UpdateWebhookEndpointRequest;
-use App\Http\Resources\Api\V1\WebhookEndpointResource;
-use App\Core\Auth\Domain\Models\Employee;
-use App\Modules\Billing\Domain\Models\WebhookEndpoint;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -117,5 +120,67 @@ class WebhookController extends Controller
     {
         return response()->json(['data' => self::AVAILABLE_EVENTS]);
     }
-}
 
+    /**
+     * GET /webhooks/{webhookEndpoint}/dead-letters
+     *
+     * Lists delivery attempts that permanently exhausted all retries (see
+     * `DispatchWebhook::failed()`), so a partner admin can inspect and
+     * replay them without shell/DB access. PA2-API-006.
+     */
+    public function deadLetters(Request $request, WebhookEndpoint $webhookEndpoint): AnonymousResourceCollection
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        if (! $actor->hasManagerRole('principal')) {
+            abort(403);
+        }
+        if ($webhookEndpoint->company_id !== $actor->company_id) {
+            abort(404);
+        }
+
+        return WebhookDeliveryResource::collection(
+            $webhookEndpoint->deliveries()
+                ->deadLettered()
+                ->orderByDesc('delivered_at')
+                ->paginate((int) $request->integer('per_page', 20))
+        );
+    }
+
+    /**
+     * POST /webhooks/{webhookEndpoint}/dead-letters/{delivery}/replay
+     *
+     * Re-dispatches the exact same event/payload behind a dead-lettered
+     * delivery. This does not re-run the business action that originally
+     * emitted the event, so the partner receives the same `event`/`data`
+     * again — idempotent from a functional standpoint, matching the
+     * "webhook rejoue sans doublon fonctionnel" requirement in
+     * docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md. The endpoint's
+     * `failure_count` is reset so a manual replay gets a fresh run of
+     * retries instead of immediately tripping the auto-disable threshold.
+     */
+    public function replayDeadLetter(Request $request, WebhookEndpoint $webhookEndpoint, WebhookDelivery $delivery): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        if (! $actor->hasManagerRole('principal')) {
+            abort(403);
+        }
+        if ($webhookEndpoint->company_id !== $actor->company_id) {
+            abort(404);
+        }
+        if ($delivery->webhook_endpoint_id !== $webhookEndpoint->id || $delivery->dead_lettered_at === null) {
+            abort(404);
+        }
+
+        $webhookEndpoint->update(['failure_count' => 0, 'active' => true]);
+
+        /** @var array<string, mixed> $payload */
+        $payload = $delivery->payload['data'] ?? [];
+        $event = (string) $delivery->event;
+
+        DispatchWebhook::dispatch($webhookEndpoint, $event, $payload);
+
+        return response()->json(['message' => 'Webhook delivery re-queued.'], 202);
+    }
+}

--- a/api/database/migrations/tenant/2026_07_23_000002_add_dead_letter_to_webhook_deliveries.php
+++ b/api/database/migrations/tenant/2026_07_23_000002_add_dead_letter_to_webhook_deliveries.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-API-006 — Outbound partner webhooks: dead-letter handling.
+ *
+ * `DispatchWebhook` already retries (3 attempts, backoff 30s/120s/600s) and
+ * disables an endpoint automatically after 10 accumulated failures, but once
+ * a job exhausted its retries the failure was only visible in the generic
+ * `failed_jobs` table — with no link back to the originating webhook event,
+ * and no dedicated way for a partner-facing admin to see or replay it.
+ *
+ * This adds a `dead_lettered_at` marker on `webhook_deliveries` so the last,
+ * permanently-failed delivery attempt for an event can be flagged and later
+ * replayed (see WebhookController::deadLetters()/replay()).
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (Schema::hasTable('webhook_deliveries') && ! Schema::hasColumn('webhook_deliveries', 'dead_lettered_at')) {
+            Schema::table('webhook_deliveries', function (Blueprint $table) {
+                $table->timestampTz('dead_lettered_at')->nullable()->index();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('webhook_deliveries') && Schema::hasColumn('webhook_deliveries', 'dead_lettered_at')) {
+            Schema::table('webhook_deliveries', function (Blueprint $table) {
+                $table->dropColumn('dead_lettered_at');
+            });
+        }
+    }
+};

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7816,6 +7816,53 @@ paths:
         "401":
           $ref: "#/components/responses/Error401"
 
+  /webhooks/{webhook}/dead-letters:
+    get:
+      tags: ["Integrations"]
+      summary: "Lister les livraisons webhook dead-letter (retries epuises)"
+      parameters:
+        - name: webhook
+          in: path
+          required: true
+          schema: { type: integer }
+        - name: per_page
+          in: query
+          required: false
+          schema: { type: integer, default: 20 }
+      responses:
+        "200":
+          description: "Liste des livraisons dead-letter"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+
+  /webhooks/{webhook}/dead-letters/{delivery}/replay:
+    post:
+      tags: ["Integrations"]
+      summary: "Rejouer une livraison webhook dead-letter"
+      description: "Redispatch le meme evenement/payload sans re-executer l'action metier d'origine (pas de doublon fonctionnel cote plateforme)."
+      parameters:
+        - name: webhook
+          in: path
+          required: true
+          schema: { type: integer }
+        - name: delivery
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "202":
+          description: "Livraison re-mise en file"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+
   /webhooks/{webhook}/test:
     post:
       tags: ["Integrations"]

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -163,6 +163,8 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
         Route::get('/webhooks/{webhookEndpoint}', [WebhookController::class, 'show']);
         Route::put('/webhooks/{webhookEndpoint}', [WebhookController::class, 'update']);
         Route::delete('/webhooks/{webhookEndpoint}', [WebhookController::class, 'destroy']);
+        Route::get('/webhooks/{webhookEndpoint}/dead-letters', [WebhookController::class, 'deadLetters']);
+        Route::post('/webhooks/{webhookEndpoint}/dead-letters/{delivery}/replay', [WebhookController::class, 'replayDeadLetter']);
 
         // ── Audit Trail
         Route::get('/audit-logs', [AuditLogController::class, 'index']);

--- a/api/tests/Feature/WebhookDeadLetterTest.php
+++ b/api/tests/Feature/WebhookDeadLetterTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\DispatchWebhook;
+use App\Modules\Billing\Domain\Models\WebhookDelivery;
+use App\Modules\Billing\Domain\Models\WebhookEndpoint;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use RuntimeException;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-API-006 — Outbound partner webhooks: dead-letter handling.
+ *
+ * Covers `DispatchWebhook::failed()` (called by the queue worker once all
+ * retries are exhausted) and the manager-facing dead-letter list/replay
+ * endpoints. See docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md.
+ */
+class WebhookDeadLetterTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_job_failed_hook_creates_a_dead_lettered_delivery(): void
+    {
+        $company = Company::factory()->create();
+        $endpoint = WebhookEndpoint::create([
+            'company_id' => $company->id,
+            'url' => 'https://example.com/hook',
+            'events' => ['employee.created'],
+            'secret' => 'secret',
+            'active' => true,
+        ]);
+
+        $job = new DispatchWebhook($endpoint, 'employee.created', ['id' => 42]);
+        $job->failed(new RuntimeException('Connection refused'));
+
+        $this->assertDatabaseHas('webhook_deliveries', [
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'employee.created',
+            'response_code' => 0,
+        ]);
+
+        $delivery = WebhookDelivery::where('webhook_endpoint_id', $endpoint->id)->first();
+        $this->assertNotNull($delivery);
+        $this->assertNotNull($delivery->dead_lettered_at);
+        $this->assertStringContainsString('Connection refused', (string) $delivery->response_body);
+    }
+
+    public function test_manager_can_list_dead_lettered_deliveries_for_own_endpoint(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $endpoint = WebhookEndpoint::create([
+            'company_id' => $company->id,
+            'url' => 'https://example.com/hook',
+            'events' => ['employee.created'],
+            'secret' => 'secret',
+            'active' => true,
+        ]);
+
+        WebhookDelivery::create([
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'employee.created',
+            'payload' => ['event' => 'employee.created', 'data' => ['id' => 1]],
+            'response_code' => 200,
+            'response_body' => 'ok',
+            'duration_ms' => 50,
+        ]);
+        $deadLetter = WebhookDelivery::create([
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'employee.created',
+            'payload' => ['event' => 'employee.created', 'data' => ['id' => 2]],
+            'response_code' => 0,
+            'response_body' => 'timeout',
+            'duration_ms' => 0,
+            'dead_lettered_at' => now(),
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson("/api/v1/webhooks/{$endpoint->id}/dead-letters");
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $deadLetter->id);
+    }
+
+    public function test_manager_cannot_list_dead_letters_for_another_companys_endpoint(): void
+    {
+        $ownCompany = Company::factory()->create();
+        $otherCompany = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $ownCompany->id]);
+        $endpoint = WebhookEndpoint::create([
+            'company_id' => $otherCompany->id,
+            'url' => 'https://example.com/hook',
+            'events' => ['employee.created'],
+            'secret' => 'secret',
+            'active' => true,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson("/api/v1/webhooks/{$endpoint->id}/dead-letters");
+
+        $response->assertNotFound();
+    }
+
+    public function test_manager_can_replay_a_dead_lettered_delivery(): void
+    {
+        Queue::fake();
+
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $endpoint = WebhookEndpoint::create([
+            'company_id' => $company->id,
+            'url' => 'https://example.com/hook',
+            'events' => ['employee.created'],
+            'secret' => 'secret',
+            'active' => false,
+            'failure_count' => 10,
+        ]);
+        $deadLetter = WebhookDelivery::create([
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'employee.created',
+            'payload' => ['event' => 'employee.created', 'data' => ['id' => 7]],
+            'response_code' => 0,
+            'response_body' => 'timeout',
+            'duration_ms' => 0,
+            'dead_lettered_at' => now(),
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/webhooks/{$endpoint->id}/dead-letters/{$deadLetter->id}/replay");
+
+        $response->assertStatus(202);
+
+        Queue::assertPushed(DispatchWebhook::class, function (DispatchWebhook $job) {
+            return true;
+        });
+
+        $endpoint->refresh();
+        $this->assertTrue($endpoint->active);
+        $this->assertSame(0, $endpoint->failure_count);
+    }
+
+    public function test_replay_rejects_a_delivery_that_is_not_dead_lettered(): void
+    {
+        Queue::fake();
+
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $endpoint = WebhookEndpoint::create([
+            'company_id' => $company->id,
+            'url' => 'https://example.com/hook',
+            'events' => ['employee.created'],
+            'secret' => 'secret',
+            'active' => true,
+        ]);
+        $successfulDelivery = WebhookDelivery::create([
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'employee.created',
+            'payload' => ['event' => 'employee.created', 'data' => ['id' => 1]],
+            'response_code' => 200,
+            'response_body' => 'ok',
+            'duration_ms' => 50,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/webhooks/{$endpoint->id}/dead-letters/{$successfulDelivery->id}/replay");
+
+        $response->assertNotFound();
+        Queue::assertNotPushed(DispatchWebhook::class);
+    }
+
+    public function test_non_manager_cannot_list_or_replay_dead_letters(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $endpoint = WebhookEndpoint::create([
+            'company_id' => $company->id,
+            'url' => 'https://example.com/hook',
+            'events' => ['employee.created'],
+            'secret' => 'secret',
+            'active' => true,
+        ]);
+        $deadLetter = WebhookDelivery::create([
+            'webhook_endpoint_id' => $endpoint->id,
+            'event' => 'employee.created',
+            'payload' => ['event' => 'employee.created', 'data' => ['id' => 1]],
+            'response_code' => 0,
+            'response_body' => 'timeout',
+            'duration_ms' => 0,
+            'dead_lettered_at' => now(),
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson("/api/v1/webhooks/{$endpoint->id}/dead-letters")->assertForbidden();
+        $this->postJson("/api/v1/webhooks/{$endpoint->id}/dead-letters/{$deadLetter->id}/replay")->assertForbidden();
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -1116,6 +1116,9 @@ trait CreatesMvpSchema
                 $table->text('response_body')->nullable();
                 $table->unsignedInteger('duration_ms')->nullable();
                 $table->timestampTz('delivered_at')->useCurrent();
+                // PA2-API-006: dead-letter marker, see
+                // database/migrations/tenant/2026_07_23_000002_add_dead_letter_to_webhook_deliveries.php
+                $table->timestampTz('dead_lettered_at')->nullable();
             });
         }
 

--- a/docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md
+++ b/docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md
@@ -139,6 +139,15 @@ Chaque webhook production devra inclure :
 
 Le partenaire doit refuser un timestamp trop ancien et ignorer proprement un `event_id` deja traite. Les retries doivent etre consideres normaux.
 
+### Retry et dead-letter
+
+Chaque livraison echoue jusqu'a 3 tentatives (backoff 30s / 120s / 600s). Au-dela de 10 echecs cumules, l'endpoint est automatiquement desactive (`active=false`) pour eviter de marteler un partenaire indisponible.
+
+Si les 3 tentatives echouent, la livraison est marquee dead-letter (`dead_lettered_at` non nul) plutot que silencieusement perdue :
+
+- `GET /api/v1/webhooks/{id}/dead-letters` liste les livraisons dead-letter d'un endpoint (managers uniquement).
+- `POST /api/v1/webhooks/{id}/dead-letters/{delivery}/replay` remet en file le meme evenement/payload d'origine (202) et reactive l'endpoint pour lui laisser une nouvelle chance. Le replay ne re-execute pas l'action metier d'origine cote plateforme : c'est le meme `event`/`data`, donc pas de doublon fonctionnel emis — seul le partenaire doit deduplicquer via l'`event_id`/`Webhook-Id` s'il retraite un evenement deja vu.
+
 ### Exigences partenaire
 
 - Endpoint HTTPS public.


### PR DESCRIPTION
Closes #993.

## Problem

`DispatchWebhook` already had retries (3 attempts, 30s/120s/600s backoff), HMAC signatures, and auto-disable after 10 accumulated failures, but a delivery that permanently exhausted all retries was only recorded in the generic `failed_jobs` table — with no link back to the originating webhook event, and no way for a partner-facing manager to see or replay it without shell/DB access.

## Changes

- `DispatchWebhook::failed()`: records a dedicated dead-lettered `WebhookDelivery` row (new `dead_lettered_at` column) when the queue worker exhausts all retries for a job.
- `GET /api/v1/webhooks/{id}/dead-letters`: lists dead-lettered deliveries for a manager's own endpoint (paginated).
- `POST /api/v1/webhooks/{id}/dead-letters/{delivery}/replay`: re-dispatches the exact same event/payload, resets `failure_count`/`active`. Does not re-run the original business action, so no functional duplicate event is emitted platform-side — matches the existing "webhook rejoue sans doublon fonctionnel" partner requirement.
- New `WebhookDeliveryResource`, migration for `webhook_deliveries.dead_lettered_at`, and `CreatesMvpSchema` test fixture updated to match.
- Documented the retry/dead-letter/replay contract in `docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md` and `api/openapi.yaml`.
- New `WebhookDeadLetterTest` (6 tests) covering the `failed()` hook, listing, replay, cross-tenant isolation (404), and RBAC (403 for non-managers).

## Testing

```
php vendor/bin/pest tests/Feature/WebhookDeadLetterTest.php tests/Feature/Security/WebhookSsrfGuardTest.php tests/Feature/PaymentWebhookControllerTest.php
# 23 passed (74 assertions)

php vendor/bin/phpstan analyse -c phpstan-strict.neon app/Modules/Billing/Interfaces/Api/V1/WebhookController.php app/Modules/Billing/Domain/Models/WebhookDelivery.php
# 1 pre-existing finding (unchanged line, present on main), 0 new findings

php vendor/bin/pint --test <changed files>
# clean after running pint
```

🤖 Generated autonomously per repo owner's request to work through open backlog issues one at a time.