### PR TITLE
PA2-API-005: rate limit web login, platform login, and kiosk punch endpoints

### DIFF
--- a/api/app/Http/Controllers/Web/PlatformAuthController.php
+++ b/api/app/Http/Controllers/Web/PlatformAuthController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 
 class PlatformAuthController extends Controller
 {
@@ -30,6 +31,15 @@ class PlatformAuthController extends Controller
         $superAdmin = SuperAdmin::query()->where('email', $validated['email'])->first();
 
         if (! $superAdmin || ! Hash::check($validated['password'], $superAdmin->password_hash)) {
+            // PA2-API-005: security-relevant event, logged to the dedicated
+            // 'audit' channel so brute-force attempts against the super-admin
+            // login are visible independently of the per-minute throttle.
+            Log::channel('audit')->warning('platform_login.failed', [
+                'email' => $validated['email'],
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ]);
+
             return back()->withInput(['email' => $validated['email']])->withErrors([
                 'email' => 'Identifiants invalides.',
             ]);

--- a/api/app/Http/Controllers/Web/WebAuthController.php
+++ b/api/app/Http/Controllers/Web/WebAuthController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 
 class WebAuthController extends Controller
 {
@@ -32,6 +33,15 @@ class WebAuthController extends Controller
             ->first();
 
         if (! $employee || ! Hash::check($validated['password'], $employee->password_hash)) {
+            // PA2-API-005: security-relevant event, logged to the dedicated
+            // 'audit' channel so brute-force attempts against the employee web
+            // login are visible independently of the per-minute throttle.
+            Log::channel('audit')->warning('web_login.failed', [
+                'email' => $validated['email'],
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ]);
+
             return back()
                 ->withInput(['email' => $validated['email']])
                 ->withErrors(['email' => 'Identifiants invalides.']);

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/KioskController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/KioskController.php
@@ -358,7 +358,18 @@ class KioskController extends Controller
         }
 
         $token = (string) $request->header('X-Kiosk-Token', '');
-        abort_if($token === '' || ! Hash::check($token, (string) $kiosk->sync_token_hash), 401, 'INVALID_KIOSK_TOKEN');
+        if ($token === '' || ! Hash::check($token, (string) $kiosk->sync_token_hash)) {
+            // PA2-API-005: security-relevant event, logged to the dedicated
+            // 'audit' channel so brute-force attempts against a kiosk device
+            // token are visible independently of the per-minute throttle.
+            Log::channel('audit')->warning('kiosk_auth.failed', [
+                'device_code' => $kiosk->device_code,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ]);
+
+            abort(401, 'INVALID_KIOSK_TOKEN');
+        }
 
         return $kiosk;
     }

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -165,6 +165,29 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute((int) config('security.rate_limits.webhooks_inbound_per_minute', 60))
                 ->by('webhooks-inbound:'.$request->ip());
         });
+
+        // PA2-API-005 — Session-based web login forms (employee login, super-admin
+        // platform login) are not covered by the API 'auth-sensitive' limiter
+        // above, which only guards the Sanctum token endpoints. Keyed by e-mail +
+        // IP, mirroring 'auth-sensitive', to slow down brute-force credential
+        // stuffing without needing a Sanctum token.
+        RateLimiter::for('web-login', function (Request $request) {
+            $email = strtolower((string) $request->input('email', 'anonymous'));
+
+            return Limit::perMinute((int) config('security.rate_limits.web_login_per_minute', 10))
+                ->by('web-login:'.$email.'|'.$request->ip());
+        });
+
+        // PA2-API-005 — The kiosk web punch endpoint (public, device-code based,
+        // no Sanctum auth) needs its own throttle bucket keyed by device code so a
+        // single compromised/misbehaving kiosk cannot exhaust another kiosk's
+        // quota, while still bounding brute-force attempts against a device code.
+        RateLimiter::for('kiosk-punch', function (Request $request) {
+            $deviceCode = strtoupper((string) $request->route('deviceCode', 'unknown'));
+
+            return Limit::perMinute((int) config('security.rate_limits.kiosk_punch_per_minute', 30))
+                ->by('kiosk-punch:'.$deviceCode.'|'.$request->ip());
+        });
     }
 
     private function resolvePlanLimit(string $plan): int

--- a/api/config/security.php
+++ b/api/config/security.php
@@ -9,6 +9,11 @@ return [
         'ai_per_minute' => (int) env('RATE_LIMIT_AI_PER_MINUTE', 20),
         'client_analytics_per_minute' => (int) env('RATE_LIMIT_CLIENT_ANALYTICS_PER_MINUTE', 120),
         'webhooks_inbound_per_minute' => (int) env('RATE_LIMIT_WEBHOOKS_INBOUND_PER_MINUTE', 60),
+        // PA2-API-005: web (session-based) login forms and kiosk punch endpoints
+        // sit outside the API 'auth-sensitive'/'api' limiters, so they need their
+        // own dedicated buckets to stay protected against brute-force attempts.
+        'web_login_per_minute' => (int) env('RATE_LIMIT_WEB_LOGIN_PER_MINUTE', 10),
+        'kiosk_punch_per_minute' => (int) env('RATE_LIMIT_KIOSK_PUNCH_PER_MINUTE', 30),
     ],
 
     'plan_rate_limits' => [

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -48,7 +48,11 @@ Route::get('/docs/openapi.yaml', function () {
 
 Route::middleware('guest:super_admin_web')->group(function (): void {
     Route::get('/platform/login', [PlatformAuthController::class, 'showLogin'])->name('platform.login');
-    Route::post('/platform/login', [PlatformAuthController::class, 'login'])->name('platform.login.store');
+    // PA2-API-005: dedicated 'web-login' throttle since this session-based form
+    // is not covered by the API 'auth-sensitive' limiter.
+    Route::post('/platform/login', [PlatformAuthController::class, 'login'])
+        ->middleware('throttle:web-login')
+        ->name('platform.login.store');
 });
 
 Route::post('/platform/logout', [PlatformAuthController::class, 'logout'])
@@ -66,13 +70,22 @@ Route::middleware('auth:super_admin_web')->prefix('platform')->name('platform.')
 
 Route::middleware('guest:web')->group(function (): void {
     Route::get('/login', [WebAuthController::class, 'showLogin'])->name('login');
-    Route::post('/login', [WebAuthController::class, 'login'])->name('login.store');
+    // PA2-API-005: dedicated 'web-login' throttle since this session-based form
+    // is not covered by the API 'auth-sensitive' limiter.
+    Route::post('/login', [WebAuthController::class, 'login'])
+        ->middleware('throttle:web-login')
+        ->name('login.store');
 });
 
 Route::get('/activate/{token}', [InvitationController::class, 'showActivationForm'])->name('invitation.activate.show');
 Route::post('/activate/{token}', [InvitationController::class, 'activate'])->name('invitation.activate.store');
 Route::get('/kiosk/{deviceCode}', [KioskController::class, 'show'])->name('kiosk.show');
-Route::post('/kiosk/{deviceCode}/punch', [KioskController::class, 'punch'])->name('kiosk.punch');
+// PA2-API-005: public, device-code based, unauthenticated-by-Sanctum kiosk
+// punch endpoint gets its own 'kiosk-punch' throttle bucket (keyed by device
+// code + IP) to guard against brute force / abuse.
+Route::post('/kiosk/{deviceCode}/punch', [KioskController::class, 'punch'])
+    ->middleware('throttle:kiosk-punch')
+    ->name('kiosk.punch');
 
 Route::post('/logout', [WebAuthController::class, 'logout'])
     ->middleware('auth:web')

--- a/api/tests/Feature/Security/SensitiveRateLimitTest.php
+++ b/api/tests/Feature/Security/SensitiveRateLimitTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Security;
 
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceKiosk;
+use Illuminate\Support\Facades\Hash;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
@@ -71,5 +73,59 @@ class SensitiveRateLimitTest extends TestCase
         $this->postJson('/api/v1/webhooks/stripe', $payload)->assertOk();
         $this->postJson('/api/v1/webhooks/stripe', $payload)->assertStatus(429);
     }
-}
 
+    public function test_web_login_is_rate_limited_by_email_and_ip(): void
+    {
+        config(['security.rate_limits.web_login_per_minute' => 2]);
+
+        $payload = [
+            'email' => 'web-login-limited@example.test',
+            'password' => 'wrong-password',
+        ];
+
+        $this->get('/login');
+        $token = session()->token();
+
+        $this->withSession(['_token' => $token])->post('/login', ['_token' => $token, ...$payload])->assertRedirect('/login');
+        $this->withSession(['_token' => $token])->post('/login', ['_token' => $token, ...$payload])->assertRedirect('/login');
+        $this->withSession(['_token' => $token])->post('/login', ['_token' => $token, ...$payload])->assertStatus(429);
+    }
+
+    public function test_platform_login_is_rate_limited_by_email_and_ip(): void
+    {
+        config(['security.rate_limits.web_login_per_minute' => 2]);
+
+        $payload = [
+            'email' => 'platform-login-limited@example.test',
+            'password' => 'wrong-password',
+        ];
+
+        $this->get('/platform/login');
+        $token = session()->token();
+
+        $this->withSession(['_token' => $token])->post('/platform/login', ['_token' => $token, ...$payload])->assertRedirect('/platform/login');
+        $this->withSession(['_token' => $token])->post('/platform/login', ['_token' => $token, ...$payload])->assertRedirect('/platform/login');
+        $this->withSession(['_token' => $token])->post('/platform/login', ['_token' => $token, ...$payload])->assertStatus(429);
+    }
+
+    public function test_kiosk_web_punch_is_rate_limited_by_device_code(): void
+    {
+        config(['security.rate_limits.kiosk_punch_per_minute' => 2]);
+
+        $company = Company::factory()->create();
+        $kiosk = AttendanceKiosk::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Rate Limit Kiosk',
+            'device_code' => 'RATELIMIT01',
+            'biometric_mode' => 'fingerprint',
+            'sync_token_hash' => Hash::make('plain-token'),
+            'status' => 'active',
+        ]);
+
+        $payload = ['identifier' => 'unknown-employee', 'action' => 'check_in'];
+
+        $this->post('/kiosk/'.$kiosk->device_code.'/punch', $payload);
+        $this->post('/kiosk/'.$kiosk->device_code.'/punch', $payload);
+        $this->post('/kiosk/'.$kiosk->device_code.'/punch', $payload)->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## What Problem This Solves
Session-based login forms (employee `/login`, super-admin `/platform/login`) and the public, device-code based kiosk web punch endpoint (`/kiosk/{deviceCode}/punch`) were not covered by the existing API rate limiters ('api', 'auth-sensitive'), which only guard Sanctum token endpoints. This left these entry points exposed to brute-force credential stuffing and kiosk token/punch abuse, with no security-relevant audit trail for failed attempts.

## Why This Change Was Made
Closes #992 (PA2-API-005 — Rate limit et brute-force). Acceptance criteria: login, trial, kiosk, webhooks protected + security logs.

- Added a dedicated `web-login` rate limiter (keyed by email + IP, default 10/min) applied to both `/login` and `/platform/login`.
- Added a dedicated `kiosk-punch` rate limiter (keyed by device code + IP, default 30/min) applied to `/kiosk/{deviceCode}/punch`.
- Both limits are configurable via `RATE_LIMIT_WEB_LOGIN_PER_MINUTE` and `RATE_LIMIT_KIOSK_PUNCH_PER_MINUTE` env vars in `config/security.php`.
- Failed web login, platform login, and kiosk token auth attempts are now logged to the dedicated `audit` log channel (email/device_code + IP + user agent), independent of the throttle, so brute-force attempts are visible in security logs even before they trip the rate limit.
- Inbound webhook rate limiting (`webhooks-inbound`) was already implemented in a prior change; this PR completes the remaining login/kiosk gaps from the ticket's acceptance criteria.

## User Impact
- No behavior change for legitimate users under normal usage.
- Attackers attempting brute-force login or kiosk token guessing are throttled with HTTP 429 after the configured threshold, and the attempts are recorded in the audit log for security monitoring.

## Evidence
```
PASS  Tests\Feature\Security\SensitiveRateLimitTest
 ✓ public auth login is rate limited by email and ip
 ✓ privacy export is rate limited per authenticated employee
 ✓ inbound webhooks are rate limited per ip
 ✓ web login is rate limited by email and ip
 ✓ platform login is rate limited by email and ip
 ✓ kiosk web punch is rate limited by device code

Tests: 6 passed (20 assertions)
```

Fixes kitokoh/leopardo-hr#992