### PR TITLE
PA2-PAY-017: add currency, country, and period to accounting CSV export

### DIFF
--- a/api/app/Modules/Payroll/Infrastructure/Exports/PayrollAccountingExportService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Exports/PayrollAccountingExportService.php
@@ -4,9 +4,17 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Infrastructure\Exports;
 
+use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use Closure;
 
+/**
+ * PA2-PAY-017 — Accounting-oriented CSV export of a payroll run's pay slips,
+ * for a company's accountant/bookkeeper to import into external tools. Each
+ * row carries the currency, country, and pay period alongside the amounts so
+ * the file remains self-describing once downloaded (no implicit context
+ * lost outside of the app).
+ */
 class PayrollAccountingExportService
 {
     /**
@@ -16,22 +24,30 @@ class PayrollAccountingExportService
     public function generateCsvClosure(PayrollRun $run): Closure
     {
         $slips = $run->paySlips()->with('employee')->get();
+        $currency = $this->resolveCurrency($run);
+        $periodStart = $run->period_start->toDateString();
+        $periodEnd = $run->period_end->toDateString();
+        $countryCode = (string) $run->country_code;
 
-        return function () use ($slips) {
+        return function () use ($slips, $currency, $periodStart, $periodEnd, $countryCode) {
             $file = fopen('php://output', 'w');
-            
+
             // Add BOM for Excel UTF-8 compatibility
             fwrite($file, "\xEF\xBB\xBF");
-            
+
             fputcsv($file, [
                 'Matricule',
                 'Nom',
                 'Prénom',
                 'Type Salaire',
+                'Pays',
+                'Devise',
+                'Période Début',
+                'Période Fin',
                 'Salaire Brut',
                 'Déductions',
                 'Salaire Net',
-                'Coût Employeur'
+                'Coût Employeur',
             ], ';');
 
             foreach ($slips as $slip) {
@@ -40,14 +56,33 @@ class PayrollAccountingExportService
                     $slip->employee->last_name ?? '',
                     $slip->employee->first_name ?? '',
                     $slip->employee->salary_type ?? '',
+                    $countryCode,
+                    $currency,
+                    $periodStart,
+                    $periodEnd,
                     number_format((float) $slip->gross_salary, 2, '.', ''),
                     number_format((float) $slip->total_deductions, 2, '.', ''),
                     number_format((float) $slip->net_salary, 2, '.', ''),
-                    number_format((float) $slip->total_cost, 2, '.', '')
+                    number_format((float) $slip->total_cost, 2, '.', ''),
                 ], ';');
             }
 
             fclose($file);
         };
+    }
+
+    /**
+     * The payroll run itself does not persist a currency column (amounts are
+     * computed in the company's currency by CountryRules), so this falls
+     * back to the owning company's configured currency.
+     */
+    private function resolveCurrency(PayrollRun $run): string
+    {
+        /** @var Company|null $company */
+        $company = $run->relationLoaded('company')
+            ? $run->getRelation('company')
+            : Company::query()->where('id', $run->company_id)->first();
+
+        return strtoupper((string) ($company?->currency ?? 'DZD'));
     }
 }

--- a/api/tests/Feature/PayrollAccountingExportTest.php
+++ b/api/tests/Feature/PayrollAccountingExportTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-017 — accounting CSV export must carry currency, country, and pay
+ * period alongside amounts, so the downloaded file is self-describing for an
+ * accountant working across several tenants/countries.
+ */
+class PayrollAccountingExportTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_export_csv_includes_currency_country_and_period(): void
+    {
+        $company = Company::factory()->create(['country' => 'MA', 'currency' => 'MAD']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Amina',
+            'last_name' => 'Benali',
+            'matricule' => 'EMP-042',
+        ]);
+
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'country_code' => 'MA',
+            'status' => 'validated',
+            'total_gross' => 5000,
+            'total_deductions' => 500,
+            'total_net' => 4500,
+            'total_employer_cost' => 5800,
+            'employee_count' => 1,
+        ]);
+
+        PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'gross_salary' => 5000,
+            'total_deductions' => 500,
+            'net_salary' => 4500,
+            'employer_contributions' => 800,
+            'total_cost' => 5800,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'validated',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->get("/api/v1/payroll-runs/{$run->id}/export");
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+
+        $csv = $response->streamedContent();
+
+        // UTF-8 BOM kept for Excel compatibility.
+        $this->assertStringStartsWith("\xEF\xBB\xBF", $csv);
+
+        $body = substr($csv, 3);
+        $lines = array_values(array_filter(explode("\n", $body)));
+
+        $this->assertStringContainsString('Pays', $lines[0]);
+        $this->assertStringContainsString('Devise', $lines[0]);
+        $this->assertStringContainsString('Période Début', $lines[0]);
+        $this->assertStringContainsString('Période Fin', $lines[0]);
+
+        $this->assertStringContainsString('EMP-042', $lines[1]);
+        $this->assertStringContainsString('MA', $lines[1]);
+        $this->assertStringContainsString('MAD', $lines[1]);
+        $this->assertStringContainsString('2026-05-01', $lines[1]);
+        $this->assertStringContainsString('2026-05-31', $lines[1]);
+        $this->assertStringContainsString('5000.00', $lines[1]);
+        $this->assertStringContainsString('4500.00', $lines[1]);
+    }
+
+    public function test_export_requires_manager_role(): void
+    {
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'country_code' => 'DZ',
+            'status' => 'validated',
+            'total_gross' => 0,
+            'total_deductions' => 0,
+            'total_net' => 0,
+            'total_employer_cost' => 0,
+            'employee_count' => 0,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->get("/api/v1/payroll-runs/{$run->id}/export")->assertStatus(403);
+    }
+
+    public function test_export_is_scoped_to_tenant(): void
+    {
+        $companyA = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $companyB = Company::factory()->create(['country' => 'FR', 'currency' => 'EUR']);
+
+        $managerB = Employee::factory()->manager()->create(['company_id' => $companyB->id]);
+
+        $runA = PayrollRun::query()->create([
+            'company_id' => $companyA->id,
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'country_code' => 'DZ',
+            'status' => 'validated',
+            'total_gross' => 0,
+            'total_deductions' => 0,
+            'total_net' => 0,
+            'total_employer_cost' => 0,
+            'employee_count' => 0,
+        ]);
+
+        Sanctum::actingAs($managerB);
+
+        $this->get("/api/v1/payroll-runs/{$runA->id}/export")->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## What Problem This Solves
The accounting CSV export (`GET /api/v1/payroll-runs/{id}/export`) only listed employee identity and amount columns (matricule, name, salary type, gross/net/deductions/employer cost). Once downloaded, the file carried no currency, country, or pay-period context — an accountant reviewing exports from several tenants/countries had to track that context out-of-band, and a file opened weeks later gave no clue which period or currency it represented.

## Why This Change Was Made
Closes #1050 (PA2-PAY-017 — Export comptable pilote). Acceptance criteria: "CSV Excel paiements avec devise pays periode" (payments CSV/Excel with currency, country, period).

- `PayrollAccountingExportService` now emits `Pays`, `Devise`, `Periode Debut`, `Periode Fin` columns on every row, alongside the existing identity/amount columns.
- Currency is resolved from the owning `Company` (payroll runs don't persist their own currency column; amounts are already computed in the company's currency by the country rules engine), country from the run's `country_code`.
- UTF-8 BOM (Excel compatibility) and the existing `;`-delimited CSV format are preserved; no behavior change to the route, auth, or existing consumers beyond added columns.

## User Impact
- Downloaded accounting exports are now self-describing: currency, country, and period travel with the file instead of being implicit context that gets lost.
- No breaking change for any existing column — this is purely additive (4 new columns appended after 'Type Salaire').

## Evidence
```
PASS  Tests\Feature\PayrollAccountingExportTest
 ✓ export csv includes currency country and period
 ✓ export requires manager role
 ✓ export is scoped to tenant

Tests: 3 passed (17 assertions)
```

No regression:
```
PASS  Tests\Feature\PayrollCycleIntegrationTest   (6 passed, 21 assertions)
PASS  Tests\Unit\BankExportGeneratorTest          (5 passed, 18 assertions)
PASS  Tests\Feature\PayrollRunControllerTest      (10 passed, 30 assertions)
```

`vendor/bin/pint` and `vendor/bin/phpstan analyse --configuration=phpstan-modules.neon` clean on touched files.

Fixes kitokoh/leopardo-hr#1050