### PR TITLE
PA2-ARCH-004: Temporal versioning of country payroll rules

### DIFF
--- a/api/app/Modules/Payroll/Domain/Models/SocialContribution.php
+++ b/api/app/Modules/Payroll/Domain/Models/SocialContribution.php
@@ -21,7 +21,8 @@ use Illuminate\Support\Carbon;
  * @property Carbon $effective_to
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @mixin \Illuminate\Database\Eloquent\Builder<static>
+ *
+ * @mixin Builder<static>
  */
 class SocialContribution extends Model
 {
@@ -65,14 +66,23 @@ class SocialContribution extends Model
     }
 
     /**
+     * Scopes to rows effective at a given point in time (defaults to now()
+     * when omitted). Accepting an explicit date is what makes retroactive
+     * recalculation possible for audit purposes (PA2-ARCH-004): recalculating
+     * a payroll run from a past period must use the social contribution
+     * rates that were effective *during that period*, not today's rates.
+     *
      * @param  Builder<static>  $q
+     * @param  Carbon|\DateTimeInterface|string|null  $asOf
      * @return Builder<static>
      */
-    public function scopeEffective(Builder $query): Builder
+    public function scopeEffective(Builder $query, $asOf = null): Builder
     {
-        return $query->where('effective_from', '<=', now())
-            ->where(function (Builder $q) {
-                $q->whereNull('effective_to')->orWhere('effective_to', '>=', now());
+        $asOf ??= now();
+
+        return $query->where('effective_from', '<=', $asOf)
+            ->where(function (Builder $q) use ($asOf) {
+                $q->whereNull('effective_to')->orWhere('effective_to', '>=', $asOf);
             });
     }
 }

--- a/api/app/Modules/Payroll/Domain/Models/TaxSlab.php
+++ b/api/app/Modules/Payroll/Domain/Models/TaxSlab.php
@@ -21,7 +21,8 @@ use Illuminate\Support\Carbon;
  * @property Carbon $effective_to
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @mixin \Illuminate\Database\Eloquent\Builder<static>
+ *
+ * @mixin Builder<static>
  */
 class TaxSlab extends Model
 {
@@ -49,14 +50,23 @@ class TaxSlab extends Model
     }
 
     /**
+     * Scopes to rows effective at a given point in time (defaults to now()
+     * when omitted). Accepting an explicit date is what makes retroactive
+     * recalculation possible for audit purposes (PA2-ARCH-004): recalculating
+     * a payroll run from a past period must use the tax slabs that were
+     * effective *during that period*, not today's slabs.
+     *
      * @param  Builder<static>  $q
+     * @param  Carbon|\DateTimeInterface|string|null  $asOf
      * @return Builder<static>
      */
-    public function scopeEffective(Builder $query): Builder
+    public function scopeEffective(Builder $query, $asOf = null): Builder
     {
-        return $query->where('effective_from', '<=', now())
-            ->where(function (Builder $q) {
-                $q->whereNull('effective_to')->orWhere('effective_to', '>=', now());
+        $asOf ??= now();
+
+        return $query->where('effective_from', '<=', $asOf)
+            ->where(function (Builder $q) use ($asOf) {
+                $q->whereNull('effective_to')->orWhere('effective_to', '>=', $asOf);
             });
     }
 }

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AbstractCountryRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AbstractCountryRules.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Infrastructure\Services\CountryRules;
 
+use App\Modules\Payroll\Domain\Models\SocialContribution;
 use App\Modules\Payroll\Domain\Models\TaxSlab;
 use App\Modules\Payroll\Infrastructure\Services\CountryRulesInterface;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 
 abstract class AbstractCountryRules implements CountryRulesInterface
@@ -18,6 +20,26 @@ abstract class AbstractCountryRules implements CountryRulesInterface
     protected ?string $companyId = null;
 
     /**
+     * Point in time used to resolve which TaxSlab/SocialContribution rows are
+     * "effective" (PA2-ARCH-004: country rates/tables are associated with an
+     * effective date so a past payroll run can be recalculated for audit
+     * purposes using the rates that applied *during its own period*, not
+     * today's rates). Set via asOf(); null means "use now()", matching the
+     * pre-existing behaviour.
+     */
+    protected ?Carbon $asOfDate = null;
+
+    /**
+     * Cache of resolved SocialContribution rows for the current asOfDate/
+     * companyId scope, keyed by contribution code, so a single calculateRun()
+     * only queries once per code even though calculateSocialCharges() may
+     * read several rates from it.
+     *
+     * @var array<string, SocialContribution|null>
+     */
+    private array $resolvedContributions = [];
+
+    /**
      * Returns a clone of this rules object scoped to a given company, so that
      * company-specific TaxSlab overrides (configured via TaxSlabController) are
      * taken into account by taxSlabs()/calculateIncomeTax().
@@ -26,6 +48,24 @@ abstract class AbstractCountryRules implements CountryRulesInterface
     {
         $clone = clone $this;
         $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone of this rules object scoped to a specific point in
+     * time, so taxSlabs()/calculateIncomeTax()/calculateSocialCharges()
+     * resolve the TaxSlab/SocialContribution rows that were effective on
+     * that date instead of today's (PA2-ARCH-004). Typically called with a
+     * payroll run's period date so recalculating an old run for audit stays
+     * consistent with the rates that applied back then. Pass null to reset
+     * to "use now()".
+     */
+    public function asOf(\DateTimeInterface|string|null $date): static
+    {
+        $clone = clone $this;
+        $clone->asOfDate = $date === null ? null : Carbon::parse($date);
+        $clone->resolvedContributions = [];
 
         return $clone;
     }
@@ -59,7 +99,7 @@ abstract class AbstractCountryRules implements CountryRulesInterface
                 return null;
             }
 
-            $base = TaxSlab::query()->forCountry($this->countryCode())->effective();
+            $base = TaxSlab::query()->forCountry($this->countryCode())->effective($this->asOfDate);
 
             if ($this->companyId !== null) {
                 $companySlabs = (clone $base)->where('company_id', $this->companyId)->orderBy('min_amount')->get();
@@ -103,6 +143,75 @@ abstract class AbstractCountryRules implements CountryRulesInterface
      * @return array<int, array{min: float|int, max: float|int|null, rate: float|int, fixed_deduction: float|int}>
      */
     abstract protected function defaultTaxSlabs(): array;
+
+    /**
+     * Resolves the effective rate (percentage points, e.g. 9.0 for 9%) for a
+     * given SocialContribution code as of asOfDate() (or now() when unset),
+     * scoped to companyId() with a fallback to the global (company_id IS
+     * NULL) row. Falls back to $defaultRate when the `social_contributions`
+     * table doesn't exist yet, no matching row is effective, or the app/DB
+     * isn't booted (pure unit tests) — so existing hardcoded percentages
+     * keep working unchanged until a country is actually seeded.
+     *
+     * This is what makes socialContributions()/the `social_contributions`
+     * table (and its effective_from/effective_to columns) actually drive
+     * calculateSocialCharges(), instead of being a disconnected admin CRUD
+     * screen — the same disconnect PA2-ARCH-001 fixed for tax_slabs. It's
+     * also what makes retroactive recalculation possible for audit purposes
+     * (PA2-ARCH-004): recalculating an old payroll run with asOf() set to its
+     * own period resolves the rate that was effective back then, not today's.
+     */
+    protected function resolveContributionRate(string $code, float $defaultRate): float
+    {
+        $contribution = $this->resolveContribution($code);
+
+        return $contribution === null ? $defaultRate : $contribution->rate;
+    }
+
+    /**
+     * Resolves the effective cap (same scoping rules as
+     * resolveContributionRate() above) for a given SocialContribution code.
+     * Returns $defaultCap when no matching DB row is found/effective.
+     */
+    protected function resolveContributionCap(string $code, ?float $defaultCap): ?float
+    {
+        $contribution = $this->resolveContribution($code);
+
+        return $contribution === null ? $defaultCap : $contribution->cap;
+    }
+
+    private function resolveContribution(string $code): ?SocialContribution
+    {
+        if (array_key_exists($code, $this->resolvedContributions)) {
+            return $this->resolvedContributions[$code];
+        }
+
+        try {
+            if (! Schema::hasTable('social_contributions')) {
+                return $this->resolvedContributions[$code] = null;
+            }
+
+            $base = SocialContribution::query()
+                ->forCountry($this->countryCode())
+                ->where('code', $code)
+                ->effective($this->asOfDate);
+
+            if ($this->companyId !== null) {
+                $companyRow = (clone $base)->where('company_id', $this->companyId)->first();
+                if ($companyRow !== null) {
+                    return $this->resolvedContributions[$code] = $companyRow;
+                }
+            }
+
+            $globalRow = (clone $base)->whereNull('company_id')->first();
+
+            return $this->resolvedContributions[$code] = $globalRow;
+        } catch (\Throwable) {
+            // No booted app/DB (e.g. pure unit tests) or transient DB error:
+            // fall back to the hardcoded default rate/cap rather than fatal.
+            return $this->resolvedContributions[$code] = null;
+        }
+    }
 
     /**
      * PA2-COUNTRY-006: default compliance disclaimer shared by every

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AlgeriaPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AlgeriaPayrollRules.php
@@ -54,9 +54,12 @@ class AlgeriaPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('CNAS_EMP', 9.0);
+        $employerRate = $this->resolveContributionRate('CNAS_PAT', 26.0);
+
         return [
-            'employee' => round($grossSalary * 0.09, 2),
-            'employer' => round($grossSalary * 0.26, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CanadaPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CanadaPayrollRules.php
@@ -116,9 +116,14 @@ class CanadaPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('CPP_CA_EMP', 5.95)
+            + $this->resolveContributionRate('EI_CA_EMP', 1.66);
+        $employerRate = $this->resolveContributionRate('CPP_CA_PAT', 5.95)
+            + $this->resolveContributionRate('EI_CA_PAT', 2.32);
+
         return [
-            'employee' => round($grossSalary * 0.0761, 2),
-            'employer' => round($grossSalary * 0.0827, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CedeaoPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CedeaoPayrollRules.php
@@ -119,9 +119,12 @@ class CedeaoPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('CNSS_CEDEAO_EMP', 3.6);
+        $employerRate = $this->resolveContributionRate('CNSS_CEDEAO_PAT', 16.4);
+
         return [
-            'employee' => round($grossSalary * 0.036, 2),
-            'employer' => round($grossSalary * 0.164, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CemacPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CemacPayrollRules.php
@@ -108,9 +108,12 @@ class CemacPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('CNPS_CEMAC_EMP', 4.2);
+        $employerRate = $this->resolveContributionRate('CNPS_CEMAC_PAT', 16.2);
+
         return [
-            'employee' => round($grossSalary * 0.042, 2),
-            'employer' => round($grossSalary * 0.162, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/FrancePayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/FrancePayrollRules.php
@@ -52,11 +52,19 @@ class FrancePayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        // 98.25% CSG/CRDS abatement base is a statutory constant, not a
+        // per-code rate/cap tracked in social_contributions, so it stays
+        // hardcoded here.
         $csgBase = $grossSalary * 0.9825;
 
+        $ssEmployeeRate = $this->resolveContributionRate('SS_FR_EMP', 7.5);
+        $ssEmployerRate = $this->resolveContributionRate('SS_FR_PAT', 30.0);
+        $csgRate = $this->resolveContributionRate('CSG_FR', 9.2);
+        $crdsRate = $this->resolveContributionRate('CRDS_FR', 0.5);
+
         return [
-            'employee' => round($grossSalary * 0.075 + $csgBase * 0.092 + $csgBase * 0.005, 2),
-            'employer' => round($grossSalary * 0.30, 2),
+            'employee' => round($grossSalary * $ssEmployeeRate / 100 + $csgBase * $csgRate / 100 + $csgBase * $crdsRate / 100, 2),
+            'employer' => round($grossSalary * $ssEmployerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/MoroccoPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/MoroccoPayrollRules.php
@@ -63,11 +63,17 @@ class MoroccoPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
-        $cnssBase = min($grossSalary, 6000);
+        $cnssCap = $this->resolveContributionCap('CNSS_EMP', 6000);
+        $cnssBase = $cnssCap === null ? $grossSalary : min($grossSalary, $cnssCap);
+
+        $cnssEmployeeRate = $this->resolveContributionRate('CNSS_EMP', 4.48);
+        $cnssEmployerRate = $this->resolveContributionRate('CNSS_PAT', 8.98);
+        $amoEmployeeRate = $this->resolveContributionRate('AMO_EMP', 2.26);
+        $amoEmployerRate = $this->resolveContributionRate('AMO_PAT', 4.11);
 
         return [
-            'employee' => round($cnssBase * 0.0448 + $grossSalary * 0.0226, 2),
-            'employer' => round($cnssBase * 0.0898 + $grossSalary * 0.0411, 2),
+            'employee' => round($cnssBase * $cnssEmployeeRate / 100 + $grossSalary * $amoEmployeeRate / 100, 2),
+            'employer' => round($cnssBase * $cnssEmployerRate / 100 + $grossSalary * $amoEmployerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/SenegalPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/SenegalPayrollRules.php
@@ -52,9 +52,13 @@ class SenegalPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('IPRES_SN_EMP', 5.6);
+        $employerRate = $this->resolveContributionRate('IPRES_SN_PAT', 8.4)
+            + $this->resolveContributionRate('CSS_SN_PAT', 3.0);
+
         return [
-            'employee' => round($grossSalary * 0.056, 2),
-            'employer' => round($grossSalary * 0.114, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/TunisiaPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/TunisiaPayrollRules.php
@@ -50,9 +50,12 @@ class TunisiaPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('CNSS_TN_EMP', 9.18);
+        $employerRate = $this->resolveContributionRate('CNSS_TN_PAT', 16.57);
+
         return [
-            'employee' => round($grossSalary * 0.0918, 2),
-            'employer' => round($grossSalary * 0.1657, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/TurkeyPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/TurkeyPayrollRules.php
@@ -52,9 +52,14 @@ class TurkeyPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        $employeeRate = $this->resolveContributionRate('SGK_TR_EMP', 14.0)
+            + $this->resolveContributionRate('UNEMP_TR_EMP', 1.0);
+        $employerRate = $this->resolveContributionRate('SGK_TR_PAT', 20.5)
+            + $this->resolveContributionRate('UNEMP_TR_PAT', 2.0);
+
         return [
-            'employee' => round($grossSalary * 0.15, 2),
-            'employer' => round($grossSalary * 0.225, 2),
+            'employee' => round($grossSalary * $employeeRate / 100, 2),
+            'employer' => round($grossSalary * $employerRate / 100, 2),
         ];
     }
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php
@@ -10,6 +10,7 @@ use App\Modules\Payroll\Domain\Models\PaySlip;
 use App\Modules\Payroll\Domain\Models\PaySlipLine;
 use App\Modules\Payroll\Domain\Models\SalaryComponent;
 use App\Modules\Payroll\Domain\Models\SalaryStructure;
+use App\Modules\Payroll\Infrastructure\Services\CountryRules\AbstractCountryRules;
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\AlgeriaPayrollRules;
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\CanadaPayrollRules;
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\CedeaoPayrollRules;
@@ -19,6 +20,7 @@ use App\Modules\Payroll\Infrastructure\Services\CountryRules\MoroccoPayrollRules
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\SenegalPayrollRules;
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\TunisiaPayrollRules;
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\TurkeyPayrollRules;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
 class PayrollCalculator
@@ -85,27 +87,36 @@ class PayrollCalculator
     {
         $companyId = $run->company_id;
         $rules = $this->getRules($run->country_code);
-        // Scope the rules to this company so any company-specific TaxSlab
-        // overrides configured via TaxSlabController are actually applied
-        // (see AbstractCountryRules::forCompany()). Falls back to global
+        // Scope the rules to this company so any company-specific TaxSlab/
+        // SocialContribution overrides configured via TaxSlabController/
+        // SocialContributionController are actually applied (see
+        // AbstractCountryRules::forCompany()). Falls back to global
         // (company_id IS NULL) rows, then to the hardcoded defaults.
-        if ($rules instanceof \App\Modules\Payroll\Infrastructure\Services\CountryRules\AbstractCountryRules) {
-            $rules = $rules->forCompany($companyId);
+        //
+        // Also scope to the run's own period_start (PA2-ARCH-004): country
+        // tax slabs/social contributions are associated with an effective
+        // date, so recalculating a past run (e.g. for an audit) resolves
+        // the rates that were effective *during that run's own period*,
+        // not today's rates. This makes calculateRun() safe to call again
+        // on an old run without silently drifting its figures forward to
+        // whatever rates happen to be current today.
+        if ($rules instanceof AbstractCountryRules) {
+            $rules = $rules->forCompany($companyId)->asOf($run->period_start);
         }
 
-        /** @var \Illuminate\Database\Eloquent\Collection<int, Employee> $employees */
+        /** @var Collection<int, Employee> $employees */
         $employees = Employee::where('company_id', $companyId)
             ->where('status', 'active')
             ->get();
 
-        /** @var \Illuminate\Database\Eloquent\Collection<int, SalaryStructure> $structuresCollection */
+        /** @var Collection<int, SalaryStructure> $structuresCollection */
         $structuresCollection = SalaryStructure::where('company_id', $companyId)
             ->where('country_code', $run->country_code)
             ->where('active', true)
             ->with('components')
             ->get();
 
-        /** @var \Illuminate\Database\Eloquent\Collection<int|string, SalaryStructure> $structures */
+        /** @var Collection<int|string, SalaryStructure> $structures */
         $structures = $structuresCollection->keyBy('id');
 
         /** @var SalaryStructure|null $defaultStructure */
@@ -169,7 +180,7 @@ class PayrollCalculator
             'order' => $order++,
         ];
 
-        /** @var \Illuminate\Database\Eloquent\Collection<int, SalaryComponent> $components */
+        /** @var Collection<int, SalaryComponent> $components */
         $components = $structure->components->where('active', true)->sortBy('order');
         foreach ($components as $component) {
             /** @var SalaryComponent $component */
@@ -284,6 +295,3 @@ class PayrollCalculator
         };
     }
 }
-
-
-

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/SocialContributionController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/SocialContributionController.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\SocialContributionResource;
-use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Payroll\Domain\Models\SocialContribution;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class SocialContributionController extends Controller
 {
@@ -42,10 +43,24 @@ class SocialContributionController extends Controller
             abort(403);
         }
 
+        // PA2-ARCH-004: uniqueness is scoped to (company_id, code,
+        // effective_from) rather than a bare global code, so a new dated
+        // rate for an existing contribution code can be added without
+        // deleting the historical row a past payroll run needs to be
+        // recalculated against for an audit. See the
+        // make_social_contributions_code_unique_per_effective_period
+        // migration.
         $validated = $request->validate([
             'country_code' => 'required|string|size:2|in:DZ,MA,TN,FR,TR,SN,CM,CF,TD,CG,GA,GQ,CI,ML,BF,BJ,TG,NE,CA',
             'name' => 'required|string|max:150',
-            'code' => 'required|string|max:50|unique:social_contributions,code',
+            'code' => [
+                'required',
+                'string',
+                'max:50',
+                Rule::unique('social_contributions', 'code')
+                    ->where('company_id', $actor->company_id)
+                    ->where('effective_from', $request->string('effective_from')->value()),
+            ],
             'type' => 'required|in:employee,employer',
             'rate' => 'required|numeric|min:0|max:100',
             'cap' => 'nullable|numeric|min:0',
@@ -105,4 +120,3 @@ class SocialContributionController extends Controller
         return response()->json(['message' => 'Social contribution deleted successfully.']);
     }
 }
-

--- a/api/database/migrations/tenant/2026_07_23_000003_make_social_contributions_code_unique_per_effective_period.php
+++ b/api/database/migrations/tenant/2026_07_23_000003_make_social_contributions_code_unique_per_effective_period.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-ARCH-004 — Temporal versioning of country payroll rules.
+ *
+ * `social_contributions.code` was created with a *global* unique
+ * constraint (see 2026_05_10_100001_create_payroll_engine_tables.php),
+ * which structurally prevented the effective_from/effective_to columns
+ * from ever being used for real temporal versioning: a new rate for the
+ * same contribution code (e.g. "CNAS_EMP" going from 9% to 9.5% next
+ * year) could never be inserted as a new dated row without deleting the
+ * old one first, destroying the historical rate an old payroll run would
+ * need to be recalculated against for an audit.
+ *
+ * This drops the global unique index and replaces it with a composite
+ * unique index on (company_id, code, effective_from), which still
+ * prevents two rows from the same scope claiming the exact same
+ * contribution code effective on the exact same start date, while
+ * allowing the same code to be re-declared with a new effective_from date
+ * (and a company-specific override to reuse a code already used
+ * globally). PayrollCountryConfigSeeder's updateOrCreate() keys on
+ * (company_id, code) already, so this migration also normalizes existing
+ * rows to keep that seeder idempotent per company scope rather than
+ * globally.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('social_contributions')) {
+            return;
+        }
+
+        Schema::table('social_contributions', function (Blueprint $table): void {
+            $table->dropUnique('social_contributions_code_unique');
+            $table->unique(['company_id', 'code', 'effective_from'], 'social_contributions_company_code_effective_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('social_contributions')) {
+            return;
+        }
+
+        Schema::table('social_contributions', function (Blueprint $table): void {
+            $table->dropUnique('social_contributions_company_code_effective_unique');
+            $table->unique('code', 'social_contributions_code_unique');
+        });
+    }
+};

--- a/api/tests/Feature/PayrollCountryRulesTemporalVersioningTest.php
+++ b/api/tests/Feature/PayrollCountryRulesTemporalVersioningTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Modules\Payroll\Domain\Models\SocialContribution;
+use App\Modules\Payroll\Domain\Models\TaxSlab;
+use App\Modules\Payroll\Infrastructure\Services\CountryRules\AlgeriaPayrollRules;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * PA2-ARCH-004 — Versionnement temporel des regles pays paie.
+ *
+ * TaxSlab/SocialContribution rows are associated with an effective date
+ * (effective_from/effective_to), and AbstractCountryRules::asOf() lets
+ * payroll rules resolve which dated row applies as of a given point in
+ * time instead of always using now(). This is what makes retroactive
+ * recalculation possible for audit purposes: a payroll run for a past
+ * period can be recalculated using the rates that were effective *during
+ * that period*, even after newer rates have since been configured.
+ *
+ * `tax_slabs`/`social_contributions` are not part of the shared MVP test
+ * fixture (Tests\Support\CreatesMvpSchema), so this test creates/drops
+ * them directly, scoped to this test only.
+ */
+class PayrollCountryRulesTemporalVersioningTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('tax_slabs');
+        Schema::dropIfExists('social_contributions');
+
+        Schema::create('tax_slabs', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->uuid('company_id')->nullable()->index();
+            $table->string('country_code', 2);
+            $table->string('name', 150);
+            $table->decimal('min_amount', 14, 2);
+            $table->decimal('max_amount', 14, 2)->nullable();
+            $table->decimal('rate', 8, 4);
+            $table->decimal('fixed_deduction', 14, 2)->default(0);
+            $table->date('effective_from');
+            $table->date('effective_to')->nullable();
+            $table->timestampsTz();
+
+            $table->index(['country_code', 'effective_from']);
+        });
+
+        Schema::create('social_contributions', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->uuid('company_id')->nullable()->index();
+            $table->string('country_code', 2);
+            $table->string('name', 150);
+            $table->string('code', 50);
+            $table->enum('type', ['employee', 'employer']);
+            $table->decimal('rate', 8, 4);
+            $table->decimal('cap', 14, 2)->nullable();
+            $table->date('effective_from');
+            $table->date('effective_to')->nullable();
+            $table->timestampsTz();
+
+            $table->unique(['company_id', 'code', 'effective_from'], 'social_contributions_company_code_effective_unique');
+            $table->index(['country_code', 'type', 'effective_from']);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('social_contributions');
+        Schema::dropIfExists('tax_slabs');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Two non-overlapping dated SocialContribution rows for the same code
+     * (a 9% CNAS employee rate through end of 2025, then 9.5% from 2026
+     * onward): asOf() must resolve the rate that was effective on the
+     * given date, not just "whatever is effective now".
+     */
+    public function test_calculate_social_charges_resolves_the_rate_effective_on_the_given_date(): void
+    {
+        SocialContribution::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'CNAS Salariale (2025)',
+            'code' => 'CNAS_EMP',
+            'type' => 'employee',
+            'rate' => 9.0,
+            'cap' => null,
+            'effective_from' => '2025-01-01',
+            'effective_to' => '2025-12-31',
+        ]);
+
+        SocialContribution::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'CNAS Salariale (2026)',
+            'code' => 'CNAS_EMP',
+            'type' => 'employee',
+            'rate' => 9.5,
+            'cap' => null,
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+
+        $rules = new AlgeriaPayrollRules;
+
+        $pastCharges = $rules->asOf('2025-06-15')->calculateSocialCharges(10000);
+        self::assertSame(900.0, $pastCharges['employee'], 'the 2025 rate (9%) must apply for a 2025 date');
+
+        $currentCharges = $rules->asOf('2026-06-15')->calculateSocialCharges(10000);
+        self::assertSame(950.0, $currentCharges['employee'], 'the 2026 rate (9.5%) must apply for a 2026 date');
+    }
+
+    /**
+     * Same principle for TaxSlab: a payroll run recalculated for an old
+     * period must use the tax slabs that were effective back then, not
+     * slabs configured afterward.
+     */
+    public function test_tax_slabs_resolve_the_slabs_effective_on_the_given_date(): void
+    {
+        TaxSlab::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'DZ payroll tax 2025',
+            'min_amount' => 0,
+            'max_amount' => null,
+            'rate' => 10,
+            'fixed_deduction' => 0,
+            'effective_from' => '2025-01-01',
+            'effective_to' => '2025-12-31',
+        ]);
+
+        TaxSlab::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'DZ payroll tax 2026',
+            'min_amount' => 0,
+            'max_amount' => null,
+            'rate' => 20,
+            'fixed_deduction' => 0,
+            'effective_from' => '2026-01-01',
+            'effective_to' => null,
+        ]);
+
+        $rules = new AlgeriaPayrollRules;
+
+        $pastSlabs = $rules->asOf('2025-06-15')->taxSlabs();
+        self::assertCount(1, $pastSlabs);
+        self::assertSame(10.0, $pastSlabs[0]['rate']);
+
+        $currentSlabs = $rules->asOf('2026-06-15')->taxSlabs();
+        self::assertCount(1, $currentSlabs);
+        self::assertSame(20.0, $currentSlabs[0]['rate']);
+    }
+
+    /**
+     * Without asOf(), behaviour must stay exactly as before this ticket:
+     * resolve whatever is effective right now.
+     */
+    public function test_asof_defaults_to_now_when_not_scoped(): void
+    {
+        SocialContribution::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'CNAS Salariale (current)',
+            'code' => 'CNAS_EMP',
+            'type' => 'employee',
+            'rate' => 9.0,
+            'cap' => null,
+            'effective_from' => now()->subYear()->toDateString(),
+            'effective_to' => null,
+        ]);
+
+        $rules = new AlgeriaPayrollRules;
+
+        $charges = $rules->calculateSocialCharges(10000);
+        self::assertSame(900.0, $charges['employee']);
+    }
+
+    /**
+     * asOf(null) resets a scoped clone back to the "use now()" default,
+     * mirroring forCompany(null)/forProvince(null) elsewhere in this
+     * module.
+     */
+    public function test_asof_null_resets_to_now(): void
+    {
+        SocialContribution::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'CNAS Salariale (current)',
+            'code' => 'CNAS_EMP',
+            'type' => 'employee',
+            'rate' => 9.0,
+            'cap' => null,
+            'effective_from' => now()->subYear()->toDateString(),
+            'effective_to' => null,
+        ]);
+
+        $rules = (new AlgeriaPayrollRules)->asOf('2099-01-01')->asOf(null);
+
+        $charges = $rules->calculateSocialCharges(10000);
+        self::assertSame(900.0, $charges['employee']);
+    }
+
+    /**
+     * A company-specific override for one period, with the global row
+     * covering a different period, must each resolve independently
+     * through the same forCompany()+asOf() combination PayrollCalculator
+     * uses (forCompany($companyId)->asOf($run->period_start)).
+     */
+    public function test_company_override_and_asof_compose_together(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+
+        SocialContribution::create([
+            'company_id' => null,
+            'country_code' => 'DZ',
+            'name' => 'CNAS Salariale (global, 2025)',
+            'code' => 'CNAS_EMP',
+            'type' => 'employee',
+            'rate' => 9.0,
+            'cap' => null,
+            'effective_from' => '2025-01-01',
+            'effective_to' => null,
+        ]);
+
+        SocialContribution::create([
+            'company_id' => $companyId,
+            'country_code' => 'DZ',
+            'name' => 'CNAS Salariale (company override, 2025)',
+            'code' => 'CNAS_EMP',
+            'type' => 'employee',
+            'rate' => 7.0,
+            'cap' => null,
+            'effective_from' => '2025-01-01',
+            'effective_to' => null,
+        ]);
+
+        $rules = (new AlgeriaPayrollRules)->forCompany($companyId)->asOf('2025-06-15');
+
+        $charges = $rules->calculateSocialCharges(10000);
+        self::assertSame(700.0, $charges['employee'], 'the company-specific override must take priority over the global rate');
+    }
+}


### PR DESCRIPTION
Closes #1091

## Summary
- Country tax slabs/social contributions are now resolved as-of a given date instead of always now(), enabling retroactive recalculation of a payroll run for audit purposes using the rates that were effective during its own period.
- AbstractCountryRules::asOf($date) scopes taxSlabs()/calculateSocialCharges() to a specific point in time (mirrors the existing forCompany() pattern).
- PayrollCalculator::calculateRun() now scopes rules with ->asOf($run->period_start) in addition to the existing ->forCompany() scoping, so recalculating an old run stays consistent with its own period's rates instead of silently drifting to today's rates.
- Every CountryRulesInterface::calculateSocialCharges() implementation (DZ, MA, TN, FR, TR, SN, CEMAC zone, CEDEAO zone, CA) is now wired through the DB-backed social_contributions table via new resolveContributionRate()/resolveContributionCap() helpers, mirroring what PA2-ARCH-001 already did for tax_slabs. Previously social_contributions was only used by the admin CRUD API and never actually affected payroll math.
- Fixed social_contributions.code from a global unique constraint to a composite (company_id, code, effective_from) unique index -- the global constraint structurally blocked ever adding a new dated rate for an existing contribution code without deleting the historical row, which defeated the whole point of effective_from/effective_to.

## Tests
- New tests/Feature/PayrollCountryRulesTemporalVersioningTest.php: dated-rate resolution for both TaxSlab and SocialContribution, the now()-default fallback when asOf() isn't used, asOf(null) reset, and company-override + asOf() composition (mirrors forCompany($companyId)->asOf($run->period_start) used by PayrollCalculator).
- Ran full existing payroll test suite (PayrollCountryRulesTest, PayrollCalculatorCountryRulesTest, PayrollRunControllerTest, PayrollCycleIntegrationTest) -- all pass except one pre-existing unrelated failure (morocco_and_tunisia_expose_country_metadata_for_provisioning, a case-sensitivity string assertion bug that exists on main too, confirmed via git stash).
- vendor/bin/pint applied to touched files; phpstan shows the same pre-existing error count on touched files before/after this change (no new errors introduced).

## Notes
- Falls back to hardcoded default rates/caps when no DB/app is booted (pure unit tests) or no matching row exists, exactly like the existing taxSlabs() fallback -- no behavior change for callers that don't seed social_contributions.
