### PR TITLE
feat(payroll): snapshot tenant currency on salary advances (PA2-PAY-002)

### DIFF
--- a/api/app/Http/Resources/Api/V1/SalaryAdvanceResource.php
+++ b/api/app/Http/Resources/Api/V1/SalaryAdvanceResource.php
@@ -21,12 +21,15 @@ class SalaryAdvanceResource extends JsonResource
             'company_name' => app()->bound('current_company') ? currentCompany()?->name : null,
             'employee_id' => $this->employee_id,
             'amount' => $this->amount,
-            // PA2-COUNTRY-003: salary_advances has no currency column of its
-            // own, so $this->currency is always null. Derive the real value
-            // from the owning company (loaded employee.company, then the
-            // resolved tenant) so mobile/web clients stop defaulting to the
-            // hardcoded 'DZD' fallback for every non-Algerian tenant.
-            'currency' => $this->employee?->company?->currency
+            // PA2-PAY-002: prefer the currency snapshotted on the advance at
+            // creation time (see SalaryAdvanceService::create()) so the
+            // receipt stays historically accurate even if the tenant's
+            // currency setting is edited afterwards. Rows created before
+            // this snapshot existed fall back to the owning company's
+            // current currency (PA2-COUNTRY-003), then the resolved tenant,
+            // then a last-resort 'DZD' default.
+            'currency' => $this->currency
+                ?? $this->employee?->company?->currency
                 ?? (app()->bound('current_company') ? currentCompany()?->currency : null)
                 ?? 'DZD',
             'reason' => $this->reason,

--- a/api/app/Jobs/GeneratePaymentDocumentJob.php
+++ b/api/app/Jobs/GeneratePaymentDocumentJob.php
@@ -173,6 +173,10 @@ class GeneratePaymentDocumentJob implements ShouldQueue, TenantScopedJob
             'requested_by' => $requestedBy,
             'metadata' => [
                 'amount' => $advance->amount,
+                // PA2-PAY-002: snapshot the advance's own currency (set at
+                // creation time) so the receipt stays historically accurate
+                // even if the tenant's currency setting changes later.
+                'currency' => $advance->currency,
                 'payment_reference' => $advance->payment_reference,
                 'payment_declared_at' => $advance->payment_declared_at?->toIso8601String(),
             ],

--- a/api/app/Modules/Payroll/Domain/Models/SalaryAdvance.php
+++ b/api/app/Modules/Payroll/Domain/Models/SalaryAdvance.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Carbon;
  * @property int|null $company_id
  * @property int|null $employee_id
  * @property float $amount
+ * @property string|null $currency
  * @property string|null $reason
  * @property string $status
  * @property string|null $approved_by
@@ -36,7 +37,7 @@ class SalaryAdvance extends Model
     protected $table = 'salary_advances';
 
     protected $fillable = [
-        'company_id', 'employee_id', 'amount', 'reason', 'status',
+        'company_id', 'employee_id', 'amount', 'currency', 'reason', 'status',
         'approved_by', 'decision_comment', 'repayment_months',
         'monthly_deduction', 'amount_remaining', 'repayment_plan',
         // Plan 60 — double validation

--- a/api/app/Modules/Payroll/Infrastructure/Services/SalaryAdvanceService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/SalaryAdvanceService.php
@@ -16,9 +16,14 @@ class SalaryAdvanceService
         $amount = (float) $data['amount'];
         $months = (int) ($data['repayment_months'] ?? 1);
 
+        // PA2-PAY-002: snapshot the tenant currency at creation time so the
+        // advance receipt stays historically accurate even if the
+        // company's currency setting changes later.
+        $currency = $data['currency'] ?? $employee->company?->currency ?? 'DZD';
+
         return SalaryAdvance::create([
             'company_id' => $employee->company_id, 'employee_id' => $employee->id,
-            'amount' => $amount, 'reason' => $data['reason'] ?? null,
+            'amount' => $amount, 'currency' => $currency, 'reason' => $data['reason'] ?? null,
             'status' => 'pending', 'repayment_months' => $months, 'amount_remaining' => $amount,
         ]);
     }

--- a/api/database/factories/SalaryAdvanceFactory.php
+++ b/api/database/factories/SalaryAdvanceFactory.php
@@ -15,6 +15,7 @@ class SalaryAdvanceFactory extends Factory
 
         return [
             'amount' => $amount,
+            'currency' => 'DZD',
             'reason' => $this->faker->sentence(6),
             'status' => 'pending',
             'repayment_months' => rand(1, 6),

--- a/api/database/migrations/tenant/2026_07_23_000003_add_currency_to_salary_advances_table.php
+++ b/api/database/migrations/tenant/2026_07_23_000003_add_currency_to_salary_advances_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-PAY-002 — Salary advance currency snapshot.
+ *
+ * `salary_advances` had no `currency` column of its own, so
+ * `SalaryAdvanceResource` had to fall back to the *current* company
+ * currency (or hardcoded 'DZD') at read time. That means an advance
+ * receipt silently changes currency if the tenant's company currency is
+ * ever edited after the advance was created/paid — which is wrong for a
+ * financial document that must stay historically accurate.
+ *
+ * This adds a `currency` column snapshotted once at creation time (see
+ * SalaryAdvanceService::create()) and backfills existing rows from their
+ * owning company, so payment receipts remain accurate even if the
+ * tenant's currency setting changes later.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('salary_advances', function (Blueprint $table): void {
+            $table->char('currency', 3)->nullable()->after('amount');
+        });
+
+        // Backfill existing rows from their owning company's current
+        // currency so historical advances are not left with a NULL value.
+        DB::table('salary_advances')
+            ->join('companies', 'companies.id', '=', 'salary_advances.company_id')
+            ->update(['salary_advances.currency' => DB::raw('companies.currency')]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('salary_advances', function (Blueprint $table): void {
+            $table->dropColumn('currency');
+        });
+    }
+};

--- a/api/resources/views/pdf/payment-document-advance.blade.php
+++ b/api/resources/views/pdf/payment-document-advance.blade.php
@@ -26,7 +26,7 @@
     </div>
 
     <table>
-        <tr><th>{{ __('pdf.payment_advance_amount') }}</th><td>{{ number_format((float) ($salaryAdvance?->amount ?? $metadata['amount'] ?? 0), 2, ',', ' ') }}</td></tr>
+        <tr><th>{{ __('pdf.payment_advance_amount') }}</th><td>{{ number_format((float) ($salaryAdvance?->amount ?? $metadata['amount'] ?? 0), 2, ',', ' ') }} {{ $salaryAdvance?->currency ?? $metadata['currency'] ?? '' }}</td></tr>
         <tr><th>{{ __('pdf.payment_advance_reason') }}</th><td>{{ $salaryAdvance?->reason ?? __('pdf.payment_document_not_specified') }}</td></tr>
         <tr><th>{{ __('pdf.payment_advance_payment_reference') }}</th><td>{{ $salaryAdvance?->payment_reference ?? ($metadata['payment_reference'] ?? __('pdf.payment_document_not_specified')) }}</td></tr>
         <tr><th>{{ __('pdf.payment_advance_declared_on') }}</th><td>{{ $salaryAdvance?->payment_declared_at?->format('Y-m-d H:i') ?? ($metadata['payment_declared_at'] ?? __('pdf.payment_document_not_specified')) }}</td></tr>

--- a/api/tests/Feature/CountryCurrencyPropagationTest.php
+++ b/api/tests/Feature/CountryCurrencyPropagationTest.php
@@ -65,6 +65,9 @@ class CountryCurrencyPropagationTest extends TestCase
             'role' => 'employee',
         ]);
 
+        // Legacy row created before the PA2-PAY-002 currency snapshot
+        // existed: no `currency` value stored, so the resource must fall
+        // back to the owning company's current currency.
         SalaryAdvance::query()->forceCreate([
             'company_id' => $company->id,
             'employee_id' => $employee->id,
@@ -78,5 +81,41 @@ class CountryCurrencyPropagationTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('data.0.currency', 'MAD');
+    }
+
+    /**
+     * PA2-PAY-002: a salary advance must keep the currency that was active
+     * on the tenant when it was created, even after the company's currency
+     * setting is changed afterwards (e.g. a company migrating from MAD to
+     * EUR must not have its historical advance receipts silently reported
+     * in the new currency).
+     */
+    public function test_salary_advance_keeps_creation_time_currency_after_company_currency_changes(): void
+    {
+        $company = Company::factory()->create(['country' => 'MA', 'currency' => 'MAD']);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->postJson('/api/v1/salary-advances', [
+            'amount' => 2000,
+            'reason' => 'Car repair',
+        ]);
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.currency', 'MAD');
+
+        $advanceId = $response->json('data.id');
+
+        // Company later migrates to a new currency.
+        $company->update(['currency' => 'EUR']);
+
+        $again = $this->getJson("/api/v1/salary-advances/{$advanceId}");
+
+        $again->assertOk();
+        $again->assertJsonPath('data.currency', 'MAD');
     }
 }

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -479,6 +479,10 @@ trait CreatesMvpSchema
             $table->uuid('company_id')->index();
             $table->unsignedInteger('employee_id')->index();
             $table->decimal('amount', 12, 2);
+            // PA2-PAY-002: snapshot the tenant currency at creation time so
+            // advance receipts stay historically accurate even if the
+            // company's currency setting changes later.
+            $table->char('currency', 3)->nullable();
             $table->text('reason')->nullable();
             $table->string('status', 20)->default('pending');
             $table->unsignedInteger('approved_by')->nullable();

--- a/api/tests/Support/sql/mvp_schema.pgsql.sql
+++ b/api/tests/Support/sql/mvp_schema.pgsql.sql
@@ -510,6 +510,7 @@ CREATE TABLE shared_tenants.salary_advances (
     company_id uuid NOT NULL,
     employee_id integer NOT NULL,
     amount numeric(12, 2) NOT NULL,
+    currency char(3) NULL,
     reason text NULL,
     status varchar(20) NOT NULL DEFAULT 'pending',
     approved_by integer NULL,


### PR DESCRIPTION
Closes #1002

## Problem
`salary_advances` had no `currency` column of its own. `SalaryAdvanceResource` always derived the currency from the *current* company currency at read time, which means a paid advance receipt would silently change currency if the tenant's company currency setting was ever edited after the advance was created/paid. That's wrong for a historical financial document — the acceptance criteria for this ticket is that the advance receipt keeps the tenant's currency as it was at the time of the request.

## Changes
- Add a nullable `currency` column to `salary_advances` (migration + SQLite/Postgres test fixtures), backfilled from the owning company for any existing rows.
- Snapshot the tenant's currency once at advance creation time in `SalaryAdvanceService::create()`.
- `SalaryAdvanceResource` now prefers the snapshotted currency, falling back to the owning company's current currency (existing PA2-COUNTRY-003 behavior) for legacy rows created before this change, then a last-resort `'DZD'` default.
- `GeneratePaymentDocumentJob` now snapshots the advance currency into the payment document metadata, and the advance receipt PDF displays the currency next to the amount.
- Added a regression test proving the advance keeps its creation-time currency after the company's currency setting changes.

## Testing
- `php artisan test --filter=CountryCurrencyPropagationTest` — 3/3 passed (new regression test included)
- `php artisan test --filter=SalaryAdvance` — 11/11 passed
- `php artisan test --filter=PaymentDocumentControllerTest` — 5/5 passed
- Full suite: same 213 pre-existing failures as `main` (unrelated SQLite date-format issues), no new failures introduced.