### PR TITLE
fix(attendance): include logs dated exactly on date_to in anomaly summary (PA2-ATT-011)

### DIFF
--- a/api/app/Modules/Attendance/Infrastructure/Services/AttendanceAnomalyService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/AttendanceAnomalyService.php
@@ -52,7 +52,11 @@ class AttendanceAnomalyService
                 'gps_lng',
             ])
             ->where('company_id', $companyId)
-            ->whereBetween('date', [$dateFrom, $dateTo])
+            // The `date` column is stored as a full timestamp (e.g. "2026-05-10 00:00:00").
+            // whereBetween() with two plain date strings would exclude every log dated
+            // exactly on $dateTo because "2026-05-10 00:00:00" sorts after "2026-05-10"
+            // lexicographically, so the upper bound must include the end of that day.
+            ->whereBetween('date', [$dateFrom, Carbon::parse($dateTo)->endOfDay()])
             ->when($filters['employee_id'] ?? null, fn ($query, $employeeId) => $query->where('employee_id', $employeeId))
             ->when($departmentEmployeeIds !== null, fn ($query) => $query->whereIn('employee_id', $departmentEmployeeIds))
             ->orderByDesc('date')

--- a/api/tests/Feature/Attendance/AttendanceAnomaliesTest.php
+++ b/api/tests/Feature/Attendance/AttendanceAnomaliesTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Attendance;
 
-use App\Modules\Attendance\Domain\Models\AttendanceLog;
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use Illuminate\Support\Carbon;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
@@ -162,6 +162,35 @@ class AttendanceAnomaliesTest extends TestCase
         $response->assertJsonCount(0, 'data.items');
     }
 
+    public function test_attendance_anomalies_include_logs_dated_exactly_on_the_date_to_boundary(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        app()->instance('current_company', $company);
+        AttendanceLog::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-10',
+            'check_in' => Carbon::parse('2026-05-10 09:20:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-10 17:00:00', 'UTC'),
+            'late_minutes' => 20,
+            'status' => 'late',
+        ]);
+        app()->forgetInstance('current_company');
+
+        Sanctum::actingAs($manager);
+
+        // date_from and date_to are the same single day: the log dated on that
+        // exact day must be included in the summary (regression for PA2-ATT-011).
+        $response = $this->getJson('/api/v1/attendance/anomalies?date_from=2026-05-10&date_to=2026-05-10');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.summary.total', 1);
+        $response->assertJsonPath('data.summary.by_type.late_arrival', 1);
+    }
+
     public function test_attendance_anomalies_include_geofence_and_repeated_exact_check_ins(): void
     {
         $company = Company::factory()->create([
@@ -207,4 +236,3 @@ class AttendanceAnomaliesTest extends TestCase
         $response->assertJsonPath('data.summary.by_type.out_of_geofence', 1);
     }
 }
-


### PR DESCRIPTION
Closes #1026

## Summary
`AttendanceAnomalyService::summarize()` filters logs with `whereBetween('date', [$dateFrom, $dateTo])`, but `attendance_logs.date` is stored as a full timestamp (`2026-05-10 00:00:00`). Comparing that against the plain date string `2026-05-10` lexicographically excludes every log dated exactly on the `date_to` boundary day, since `"2026-05-10 00:00:00" > "2026-05-10"`.

This silently dropped anomalies (late arrivals, missing check-outs, manual corrections, overtime, rapid device sequences, repeated check-ins, out-of-geofence punches) whenever they occurred on the last day of the requested range — including the common single-day query `date_from == date_to`.

## Fix
- Use `Carbon::parse($dateTo)->endOfDay()` as the upper bound so boundary-day logs are included.
- Added a regression test for a single-day range query that previously returned an empty summary.
- Fixed two pre-existing failing tests in `AttendanceAnomaliesTest` that were exercising this exact bug (both now pass).

## Testing
- `vendor/bin/pint` clean on touched files.
- `vendor/bin/phpstan analyse ... -c phpstan-modules.neon` — no errors.
- `vendor/bin/pest --filter=AttendanceAnomaliesTest` — 5/5 pass (was 2/4 failing before the fix).
- `vendor/bin/pest --testsuite=Feature --filter=Attendance` — improved from 15 failed/85 passed to 13 failed/87 passed; no new regressions (remaining 13 failures are pre-existing/unrelated, confirmed to also fail identically on `main`).