### PR TITLE
feat(notification): PA2-COMM-006 - localizable communication templates

### DIFF
--- a/api/app/Jobs/GeneratePaySlipPdfJob.php
+++ b/api/app/Jobs/GeneratePaySlipPdfJob.php
@@ -149,10 +149,13 @@ class GeneratePaySlipPdfJob implements ShouldQueue, TenantScopedJob
     private function notifyEmployee(PushNotificationService $pushService, Employee $employee, PayrollRun $run): void
     {
         try {
+            // PA2-COMM-006 — title/body come from the localized
+            // `notifications.payroll_ready_*` keys, resolved for the
+            // employee's own locale (App::setLocale() above already set it).
             $period = $run->period_end->format('M Y');
             $pushService->sendToEmployee($employee, [
-                'title' => 'Bulletin de paie disponible',
-                'body' => "Votre bulletin de paie {$period} est prêt.",
+                'title' => trans('notifications.payroll_ready_title'),
+                'body' => trans('notifications.payroll_ready_body_with_period', ['period' => $period]),
                 'data' => [
                     'type' => 'pay_slip_ready',
                     'payroll_run_id' => $run->id,

--- a/api/app/Modules/Notification/Infrastructure/Services/CommunicationService.php
+++ b/api/app/Modules/Notification/Infrastructure/Services/CommunicationService.php
@@ -12,6 +12,7 @@ use App\Modules\Notification\Domain\Models\Notification;
 use App\Modules\Notification\Domain\Models\NotificationPreference;
 use App\Modules\Notification\Infrastructure\Services\Providers\AuditMessageProvider;
 use App\Modules\Notification\Infrastructure\Services\PushNotificationService;
+use App\Support\I18nCatalog;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -36,8 +37,9 @@ class CommunicationService
         $preference = $this->preferencesFor($employee);
         $requestedChannels = $this->normalizeChannels($channels ?? config('communication.default_channels', ['app', 'push']));
         $category = (string) ($context['category'] ?? $template['category'] ?? 'system');
-        $title = (string) ($context['title'] ?? $template['title']);
-        $body = (string) ($context['body'] ?? $template['body']);
+        $locale = $this->localeFor($employee, $context);
+        $title = (string) ($context['title'] ?? $this->translate($template, 'title_key', $locale, $context));
+        $body = (string) ($context['body'] ?? $this->translate($template, 'body_key', $locale, $context));
         $metadata = $this->sanitizeMetadata($context);
 
         $notification = null;
@@ -104,12 +106,55 @@ class CommunicationService
 
             return is_array($fallback) ? $fallback : [
                 'category' => 'system',
-                'title' => 'Notification Leopardo RH',
-                'body' => 'Une nouvelle information est disponible dans votre espace.',
+                'title_key' => 'notifications.generic_title',
+                'body_key' => 'notifications.generic_body',
             ];
         }
 
         return $template;
+    }
+
+    /**
+     * Resolves the recipient's locale for this notification: an explicit
+     * `locale` in the caller context wins, then the employee's own
+     * `preferred_language`, then the tenant company's default language.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    private function localeFor(Employee $employee, array $context): string
+    {
+        $requested = $context['locale'] ?? $employee->preferred_language ?? $employee->company?->language;
+
+        return I18nCatalog::normalizeLocale(is_string($requested) ? $requested : null);
+    }
+
+    /**
+     * Resolves a template's title/body from its translation key, forwarding
+     * only the caller context keys declared in `vars` as `trans()`
+     * replacement parameters (e.g. `:task`, `:author`).
+     *
+     * @param  array<string, mixed>  $template
+     * @param  array<string, mixed>  $context
+     */
+    private function translate(array $template, string $keyField, string $locale, array $context): string
+    {
+        $key = $template[$keyField] ?? null;
+
+        if (is_string($key) === false || $key === '') {
+            return '';
+        }
+
+        $vars = $template['vars'] ?? [];
+        $vars = is_array($vars) ? $vars : [];
+        $replace = [];
+
+        foreach ($vars as $var) {
+            if (is_string($var) && array_key_exists($var, $context)) {
+                $replace[$var] = (string) $context[$var];
+            }
+        }
+
+        return trans($key, $replace, $locale);
     }
 
     private function preferencesFor(Employee $employee): NotificationPreference

--- a/api/app/Modules/Planning/Interfaces/Api/V1/TaskController.php
+++ b/api/app/Modules/Planning/Interfaces/Api/V1/TaskController.php
@@ -240,11 +240,13 @@ class TaskController extends Controller
         $authorName = trim($author->first_name.' '.$author->last_name);
 
         foreach ($recipients as $recipient) {
-            $locale = $recipient->preferred_language ?: config('app.fallback_locale', 'en');
-
+            // Title/body are resolved by CommunicationService from the
+            // `task_comment_added` template using the recipient's own
+            // locale (preferred_language, falling back to the company
+            // language) — see PA2-COMM-006.
             $this->communicationService->notifyEmployee($recipient, 'task_comment_added', [
-                'title' => trans('notifications.task_comment_added_title', ['task' => $task->title], $locale),
-                'body' => trans('notifications.task_comment_added_body', ['author' => $authorName], $locale),
+                'task' => $task->title,
+                'author' => $authorName,
                 'task_id' => $task->id,
                 'task_comment_id' => $comment->id,
             ], ['app']);

--- a/api/config/communication.php
+++ b/api/config/communication.php
@@ -48,41 +48,63 @@ return [
         'status',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Localizable templates
+    |--------------------------------------------------------------------------
+    |
+    | PA2-COMM-006 — Every template only carries a `category` plus the
+    | translation keys (`lang/{locale}/notifications.php`) used to resolve
+    | its title/body for the recipient's locale. `vars` lists the caller
+    | context keys that get forwarded to `trans()` as replacement
+    | parameters (e.g. `:task`, `:author`, `:period`), so a caller can
+    | still pass an explicit `title`/`body` in `$context` to override the
+    | localized text (used by callers with fully custom content, like
+    | manager-authored announcements).
+    |
+    */
+
     'templates' => [
         'generic' => [
             'category' => 'system',
-            'title' => 'Notification Leopardo RH',
-            'body' => 'Une nouvelle information est disponible dans votre espace.',
+            'title_key' => 'notifications.generic_title',
+            'body_key' => 'notifications.generic_body',
         ],
         'absence_approved' => [
             'category' => 'hr',
-            'title' => 'Demande d’absence approuvée',
-            'body' => 'Votre demande d’absence a été approuvée.',
+            'title_key' => 'notifications.absence_approved_title',
+            'body_key' => 'notifications.absence_approved_body',
         ],
         'absence_rejected' => [
             'category' => 'hr',
-            'title' => 'Demande d’absence refusée',
-            'body' => 'Votre demande d’absence a été refusée.',
+            'title_key' => 'notifications.absence_rejected_title',
+            'body_key' => 'notifications.absence_rejected_body',
         ],
         'payroll_ready' => [
             'category' => 'payroll',
-            'title' => 'Bulletin de paie disponible',
-            'body' => 'Votre nouveau bulletin de paie est disponible dans votre espace.',
+            'title_key' => 'notifications.payroll_ready_title',
+            'body_key' => 'notifications.payroll_ready_body',
         ],
         'security_alert' => [
             'category' => 'security',
-            'title' => 'Alerte de sécurité',
-            'body' => 'Une action sensible vient d’être détectée sur votre compte.',
+            'title_key' => 'notifications.security_alert_title',
+            'body_key' => 'notifications.security_alert_body',
         ],
         'task_comment_added' => [
             'category' => 'task',
-            'title' => 'Nouveau commentaire sur une tâche',
-            'body' => 'Un nouveau commentaire a été ajouté à une tâche que vous suivez.',
+            'title_key' => 'notifications.task_comment_added_title',
+            'body_key' => 'notifications.task_comment_added_body',
+            'vars' => ['task', 'author'],
         ],
         'platform_announcement' => [
             'category' => 'platform',
-            'title' => 'Annonce de la plateforme Leopardo',
-            'body' => 'Une nouvelle annonce de la plateforme est disponible.',
+            'title_key' => 'notifications.platform_announcement_title',
+            'body_key' => 'notifications.platform_announcement_body',
+        ],
+        'company_announcement' => [
+            'category' => 'system',
+            'title_key' => 'notifications.company_announcement_title',
+            'body_key' => 'notifications.company_announcement_body',
         ],
     ],
 ];

--- a/api/lang/ar/notifications.php
+++ b/api/lang/ar/notifications.php
@@ -3,4 +3,26 @@
 return [
     'task_comment_added_title' => 'تعليق جديد على ":task"',
     'task_comment_added_body' => 'أضاف :author تعليقًا جديدًا على مهمة تشارك فيها.',
+
+    'generic_title' => 'إشعار Leopardo RH',
+    'generic_body' => 'تتوفر معلومات جديدة في مساحتك.',
+
+    'absence_approved_title' => 'تمت الموافقة على طلب الغياب',
+    'absence_approved_body' => 'تمت الموافقة على طلب غيابك.',
+
+    'absence_rejected_title' => 'تم رفض طلب الغياب',
+    'absence_rejected_body' => 'تم رفض طلب غيابك.',
+
+    'payroll_ready_title' => 'كشف الراتب متاح',
+    'payroll_ready_body' => 'كشف راتبك الجديد متاح في مساحتك.',
+    'payroll_ready_body_with_period' => 'كشف راتبك لشهر :period جاهز.',
+
+    'security_alert_title' => 'تنبيه أمني',
+    'security_alert_body' => 'تم اكتشاف إجراء حساس للتو على حسابك.',
+
+    'platform_announcement_title' => 'إعلان منصة Leopardo',
+    'platform_announcement_body' => 'يتوفر إعلان جديد للمنصة.',
+
+    'company_announcement_title' => 'إعلان الشركة',
+    'company_announcement_body' => 'تم نشر إعلان جديد في شركتك.',
 ];

--- a/api/lang/en/notifications.php
+++ b/api/lang/en/notifications.php
@@ -3,4 +3,26 @@
 return [
     'task_comment_added_title' => 'New comment on ":task"',
     'task_comment_added_body' => ':author added a new comment to a task you are involved in.',
+
+    'generic_title' => 'Leopardo HR notification',
+    'generic_body' => 'New information is available in your space.',
+
+    'absence_approved_title' => 'Leave request approved',
+    'absence_approved_body' => 'Your leave request has been approved.',
+
+    'absence_rejected_title' => 'Leave request rejected',
+    'absence_rejected_body' => 'Your leave request has been rejected.',
+
+    'payroll_ready_title' => 'Payslip available',
+    'payroll_ready_body' => 'Your new payslip is available in your space.',
+    'payroll_ready_body_with_period' => 'Your :period payslip is ready.',
+
+    'security_alert_title' => 'Security alert',
+    'security_alert_body' => 'A sensitive action was just detected on your account.',
+
+    'platform_announcement_title' => 'Leopardo platform announcement',
+    'platform_announcement_body' => 'A new platform announcement is available.',
+
+    'company_announcement_title' => 'Company announcement',
+    'company_announcement_body' => 'A new announcement was published in your company.',
 ];

--- a/api/lang/fr/notifications.php
+++ b/api/lang/fr/notifications.php
@@ -3,4 +3,26 @@
 return [
     'task_comment_added_title' => 'Nouveau commentaire sur « :task »',
     'task_comment_added_body' => ':author a ajouté un nouveau commentaire sur une tâche qui vous concerne.',
+
+    'generic_title' => 'Notification Leopardo RH',
+    'generic_body' => 'Une nouvelle information est disponible dans votre espace.',
+
+    'absence_approved_title' => 'Demande d’absence approuvée',
+    'absence_approved_body' => 'Votre demande d’absence a été approuvée.',
+
+    'absence_rejected_title' => 'Demande d’absence refusée',
+    'absence_rejected_body' => 'Votre demande d’absence a été refusée.',
+
+    'payroll_ready_title' => 'Bulletin de paie disponible',
+    'payroll_ready_body' => 'Votre nouveau bulletin de paie est disponible dans votre espace.',
+    'payroll_ready_body_with_period' => 'Votre bulletin de paie :period est prêt.',
+
+    'security_alert_title' => 'Alerte de sécurité',
+    'security_alert_body' => 'Une action sensible vient d’être détectée sur votre compte.',
+
+    'platform_announcement_title' => 'Annonce de la plateforme Leopardo',
+    'platform_announcement_body' => 'Une nouvelle annonce de la plateforme est disponible.',
+
+    'company_announcement_title' => 'Annonce de l’entreprise',
+    'company_announcement_body' => 'Une nouvelle annonce a été publiée dans votre entreprise.',
 ];

--- a/api/lang/tr/notifications.php
+++ b/api/lang/tr/notifications.php
@@ -3,4 +3,26 @@
 return [
     'task_comment_added_title' => '":task" görevine yeni yorum',
     'task_comment_added_body' => ':author, ilgili olduğunuz bir göreve yeni bir yorum ekledi.',
+
+    'generic_title' => 'Leopardo RH bildirimi',
+    'generic_body' => 'Alanınızda yeni bilgi mevcut.',
+
+    'absence_approved_title' => 'İzin talebi onaylandı',
+    'absence_approved_body' => 'İzin talebiniz onaylandı.',
+
+    'absence_rejected_title' => 'İzin talebi reddedildi',
+    'absence_rejected_body' => 'İzin talebiniz reddedildi.',
+
+    'payroll_ready_title' => 'Bordro hazır',
+    'payroll_ready_body' => 'Yeni bordronuz alanınızda mevcut.',
+    'payroll_ready_body_with_period' => ':period bordronuz hazır.',
+
+    'security_alert_title' => 'Güvenlik uyarısı',
+    'security_alert_body' => 'Hesabınızda hassas bir işlem tespit edildi.',
+
+    'platform_announcement_title' => 'Leopardo platform duyurusu',
+    'platform_announcement_body' => 'Yeni bir platform duyurusu mevcut.',
+
+    'company_announcement_title' => 'Şirket duyurusu',
+    'company_announcement_body' => 'Şirketinizde yeni bir duyuru yayınlandı.',
 ];

--- a/api/tests/Feature/CommunicationServiceTest.php
+++ b/api/tests/Feature/CommunicationServiceTest.php
@@ -180,6 +180,90 @@ class CommunicationServiceTest extends TestCase
         ]);
     }
 
+    /**
+     * PA2-COMM-006 — title/body must be resolved from the localizable
+     * `notifications.*` translation keys using the employee's own
+     * preferred locale, not a single hardcoded French string.
+     */
+    public function test_notification_title_and_body_use_employee_preferred_locale(): void
+    {
+        $employee = $this->employee();
+        $employee->forceFill(['preferred_language' => 'en'])->save();
+
+        $result = app(CommunicationService::class)->notifyEmployee($employee, 'absence_approved', [], ['app']);
+
+        $this->assertDatabaseHas('notifications', [
+            'id' => $result['notification_id'],
+            'title' => 'Leave request approved',
+            'body' => 'Your leave request has been approved.',
+        ]);
+    }
+
+    /**
+     * When the employee has no explicit preferred_language, the recipient's
+     * locale falls back to the tenant company's own default language.
+     */
+    public function test_notification_falls_back_to_company_language_when_employee_has_none(): void
+    {
+        $company = Company::factory()->create(['timezone' => 'Africa/Algiers', 'language' => 'en']);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'employee-'.$company->id.'@example.test',
+            'preferred_language' => null,
+        ]);
+
+        $result = app(CommunicationService::class)->notifyEmployee($employee, 'security_alert', [], ['app']);
+
+        $this->assertDatabaseHas('notifications', [
+            'id' => $result['notification_id'],
+            'title' => 'Security alert',
+            'body' => 'A sensitive action was just detected on your account.',
+        ]);
+    }
+
+    /**
+     * Template variables declared in `config('communication.templates')`
+     * (e.g. `task_comment_added`'s `:task`/`:author`) must be forwarded from
+     * the caller context into the translated string.
+     */
+    public function test_template_variables_are_interpolated_into_translated_body(): void
+    {
+        $employee = $this->employee();
+        $employee->forceFill(['preferred_language' => 'fr'])->save();
+
+        $result = app(CommunicationService::class)->notifyEmployee($employee, 'task_comment_added', [
+            'task' => 'Verification materiel',
+            'author' => 'Amine K.',
+        ], ['app']);
+
+        $this->assertDatabaseHas('notifications', [
+            'id' => $result['notification_id'],
+            'title' => 'Nouveau commentaire sur « Verification materiel »',
+            'body' => 'Amine K. a ajouté un nouveau commentaire sur une tâche qui vous concerne.',
+        ]);
+    }
+
+    /**
+     * Callers may still pass an explicit `title`/`body` in the context to
+     * fully override the localized template (used for manager-authored
+     * free-text content like announcements).
+     */
+    public function test_explicit_title_and_body_override_the_localized_template(): void
+    {
+        $employee = $this->employee();
+
+        $result = app(CommunicationService::class)->notifyEmployee($employee, 'absence_approved', [
+            'title' => 'Custom title',
+            'body' => 'Custom body',
+        ], ['app']);
+
+        $this->assertDatabaseHas('notifications', [
+            'id' => $result['notification_id'],
+            'title' => 'Custom title',
+            'body' => 'Custom body',
+        ]);
+    }
+
     private function employee(): Employee
     {
         $company = Company::factory()->create(['timezone' => 'Africa/Algiers']);


### PR DESCRIPTION
## What Problem This Solves
Push/email/SMS/WhatsApp notification templates in `CommunicationService` were hardcoded French strings baked directly into `config/communication.php`, so every employee received notifications in French regardless of their own `preferred_language` or their company's configured language — breaking the product's multi-locale requirement (fr/en/ar/tr).

## Why This Change Was Made
PA2-COMM-006 requires push/email/WhatsApp/SMS messages to use controlled translation keys and variables instead of hardcoded strings, per `docs/PLAN_ACTION2/03_GITHUB_PROJECT_IMPORT.csv`.

## User Impact
- Notifications (in-app, push, email, SMS, WhatsApp) now render in the recipient's own locale: employee `preferred_language` first, falling back to the tenant company's `language`.
- Template variables (e.g. `:task`, `:author` for `task_comment_added`, `:period` for payslip-ready pushes) are declared per-template and safely interpolated via Laravel's `trans()`.
- Callers can still pass an explicit `title`/`body` to fully override the localized template (used by manager-authored free-text announcements), so no existing behavior for those flows changes.
- `GeneratePaySlipPdfJob`'s payslip-ready push notification is now localized instead of always French.

## Evidence
- `php vendor/bin/phpunit --filter CommunicationServiceTest` → 9/9 passing (4 new tests added: employee-locale resolution, company-language fallback, template variable interpolation, explicit title/body override).
- `php vendor/bin/phpunit --filter "CommunicationServiceTest|TaskControllerTest|DeviceTokenControllerTest|AnnouncementControllerTest|PlatformAnnouncementControllerTest|CommunicationAnalyticsControllerTest|PaySlipPdfLocaleTest|NotificationControllerTest"` → 47/47 passing.
- `php vendor/bin/phpunit --filter Absence` → 62/62 passing (no regression on absence approve/reject notification flows).
- `php -l` clean on every touched file.

Fixes kitokoh/leopardo-hr#1057