### PR TITLE
test(attendance): PA2-QA-004 - k6 progressive load test 10/20/50/100 for punch (path-based and manual)

### DIFF
--- a/.github/workflows/k6-load-smoke.yml
+++ b/.github/workflows/k6-load-smoke.yml
@@ -23,6 +23,18 @@ on:
         description: "Duration for each scenario"
         required: false
         default: "1m"
+      run_attendance_punch_scale:
+        description: "Also run the progressive attendance punch scale test (10/20/50/100 VUs)"
+        required: false
+        default: "false"
+      attendance_punch_mode:
+        description: "attendance-punch-scale.js mode: manual or path"
+        required: false
+        default: "manual"
+      attendance_stage_duration:
+        description: "Duration of each attendance-punch-scale.js stage"
+        required: false
+        default: "30s"
 
 permissions:
   contents: read
@@ -87,5 +99,48 @@ jobs:
         with:
           name: k6-api-core-smoke-summary
           path: dev-hub/load/reports/api-core-smoke-summary.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  attendance-punch-scale:
+    name: Attendance punch progressive load (10/20/50/100 VUs)
+    if: github.event.inputs.run_attendance_punch_scale == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Prepare reports directory
+        run: mkdir -p dev-hub/load/reports
+
+      - name: Run k6 attendance punch scale
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+          EMPLOYEE_TOKENS: ${{ secrets.K6_EMPLOYEE_TOKENS }}
+          PUNCH_MODE: ${{ github.event.inputs.attendance_punch_mode }}
+          STAGE_DURATION: ${{ github.event.inputs.attendance_stage_duration }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${EMPLOYEE_TOKENS}" ]]; then
+            echo "::notice::K6_EMPLOYEE_TOKENS is not configured; scenario will fall back to health probes."
+          fi
+
+          docker run --rm \
+            -e BASE_URL \
+            -e EMPLOYEE_TOKENS \
+            -e PUNCH_MODE \
+            -e STAGE_DURATION \
+            -v "${PWD}:/work" \
+            grafana/k6:latest run \
+            --summary-export /work/dev-hub/load/reports/attendance-punch-scale-summary.json \
+            /work/dev-hub/load/k6/attendance-punch-scale.js
+
+      - name: Upload k6 summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: k6-attendance-punch-scale-summary
+          path: dev-hub/load/reports/attendance-punch-scale-summary.json
           if-no-files-found: ignore
           retention-days: 14

--- a/dev-hub/load/README.md
+++ b/dev-hub/load/README.md
@@ -8,6 +8,7 @@ Ce dossier contient les scripts de charge k6 utilises pour mesurer les parcours 
 |---|---|---|
 | `k6/api-core-smoke.js` | Health, auth session, dashboard manager, employees, attendance, payroll et self-service employe | Non |
 | `k6/employee-100-attendance-payroll.js` | Benchmark 100 employes simultanes sur pointage, historique et consultation paie | Non par defaut ; check-in optionnel avec `ALLOW_ATTENDANCE_MUTATIONS=true` |
+| `k6/attendance-punch-scale.js` | Charge progressive pointage (10/20/50/100 VUs) manuel (`check-in`/`check-out`) ou path-based (`smart-attendance/geo-events`) | Oui, punchs reels crees a chaque iteration (voir Garde-fous) |
 | `k6/payroll-500-batch.js` | Benchmark calcul paie 500 employes avec seuil < 30 s | Lecture par defaut ; calcul optionnel avec `ALLOW_PAYROLL_MUTATIONS=true` |
 | `k6/admin-dashboard-10k.js` | Benchmark dashboard admin + pagination/search sur tenant 10k employes | Non |
 
@@ -65,6 +66,33 @@ k6 run dev-hub/load/k6/payroll-500-batch.js
 
 Seuil : `POST /api/v1/payroll-runs/{id}/calculate` p95 < 30000 ms.
 
+### Pointage progressif 10/20/50/100 (PA2-QA-004)
+
+Montee en charge par palier sur le pointage, en mode manuel (`check-in`/`check-out` classiques) ou path-based (evenements geofence `zone_enter`/`zone_exit` de SmartAttendance). Chaque palier dure `STAGE_DURATION` (30s par defaut) et le VU cible peut etre ajuste par palier.
+
+Mode manuel (par defaut) :
+
+```bash
+BASE_URL="https://api-staging.leopardo-rh.com" \
+EMPLOYEE_TOKENS="token1,token2,token3" \
+PUNCH_MODE=manual \
+k6 run dev-hub/load/k6/attendance-punch-scale.js
+```
+
+Mode path-based (geofence) :
+
+```bash
+BASE_URL="https://api-staging.leopardo-rh.com" \
+EMPLOYEE_TOKENS="token1,token2,token3" \
+PUNCH_MODE=path \
+GEO_LAT=33.5731 GEO_LNG=-7.5898 \
+k6 run dev-hub/load/k6/attendance-punch-scale.js
+```
+
+Paliers par defaut : 10 -> 20 -> 50 -> 100 VUs, 30s chacun (`STAGE_1_VUS`..`STAGE_4_VUS`, `STAGE_DURATION`). Seuils : moins de 2% d'erreurs, p95 punch < 1500 ms, zero echec non attendu (statuts hors 200/201/409/422 comptes comme echec).
+
+**Attention** : ce script cree reellement des pointages (check-in/check-out ou sessions geofence) a chaque iteration, contrairement aux autres scripts read-only de ce dossier. Executer uniquement sur un tenant de staging dedie aux tests de charge, jamais en production. Utiliser `ALLOW_CHECKOUT=false` pour ne garder que le check-in si l'on souhaite limiter le volume de mutations en mode manuel.
+
 ### Dashboard admin 10k employes
 
 ```bash
@@ -100,6 +128,20 @@ Seuils : p95 dashboard < 1500 ms, liste/search employes < 1800 ms.
 | `EMPLOYEE_DURATION` | `1m` | Duree employe |
 
 Les valeurs `*_VUS` inferieures a `1` sont normalisees a leur defaut pour respecter la configuration k6.
+
+### Variables `attendance-punch-scale.js`
+
+| Variable | Defaut | Usage |
+|---|---|---|
+| `PUNCH_MODE` | `manual` | `manual` (check-in/check-out) ou `path` (geofence zone_enter/zone_exit) |
+| `EMPLOYEE_TOKENS` | vide | Tokens Sanctum employe, un par VU en round-robin (fallback health si vide) |
+| `STAGE_1_VUS`..`STAGE_4_VUS` | `10`/`20`/`50`/`100` | VUs cibles par palier |
+| `STAGE_DURATION` | `30s` | Duree de chaque palier |
+| `STAGE_GRACEFUL_RAMPDOWN` | `10s` | Temps de descente en fin de test |
+| `ALLOW_CHECKOUT` | `true` | Desactiver pour ne faire que le check-in en mode manuel |
+| `GEO_LAT` / `GEO_LNG` / `GEO_ACCURACY_METERS` | `33.5731` / `-7.5898` / `15` | Coordonnees utilisees pour les evenements geofence en mode path |
+| `GEO_DWELL_SECONDS` | `1` | Delai entre `zone_enter` et `zone_exit` |
+| `PUNCH_SLEEP` | `1` | Pause entre iterations d'un VU |
 
 ## Procedure de benchmark Plan 14
 

--- a/dev-hub/load/k6/attendance-punch-scale.js
+++ b/dev-hub/load/k6/attendance-punch-scale.js
@@ -1,0 +1,132 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+const baseUrl = (__ENV.BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
+const punchMode = (__ENV.PUNCH_MODE || 'manual').toLowerCase();
+const allowCheckout = __ENV.ALLOW_CHECKOUT !== 'false';
+const tokens = (__ENV.EMPLOYEE_TOKENS || __ENV.EMPLOYEE_TOKEN || '')
+  .split(',')
+  .map((token) => token.trim())
+  .filter(Boolean);
+
+const punchLatency = new Trend('attendance_punch_latency_ms');
+const punchFailures = new Counter('attendance_punch_failures');
+
+function stageVus(name, fallback) {
+  const value = Number(__ENV[name] || fallback);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+export const options = {
+  scenarios: {
+    attendance_punch_scale: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: __ENV.STAGE_DURATION || '30s', target: stageVus('STAGE_1_VUS', 10) },
+        { duration: __ENV.STAGE_DURATION || '30s', target: stageVus('STAGE_2_VUS', 20) },
+        { duration: __ENV.STAGE_DURATION || '30s', target: stageVus('STAGE_3_VUS', 50) },
+        { duration: __ENV.STAGE_DURATION || '30s', target: stageVus('STAGE_4_VUS', 100) },
+      ],
+      gracefulRampDown: __ENV.STAGE_GRACEFUL_RAMPDOWN || '10s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.02'],
+    attendance_punch_latency_ms: ['p(95)<1500'],
+    attendance_punch_failures: ['count<1'],
+  },
+};
+
+function tokenForVu() {
+  if (tokens.length === 0) {
+    return '';
+  }
+
+  return tokens[(__VU - 1) % tokens.length];
+}
+
+function headers(token, json) {
+  const base = {
+    Accept: 'application/json',
+    Authorization: token ? `Bearer ${token}` : undefined,
+  };
+
+  if (json) {
+    base['Content-Type'] = 'application/json';
+  }
+
+  return { headers: base };
+}
+
+function recordAcceptedOrRejected(response, label) {
+  punchLatency.add(response.timings.duration);
+
+  const accepted = check(response, {
+    [`${label} accepted or business-rejected`]: (res) => [200, 201, 409, 422].includes(res.status),
+  });
+
+  if (!accepted) {
+    punchFailures.add(1);
+  }
+}
+
+function manualPunch(token) {
+  group('manual check-in/check-out (path-based=false)', () => {
+    const checkIn = http.post(`${baseUrl}/api/v1/attendance/check-in`, null, headers(token, false));
+    recordAcceptedOrRejected(checkIn, 'manual check-in');
+
+    if (allowCheckout) {
+      const checkOut = http.post(`${baseUrl}/api/v1/attendance/check-out`, null, headers(token, false));
+      recordAcceptedOrRejected(checkOut, 'manual check-out');
+    }
+  });
+}
+
+function pathBasedPunch(token) {
+  const latitude = Number(__ENV.GEO_LAT || 33.5731);
+  const longitude = Number(__ENV.GEO_LNG || -7.5898);
+  const accuracyMeters = Number(__ENV.GEO_ACCURACY_METERS || 15);
+
+  group('path-based geofence punch (zone_enter/zone_exit)', () => {
+    const enterPayload = JSON.stringify({
+      event_type: 'zone_enter',
+      latitude,
+      longitude,
+      accuracy_meters: accuracyMeters,
+    });
+    const zoneEnter = http.post(`${baseUrl}/api/v1/smart-attendance/geo-events`, enterPayload, headers(token, true));
+    recordAcceptedOrRejected(zoneEnter, 'geo zone_enter');
+
+    sleep(Number(__ENV.GEO_DWELL_SECONDS || 1));
+
+    const exitPayload = JSON.stringify({
+      event_type: 'zone_exit',
+      latitude,
+      longitude,
+      accuracy_meters: accuracyMeters,
+    });
+    const zoneExit = http.post(`${baseUrl}/api/v1/smart-attendance/geo-events`, exitPayload, headers(token, true));
+    recordAcceptedOrRejected(zoneExit, 'geo zone_exit');
+  });
+}
+
+export default function () {
+  const token = tokenForVu();
+
+  if (!token) {
+    const health = http.get(`${baseUrl}/api/v1/health/live`, { headers: { Accept: 'application/json' } });
+    check(health, { 'health fallback status is 2xx': (res) => res.status >= 200 && res.status < 300 });
+    sleep(1);
+    return;
+  }
+
+  if (punchMode === 'path') {
+    pathBasedPunch(token);
+  } else {
+    manualPunch(token);
+  }
+
+  sleep(Number(__ENV.PUNCH_SLEEP || 1));
+}


### PR DESCRIPTION
Closes #1069

## Contexte

**Ticket:** PA2-QA-004
**Priority:** P1
**Area:** Verification
**Surface:** dev-hub/k6
**Dependencies:** PA2-ATT-001

**Critere d'acceptation:** Scenario 10 20 50 100 punchs path-based ou manuel

## Ce que ce PR ajoute

- `dev-hub/load/k6/attendance-punch-scale.js` : script k6 avec un scenario `ramping-vus` qui monte par palier 10 -> 20 -> 50 -> 100 VUs (30s par palier, configurable via `STAGE_1_VUS`..`STAGE_4_VUS` / `STAGE_DURATION`).
  - `PUNCH_MODE=manual` (par defaut) : exerce `POST /api/v1/attendance/check-in` puis `POST /api/v1/attendance/check-out` (le check-out est desactivable via `ALLOW_CHECKOUT=false`).
  - `PUNCH_MODE=path` : exerce le flux path-based/geofence du module SmartAttendance (`POST /api/v1/smart-attendance/geo-events` avec `zone_enter` puis `zone_exit`), avec latitude/longitude/precision configurables.
  - Tokens employe via `EMPLOYEE_TOKENS` (round-robin par VU), fallback sur une sonde health si aucun token n'est fourni (comme les autres scripts du dossier).
  - Seuils : moins de 2% d'erreurs HTTP, p95 punch < 1500 ms, aucun echec non attendu (statuts hors 200/201/409/422).
- `dev-hub/load/README.md` : documentation du nouveau script (usage, variables, mise en garde car il cree reellement des pointages/sessions, contrairement aux autres scripts read-only du dossier).
- `.github/workflows/k6-load-smoke.yml` : job optionnel `attendance-punch-scale`, gate par un input `workflow_dispatch` (`run_attendance_punch_scale`) pour ne jamais s'executer implicitement ; secret optionnel `K6_EMPLOYEE_TOKENS`.

## Verification

- `k6 v0.54.0` installe localement, `k6 run` execute avec succes le script en mode `manual` et `path` contre un serveur HTTP mock jetable (Node) : les deux flux (check-in/check-out et zone_enter/zone_exit) partent bien avec le bon payload, les seuils passent, 0 echec.
- Verification syntaxique JS (`node --check`) et relecture manuelle du YAML du workflow (structure jobs/steps alignee sur le job `api-core-smoke` existant).
- Pas de test contre un vrai tenant de staging effectue depuis cet environnement (pas d'acces token staging ici) ; le script est pret a etre lance manuellement via le workflow ou en local avec de vrais tokens `EMPLOYEE_TOKENS`.

## Garde-fous

- Ce script cree reellement des pointages/sessions, a la difference des autres scripts read-only du dossier `dev-hub/load`. A executer uniquement sur un tenant de staging dedie aux tests de charge.