### PR TITLE
feat(payroll): partial-failure resilience, audit trail and trigger notification for bulk payment (PA2-PAY-013)

### DIFF
--- a/api/app/Jobs/ProcessBulkPaymentJob.php
+++ b/api/app/Jobs/ProcessBulkPaymentJob.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Contracts\Queue\TenantScopedJob;
+use App\Core\Auth\Domain\Models\AuditLog;
+use App\Core\Auth\Domain\Models\Employee;
 use App\Jobs\Middleware\EnsureTenantContext;
+use App\Modules\Notification\Infrastructure\Services\CommunicationService;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use App\Modules\Payroll\Domain\Models\SalaryAdvance;
@@ -67,7 +70,7 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
      */
     public function middleware(): array
     {
-        return [new EnsureTenantContext()];
+        return [new EnsureTenantContext];
     }
 
     public function handle(): void
@@ -93,49 +96,138 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
         $total = $slips->count();
         $done = 0;
 
+        // PA2-PAY-013: a single employee's failure (e.g. a stale advance
+        // record, a corrupted contract) must never abort the whole batch —
+        // every other slip must still be processed, and the failure must be
+        // visible in the final results instead of being silently swallowed.
+        $failures = [];
+
         $this->updateProgress(0, 'processing', $total);
 
         foreach ($slips as $slip) {
-            // Mark related salary advances as payment_declared
-            SalaryAdvance::query()
-                ->where('employee_id', $slip->employee_id)
-                ->where('company_id', $run->company_id)
-                ->where('validation_status', 'manager_approved')
-                ->update([
-                    'validation_status' => 'payment_declared',
-                    'payment_declared_at' => now(),
-                    'payment_declared_by' => $this->triggeredById,
+            try {
+                $this->processSlip($run, $slip);
+            } catch (Throwable $e) {
+                Log::error('ProcessBulkPaymentJob: failed to process pay slip', [
+                    'payroll_run_id' => $run->id,
+                    'pay_slip_id' => $slip->id,
+                    'employee_id' => $slip->employee_id,
+                    'error' => $e->getMessage(),
                 ]);
 
-            // Dispatch legacy payslip PDF and Plan 62 document index generation.
-            GeneratePaySlipPdfJob::dispatch($run->id, $slip->employee_id);
-            GeneratePaymentDocumentJob::dispatchForPaySlip($slip, $this->triggeredById);
+                $failures[] = [
+                    'pay_slip_id' => $slip->id,
+                    'employee_id' => $slip->employee_id,
+                    'error' => $e->getMessage(),
+                ];
+            }
 
             $done++;
-            $this->updateProgress($done, 'processing', $total);
+            $this->updateProgress($done, 'processing', $total, $failures);
         }
 
+        $succeeded = $total - count($failures);
+        $finalStatus = $failures === [] ? 'completed' : 'completed_with_errors';
+
         // ── Step 2: Mark payroll run as paid ────────────────────────────────
+        // The run is marked paid even with partial failures: the successful
+        // slips were genuinely paid and must not be re-processed on retry;
+        // failures are surfaced separately for manual follow-up.
         $run->update([
             'status' => 'paid',
             'paid_at' => now(),
         ]);
 
-        $this->updateProgress($total, 'completed', $total);
+        $this->updateProgress($total, $finalStatus, $total, $failures);
 
-        Log::info("ProcessBulkPaymentJob: PayrollRun #{$run->id} bulk-paid — {$total} slips processed.");
+        Log::info("ProcessBulkPaymentJob: PayrollRun #{$run->id} bulk-paid — {$succeeded}/{$total} slips processed successfully.");
 
-        // ── Step 3: Audit log ───────────────────────────────────────────────
-        Log::channel('stack')->info('bulk_payment_completed', [
-            'payroll_run_id' => $run->id,
+        // ── Step 3: Persist an audit trail entry with the batch results ────
+        AuditLog::query()->create([
             'company_id' => $run->company_id,
-            'triggered_by' => $this->triggeredById,
-            'slips_count' => $total,
-            'paid_at' => now()->toIso8601String(),
+            'user_id' => $this->triggeredById,
+            'action' => 'bulk_payment_processed',
+            'auditable_type' => PayrollRun::class,
+            'auditable_id' => $run->id,
+            'new_values' => [
+                'status' => $finalStatus,
+                'total_slips' => $total,
+                'succeeded' => $succeeded,
+                'failed' => count($failures),
+            ],
+            'metadata' => [
+                'payroll_run_id' => $run->id,
+                'failures' => $failures,
+                'paid_at' => now()->toIso8601String(),
+            ],
         ]);
+
+        // ── Step 4: Notify the manager who triggered the batch ──────────────
+        // Partial results must reach a human even if nobody is polling the
+        // status endpoint — this is the acceptance criterion for PA2-PAY-013.
+        $this->notifyTrigger($run, $total, $succeeded, $failures);
     }
 
-    private function updateProgress(int $done, string $status, int $total = 0): void
+    /**
+     * Processes a single pay slip: declares payment on its related salary
+     * advances and dispatches PDF/document generation. Extracted as its
+     * own method so a single slip's failure can be caught and reported
+     * per-slip without interrupting the rest of the batch (PA2-PAY-013).
+     */
+    protected function processSlip(PayrollRun $run, PaySlip $slip): void
+    {
+        // Mark related salary advances as payment_declared
+        SalaryAdvance::query()
+            ->where('employee_id', $slip->employee_id)
+            ->where('company_id', $run->company_id)
+            ->where('validation_status', 'manager_approved')
+            ->update([
+                'validation_status' => 'payment_declared',
+                'payment_declared_at' => now(),
+                'payment_declared_by' => $this->triggeredById,
+            ]);
+
+        // Dispatch legacy payslip PDF and Plan 62 document index generation.
+        GeneratePaySlipPdfJob::dispatch($run->id, $slip->employee_id);
+        GeneratePaymentDocumentJob::dispatchForPaySlip($slip, $this->triggeredById);
+    }
+
+    /**
+     * @param  array<int, array{pay_slip_id: int, employee_id: int, error: string}>  $failures
+     */
+    private function notifyTrigger(PayrollRun $run, int $total, int $succeeded, array $failures): void
+    {
+        /** @var Employee|null $trigger */
+        $trigger = Employee::query()->withoutGlobalScopes()->find($this->triggeredById);
+
+        if ($trigger === null) {
+            return;
+        }
+
+        $templateKey = $failures === [] ? 'bulk_payment_completed' : 'bulk_payment_completed_with_errors';
+
+        try {
+            app(CommunicationService::class)->notifyEmployee($trigger, $templateKey, [
+                'payroll_run_id' => $run->id,
+                'succeeded' => $succeeded,
+                'failed' => count($failures),
+                'total' => $total,
+            ]);
+        } catch (Throwable $e) {
+            // Notification failure must never mask the fact that the batch
+            // itself already completed (successfully or with errors).
+            Log::warning('ProcessBulkPaymentJob: failed to notify trigger', [
+                'payroll_run_id' => $run->id,
+                'triggered_by' => $this->triggeredById,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<int, array{pay_slip_id: int, employee_id: int, error: string}>  $failures
+     */
+    private function updateProgress(int $done, string $status, int $total = 0, array $failures = []): void
     {
         try {
             $key = "bulk_pay:run:{$this->payrollRunId}";
@@ -143,6 +235,8 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
                 'status' => $status,
                 'done' => $done,
                 'total' => $total,
+                'failed' => count($failures),
+                'failures' => $failures,
                 'updated_at' => now()->toIso8601String(),
             ]);
             Redis::connection('default')->setex($key, 3600, $data);
@@ -152,4 +246,3 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
         }
     }
 }
-

--- a/api/config/communication.php
+++ b/api/config/communication.php
@@ -90,6 +90,18 @@ return [
             'title_key' => 'notifications.payroll_ready_title',
             'body_key' => 'notifications.payroll_ready_body',
         ],
+        'bulk_payment_completed' => [
+            'category' => 'payroll',
+            'title_key' => 'notifications.bulk_payment_completed_title',
+            'body_key' => 'notifications.bulk_payment_completed_body',
+            'vars' => ['succeeded', 'total', 'failed'],
+        ],
+        'bulk_payment_completed_with_errors' => [
+            'category' => 'payroll',
+            'title_key' => 'notifications.bulk_payment_completed_with_errors_title',
+            'body_key' => 'notifications.bulk_payment_completed_with_errors_body',
+            'vars' => ['succeeded', 'total', 'failed'],
+        ],
         'security_alert' => [
             'category' => 'security',
             'title_key' => 'notifications.security_alert_title',

--- a/api/lang/ar/notifications.php
+++ b/api/lang/ar/notifications.php
@@ -29,4 +29,10 @@ return [
 
     'company_announcement_title' => 'إعلان الشركة',
     'company_announcement_body' => 'تم نشر إعلان جديد في شركتك.',
+
+    'bulk_payment_completed_title' => 'اكتمل الدفع الجماعي (:succeeded/:total)',
+    'bulk_payment_completed_body' => 'تمت معالجة الدفع الجماعي بنجاح: :succeeded من :total كشف راتب.',
+
+    'bulk_payment_completed_with_errors_title' => 'اكتمل الدفع الجماعي مع وجود أخطاء (:succeeded/:total)',
+    'bulk_payment_completed_with_errors_body' => 'انتهى الدفع الجماعي: تمت معالجة :succeeded من :total كشف راتب بنجاح، مع :failed حالة فشل. راجع سجل التدقيق للتفاصيل.',
 ];

--- a/api/lang/en/notifications.php
+++ b/api/lang/en/notifications.php
@@ -29,4 +29,10 @@ return [
 
     'company_announcement_title' => 'Company announcement',
     'company_announcement_body' => 'A new announcement was published in your company.',
+
+    'bulk_payment_completed_title' => 'Bulk payment completed (:succeeded/:total)',
+    'bulk_payment_completed_body' => 'The bulk payment was processed successfully: :succeeded of :total payslip(s).',
+
+    'bulk_payment_completed_with_errors_title' => 'Bulk payment completed with errors (:succeeded/:total)',
+    'bulk_payment_completed_with_errors_body' => 'The bulk payment has finished: :succeeded of :total payslip(s) processed successfully, :failed failure(s). Check the audit log for details.',
 ];

--- a/api/lang/fr/notifications.php
+++ b/api/lang/fr/notifications.php
@@ -29,4 +29,10 @@ return [
 
     'company_announcement_title' => 'Annonce de l’entreprise',
     'company_announcement_body' => 'Une nouvelle annonce a été publiée dans votre entreprise.',
+
+    'bulk_payment_completed_title' => 'Paiement en masse terminé (:succeeded/:total)',
+    'bulk_payment_completed_body' => 'Le paiement en masse a été traité avec succès : :succeeded bulletin(s) sur :total.',
+
+    'bulk_payment_completed_with_errors_title' => 'Paiement en masse terminé avec erreurs (:succeeded/:total)',
+    'bulk_payment_completed_with_errors_body' => 'Le paiement en masse est terminé : :succeeded bulletin(s) sur :total traité(s) avec succès, :failed échec(s). Consultez le journal d’audit pour le détail.',
 ];

--- a/api/lang/tr/notifications.php
+++ b/api/lang/tr/notifications.php
@@ -29,4 +29,10 @@ return [
 
     'company_announcement_title' => 'Şirket duyurusu',
     'company_announcement_body' => 'Şirketinizde yeni bir duyuru yayınlandı.',
+
+    'bulk_payment_completed_title' => 'Toplu ödeme tamamlandı (:succeeded/:total)',
+    'bulk_payment_completed_body' => 'Toplu ödeme başarıyla işlendi: :total bordrodan :succeeded tanesi.',
+
+    'bulk_payment_completed_with_errors_title' => 'Toplu ödeme hatalarla tamamlandı (:succeeded/:total)',
+    'bulk_payment_completed_with_errors_body' => 'Toplu ödeme tamamlandı: :total bordrodan :succeeded tanesi başarıyla işlendi, :failed hata oluştu. Ayrıntılar için denetim günlüğünü kontrol edin.',
 ];

--- a/api/tests/Feature/ProcessBulkPaymentJobTest.php
+++ b/api/tests/Feature/ProcessBulkPaymentJobTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\AuditLog;
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\GeneratePaymentDocumentJob;
+use App\Jobs\GeneratePaySlipPdfJob;
+use App\Jobs\ProcessBulkPaymentJob;
+use App\Modules\Notification\Domain\Models\Notification;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-013 — "Batch resultats partiels notification audit": a bulk
+ * payment run must process every pay slip independently (one employee's
+ * failure must never abort the others), persist an audit trail of the
+ * batch results, and notify the manager who triggered it with the
+ * succeeded/failed counts — even when the batch only partially succeeds.
+ */
+class ProcessBulkPaymentJobTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_bulk_payment_processes_all_slips_marks_run_paid_and_notifies_trigger_on_full_success(): void
+    {
+        Queue::fake();
+
+        [$company, $manager] = $this->companyAndManager();
+        $run = $this->payrollRun($company);
+        $employeeA = Employee::factory()->create(['company_id' => $company->id]);
+        $employeeB = Employee::factory()->create(['company_id' => $company->id]);
+        $this->paySlip($run, $employeeA);
+        $this->paySlip($run, $employeeB);
+
+        (new ProcessBulkPaymentJob($run->id, $manager->id))->handle();
+
+        $run->refresh();
+        $this->assertSame('paid', $run->status);
+        $this->assertNotNull($run->paid_at);
+
+        Queue::assertPushed(GeneratePaySlipPdfJob::class, 2);
+        Queue::assertPushed(GeneratePaymentDocumentJob::class, 2);
+
+        $audit = AuditLog::query()
+            ->where('auditable_type', PayrollRun::class)
+            ->where('auditable_id', $run->id)
+            ->where('action', 'bulk_payment_processed')
+            ->first();
+
+        $this->assertNotNull($audit, 'Expected an audit_logs entry for the bulk payment batch.');
+        $this->assertSame(2, $audit->new_values['succeeded']);
+        $this->assertSame(0, $audit->new_values['failed']);
+        $this->assertSame('completed', $audit->new_values['status']);
+
+        $notification = Notification::query()
+            ->where('employee_id', $manager->id)
+            ->where('type', 'payroll')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($notification, 'Expected the triggering manager to be notified of batch completion.');
+    }
+
+    public function test_bulk_payment_continues_processing_after_one_slip_fails_and_reports_partial_results(): void
+    {
+        Queue::fake();
+
+        [$company, $manager] = $this->companyAndManager();
+        $run = $this->payrollRun($company);
+        $goodEmployee = Employee::factory()->create(['company_id' => $company->id]);
+        $badEmployee = Employee::factory()->create(['company_id' => $company->id]);
+
+        $goodSlip = $this->paySlip($run, $goodEmployee);
+        $badSlip = $this->paySlip($run, $badEmployee);
+
+        // Force a real failure for exactly one slip via a thin test double
+        // that throws only for $badSlip's id, so we exercise the actual
+        // per-slip try/catch + reporting contract without touching
+        // database constraints or mocking framework internals.
+        $job = new class($run->id, $manager->id, $badSlip->id) extends ProcessBulkPaymentJob
+        {
+            public function __construct(int $payrollRunId, int $triggeredById, private readonly int $failingSlipId)
+            {
+                parent::__construct($payrollRunId, $triggeredById);
+            }
+
+            protected function processSlip(PayrollRun $run, PaySlip $slip): void
+            {
+                if ($slip->id === $this->failingSlipId) {
+                    throw new RuntimeException('Simulated failure for slip #'.$slip->id);
+                }
+
+                parent::processSlip($run, $slip);
+            }
+        };
+
+        $job->handle();
+
+        $run->refresh();
+        // Even with a partial failure, slips that succeeded were genuinely
+        // paid and the run must not be left dangling in a non-terminal state.
+        $this->assertSame('paid', $run->status);
+
+        $audit = AuditLog::query()
+            ->where('auditable_type', PayrollRun::class)
+            ->where('auditable_id', $run->id)
+            ->where('action', 'bulk_payment_processed')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $this->assertSame(2, $audit->new_values['total_slips']);
+        $this->assertSame(1, $audit->new_values['succeeded']);
+        $this->assertSame(1, $audit->new_values['failed']);
+        $this->assertSame('completed_with_errors', $audit->new_values['status']);
+        $this->assertCount(1, $audit->metadata['failures']);
+        $this->assertSame($badSlip->id, $audit->metadata['failures'][0]['pay_slip_id']);
+
+        // The good slip must always have been processed regardless of the
+        // other slip's outcome — this is the "no full-batch abort" contract.
+        Queue::assertPushed(
+            GeneratePaymentDocumentJob::class,
+            fn (GeneratePaymentDocumentJob $job): bool => $job->paymentDocumentId !== null
+        );
+
+        $notification = Notification::query()
+            ->where('employee_id', $manager->id)
+            ->where('type', 'payroll')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($notification, 'Manager must still be notified even when the batch has partial failures.');
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee}
+     */
+    private function companyAndManager(): array
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        return [$company, $manager];
+    }
+
+    private function payrollRun(Company $company): PayrollRun
+    {
+        return PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => '2026-06-01',
+            'period_end' => '2026-06-30',
+            'status' => 'validated',
+            'employee_count' => 2,
+            'total_gross' => 240000,
+            'total_deductions' => 44000,
+            'total_net' => 196000,
+        ]);
+    }
+
+    private function paySlip(PayrollRun $run, Employee $employee): PaySlip
+    {
+        return PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $run->company_id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 120000,
+            'total_deductions' => 22000,
+            'net_salary' => 98000,
+            'employer_contributions' => 31200,
+            'total_cost' => 151200,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'validated',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1046 (PA2-PAY-013 — Batch resultats partiels notification audit).

`ProcessBulkPaymentJob` previously had no isolation between pay slips: an unhandled exception on any single slip would fail the *entire* queued job (subject to its retry policy), with no persisted record of what happened and no feedback to the manager beyond the Redis polling endpoint.

## Changes

- Extracted per-slip work into `processSlip()` and wrapped it in a try/catch inside the batch loop: one employee's failure is now caught, logged, and recorded — the rest of the batch keeps going instead of the whole run aborting.
- The payroll run is still marked `paid` once the batch finishes (the slips that succeeded were genuinely paid); failures are tracked separately for follow-up rather than blocking the successful ones.
- A new `audit_logs` entry (`action=bulk_payment_processed`) is persisted with the final status (`completed` / `completed_with_errors`), total/succeeded/failed counts, and per-slip failure details in `metadata`.
- The manager who triggered the batch now receives an in-app notification (existing `CommunicationService`/notification pipeline) with the succeeded/failed counts, via two new templates — `bulk_payment_completed` and `bulk_payment_completed_with_errors` — translated in fr/en/ar/tr.
- The Redis progress payload polled by `GET /payroll-runs/{id}/bulk-pay/status` now also exposes `failed`/`failures`.

## Testing

```
php artisan test --filter=ProcessBulkPaymentJobTest
Tests: 2 passed (19 assertions)

php artisan test --filter="ProcessBulkPaymentJobTest|QueueJobsTest|PaymentBatchControllerTest|PaymentDocumentControllerTest|GeneratePaymentDocumentJobTest|LedgerTest|SalaryAdvanceSecurityTest"
Tests: 38 passed (133 assertions)
```

Ran the full `php artisan test` suite too; the only pre-existing failures (`BiometricWorkflowTest`, `Edge\*`, some demo-seeder tests) reproduce identically on `main` without this change (verified via `git stash`), so they are unrelated to this PR.

Also ran `./vendor/bin/pint` on all changed files.