### PR TITLE
feat(payroll): notify employee/manager during salary advance double-validation (PA2-PAY-008)

### DIFF
--- a/api/app/Modules/Payroll/Infrastructure/Services/SalaryAdvanceService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/SalaryAdvanceService.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Infrastructure\Services;
 
-use App\Exceptions\SalaryAdvanceNotPendingException;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Exceptions\SalaryAdvanceNotPendingException;
+use App\Modules\Notification\Infrastructure\Services\CommunicationService;
 use App\Modules\Payroll\Domain\Models\SalaryAdvance;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class SalaryAdvanceService
 {
+    public function __construct(
+        private readonly CommunicationService $communication,
+    ) {}
+
     public function create(Employee $employee, array $data): SalaryAdvance
     {
         $amount = (float) $data['amount'];
@@ -34,8 +41,11 @@ class SalaryAdvanceService
         $plan = $this->buildPlan($advance->amount, $months, $monthly);
 
         $advance->update(['status' => 'active', 'approved_by' => $approver->id, 'decision_comment' => $data['decision_comment'] ?? null, 'repayment_months' => $months, 'monthly_deduction' => $monthly, 'amount_remaining' => $advance->amount, 'repayment_plan' => $plan]);
+        $advance = $advance->fresh();
 
-        return $advance->fresh();
+        $this->notify($advance, 'salary_advance_manager_approved');
+
+        return $advance;
     }
 
     public function reject(SalaryAdvance $advance, Employee $approver, ?string $comment = null): SalaryAdvance
@@ -45,8 +55,45 @@ class SalaryAdvanceService
         }
 
         $advance->update(['status' => 'rejected', 'approved_by' => $approver->id, 'decision_comment' => $comment]);
+        $advance = $advance->fresh();
 
-        return $advance->fresh();
+        $this->notify($advance, 'salary_advance_rejected');
+
+        return $advance;
+    }
+
+    /**
+     * Notify the advance owner about a status change (PA2-PAY-008).
+     * Notification failures must never break the advance workflow.
+     */
+    public function notify(SalaryAdvance $advance, string $templateKey): void
+    {
+        $employee = $advance->employee ?? Employee::query()->withoutGlobalScopes()->find($advance->employee_id);
+
+        if ($employee instanceof Employee) {
+            $this->notifyRecipient($advance, $employee, $templateKey);
+        }
+    }
+
+    /**
+     * Notify an explicit recipient (e.g. the manager who declared payment,
+     * once the employee confirms reception) about the advance.
+     */
+    public function notifyRecipient(SalaryAdvance $advance, Employee $recipient, string $templateKey): void
+    {
+        try {
+            $this->communication->notifyEmployee($recipient, $templateKey, [
+                'salary_advance_id' => $advance->id,
+                'payment_reference' => $advance->payment_reference,
+            ]);
+        } catch (Throwable $exception) {
+            Log::warning('salary-advance: failed to notify recipient', [
+                'salary_advance_id' => $advance->id,
+                'recipient_id' => $recipient->id,
+                'template' => $templateKey,
+                'error' => $exception->getMessage(),
+            ]);
+        }
     }
 
     public function cancel(SalaryAdvance $advance): SalaryAdvance
@@ -75,4 +122,3 @@ class SalaryAdvanceService
         return $plan;
     }
 }
-

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryAdvanceController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SalaryAdvanceController.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SalaryAdvanceResource;
+use App\Jobs\GeneratePaymentDocumentJob;
+use App\Modules\Payroll\Domain\Models\SalaryAdvance;
+use App\Modules\Payroll\Infrastructure\Services\SalaryAdvanceService;
 use App\Modules\Payroll\Interfaces\Api\V1\Requests\DecideSalaryAdvanceRequest;
 use App\Modules\Payroll\Interfaces\Api\V1\Requests\SalaryAdvanceIndexRequest;
 use App\Modules\Payroll\Interfaces\Api\V1\Requests\StoreSalaryAdvanceRequest;
-use App\Http\Resources\Api\V1\SalaryAdvanceResource;
-use App\Jobs\GeneratePaymentDocumentJob;
-use App\Core\Auth\Domain\Models\Employee;
-use App\Modules\Payroll\Domain\Models\SalaryAdvance;
-use App\Modules\Payroll\Infrastructure\Services\SalaryAdvanceService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -157,6 +157,7 @@ class SalaryAdvanceController extends Controller
         $salaryAdvance->refresh();
 
         GeneratePaymentDocumentJob::dispatchForSalaryAdvance($salaryAdvance, $actor->id);
+        $this->salaryAdvanceService->notify($salaryAdvance, 'salary_advance_payment_declared');
 
         return (new SalaryAdvanceResource($salaryAdvance->load(['employee:id,first_name,last_name,email,company_id', 'employee.company:id,currency'])))->response();
     }
@@ -184,8 +185,16 @@ class SalaryAdvanceController extends Controller
             'employee_confirmed_at' => now(),
             'validation_status' => 'employee_confirmed',
         ]);
+        $salaryAdvance = $salaryAdvance->fresh();
 
-        return (new SalaryAdvanceResource($salaryAdvance->fresh()->load(['employee:id,first_name,last_name,email,company_id', 'employee.company:id,currency'])))->response();
+        if ($salaryAdvance->payment_declared_by) {
+            $manager = Employee::query()->withoutGlobalScopes()->find($salaryAdvance->payment_declared_by);
+            if ($manager instanceof Employee) {
+                $this->salaryAdvanceService->notifyRecipient($salaryAdvance, $manager, 'salary_advance_received');
+            }
+        }
+
+        return (new SalaryAdvanceResource($salaryAdvance->load(['employee:id,first_name,last_name,email,company_id', 'employee.company:id,currency'])))->response();
     }
 
     /**
@@ -214,8 +223,10 @@ class SalaryAdvanceController extends Controller
             'validation_status' => 'manager_approved',
             'status' => 'approved',
         ]);
+        $salaryAdvance = $salaryAdvance->fresh();
 
-        return (new SalaryAdvanceResource($salaryAdvance->fresh()->load(['employee:id,first_name,last_name,email,company_id', 'employee.company:id,currency'])))->response();
+        $this->salaryAdvanceService->notify($salaryAdvance, 'salary_advance_manager_approved');
+
+        return (new SalaryAdvanceResource($salaryAdvance->load(['employee:id,first_name,last_name,email,company_id', 'employee.company:id,currency'])))->response();
     }
 }
-

--- a/api/config/communication.php
+++ b/api/config/communication.php
@@ -41,8 +41,10 @@ return [
         'employee_id',
         'feature_key',
         'locale',
+        'payment_reference',
         'payroll_run_id',
         'redirect_url',
+        'salary_advance_id',
         'severity',
         'source',
         'status',
@@ -83,6 +85,26 @@ return [
             'category' => 'platform',
             'title' => 'Annonce de la plateforme Leopardo',
             'body' => 'Une nouvelle annonce de la plateforme est disponible.',
+        ],
+        'salary_advance_manager_approved' => [
+            'category' => 'payroll',
+            'title' => 'Avance sur salaire approuvée',
+            'body' => 'Votre demande d’avance sur salaire a été approuvée par votre manager. Le paiement sera déclaré prochainement.',
+        ],
+        'salary_advance_rejected' => [
+            'category' => 'payroll',
+            'title' => 'Avance sur salaire refusée',
+            'body' => 'Votre demande d’avance sur salaire a été refusée.',
+        ],
+        'salary_advance_payment_declared' => [
+            'category' => 'payroll',
+            'title' => 'Paiement de l’avance déclaré',
+            'body' => 'Le paiement de votre avance sur salaire a été déclaré. Merci de confirmer sa réception dans l’application.',
+        ],
+        'salary_advance_received' => [
+            'category' => 'payroll',
+            'title' => 'Réception d’avance confirmée',
+            'body' => 'L’employé a confirmé avoir reçu l’avance sur salaire.',
         ],
     ],
 ];

--- a/api/tests/Feature/Security/SalaryAdvanceSecurityTest.php
+++ b/api/tests/Feature/Security/SalaryAdvanceSecurityTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature\Security;
 
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Notification\Domain\Models\Notification;
 use App\Modules\Payroll\Domain\Models\SalaryAdvance;
 use Illuminate\Support\Str;
 use Tests\Support\CreatesMvpSchema;
@@ -243,6 +244,19 @@ class SalaryAdvanceSecurityTest extends TestCase
             'validation_status' => 'employee_confirmed',
             'payment_reference' => 'CASH-2026-001',
         ]);
+
+        // PA2-PAY-008: each transition notifies the relevant party.
+        $this->assertDatabaseHas('notifications', [
+            'employee_id' => $employee->id,
+            'type' => 'payroll',
+        ]);
+        $employeeNotifications = Notification::query()->where('employee_id', $employee->id)->pluck('data')->all();
+        $this->assertCount(2, $employeeNotifications); // manager_approved + payment_declared
+
+        $this->assertDatabaseHas('notifications', [
+            'employee_id' => $manager->id,
+            'type' => 'payroll',
+        ]);
     }
 
     public function test_manager_cannot_mark_salary_advance_paid_before_manager_approval(): void
@@ -339,4 +353,3 @@ class SalaryAdvanceSecurityTest extends TestCase
         return $employee;
     }
 }
-


### PR DESCRIPTION
## Summary
Closes #1041 (PA2-PAY-008).

The salary advance double-validation workflow (manager-approve → mark-paid → confirm-received) existed but never notified anyone. This PR wires it into the existing `CommunicationService` so both sides of the workflow stay informed, matching the acceptance criteria: "Demande validation paiement declare reception employee notifications".

## Changes
- `SalaryAdvanceService`: new `notify()`/`notifyRecipient()` helpers around `CommunicationService::notifyEmployee`. Failures are logged, never block the workflow.
- `SalaryAdvanceController`:
  - `managerApprove` → notifies employee (`salary_advance_manager_approved`)
  - `approve`/`reject` (legacy single-step flow) → notify employee (`salary_advance_manager_approved` / `salary_advance_rejected`)
  - `markPaid` → notifies employee (`salary_advance_payment_declared`)
  - `confirmReceived` → notifies the manager who declared payment (`salary_advance_received`)
- `config/communication.php`: new templates (`salary_advance_manager_approved`, `salary_advance_rejected`, `salary_advance_payment_declared`, `salary_advance_received`) and new public metadata keys (`payment_reference`, `salary_advance_id`).
- `SalaryAdvanceSecurityTest`: extended the double-validation happy-path test to assert notifications land in `notifications` for both employee and manager.

## Testing
- `php artisan test --filter=SalaryAdvanceSecurityTest` — 11 passed.
- Full suite: `php artisan test` — same 209 pre-existing failures on `main` before and after this change (unrelated SQLite `EXTRACT()` / date-format issues in payroll/social-declaration/attendance-correction tests), confirming no regressions introduced.
- `vendor/bin/pint` applied to all touched files.