### PR TITLE
feat(payroll): PA2-PAY-012 - nightly progressive payroll pre-calculation

### DIFF
--- a/api/app/Console/Commands/PrecalculatePayrollRuns.php
+++ b/api/app/Console/Commands/PrecalculatePayrollRuns.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\ProcessPayrollBatchJob;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Infrastructure\Services\PayrollCycleService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * PA2-PAY-012 — Nightly progressive payroll pre-calculation.
+ *
+ * Recalculating every draft payroll run only on the exact payment day (the
+ * only trigger that existed before this command — a manager clicking
+ * "Calculate" manually via `POST /payroll-runs/{id}/calculate`) means the
+ * first real signal that a run is broken (missing salary structure, bad
+ * country rules, a stuck queue worker) surfaces the same day employees are
+ * expecting to be paid, with no time left to fix it.
+ *
+ * This command runs nightly (see `withSchedule()` in `bootstrap/app.php`)
+ * and progressively (re)calculates every `draft`/`calculated` payroll run
+ * whose period is approaching its configured pay day (`PayrollCycleService`
+ * pay-cycle settings, PA2-PAY-011), each time it runs, until the run is
+ * validated by a manager. Every calculation still happens through the
+ * existing `ProcessPayrollBatchJob` (already `ShouldQueue`, `$tries = 3`,
+ * tenant-scoped via `EnsureTenantContext`) — this command only decides
+ * *which* runs are due and dispatches jobs for them; it re-uses the job's
+ * own retry policy instead of re-implementing one, and every decision
+ * (dispatched / skipped / not-yet-due) is logged on the `structured`
+ * channel so a stuck precalculation can be diagnosed from logs alone.
+ *
+ * A run recalculated every night simply gets fresher figures each time
+ * (new employees, updated salary structures, corrected attendance) right
+ * up until a manager validates it — recalculating a `calculated` run is
+ * already idempotent and side-effect-free (`PayrollCalculator::calculateRun()`
+ * deletes and regenerates that run's own pay slips inside a transaction).
+ */
+class PrecalculatePayrollRuns extends Command
+{
+    protected $signature = 'payroll:precalculate
+                                {--days=5 : Start precalculating this many days before the next payment date}
+                                {--dry-run : Preview without dispatching any job}';
+
+    protected $description = 'Progressively pre-calculate draft/calculated payroll runs approaching their pay day, with per-run retries and structured logs';
+
+    public function handle(PayrollCycleService $cycleService): int
+    {
+        $windowDays = max(1, (int) $this->option('days'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $this->info("Payroll precalculation: scanning runs due within {$windowDays} day(s) of their pay day.");
+
+        $runs = PayrollRun::query()
+            ->withoutGlobalScopes()
+            ->whereIn('status', ['draft', 'calculated'])
+            ->get();
+
+        $dispatched = 0;
+        $skipped = 0;
+        $notDue = 0;
+
+        foreach ($runs as $run) {
+            $company = $this->resolveCompany($run);
+
+            if ($company === null) {
+                $skipped++;
+                Log::channel('structured')->warning('payroll.precalculate.skip_missing_company', [
+                    'payroll_run_id' => $run->id,
+                    'company_id' => $run->company_id,
+                ]);
+
+                continue;
+            }
+
+            if (in_array($company->status, ['suspended', 'expired'], true)) {
+                $skipped++;
+                Log::channel('structured')->info('payroll.precalculate.skip_inactive_company', [
+                    'payroll_run_id' => $run->id,
+                    'company_id' => $company->id,
+                    'company_status' => $company->status,
+                ]);
+
+                continue;
+            }
+
+            $nextPaymentDate = $this->resolveNextPaymentDate($cycleService, $company, $run);
+            $daysUntilPayment = Carbon::now($company->timezone ?: 'UTC')
+                ->startOfDay()
+                ->diffInDays($nextPaymentDate, false);
+
+            if ($daysUntilPayment > $windowDays) {
+                $notDue++;
+                Log::channel('structured')->debug('payroll.precalculate.not_due', [
+                    'payroll_run_id' => $run->id,
+                    'company_id' => $company->id,
+                    'next_payment_date' => $nextPaymentDate->toDateString(),
+                    'days_until_payment' => $daysUntilPayment,
+                ]);
+
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->line("[dry-run] Would dispatch payroll_run={$run->id} company={$company->id} days_until_payment={$daysUntilPayment}");
+
+                continue;
+            }
+
+            ProcessPayrollBatchJob::dispatch($run->id, (string) $company->id);
+            $dispatched++;
+
+            Log::channel('structured')->info('payroll.precalculate.dispatched', [
+                'payroll_run_id' => $run->id,
+                'company_id' => $company->id,
+                'next_payment_date' => $nextPaymentDate->toDateString(),
+                'days_until_payment' => $daysUntilPayment,
+                'run_status' => $run->status,
+            ]);
+        }
+
+        $this->info("Precalculation complete: dispatched={$dispatched} skipped={$skipped} not_due={$notDue} total_scanned={$runs->count()}.");
+
+        Log::channel('structured')->info('payroll.precalculate.run_complete', [
+            'dispatched' => $dispatched,
+            'skipped' => $skipped,
+            'not_due' => $notDue,
+            'total_scanned' => $runs->count(),
+            'dry_run' => $dryRun,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    private function resolveCompany(PayrollRun $run): ?Company
+    {
+        if ($run->company_id === null) {
+            return null;
+        }
+
+        return Company::query()->withoutGlobalScopes()->find($run->company_id);
+    }
+
+    /**
+     * Reuses `PayrollCycleService::getCurrentCycle()`'s pay-day math
+     * (PA2-PAY-011 settings: daily/weekly/monthly, configured pay day, week
+     * start) but anchored on the payroll run's own `period_end` rather than
+     * "today" — the current cycle helper is meant for live employee-balance
+     * reads (today's pay period), while a precalculation nightly job needs
+     * the payment date for *this specific run*'s period, which may be the
+     * cycle before or after the current one at any given point in the month.
+     */
+    private function resolveNextPaymentDate(PayrollCycleService $cycleService, Company $company, PayrollRun $run): Carbon
+    {
+        $settings = $cycleService->getPayCycleSettings($company);
+
+        if ($settings['pay_cycle'] !== 'monthly') {
+            return Carbon::instance($run->period_end)->copy()->startOfDay();
+        }
+
+        $periodEnd = Carbon::instance($run->period_end);
+        $payDay = min($settings['pay_day'], $periodEnd->daysInMonth);
+
+        return $periodEnd->copy()->startOfMonth()->addDays($payDay - 1)->startOfDay();
+    }
+}

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -40,6 +40,8 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('monitor:slow-queries --threshold=500')->everyFifteenMinutes();
         // Plan 64 — Auto-close attendance logs without check-out after 12h
         $schedule->command('attendance:auto-close')->hourly();
+        // PA2-PAY-012 — Nightly progressive payroll pre-calculation
+        $schedule->command('payroll:precalculate')->dailyAt('02:00');
     })
     ->withRouting(
         api: __DIR__.'/../routes/api.php',

--- a/api/tests/Feature/Payroll/PrecalculatePayrollRunsCommandTest.php
+++ b/api/tests/Feature/Payroll/PrecalculatePayrollRunsCommandTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Payroll;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\ProcessPayrollBatchJob;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-012 — nightly progressive payroll pre-calculation.
+ */
+class PrecalculatePayrollRunsCommandTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_dispatches_batch_job_for_a_draft_run_approaching_its_pay_day(): void
+    {
+        Queue::fake();
+
+        $this->travelTo(Carbon::parse('2026-01-28'));
+
+        $company = Company::factory()->create([
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'metadata' => ['payroll' => ['pay_cycle' => 'monthly', 'pay_day' => 30]],
+        ]);
+
+        $run = PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'draft',
+        ]);
+
+        $this->artisan('payroll:precalculate')->assertSuccessful();
+
+        Queue::assertPushed(ProcessPayrollBatchJob::class, function ($job) use ($run, $company) {
+            return $this->jobTargets($job, $run->id, (string) $company->id);
+        });
+    }
+
+    public function test_skips_run_when_pay_day_is_not_within_the_window(): void
+    {
+        Queue::fake();
+
+        $this->travelTo(Carbon::parse('2026-01-05'));
+
+        $company = Company::factory()->create([
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'metadata' => ['payroll' => ['pay_cycle' => 'monthly', 'pay_day' => 30]],
+        ]);
+
+        PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'draft',
+        ]);
+
+        $this->artisan('payroll:precalculate')->assertSuccessful();
+
+        Queue::assertNotPushed(ProcessPayrollBatchJob::class);
+    }
+
+    public function test_skips_run_belonging_to_a_suspended_company(): void
+    {
+        Queue::fake();
+
+        $this->travelTo(Carbon::parse('2026-01-28'));
+
+        $company = Company::factory()->create([
+            'status' => 'suspended',
+            'timezone' => 'UTC',
+            'metadata' => ['payroll' => ['pay_cycle' => 'monthly', 'pay_day' => 30]],
+        ]);
+
+        PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'draft',
+        ]);
+
+        $this->artisan('payroll:precalculate')->assertSuccessful();
+
+        Queue::assertNotPushed(ProcessPayrollBatchJob::class);
+    }
+
+    public function test_ignores_already_validated_or_cancelled_runs(): void
+    {
+        Queue::fake();
+
+        $this->travelTo(Carbon::parse('2026-01-28'));
+
+        $company = Company::factory()->create([
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'metadata' => ['payroll' => ['pay_cycle' => 'monthly', 'pay_day' => 30]],
+        ]);
+
+        PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'validated',
+        ]);
+
+        PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'cancelled',
+        ]);
+
+        $this->artisan('payroll:precalculate')->assertSuccessful();
+
+        Queue::assertNotPushed(ProcessPayrollBatchJob::class);
+    }
+
+    public function test_recalculates_a_previously_calculated_run_again_while_still_due(): void
+    {
+        Queue::fake();
+
+        $this->travelTo(Carbon::parse('2026-01-29'));
+
+        $company = Company::factory()->create([
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'metadata' => ['payroll' => ['pay_cycle' => 'monthly', 'pay_day' => 30]],
+        ]);
+
+        $run = PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'calculated',
+            'calculated_at' => Carbon::parse('2026-01-27'),
+        ]);
+
+        $this->artisan('payroll:precalculate')->assertSuccessful();
+
+        Queue::assertPushed(ProcessPayrollBatchJob::class, function ($job) use ($run, $company) {
+            return $this->jobTargets($job, $run->id, (string) $company->id);
+        });
+    }
+
+    public function test_dry_run_does_not_dispatch_any_job(): void
+    {
+        Queue::fake();
+
+        $this->travelTo(Carbon::parse('2026-01-28'));
+
+        $company = Company::factory()->create([
+            'status' => 'active',
+            'timezone' => 'UTC',
+            'metadata' => ['payroll' => ['pay_cycle' => 'monthly', 'pay_day' => 30]],
+        ]);
+
+        PayrollRun::withoutGlobalScopes()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => Carbon::parse('2026-01-01'),
+            'period_end' => Carbon::parse('2026-01-31'),
+            'status' => 'draft',
+        ]);
+
+        $this->artisan('payroll:precalculate', ['--dry-run' => true])->assertSuccessful();
+
+        Queue::assertNotPushed(ProcessPayrollBatchJob::class);
+    }
+
+    /**
+     * `ProcessPayrollBatchJob`'s constructor args are `private readonly`, so
+     * assert against it via reflection instead of relying on public getters
+     * that don't exist on this job.
+     */
+    private function jobTargets(ProcessPayrollBatchJob $job, int $payrollRunId, string $companyId): bool
+    {
+        $ref = new \ReflectionObject($job);
+
+        $actualRunId = $ref->getProperty('payrollRunId');
+        $actualRunId->setAccessible(true);
+
+        $actualCompanyId = $ref->getProperty('companyId');
+        $actualCompanyId->setAccessible(true);
+
+        return $actualRunId->getValue($job) === $payrollRunId
+            && $actualCompanyId->getValue($job) === $companyId;
+    }
+}


### PR DESCRIPTION
Closes #1045.

## What
Adds `payroll:precalculate`, a nightly command that progressively (re)calculates every `draft`/`calculated` `PayrollRun` as it approaches its pay day, instead of only ever calculating on the exact payment day via the manual `POST /payroll-runs/{id}/calculate` endpoint.

## Why
Before this, the only trigger for payroll calculation was a manager clicking "Calculate" — meaning the first signal that a run is broken (missing salary structure, bad country rules, a stuck queue worker) surfaced the same day employees expect to be paid, with no time left to fix it.

## How
- `PrecalculatePayrollRuns` scans all `draft`/`calculated` runs, resolves each run's company and next payment date (via `PayrollCycleService`, PA2-PAY-011, anchored on the run's own `period_end` rather than "today"), and dispatches the existing `ProcessPayrollBatchJob` for any run within `--days` (default 5) of its pay day.
- Reuses `ProcessPayrollBatchJob`'s own retry policy (`ShouldQueue`, `$tries = 3`, tenant-scoped) instead of reimplementing one.
- Skips runs with a missing company or a `suspended`/`expired` company.
- Every decision (`dispatched` / `skipped` / `not_due`) is logged on the `structured` channel for diagnosing a stuck precalculation from logs alone.
- Recalculating an already-`calculated` run is idempotent/side-effect-free (`PayrollCalculator::calculateRun()` deletes+regenerates that run's own pay slips inside a transaction), so a run just gets progressively fresher figures (new employees, updated salary structures, corrected attendance) each night up until a manager validates it.
- `--dry-run` previews without dispatching any job.
- Wired into the nightly schedule at 02:00 in `bootstrap/app.php`.

## Tests
New `PrecalculatePayrollRunsCommandTest` (6 tests, all passing):
- dispatches for a draft run approaching its pay day
- skips when pay day is outside the window
- skips a run belonging to a suspended company
- ignores validated/cancelled runs
- re-dispatches an already-calculated run still due
- `--dry-run` dispatches nothing

Also ran `phpstan analyse` on the new command (no errors) and the full `PrecalculatePayrollRunsCommandTest` suite locally — all green.
