### PR TITLE
feat(platform): Redis/jobs observability endpoint (PA2-QA-006)

### DIFF
--- a/api/app/Modules/Platform/Domain/Models/ScheduledTaskRun.php
+++ b/api/app/Modules/Platform/Domain/Models/ScheduledTaskRun.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Domain\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * PA2-QA-006 — Last known outcome of a scheduled Artisan command.
+ *
+ * @property int $id
+ * @property string $name
+ * @property Carbon|null $started_at
+ * @property Carbon|null $finished_at
+ * @property int|null $runtime_ms
+ * @property string $status
+ * @property int|null $exit_code
+ * @property string|null $output
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class ScheduledTaskRun extends Model
+{
+    public const STATUS_SUCCESS = 'success';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_UNKNOWN = 'unknown';
+
+    protected $table = 'scheduled_task_runs';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+        'runtime_ms' => 'integer',
+        'exit_code' => 'integer',
+    ];
+}

--- a/api/app/Modules/Platform/Infrastructure/Services/QueueObservabilityService.php
+++ b/api/app/Modules/Platform/Infrastructure/Services/QueueObservabilityService.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Infrastructure\Services;
+
+use App\Modules\Platform\Domain\Models\ScheduledTaskRun;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * PA2-QA-006 — Observabilite Redis/jobs.
+ *
+ * Aggregates everything a super-admin needs to answer "are the background
+ * jobs healthy right now?" without SSH-ing into the box:
+ *   - Redis connectivity/latency (reuses the same probe as HealthController)
+ *   - per-queue depth (documents, pdf, payroll, notifications, webhooks, default)
+ *   - failed_jobs count + the most recent failures (queue, exception, when)
+ *   - last run (started/finished/status) of every scheduled Artisan command
+ *
+ * Every sub-check is wrapped so a single broken probe (e.g. Redis down)
+ * degrades that section instead of taking the whole endpoint down with a 500.
+ */
+class QueueObservabilityService
+{
+    /** Named queues also used by QueueHealthCheck / HealthController. */
+    private const QUEUES = ['default', 'documents', 'pdf', 'payroll', 'notifications', 'webhooks'];
+
+    /**
+     * Failed-jobs count above this threshold flips `alerts.failed_jobs` to true.
+     */
+    private const FAILED_JOBS_ALERT_THRESHOLD = 10;
+
+    /**
+     * Any single queue depth above this threshold flips `alerts.queue_depth` to true.
+     */
+    private const QUEUE_DEPTH_ALERT_THRESHOLD = 500;
+
+    /**
+     * A scheduled task whose last run is older than this (and has a known
+     * schedule) is considered stale and flips `alerts.stale_tasks` to true.
+     */
+    private const STALE_TASK_ALERT_HOURS = 26;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function snapshot(): array
+    {
+        $redis = $this->checkRedis();
+        $queues = $this->queueDepths();
+        $failedJobs = $this->failedJobs();
+        $scheduledTasks = $this->scheduledTasks();
+
+        $totalDepth = array_sum(array_column($queues, 'depth'));
+        $maxDepth = $queues === [] ? 0 : max(array_column($queues, 'depth'));
+
+        $staleTasks = array_values(array_filter(
+            $scheduledTasks,
+            static fn (array $task): bool => $task['is_stale'] === true,
+        ));
+
+        return [
+            'redis' => $redis,
+            'queue_connection' => (string) config('queue.default'),
+            'queues' => $queues,
+            'queue_total_depth' => $totalDepth,
+            'failed_jobs' => $failedJobs,
+            'scheduled_tasks' => $scheduledTasks,
+            'alerts' => [
+                'redis_down' => $redis['ok'] === false,
+                'queue_depth' => $maxDepth >= self::QUEUE_DEPTH_ALERT_THRESHOLD,
+                'failed_jobs' => $failedJobs['count'] >= self::FAILED_JOBS_ALERT_THRESHOLD,
+                'stale_tasks' => $staleTasks !== [],
+            ],
+            'thresholds' => [
+                'failed_jobs' => self::FAILED_JOBS_ALERT_THRESHOLD,
+                'queue_depth' => self::QUEUE_DEPTH_ALERT_THRESHOLD,
+                'stale_task_hours' => self::STALE_TASK_ALERT_HOURS,
+            ],
+            'generated_at' => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array{ok: bool, status?: string, latency_ms?: int, error?: string}
+     */
+    private function checkRedis(): array
+    {
+        $start = microtime(true);
+
+        try {
+            $response = Redis::connection()->ping();
+            $ok = $response === true || $response === 'PONG' || $response === '+PONG';
+
+            return [
+                'ok' => $ok,
+                'status' => $ok ? 'pong' : 'unexpected',
+                'latency_ms' => (int) round((microtime(true) - $start) * 1000),
+            ];
+        } catch (Throwable $e) {
+            return [
+                'ok' => false,
+                'status' => 'unreachable',
+                'error' => class_basename($e),
+            ];
+        }
+    }
+
+    /**
+     * @return array<int, array{name: string, depth: int, ok: bool}>
+     */
+    private function queueDepths(): array
+    {
+        $driver = (string) config('queue.default', 'sync');
+
+        if ($driver === 'sync') {
+            return array_map(
+                static fn (string $name): array => ['name' => $name, 'depth' => 0, 'ok' => true],
+                self::QUEUES,
+            );
+        }
+
+        $queues = [];
+
+        foreach (self::QUEUES as $queue) {
+            try {
+                $depth = (int) app('queue')->connection()->size($queue);
+                $queues[] = ['name' => $queue, 'depth' => $depth, 'ok' => true];
+            } catch (Throwable) {
+                $queues[] = ['name' => $queue, 'depth' => 0, 'ok' => false];
+            }
+        }
+
+        return $queues;
+    }
+
+    /**
+     * @return array{count: int|null, recent: array<int, array{id: int, queue: string, exception: string, failed_at: string|null}>}
+     */
+    private function failedJobs(): array
+    {
+        try {
+            $table = (string) config('queue.failed.table', 'failed_jobs');
+
+            if (! Schema::hasTable($table)) {
+                return ['count' => null, 'recent' => []];
+            }
+
+            $count = (int) DB::table($table)->count();
+
+            $recent = DB::table($table)
+                ->orderByDesc('id')
+                ->limit(10)
+                ->get(['id', 'queue', 'exception', 'failed_at'])
+                ->map(function (object $row): array {
+                    return [
+                        'id' => (int) $row->id,
+                        'queue' => (string) $row->queue,
+                        // First line only: full stack traces are large and
+                        // this is a dashboard summary, not a log viewer.
+                        'exception' => $this->truncateFirstLine((string) $row->exception),
+                        'failed_at' => $row->failed_at !== null ? Carbon::parse($row->failed_at)->toIso8601String() : null,
+                    ];
+                })
+                ->all();
+
+            return ['count' => $count, 'recent' => $recent];
+        } catch (Throwable) {
+            return ['count' => null, 'recent' => []];
+        }
+    }
+
+    /**
+     * Returns only the first non-empty line of a stack-trace-shaped string,
+     * capped to a dashboard-safe length.
+     */
+    private function truncateFirstLine(string $value): string
+    {
+        $firstLine = trim(strtok($value, "\n") ?: '');
+
+        return mb_strlen($firstLine) > 300 ? mb_substr($firstLine, 0, 300).'…' : $firstLine;
+    }
+
+    /**
+     * @return array<int, array{name: string, started_at: string|null, finished_at: string|null, status: string, runtime_ms: int|null, exit_code: int|null, is_stale: bool}>
+     */
+    private function scheduledTasks(): array
+    {
+        try {
+            if (! Schema::hasTable('scheduled_task_runs')) {
+                return [];
+            }
+
+            DB::statement('SET search_path TO public');
+
+            return ScheduledTaskRun::query()
+                ->orderBy('name')
+                ->get()
+                ->map(function (ScheduledTaskRun $run): array {
+                    $reference = $run->finished_at ?? $run->started_at;
+                    $isStale = $reference !== null
+                        && $reference->lt(now()->subHours(self::STALE_TASK_ALERT_HOURS));
+
+                    return [
+                        'name' => $run->name,
+                        'started_at' => $run->started_at?->toIso8601String(),
+                        'finished_at' => $run->finished_at?->toIso8601String(),
+                        'status' => $run->status,
+                        'runtime_ms' => $run->runtime_ms,
+                        'exit_code' => $run->exit_code,
+                        'is_stale' => $isStale,
+                    ];
+                })
+                ->all();
+        } catch (Throwable) {
+            return [];
+        }
+    }
+}

--- a/api/app/Modules/Platform/Infrastructure/Services/ScheduledTaskRunRecorder.php
+++ b/api/app/Modules/Platform/Infrastructure/Services/ScheduledTaskRunRecorder.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Infrastructure\Services;
+
+use App\Modules\Platform\Domain\Models\ScheduledTaskRun;
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * PA2-QA-006 — Redis/jobs observability.
+ *
+ * Persists the last start/finish outcome of every scheduled Artisan command
+ * (`Schedule::command(...)` entries in `routes/console.php` / `bootstrap/
+ * app.php`) into `scheduled_task_runs`, one row per task, so the platform
+ * admin "System" screen can display *when* each background task last ran
+ * and whether it succeeded — the "last run + alerts visible" part of the
+ * acceptance criteria that pure queue-depth metrics cannot answer.
+ *
+ * Registered via `Event::listen()` in `AppServiceProvider::boot()` (not
+ * `EventServiceProvider::$listen`) because these are framework console
+ * events, not domain events, and only fire while `schedule:run` executes
+ * (i.e. from the cron entry point), never from a web request.
+ *
+ * Deliberately best-effort: a failure to *record* an outcome must never
+ * abort the actual scheduled task or crash `schedule:run` for the other
+ * tasks queued in the same run.
+ */
+class ScheduledTaskRunRecorder
+{
+    /** @var array<string, float> Start time (microtime) per task name, keyed for this process only. */
+    private array $startedAt = [];
+
+    public function onStarting(ScheduledTaskStarting $event): void
+    {
+        $name = $this->taskName($event->task);
+        $this->startedAt[$name] = microtime(true);
+
+        $this->upsert($name, [
+            'started_at' => now(),
+            'finished_at' => null,
+            'status' => ScheduledTaskRun::STATUS_UNKNOWN,
+        ]);
+    }
+
+    public function onFinished(ScheduledTaskFinished $event): void
+    {
+        $name = $this->taskName($event->task);
+        $exitCode = $event->task->exitCode ?? null;
+        $success = $exitCode === 0;
+
+        $this->upsert($name, [
+            'finished_at' => now(),
+            'runtime_ms' => (int) round($event->runtime * 1000),
+            'status' => $success ? ScheduledTaskRun::STATUS_SUCCESS : ScheduledTaskRun::STATUS_FAILED,
+            'exit_code' => $exitCode,
+            'output' => $this->truncatedOutput($event->task),
+        ]);
+    }
+
+    public function onFailed(ScheduledTaskFailed $event): void
+    {
+        $name = $this->taskName($event->task);
+
+        $this->upsert($name, [
+            'finished_at' => now(),
+            'status' => ScheduledTaskRun::STATUS_FAILED,
+            'exit_code' => $event->task->exitCode ?? null,
+            'output' => Str::limit((string) $event->exception->getMessage(), 2000),
+        ]);
+    }
+
+    private function taskName(object $task): string
+    {
+        // `getSummaryForDisplay()` returns a human label when `->name(...)`
+        // was set, otherwise the raw command line — either way it uniquely
+        // identifies the scheduled entry across restarts.
+        if (method_exists($task, 'getSummaryForDisplay')) {
+            return (string) $task->getSummaryForDisplay();
+        }
+
+        return (string) ($task->command ?? $task->description ?? 'unknown');
+    }
+
+    /**
+     * Reads the scheduled task's redirected output file (`->output` is the
+     * filesystem path Laravel writes stdout/stderr to, defaulting to
+     * `/dev/null` when no `->sendOutputTo()`/`->appendOutputTo()` was
+     * configured for that entry — in which case there is nothing to read).
+     */
+    private function truncatedOutput(object $task): ?string
+    {
+        $path = $task->output ?? null;
+
+        if (! is_string($path) || $path === '' || $path === '/dev/null' || ! is_file($path)) {
+            return null;
+        }
+
+        try {
+            $output = (string) file_get_contents($path);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (trim($output) === '') {
+            return null;
+        }
+
+        return Str::limit(trim($output), 2000);
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    private function upsert(string $name, array $values): void
+    {
+        try {
+            if (! Schema::hasTable('scheduled_task_runs')) {
+                return;
+            }
+
+            DB::statement('SET search_path TO public');
+
+            ScheduledTaskRun::query()->updateOrCreate(
+                ['name' => $name],
+                $values,
+            );
+        } catch (Throwable $e) {
+            Log::warning('ScheduledTaskRunRecorder: failed to persist run', [
+                'task' => $name,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/QueueObservabilityController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/QueueObservabilityController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Platform\Infrastructure\Services\QueueObservabilityService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * PA2-QA-006 — Observabilite Redis/jobs.
+ *
+ * GET /api/v1/platform/observability/queues : queue depth, failed jobs
+ * (count + recent) and last run/status of every scheduled Artisan command,
+ * plus a derived `alerts` summary — everything the super-admin "System"
+ * screen needs to answer "are the background jobs healthy right now?"
+ * without SSH-ing into the box. Depends on PA2-JOB-001 (failed_jobs table,
+ * queue:health-check command).
+ */
+class QueueObservabilityController extends Controller
+{
+    public function __invoke(QueueObservabilityService $service): JsonResponse
+    {
+        // scheduled_task_runs / failed_jobs both live in the `public` schema
+        // (platform-wide, not tenant-scoped) — see PlatformCompanyHealthController
+        // for the same pattern on the super-admin routes.
+        DB::statement('SET search_path TO public');
+
+        return response()->json(['data' => $service->snapshot()]);
+    }
+}

--- a/api/app/Modules/Platform/Providers/PlatformServiceProvider.php
+++ b/api/app/Modules/Platform/Providers/PlatformServiceProvider.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\Modules\Platform\Providers;
 
+use App\Modules\Platform\Infrastructure\Services\ScheduledTaskRunRecorder;
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class PlatformServiceProvider extends ServiceProvider
@@ -15,6 +20,14 @@ class PlatformServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        // Boot Platform module
+        // PA2-QA-006 — record last start/finish outcome of every scheduled
+        // Artisan command so the platform admin "System" screen can surface
+        // it (queue depth / failed jobs already exist; this adds "last run").
+        // Only fires while `schedule:run` executes, never from web requests.
+        $this->app->singleton(ScheduledTaskRunRecorder::class);
+
+        Event::listen(ScheduledTaskStarting::class, [ScheduledTaskRunRecorder::class, 'onStarting']);
+        Event::listen(ScheduledTaskFinished::class, [ScheduledTaskRunRecorder::class, 'onFinished']);
+        Event::listen(ScheduledTaskFailed::class, [ScheduledTaskRunRecorder::class, 'onFailed']);
     }
 }

--- a/api/database/migrations/public/2026_07_25_000001_create_scheduled_task_runs_table.php
+++ b/api/database/migrations/public/2026_07_25_000001_create_scheduled_task_runs_table.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-QA-006 — Redis/jobs observability.
+ *
+ * Records the last outcome of every scheduled Artisan command (cron entries
+ * registered in `routes/console.php` / `bootstrap/app.php`) so the platform
+ * admin "System" screen can show *when* each background task last ran and
+ * whether it succeeded, instead of only exposing point-in-time queue depths.
+ *
+ * One row per task `name` (the exact scheduled command line), overwritten on
+ * every run (`upsert`) — we only need the *last* run, not a full history, to
+ * keep this cheap to query from a dashboard polling every few seconds.
+ *
+ * Lives under `database/migrations/public` (not `tenant/`): scheduled tasks
+ * are a platform-wide operational concern, not scoped to a single tenant
+ * company, exactly like `failed_jobs` (PA2-JOB-001) already is in this same
+ * directory.
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        DB::statement('SET search_path TO public');
+
+        if (Schema::hasTable('scheduled_task_runs')) {
+            return;
+        }
+
+        Schema::create('scheduled_task_runs', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name', 190)->unique();
+            $table->timestampTz('started_at')->nullable();
+            $table->timestampTz('finished_at')->nullable();
+            $table->integer('runtime_ms')->nullable();
+            $table->string('status', 20)->default('unknown');
+            $table->integer('exit_code')->nullable();
+            $table->text('output')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        DB::statement('SET search_path TO public');
+        Schema::dropIfExists('scheduled_task_runs');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -31,6 +31,7 @@ use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCountryDefaultsCo
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCrmPipelineController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformImpersonationController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformMetricsOverviewController;
+use App\Modules\Platform\Interfaces\Api\V1\Controllers\QueueObservabilityController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\TranslationCatalogController;
 use Illuminate\Support\Facades\Route;
 
@@ -177,6 +178,10 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/companies/{company}/features', [PlatformCompanyFeatureController::class, 'show']);
         Route::patch('/companies/{company}/features', [PlatformCompanyFeatureController::class, 'update']);
         Route::get('/metrics/overview', PlatformMetricsOverviewController::class);
+
+        // PA2-QA-006 — Redis/jobs observability (queue depth, failed jobs,
+        // scheduled task last-run) for the super-admin "System" screen.
+        Route::get('/observability/queues', QueueObservabilityController::class);
 
         Route::get('/company-requests', [PlatformCompanyRequestController::class, 'index']);
         Route::get('/company-requests/{id}', [PlatformCompanyRequestController::class, 'show'])->whereNumber('id');

--- a/api/tests/Feature/QueueObservabilityApiTest.php
+++ b/api/tests/Feature/QueueObservabilityApiTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Modules\Platform\Domain\Models\ScheduledTaskRun;
+use App\Modules\Platform\Infrastructure\Services\ScheduledTaskRunRecorder;
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Scheduling\CacheEventMutex;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Console\Kernel;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * PA2-QA-006 — Observabilite Redis/jobs.
+ *
+ * Covers GET /api/v1/platform/observability/queues (queue depth, failed
+ * jobs, scheduled task last-run, derived alerts) and the
+ * `ScheduledTaskRunRecorder` that feeds the `scheduled_task_runs` table
+ * from the `schedule:run` console events.
+ *
+ * `failed_jobs`, `scheduled_task_runs` and `super_admins` all live in the
+ * `public` schema (platform-wide, not tenant-scoped) — unlike
+ * `Tests\RefreshTenantDatabase`, this only migrates `database/migrations/
+ * public`, skipping the tenant migration path entirely since nothing under
+ * test needs a tenant schema.
+ */
+class QueueObservabilityApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate:fresh', [
+            '--path' => 'database/migrations/public',
+        ]);
+
+        $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    public function test_requires_super_admin_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/platform/observability/queues');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_super_admin_can_view_queue_observability_snapshot(): void
+    {
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+        DB::table('failed_jobs')->insert([
+            'uuid' => (string) Str::uuid(),
+            'connection' => 'redis',
+            'queue' => 'default',
+            'payload' => json_encode(['job' => 'Tests\\Fake']),
+            'exception' => "RuntimeException: fake failure\n#0 fake trace line",
+            'failed_at' => now(),
+        ]);
+
+        $response = $this->getJson('/api/v1/platform/observability/queues');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                'redis',
+                'queue_connection',
+                'queues',
+                'queue_total_depth',
+                'failed_jobs' => ['count', 'recent'],
+                'scheduled_tasks',
+                'alerts' => ['redis_down', 'queue_depth', 'failed_jobs', 'stale_tasks'],
+                'thresholds',
+                'generated_at',
+            ],
+        ]);
+        $response->assertJsonPath('data.failed_jobs.count', 1);
+        $response->assertJsonPath('data.failed_jobs.recent.0.queue', 'default');
+        $response->assertJsonPath('data.failed_jobs.recent.0.exception', 'RuntimeException: fake failure');
+    }
+
+    public function test_recorder_persists_last_run_status_of_scheduled_tasks(): void
+    {
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+        Carbon::setTestNow(Carbon::parse('2026-07-25 03:00:00', 'UTC'));
+
+        $recorder = app(ScheduledTaskRunRecorder::class);
+
+        $successTask = $this->fakeScheduledTask('billing:check-trials', 0);
+        $successName = $successTask->getSummaryForDisplay();
+        $recorder->onStarting(new ScheduledTaskStarting($successTask));
+        $recorder->onFinished(new ScheduledTaskFinished($successTask, 1.25));
+
+        $failedTask = $this->fakeScheduledTask('billing:generate-invoices', 1);
+        $failedName = $failedTask->getSummaryForDisplay();
+        $recorder->onStarting(new ScheduledTaskStarting($failedTask));
+        $recorder->onFailed(new ScheduledTaskFailed($failedTask, new \RuntimeException('boom')));
+
+        $this->assertSame(2, ScheduledTaskRun::query()->count());
+
+        $success = ScheduledTaskRun::query()->where('name', $successName)->first();
+        $this->assertNotNull($success);
+        $this->assertSame(ScheduledTaskRun::STATUS_SUCCESS, $success->status);
+        $this->assertSame(0, $success->exit_code);
+
+        $failed = ScheduledTaskRun::query()->where('name', $failedName)->first();
+        $this->assertNotNull($failed);
+        $this->assertSame(ScheduledTaskRun::STATUS_FAILED, $failed->status);
+
+        $response = $this->getJson('/api/v1/platform/observability/queues');
+        $response->assertOk();
+
+        $names = collect($response->json('data.scheduled_tasks'))->pluck('name');
+        $this->assertTrue($names->contains($successName));
+        $this->assertTrue($names->contains($failedName));
+
+        $failedEntry = collect($response->json('data.scheduled_tasks'))
+            ->firstWhere('name', $failedName);
+        $this->assertSame('failed', $failedEntry['status']);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_stale_scheduled_task_flips_alert(): void
+    {
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+
+        ScheduledTaskRun::query()->create([
+            'name' => 'contracts:alert-expiring',
+            'started_at' => now()->subHours(30),
+            'finished_at' => now()->subHours(30),
+            'status' => ScheduledTaskRun::STATUS_SUCCESS,
+            'exit_code' => 0,
+        ]);
+
+        $response = $this->getJson('/api/v1/platform/observability/queues');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.alerts.stale_tasks', true);
+
+        $entry = collect($response->json('data.scheduled_tasks'))
+            ->firstWhere('name', 'contracts:alert-expiring');
+        $this->assertTrue($entry['is_stale']);
+    }
+
+    private function superAdmin(): SuperAdmin
+    {
+        return SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => fake()->unique()->safeEmail(),
+            'password_hash' => Hash::make('password123'),
+        ]);
+    }
+
+    /**
+     * Builds a real `Illuminate\Console\Scheduling\Event` instance (the
+     * class the framework events are strictly type-hinted against) without
+     * going through a full `schedule:run` cycle.
+     */
+    private function fakeScheduledTask(string $command, int $exitCode): Event
+    {
+        $task = new Event(app(CacheEventMutex::class), $command);
+        $task->exitCode = $exitCode;
+
+        return $task;
+    }
+}

--- a/front/admin-dashboard/src/components/system/QueueObservabilityCard.vue
+++ b/front/admin-dashboard/src/components/system/QueueObservabilityCard.vue
@@ -1,0 +1,204 @@
+<template>
+  <section class="card">
+    <div class="flex items-center justify-between border-b border-slate-200/50 px-6 py-5 dark:border-slate-800/50">
+      <div>
+        <h3 class="text-xl font-bold text-slate-900 dark:text-white">Observabilité Redis / Jobs</h3>
+        <p class="text-xs text-slate-400 mt-0.5">
+          Profondeur des files, jobs échoués et dernière exécution des tâches planifiées.
+        </p>
+      </div>
+      <button
+        @click="$emit('refresh')"
+        :disabled="loading"
+        class="p-2 rounded-lg text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50"
+        title="Actualiser"
+      >
+        <ArrowPathIcon class="h-5 w-5" :class="{ 'animate-spin': loading }" />
+      </button>
+    </div>
+
+    <div class="p-6 space-y-6">
+      <!-- Alert banners -->
+      <div v-if="hasAnyAlert" class="space-y-2">
+        <div
+          v-if="data?.alerts?.redis_down"
+          class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-bold text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400"
+        >
+          <ExclamationTriangleIcon class="h-5 w-5 flex-shrink-0" />
+          Redis inaccessible — les files ne peuvent pas être traitées.
+        </div>
+        <div
+          v-if="data?.alerts?.queue_depth"
+          class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400"
+        >
+          <ExclamationTriangleIcon class="h-5 w-5 flex-shrink-0" />
+          Profondeur de file anormalement élevée (seuil: {{ data?.thresholds?.queue_depth }}).
+        </div>
+        <div
+          v-if="data?.alerts?.failed_jobs"
+          class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-bold text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400"
+        >
+          <ExclamationTriangleIcon class="h-5 w-5 flex-shrink-0" />
+          {{ data?.failed_jobs?.count }} jobs échoués (seuil: {{ data?.thresholds?.failed_jobs }}).
+        </div>
+        <div
+          v-if="data?.alerts?.stale_tasks"
+          class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400"
+        >
+          <ExclamationTriangleIcon class="h-5 w-5 flex-shrink-0" />
+          Une ou plusieurs tâches planifiées n'ont pas tourné depuis plus de
+          {{ data?.thresholds?.stale_task_hours }}h.
+        </div>
+      </div>
+      <div
+        v-else-if="data"
+        class="flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-400"
+      >
+        <CheckCircleIcon class="h-5 w-5 flex-shrink-0" />
+        Aucune alerte — Redis, files et tâches planifiées sont sains.
+      </div>
+
+      <!-- Redis + queue summary -->
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div class="rounded-xl border border-slate-200/60 dark:border-slate-800/60 p-3">
+          <div class="text-[10px] font-black uppercase tracking-widest text-slate-400">Redis</div>
+          <div class="mt-1 flex items-center gap-1.5">
+            <span :class="['h-2 w-2 rounded-full', data?.redis?.ok ? 'bg-emerald-500' : 'bg-red-500']"></span>
+            <span class="text-sm font-bold" :class="data?.redis?.ok ? 'text-emerald-600' : 'text-red-600'">
+              {{ data?.redis?.ok ? (data?.redis?.latency_ms + ' ms') : (data?.redis?.status || 'indisponible') }}
+            </span>
+          </div>
+        </div>
+        <div class="rounded-xl border border-slate-200/60 dark:border-slate-800/60 p-3">
+          <div class="text-[10px] font-black uppercase tracking-widest text-slate-400">Profondeur totale</div>
+          <div class="mt-1 text-sm font-bold text-slate-900 dark:text-white">{{ data?.queue_total_depth ?? 0 }}</div>
+        </div>
+        <div class="rounded-xl border border-slate-200/60 dark:border-slate-800/60 p-3">
+          <div class="text-[10px] font-black uppercase tracking-widest text-slate-400">Jobs échoués</div>
+          <div
+            class="mt-1 text-sm font-bold"
+            :class="data?.alerts?.failed_jobs ? 'text-red-600' : 'text-slate-900 dark:text-white'"
+          >
+            {{ data?.failed_jobs?.count ?? '—' }}
+          </div>
+        </div>
+        <div class="rounded-xl border border-slate-200/60 dark:border-slate-800/60 p-3">
+          <div class="text-[10px] font-black uppercase tracking-widest text-slate-400">Connexion file</div>
+          <div class="mt-1 text-sm font-bold text-slate-900 dark:text-white">{{ data?.queue_connection ?? '—' }}</div>
+        </div>
+      </div>
+
+      <!-- Per-queue depth -->
+      <div v-if="data?.queues?.length">
+        <h4 class="text-xs font-black uppercase tracking-widest text-slate-400 mb-2">Files</h4>
+        <div class="space-y-1.5">
+          <div
+            v-for="queue in data.queues"
+            :key="queue.name"
+            class="flex items-center justify-between text-sm px-3 py-1.5 rounded-lg bg-slate-50 dark:bg-slate-800/50"
+          >
+            <span class="font-medium text-slate-700 dark:text-slate-300">{{ queue.name }}</span>
+            <span :class="['font-bold', queue.ok ? 'text-slate-900 dark:text-white' : 'text-red-600']">
+              {{ queue.ok ? queue.depth : 'indisponible' }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Scheduled tasks last run -->
+      <div v-if="data?.scheduled_tasks?.length">
+        <h4 class="text-xs font-black uppercase tracking-widest text-slate-400 mb-2">Dernière exécution des tâches planifiées</h4>
+        <div class="space-y-1.5">
+          <div
+            v-for="task in data.scheduled_tasks"
+            :key="task.name"
+            class="flex items-center justify-between text-sm px-3 py-2 rounded-lg"
+            :class="task.is_stale ? 'bg-amber-50 dark:bg-amber-950/20' : 'bg-slate-50 dark:bg-slate-800/50'"
+          >
+            <span class="font-medium text-slate-700 dark:text-slate-300 truncate mr-3">{{ task.name }}</span>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <span
+                :class="[
+                  'px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-widest',
+                  task.status === 'success' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' :
+                  task.status === 'failed' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
+                  'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                ]"
+              >
+                {{ task.status }}
+              </span>
+              <span v-if="task.is_stale" class="text-[10px] font-black uppercase tracking-widest text-amber-600">stale</span>
+              <span class="text-slate-500 dark:text-slate-400">{{ formatTime(task.finished_at || task.started_at) }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-else-if="data" class="text-sm text-slate-500 dark:text-slate-400">
+        Aucune tâche planifiée n'a encore été enregistrée.
+      </div>
+
+      <!-- Recent failed jobs -->
+      <div v-if="data?.failed_jobs?.recent?.length">
+        <h4 class="text-xs font-black uppercase tracking-widest text-slate-400 mb-2">Jobs échoués récents</h4>
+        <div class="space-y-1.5">
+          <div
+            v-for="job in data.failed_jobs.recent"
+            :key="job.id"
+            class="text-sm px-3 py-2 rounded-lg bg-red-50 dark:bg-red-950/20"
+          >
+            <div class="flex items-center justify-between">
+              <span class="font-bold text-red-700 dark:text-red-400">{{ job.queue }}</span>
+              <span class="text-slate-500 dark:text-slate-400 text-xs">{{ formatTime(job.failed_at) }}</span>
+            </div>
+            <div class="text-xs text-slate-600 dark:text-slate-400 truncate mt-0.5">{{ job.exception }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { ArrowPathIcon, ExclamationTriangleIcon, CheckCircleIcon } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
+
+const props = defineProps({
+  data: {
+    type: Object,
+    default: null,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+defineEmits(['refresh'])
+
+const hasAnyAlert = computed(() => {
+  const alerts = props.data?.alerts
+  return !!alerts && Object.values(alerts).some(Boolean)
+})
+
+function formatTime(value) {
+  if (!value) return 'Jamais'
+
+  const date = new Date(value)
+  const now = new Date()
+  const diff = now - date
+
+  if (diff < 60000) return "À l'instant"
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`
+  return date.toLocaleDateString(toIntlLocale(localeStore.current), {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+</script>

--- a/front/admin-dashboard/src/views/system/SystemView.vue
+++ b/front/admin-dashboard/src/views/system/SystemView.vue
@@ -42,6 +42,13 @@
       </div>
     </div>
 
+    <!-- Queue / Jobs Observability (PA2-QA-006) -->
+    <QueueObservabilityCard
+      :data="queueObservability"
+      :loading="isLoadingObservability"
+      @refresh="loadQueueObservability"
+    />
+
     <!-- System Status Overview -->
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 animate-slide-up">
       <SystemStatusCard
@@ -225,9 +232,11 @@ import {
   BeakerIcon
 } from '@heroicons/vue/24/outline'
 import { useToast } from 'vue-toastification'
+import api from '@/services/api'
 
 // Components
 import SystemStatusCard from '@/components/system/SystemStatusCard.vue'
+import QueueObservabilityCard from '@/components/system/QueueObservabilityCard.vue'
 import RealTimeMetricsChart from '@/components/system/RealTimeMetricsChart.vue'
 import ResourceUsageWidget from '@/components/system/ResourceUsageWidget.vue'
 import BackupManagement from '@/components/system/BackupManagement.vue'
@@ -242,6 +251,8 @@ const toast = useToast()
 
 // Reactive state
 const isRunningHealthCheck = ref(false)
+const queueObservability = ref(null)
+const isLoadingObservability = ref(false)
 const isCreatingBackup = ref(false)
 const showCreateTaskModal = ref(false)
 const showImportModal = ref(false)
@@ -321,6 +332,7 @@ let metricsInterval = null
 
 onMounted(async () => {
   await loadSystemData()
+  await loadQueueObservability()
   startMetricsRefresh()
 })
 
@@ -345,6 +357,22 @@ async function loadSystemData() {
   } catch (error) {
     console.error('Failed to load system data:', error)
     toast.error('Erreur lors du chargement des données système')
+  }
+}
+
+// PA2-QA-006 — Redis/jobs observability: queue depth, failed jobs and last
+// run of scheduled tasks, backed by GET /platform/observability/queues.
+async function loadQueueObservability() {
+  isLoadingObservability.value = true
+
+  try {
+    const response = await api.get('/platform/observability/queues')
+    queueObservability.value = response.data?.data || null
+  } catch (error) {
+    console.error('Failed to load queue observability:', error)
+    toast.error('Erreur lors du chargement de l\'observabilité des jobs')
+  } finally {
+    isLoadingObservability.value = false
   }
 }
 


### PR DESCRIPTION
## Summary
Implements **PA2-QA-006** — observabilité Redis/jobs for the super-admin "System" screen.

Closes #1071

## What
- `GET /api/v1/platform/observability/queues` — queue connection health, per-queue depth, failed jobs (count + recent), last start/finish status of every scheduled Artisan command, and a derived `alerts` object (`redis_down`, `queue_depth`, `failed_jobs`, `stale_tasks`).
- `ScheduledTaskRunRecorder` — listens to `ScheduledTaskStarting`/`Finished`/`Failed` and persists last-run status/exit code/duration per scheduled command in a new `scheduled_task_runs` table (public schema, depends on PA2-JOB-001's `failed_jobs` table).
- `QueueObservabilityCard.vue` — renders alert banners, redis/queue summary, per-queue depth, scheduled task last-run list and recent failed jobs on the admin `System` view.

## Testing
- New `QueueObservabilityApiTest` (4 tests, 34 assertions): auth requirement, snapshot shape + failed-job surfacing, recorder persistence, stale-task alert. All passing locally against Postgres 17.
- `PlatformMetricsOverviewApiTest` re-run to confirm no regression.
- Frontend: `npm run build` succeeds; `eslint` on changed files shows no new errors (only pre-existing unused-var warnings in `SystemView.vue`).

## Notes
- Ran into a pre-existing, unrelated migration bug in `database/migrations/tenant/2026_07_23_000003_add_currency_to_salary_advances_table.php` (fails identically on `main` against a real Postgres backend, not something introduced here) — worked around it in the new test by migrating only `database/migrations/public` since nothing under test needs the tenant schema.