### PR TITLE
feat(attendance): kiosk multi-event work_type support (PA2-ATT-010)

### DIFF
--- a/api/app/Modules/Attendance/Infrastructure/Services/KioskAttendanceService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/KioskAttendanceService.php
@@ -18,9 +18,9 @@ class KioskAttendanceService
         private readonly TenantManager $tenantManager,
     ) {}
 
-    public function punch(AttendanceKiosk $kiosk, string $identifier, string $action = 'check_in'): AttendanceLog
+    public function punch(AttendanceKiosk $kiosk, string $identifier, string $action = 'check_in', string $workType = 'normal'): AttendanceLog
     {
-        return $this->tenantManager->withinTenant($kiosk->company, function () use ($kiosk, $identifier, $action) {
+        return $this->tenantManager->withinTenant($kiosk->company, function () use ($kiosk, $identifier, $action, $workType) {
             $employee = Employee::query()
                 ->where('company_id', $kiosk->company_id)
                 ->where(function ($query) use ($identifier): void {
@@ -41,11 +41,20 @@ class KioskAttendanceService
 
             $kiosk->forceFill(['last_seen_at' => now()])->save();
 
+            // PA2-ATT-010: kiosk punches feed the same multi-event work_type
+            // model as mobile (normal/overtime/break/resume/mission/travel/
+            // training/other) instead of being locked to plain check_in/out.
             if ($action === 'check_out') {
-                return $this->attendanceService->checkOut($employee, new CheckInDTO(method: 'kiosk_'.$kiosk->biometric_mode));
+                return $this->attendanceService->checkOut($employee, new CheckInDTO(
+                    method: 'kiosk_'.$kiosk->biometric_mode,
+                    work_type: $workType,
+                ));
             }
 
-            return $this->attendanceService->checkIn($employee, new CheckInDTO(method: 'kiosk_'.$kiosk->biometric_mode));
+            return $this->attendanceService->checkIn($employee, new CheckInDTO(
+                method: 'kiosk_'.$kiosk->biometric_mode,
+                work_type: $workType,
+            ));
         });
     }
 
@@ -85,7 +94,10 @@ class KioskAttendanceService
                     biometric_type: $event['biometric_type'] ?? $kiosk->biometric_mode,
                     synced_from_offline: true,
                     action: $event['action'] ?? 'check_in',
-                    source_device_code: $kiosk->device_code
+                    source_device_code: $kiosk->device_code,
+                    // PA2-ATT-010: offline-synced kiosk events also carry the
+                    // multi-event work_type, matching mobile's offline sync.
+                    work_type: $event['work_type'] ?? 'normal',
                 ));
 
                 $processed[] = $log->id;

--- a/api/app/Modules/Attendance/Interfaces/Api/V1/KioskController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/KioskController.php
@@ -65,6 +65,10 @@ class KioskController extends Controller
         $validated = $request->validate([
             'identifier' => ['required', 'string', 'max:150'],
             'action' => ['nullable', 'in:check_in,check_out'],
+            // PA2-ATT-010: kiosk punches must feed the same multi-event
+            // work_type model as mobile (normal/overtime/break/resume/
+            // mission/travel/training/other), not just plain in/out.
+            'work_type' => ['nullable', 'string', 'in:normal,overtime,break,resume,mission,travel,training,other'],
         ]);
 
         $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
@@ -76,6 +80,7 @@ class KioskController extends Controller
             kiosk: $kiosk,
             identifier: trim($validated['identifier']),
             action: $validated['action'] ?? 'check_in',
+            workType: $validated['work_type'] ?? 'normal',
         );
 
         // REST convention: 201 Created for check_in, 200 OK for check_out
@@ -89,6 +94,8 @@ class KioskController extends Controller
                 'check_in' => optional($log->check_in)->toIso8601String(),
                 'check_out' => optional($log->check_out)->toIso8601String(),
                 'method' => $log->method,
+                'work_type' => $log->work_type,
+                'session_number' => $log->session_number,
                 'status' => $log->status,
             ],
         ], $statusCode);
@@ -142,6 +149,9 @@ class KioskController extends Controller
             'events.*.occurred_at' => ['nullable', 'date'],
             'events.*.external_event_id' => ['nullable', 'string', 'max:100'],
             'events.*.biometric_type' => ['nullable', 'in:fingerprint,face,mixed'],
+            // PA2-ATT-010: offline-synced kiosk events must also carry the
+            // multi-event work_type, same as mobile's offline sync payloads.
+            'events.*.work_type' => ['nullable', 'string', 'in:normal,overtime,break,resume,mission,travel,training,other'],
         ]);
 
         $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
@@ -313,6 +323,9 @@ class KioskController extends Controller
         $validated = $request->validate([
             'qr_data' => ['required', 'string', 'max:500'],
             'action' => ['nullable', 'in:check_in,check_out'],
+            // PA2-ATT-010: QR-code kiosk punches must also feed the same
+            // multi-event work_type model as mobile.
+            'work_type' => ['nullable', 'string', 'in:normal,overtime,break,resume,mission,travel,training,other'],
         ]);
 
         $kiosk = $this->resolveAuthorizedKiosk($request, $deviceCode);
@@ -323,10 +336,15 @@ class KioskController extends Controller
         $qrPayload = json_decode(base64_decode($validated['qr_data'], true), true);
         $identifier = $qrPayload['employee_id'] ?? $qrPayload['matricule'] ?? $validated['qr_data'];
 
+        $allowedWorkTypes = ['normal', 'overtime', 'break', 'resume', 'mission', 'travel', 'training', 'other'];
+        $qrWorkType = is_array($qrPayload) ? ($qrPayload['work_type'] ?? null) : null;
+        $qrWorkType = in_array($qrWorkType, $allowedWorkTypes, true) ? $qrWorkType : null;
+
         $log = $this->kioskAttendanceService->punch(
             kiosk: $kiosk,
             identifier: (string) $identifier,
             action: $validated['action'] ?? 'check_in',
+            workType: $validated['work_type'] ?? $qrWorkType ?? 'normal',
         );
 
         $action = $validated['action'] ?? 'check_in';
@@ -339,6 +357,8 @@ class KioskController extends Controller
                 'check_in' => optional($log->check_in)->toIso8601String(),
                 'check_out' => optional($log->check_out)->toIso8601String(),
                 'method' => 'qr_code',
+                'work_type' => $log->work_type,
+                'session_number' => $log->session_number,
                 'status' => $log->status,
             ],
         ], $statusCode);

--- a/api/tests/Feature/KioskMultiEventPunchTest.php
+++ b/api/tests/Feature/KioskMultiEventPunchTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-ATT-010 — Kiosk synchronise avec multi-evenements.
+ *
+ * The kiosk punch surface (direct punch, offline sync, QR punch) must feed
+ * the same multi-event work_type model already used by the mobile app
+ * (normal/overtime/break/resume/mission/travel/training/other), instead of
+ * being limited to a hardcoded "normal" check_in/check_out.
+ */
+class KioskMultiEventPunchTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_kiosk_punch_records_the_requested_work_type(): void
+    {
+        [$manager, $employee] = $this->seedCompanyManagerAndBiometricEmployee();
+        [$deviceCode, $syncToken] = $this->registerKiosk($manager);
+
+        $this->withHeader('X-Kiosk-Token', $syncToken)
+            ->postJson('/api/v1/kiosks/'.$deviceCode.'/punch', [
+                'identifier' => 'FP-001',
+                'action' => 'check_in',
+                'work_type' => 'mission',
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.work_type', 'mission');
+
+        DB::statement('SET search_path TO shared_tenants,public');
+        $this->assertDatabaseHas('attendance_logs', [
+            'employee_id' => $employee->id,
+            'work_type' => 'mission',
+        ]);
+    }
+
+    public function test_kiosk_punch_defaults_to_normal_work_type_when_omitted(): void
+    {
+        [$manager] = $this->seedCompanyManagerAndBiometricEmployee();
+        [$deviceCode, $syncToken] = $this->registerKiosk($manager);
+
+        $this->withHeader('X-Kiosk-Token', $syncToken)
+            ->postJson('/api/v1/kiosks/'.$deviceCode.'/punch', [
+                'identifier' => 'FP-001',
+                'action' => 'check_in',
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.work_type', 'normal');
+    }
+
+    public function test_kiosk_punch_rejects_an_invalid_work_type(): void
+    {
+        [$manager] = $this->seedCompanyManagerAndBiometricEmployee();
+        [$deviceCode, $syncToken] = $this->registerKiosk($manager);
+
+        $this->withHeader('X-Kiosk-Token', $syncToken)
+            ->postJson('/api/v1/kiosks/'.$deviceCode.'/punch', [
+                'identifier' => 'FP-001',
+                'action' => 'check_in',
+                'work_type' => 'not-a-real-type',
+            ])
+            ->assertStatus(422);
+    }
+
+    public function test_kiosk_offline_sync_preserves_work_type_per_event(): void
+    {
+        [$manager, $employee] = $this->seedCompanyManagerAndBiometricEmployee();
+        [$deviceCode, $syncToken] = $this->registerKiosk($manager);
+
+        $this->withHeader('X-Kiosk-Token', $syncToken)
+            ->postJson('/api/v1/kiosks/'.$deviceCode.'/sync', [
+                'events' => [
+                    [
+                        'identifier' => 'FP-001',
+                        'action' => 'check_in',
+                        'occurred_at' => '2026-04-19T08:00:00Z',
+                        'external_event_id' => 'evt-mission-001',
+                        'biometric_type' => 'fingerprint',
+                        'work_type' => 'mission',
+                    ],
+                    [
+                        'identifier' => 'FP-001',
+                        'action' => 'check_out',
+                        'occurred_at' => '2026-04-19T17:00:00Z',
+                        'external_event_id' => 'evt-mission-002',
+                        'biometric_type' => 'fingerprint',
+                        'work_type' => 'mission',
+                    ],
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.processed_count', 2);
+
+        // Note: check_in and check_out for the same session share a single
+        // attendance_logs row; external_event_id is updated to the closing
+        // event's id on check_out. Assert the merged row carries work_type.
+        DB::statement('SET search_path TO shared_tenants,public');
+        $this->assertDatabaseHas('attendance_logs', [
+            'employee_id' => $employee->id,
+            'external_event_id' => 'evt-mission-002',
+            'work_type' => 'mission',
+        ]);
+    }
+
+    public function test_kiosk_qr_punch_records_the_requested_work_type(): void
+    {
+        [$manager, $employee] = $this->seedCompanyManagerAndBiometricEmployee();
+        [$deviceCode, $syncToken] = $this->registerKiosk($manager);
+
+        $qrData = base64_encode(json_encode(['matricule' => 'EMP-001']));
+
+        $this->withHeader('X-Kiosk-Token', $syncToken)
+            ->postJson('/api/v1/kiosks/'.$deviceCode.'/qr-punch', [
+                'qr_data' => $qrData,
+                'action' => 'check_in',
+                'work_type' => 'travel',
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.work_type', 'travel');
+
+        DB::statement('SET search_path TO shared_tenants,public');
+        $this->assertDatabaseHas('attendance_logs', [
+            'employee_id' => $employee->id,
+            'work_type' => 'travel',
+        ]);
+    }
+
+    /**
+     * @return array{0: Employee, 1: Employee} [manager, employee]
+     */
+    private function seedCompanyManagerAndBiometricEmployee(): array
+    {
+        $company = Company::query()->create([
+            'name' => 'Company A',
+            'slug' => 'company-a-'.Str::random(6),
+            'sector' => 'services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@kiosk-multi.test',
+            'plan_id' => 1,
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        DB::statement('SET search_path TO shared_tenants,public');
+
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Karim',
+            'last_name' => 'Employe',
+            'email' => 'karim@kiosk-multi.test',
+            'matricule' => 'EMP-001',
+            'zkteco_id' => 'FP-001',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+            'biometric_fingerprint_enabled' => true,
+            'biometric_fingerprint_reference_path' => 'FP-001',
+        ]);
+
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'first_name' => 'Manager',
+            'last_name' => 'Principal',
+            'email' => 'manager@kiosk-multi.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+
+        DB::statement('SET search_path TO public');
+
+        return [$manager, $employee];
+    }
+
+    /**
+     * @return array{0: string, 1: string} [device_code, sync_token]
+     */
+    private function registerKiosk(Employee $manager): array
+    {
+        $kioskResponse = $this->actingAs($manager, 'sanctum')
+            ->postJson('/api/v1/kiosks', [
+                'name' => 'Entree principale',
+                'biometric_mode' => 'fingerprint',
+            ])
+            ->assertCreated();
+
+        return [
+            $kioskResponse->json('data.device_code'),
+            $kioskResponse->json('data.sync_token'),
+        ];
+    }
+}


### PR DESCRIPTION
Closes #1025

## Summary
Kiosk punches (direct punch, offline sync, QR punch) now feed the same multi-event work_type model already used by mobile (normal/overtime/break/resume/mission/travel/training/other), instead of being hardcoded to plain check_in/check_out.

## Changes
- `KioskAttendanceService::punch()` accepts a `workType` param, forwarded to `CheckInDTO` for both check-in and check-out.
- `syncPunches()` reads `work_type` per offline event, defaulting to `normal`.
- `KioskController` validates `work_type` on `/punch`, `/sync`, and `/qr-punch`, and returns `work_type` + `session_number` in punch responses.
- QR punch also accepts `work_type` from the decoded QR payload as a fallback when not given explicitly in the request body.

## Tests
Added `api/tests/Feature/KioskMultiEventPunchTest.php` covering:
- direct punch with an explicit work_type
- direct punch defaulting to normal when omitted
- rejection of an invalid work_type (422)
- offline sync preserving work_type per event
- QR punch with an explicit work_type

All 5 new tests pass locally against Postgres (matching .env.testing). Also re-ran `tests/Feature/Security/KioskCrossTenantIsolationTest.php` and the full `tests/Feature/Attendance` suite: no regressions (3 unrelated pre-existing failures due to missing GD extension in this sandbox, unrelated to this change).
