### PR TITLE
PA2-PAY-011: configurable company pay cycle settings

### DIFF
--- a/api/app/Modules/Payroll/Infrastructure/Services/PayrollCycleService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PayrollCycleService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Infrastructure\Services;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Tenant\Domain\Models\CompanySetting;
-use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use App\Modules\Payroll\Domain\Models\SalaryAdvance;
@@ -19,6 +19,61 @@ use Illuminate\Support\Facades\Schema;
  */
 class PayrollCycleService
 {
+    /**
+     * PA2-PAY-011 — Returns the configurable pay cycle settings for a company
+     * (daily/weekly/monthly, pay day, week start), as currently persisted in
+     * the company's `metadata.payroll` bag. Read-only counterpart of
+     * updatePayCycleSettings().
+     *
+     * @return array{pay_cycle: string, pay_day: int, week_start: int}
+     */
+    public function getPayCycleSettings(Company $company): array
+    {
+        return $this->payrollSettings($company);
+    }
+
+    /**
+     * PA2-PAY-011 — Persists company-level pay cycle configuration
+     * (daily/hebdomadaire/mensuel, pay day, week start) into the company's
+     * `metadata.payroll` bag so subsequent getCurrentCycle()/getEmployeeBalance()
+     * calls immediately reflect the new rule. Only the provided keys are
+     * updated; omitted keys keep their previous value.
+     *
+     * @param  array{pay_cycle?: string, pay_day?: int, week_start?: int}  $changes
+     * @return array{pay_cycle: string, pay_day: int, week_start: int}
+     */
+    public function updatePayCycleSettings(Company $company, array $changes): array
+    {
+        $current = $this->payrollSettings($company);
+
+        $metadata = $company->metadata ?? [];
+        $metadata = is_array($metadata) ? $metadata : [];
+        $payroll = $metadata['payroll'] ?? [];
+        $payroll = is_array($payroll) ? $payroll : [];
+
+        if (array_key_exists('pay_cycle', $changes)) {
+            $payCycle = $changes['pay_cycle'];
+            $payroll['pay_cycle'] = in_array($payCycle, ['daily', 'weekly', 'monthly'], true)
+                ? $payCycle
+                : $current['pay_cycle'];
+        }
+
+        if (array_key_exists('pay_day', $changes)) {
+            $payroll['pay_day'] = max(1, min((int) $changes['pay_day'], 31));
+        }
+
+        if (array_key_exists('week_start', $changes)) {
+            $payroll['week_start'] = max(1, min((int) $changes['week_start'], 7));
+        }
+
+        $metadata['payroll'] = $payroll;
+
+        $company->metadata = $metadata;
+        $company->save();
+
+        return $this->payrollSettings($company->fresh());
+    }
+
     /**
      * @return array{start: Carbon, end: Carbon, label: string}
      */
@@ -383,4 +438,3 @@ class PayrollCycleService
         ];
     }
 }
-

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollCycleController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollCycleController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
-use App\Http\Controllers\Controller;
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Http\Controllers\Controller;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Infrastructure\Services\PayrollCycleService;
 use Illuminate\Http\JsonResponse;
@@ -34,6 +34,63 @@ class PayrollCycleController extends Controller
             ->paginate($request->integer('per_page', 15));
 
         return response()->json($runs);
+    }
+
+    /**
+     * PA2-PAY-011 — GET /payroll/cycle-settings: expose the company's
+     * configurable pay cycle rule (daily/weekly/monthly, pay day, week start)
+     * to managers so they can review it before changing it.
+     */
+    public function cycleSettings(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        if (! $actor->isManager()) {
+            abort(403);
+        }
+
+        $company = $actor->company;
+        if (! $company instanceof Company) {
+            abort(404);
+        }
+
+        return response()->json([
+            'data' => $this->cycleService->getPayCycleSettings($company),
+        ]);
+    }
+
+    /**
+     * PA2-PAY-011 — PUT /payroll/cycle-settings: let a manager configure the
+     * company-wide pay cycle rule (journalier/hebdomadaire/mensuel), pay day,
+     * and week start. Applies immediately to getCurrentCycle()/balances.
+     */
+    public function updateCycleSettings(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        if (! $actor->isManager()) {
+            abort(403);
+        }
+
+        $company = $actor->company;
+        if (! $company instanceof Company) {
+            abort(404);
+        }
+
+        $validated = $request->validate([
+            'pay_cycle' => ['sometimes', 'string', 'in:daily,weekly,monthly'],
+            'pay_day' => ['sometimes', 'integer', 'min:1', 'max:31'],
+            'week_start' => ['sometimes', 'integer', 'min:1', 'max:7'],
+        ]);
+
+        $settings = $this->cycleService->updatePayCycleSettings($company, $validated);
+
+        return response()->json([
+            'data' => $settings,
+            'message' => 'Cycle de paie mis a jour.',
+        ]);
     }
 
     public function current(Request $request): JsonResponse
@@ -116,4 +173,3 @@ class PayrollCycleController extends Controller
         ]);
     }
 }
-

--- a/api/routes/modules/payroll_engine.php
+++ b/api/routes/modules/payroll_engine.php
@@ -102,6 +102,10 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
         Route::get('/payroll/cycles/current', [PayrollCycleController::class, 'current']);
         Route::get('/payroll/mobile-summary', [PayrollCycleController::class, 'mobileSummary']);
 
+        // PA2-PAY-011 — Configurable company pay cycle rule (daily/weekly/monthly)
+        Route::get('/payroll/cycle-settings', [PayrollCycleController::class, 'cycleSettings']);
+        Route::put('/payroll/cycle-settings', [PayrollCycleController::class, 'updateCycleSettings']);
+
         // Plan 65 — Bulk payment
         Route::get('/payment-batches', [PaymentBatchController::class, 'index']);
         Route::post('/payment-batches', [PaymentBatchController::class, 'store']);

--- a/api/tests/Feature/PayrollCycleSettingsTest.php
+++ b/api/tests/Feature/PayrollCycleSettingsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-011 — company-configurable pay cycle rule (journalier/hebdomadaire/
+ * mensuel, pay day, week start) exposed via GET/PUT /payroll/cycle-settings.
+ */
+class PayrollCycleSettingsTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_manager_can_read_default_cycle_settings(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->getJson('/api/v1/payroll/cycle-settings');
+
+        $response->assertOk()->assertJson([
+            'data' => [
+                'pay_cycle' => 'monthly',
+                'pay_day' => 1,
+                'week_start' => 1,
+            ],
+        ]);
+    }
+
+    public function test_manager_can_update_cycle_to_weekly(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->putJson('/api/v1/payroll/cycle-settings', [
+            'pay_cycle' => 'weekly',
+            'week_start' => 1,
+        ]);
+
+        $response->assertOk()->assertJson([
+            'data' => [
+                'pay_cycle' => 'weekly',
+                'week_start' => 1,
+            ],
+        ]);
+
+        $company->refresh();
+        $this->assertSame('weekly', $company->metadata['payroll']['pay_cycle'] ?? null);
+    }
+
+    public function test_updated_cycle_is_reflected_immediately_in_current_cycle(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($manager);
+
+        $this->putJson('/api/v1/payroll/cycle-settings', ['pay_cycle' => 'daily'])->assertOk();
+
+        $current = $this->getJson('/api/v1/payroll/cycles/current');
+
+        $current->assertOk();
+        $this->assertSame(
+            now($company->timezone ?: 'UTC')->toDateString(),
+            $current->json('period_start')
+        );
+        $this->assertSame(
+            now($company->timezone ?: 'UTC')->toDateString(),
+            $current->json('period_end')
+        );
+    }
+
+    public function test_partial_update_only_changes_provided_fields(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($manager);
+
+        $this->putJson('/api/v1/payroll/cycle-settings', [
+            'pay_cycle' => 'monthly',
+            'pay_day' => 15,
+        ])->assertOk();
+
+        $response = $this->putJson('/api/v1/payroll/cycle-settings', [
+            'week_start' => 3,
+        ]);
+
+        $response->assertOk()->assertJson([
+            'data' => [
+                'pay_cycle' => 'monthly',
+                'pay_day' => 15,
+                'week_start' => 3,
+            ],
+        ]);
+    }
+
+    public function test_invalid_pay_cycle_is_rejected(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->putJson('/api/v1/payroll/cycle-settings', [
+            'pay_cycle' => 'yearly',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_employee_cannot_read_or_update_cycle_settings(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/v1/payroll/cycle-settings')->assertStatus(403);
+        $this->putJson('/api/v1/payroll/cycle-settings', ['pay_cycle' => 'weekly'])->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## What Problem This Solves
The pay cycle (`daily`/`weekly`/`monthly`), pay day, and week start were only readable via `PayrollCycleService::payrollSettings()` (used internally by `getCurrentCycle()`/`getEmployeeBalance()`), sourced from the company's `metadata.payroll` bag or a legacy `company_settings` table. There was no API endpoint for a manager to actually configure these per-company rules — the ticket's acceptance criteria ("Journalier hebdomadaire mensuel configurables par regle entreprise") had no way to be satisfied from the frontend.

## Why This Change Was Made
Closes #1044 (PA2-PAY-011 — Cycles paie par entreprise). Depends on PA2-COUNTRY-001 (merged) and PA2-PAY-007 (ledger, merged/in review); this change only touches the cycle configuration itself and does not depend on ledger internals.

- `PayrollCycleService::getPayCycleSettings(Company)`: read-only accessor returning the current `pay_cycle`/`pay_day`/`week_start`.
- `PayrollCycleService::updatePayCycleSettings(Company, array)`: validates and persists partial updates into `Company.metadata.payroll`, so unspecified fields keep their previous value.
- `GET /api/v1/payroll/cycle-settings`: manager-only, returns current settings.
- `PUT /api/v1/payroll/cycle-settings`: manager-only, validates `pay_cycle` (`daily|weekly|monthly`), `pay_day` (1-31), `week_start` (1-7, ISO weekday), all `sometimes`.
- Changes are picked up immediately by `getCurrentCycle()` and employee balance/mobile-summary calculations (no cache to invalidate — same metadata bag they already read from).
- Employees (non-managers) get `403` on both endpoints, consistent with the rest of the payroll-cycle surface (`index`, `mobileSummary`).

## User Impact
- Managers/comptables can now switch a company between daily, weekly, and monthly pay cycles, and adjust the pay day / week start, directly through the API, instead of being stuck with the `monthly`/day-1 default forever.
- No change for existing companies that never call the new endpoint — defaults are unchanged.

## Evidence
```
PASS  Tests\Feature\PayrollCycleSettingsTest
 ✓ manager can read default cycle settings
 ✓ manager can update cycle to weekly
 ✓ updated cycle is reflected immediately in current cycle
 ✓ partial update only changes provided fields
 ✓ invalid pay cycle is rejected
 ✓ employee cannot read or update cycle settings

Tests: 6 passed (15 assertions)
```

No regression:
```
PASS  Tests\Feature\PayrollCycleIntegrationTest  (6 passed, 21 assertions)
PASS  Tests\Feature\FrontendApiContractTest      (114 passed, 114 assertions)
```

`vendor/bin/pint --test` and `vendor/bin/phpstan analyse --configuration=phpstan-modules.neon` clean on all touched files.

(Unrelated pre-existing failure confirmed on `main` before this change: `Tests\Feature\Attendance\AttendanceAnomaliesTest` — not touched by this PR.)

Fixes kitokoh/leopardo-hr#1044