### PR TITLE
feat(attendance): notify employee on auto-close of forgotten check-out (PA2-ATT-007)

### DIFF
--- a/api/app/Console/Commands/AutoCloseAttendanceCommand.php
+++ b/api/app/Console/Commands/AutoCloseAttendanceCommand.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\DispatchCommunicationJob;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -91,6 +92,8 @@ class AutoCloseAttendanceCommand extends Command
                 'check_in' => $log->check_in?->toIso8601String(),
                 'auto_check_out' => $autoCheckOut->toIso8601String(),
             ]);
+
+            $this->notifyAutoClose($log, $autoCheckOut);
         });
 
         $this->info("Auto-closed {$closed} attendance log(s).");
@@ -98,6 +101,30 @@ class AutoCloseAttendanceCommand extends Command
         Log::info('attendance:auto-close run complete', ['closed' => $closed]);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Notify the employee that their forgotten check-out was auto-closed by
+     * the system, so they know a correction request is available if the
+     * computed hours/overtime are wrong (PA2-ATT-007).
+     */
+    private function notifyAutoClose(AttendanceLog $log, Carbon $autoCheckOut): void
+    {
+        if (! $log->employee_id || ! $log->company_id) {
+            return;
+        }
+
+        DispatchCommunicationJob::dispatch(
+            employeeId: $log->employee_id,
+            companyId: (string) $log->company_id,
+            templateKey: 'attendance_auto_closed',
+            context: [
+                'attendance_log_id' => $log->id,
+                'date' => $log->date?->toDateString(),
+                'auto_check_out' => $autoCheckOut->toIso8601String(),
+                'hours_worked' => $log->hours_worked,
+            ],
+        );
     }
 
     private function resolveCompany(AttendanceLog $log): ?Company
@@ -126,4 +153,3 @@ class AutoCloseAttendanceCommand extends Command
         ];
     }
 }
-

--- a/api/config/communication.php
+++ b/api/config/communication.php
@@ -36,10 +36,13 @@ return [
     'public_metadata_keys' => [
         'absence_id',
         'attendance_log_id',
+        'auto_check_out',
         'category',
         'company_id',
+        'date',
         'employee_id',
         'feature_key',
+        'hours_worked',
         'locale',
         'payroll_run_id',
         'redirect_url',
@@ -83,6 +86,11 @@ return [
             'category' => 'platform',
             'title' => 'Annonce de la plateforme Leopardo',
             'body' => 'Une nouvelle annonce de la plateforme est disponible.',
+        ],
+        'attendance_auto_closed' => [
+            'category' => 'hr',
+            'title' => 'Journée de pointage clôturée automatiquement',
+            'body' => 'Nous avons détecté un oubli de départ et clôturé votre journée automatiquement selon la règle de votre entreprise. Vérifiez les heures calculées et demandez une correction si besoin.',
         ],
     ],
 ];

--- a/api/tests/Feature/Attendance/AutoCloseAttendanceCommandTest.php
+++ b/api/tests/Feature/Attendance/AutoCloseAttendanceCommandTest.php
@@ -2,9 +2,10 @@
 
 namespace Tests\Feature\Attendance;
 
-use App\Modules\Attendance\Domain\Models\AttendanceLog;
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
+use App\Modules\Notification\Domain\Models\Notification;
 use App\Modules\Planning\Domain\Models\Schedule;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
@@ -96,5 +97,63 @@ class AutoCloseAttendanceCommandTest extends TestCase
         $this->assertTrue($log->punch_meta['auto_close']['correction_window']);
         $this->assertSame(10, $log->punch_meta['auto_close']['policy']['threshold_hours']);
     }
-}
 
+    public function test_auto_close_notifies_the_employee_so_they_can_request_a_correction(): void
+    {
+        $company = Company::query()->create([
+            'name' => 'Company B',
+            'slug' => 'company-b',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'b@company.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+            'timezone' => 'Africa/Algiers',
+            'metadata' => [
+                'attendance_auto_close' => [
+                    'enabled' => true,
+                    'threshold_hours' => 10,
+                    'workday_hours' => 8,
+                    'overtime_margin_minutes' => 15,
+                ],
+            ],
+        ]);
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'email' => 'employee@b.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $checkIn = Carbon::parse('2026-05-31 06:00:00', 'UTC');
+        $log = AttendanceLog::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-31',
+            'session_number' => 1,
+            'check_in' => $checkIn,
+            'method' => 'mobile',
+            'work_type' => 'normal',
+            'status' => 'incomplete',
+        ]);
+
+        $this->travelTo(Carbon::parse('2026-05-31 20:00:00', 'UTC'));
+
+        Artisan::call('attendance:auto-close', ['--threshold' => 12]);
+
+        $notification = Notification::query()
+            ->where('company_id', $company->id)
+            ->where('employee_id', $employee->id)
+            ->where('type', 'hr')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($notification, 'Employee should be notified that their attendance was auto-closed.');
+        $this->assertSame($log->id, $notification->data['attendance_log_id'] ?? null);
+        $this->assertFalse($notification->is_read);
+    }
+}


### PR DESCRIPTION
Closes #1022

## Summary
The daily auto-close command (`AutoCloseAttendanceCommand`) auto-closes forgotten check-outs but never told the employee it happened. This adds a notification via the existing communication pipeline so employees know their session was auto-closed and can request a correction if the auto check-out time is wrong.

## Changes
- New `attendance_auto_closed` template in `config/communication.php` (category `hr`) with required public metadata keys (`date`, `auto_check_out`, `hours_worked`).
- `AutoCloseAttendanceCommand` now dispatches `DispatchCommunicationJob` to the employee after each auto-close.
- New feature test asserting a `Notification` row is created for the employee with the correct `attendance_log_id`.

## Testing
- `vendor/bin/pint` clean on touched files.
- PHPStan (`phpstan-modules.neon`) clean on the command file.
- `vendor/bin/pest --filter=AutoCloseAttendanceCommandTest` passes (2/2).
- Confirmed the pre-existing 15 failing tests in `--testsuite=Feature --filter=Attendance` also fail identically on `main` (unrelated SQLite/Postgres syntax and date-format issues), so this change introduces no regressions.