### PR TITLE
feat(hr): audit trail for HR role nomination/revocation (PA2-MOB-007)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -3,6 +3,14 @@
 Toutes les modifications notables de ce projet sont documentées ici.
 Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- **Audit trail pour la nomination/revocation de rôles RH (PA2-MOB-007)**
+  - Nouvel événement `EmployeeRoleAssigned`, journalisé dans `audit_logs` (actions `role_assigned` / `role_revoked`) avec l'ancien et le nouveau `manager_role`, et l'identité du manager principal ayant fait le changement
+  - Couvre les deux chemins existants : `POST /employees/{id}/assign-role` (dashboard web) **et** `PATCH /employees/{id}` (utilisé par l'app mobile manager `TeamScreen._toggleHrRole`), qui contournait auparavant tout audit
+  - Tests Feature : `RoleAssignmentAuditTest` (6 tests couvrant nomination/revocation sur les deux endpoints, non-régression sur les champs non lies au rôle, et rejet d'un manager non-principal)
+
 ## [4.21.0] - 2026-07-01
 
 ### Changed

--- a/api/app/Events/EmployeeRoleAssigned.php
+++ b/api/app/Events/EmployeeRoleAssigned.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Core\Auth\Domain\Models\Employee;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Dispatched whenever a manager_role (rh, comptable, dept, superviseur,
+ * marketing, principal) is assigned to or revoked from an employee.
+ *
+ * Feeds the immutable audit trail (AuditLogController) so principal
+ * managers can review every RH/permission change on their team, per
+ * PA2-MOB-007 (Gestion RH mobile — nommer/revoquer RH, permissions, audit).
+ */
+class EmployeeRoleAssigned
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly Employee $employee,
+        public readonly Employee $actor,
+        public readonly ?string $previousRole,
+        public readonly ?string $newRole,
+    ) {}
+}

--- a/api/app/Listeners/AuditLogger.php
+++ b/api/app/Listeners/AuditLogger.php
@@ -11,6 +11,7 @@ use App\Events\AttendanceCheckedIn;
 use App\Events\AttendanceCheckedOut;
 use App\Events\EmployeeArchived;
 use App\Events\EmployeeCreated;
+use App\Events\EmployeeRoleAssigned;
 use App\Events\PayrollValidated;
 use App\Core\Auth\Domain\Models\AuditLog;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -34,6 +35,12 @@ class AuditLogger implements ShouldQueue
 
     public function handle(object $event): void
     {
+        if ($event instanceof EmployeeRoleAssigned) {
+            $this->handleRoleAssigned($event);
+
+            return;
+        }
+
         $class = $event::class;
         $mapping = self::EVENT_MAP[$class] ?? null;
 
@@ -67,6 +74,33 @@ class AuditLogger implements ShouldQueue
         } catch (\Throwable $e) {
             Log::error('AuditLogger: failed to write audit log', [
                 'event' => $class,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * PA2-MOB-007 — nominate/revoke RH permissions must leave an audit
+     * trail with both the previous and new manager_role, and the
+     * identity of the principal manager who made the change.
+     */
+    private function handleRoleAssigned(EmployeeRoleAssigned $event): void
+    {
+        try {
+            AuditLog::create([
+                'company_id' => $event->employee->company_id,
+                'user_id' => $event->actor->id,
+                'action' => $event->newRole ? 'role_assigned' : 'role_revoked',
+                'auditable_type' => $event->employee->getMorphClass(),
+                'auditable_id' => $event->employee->getKey(),
+                'old_values' => ['manager_role' => $event->previousRole],
+                'new_values' => ['manager_role' => $event->newRole],
+                'ip_address' => request()?->ip(),
+                'user_agent' => request()?->userAgent() ? mb_substr((string) request()?->userAgent(), 0, 500) : null,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('AuditLogger: failed to write role assignment audit log', [
+                'employee_id' => $event->employee->id,
                 'error' => $e->getMessage(),
             ]);
         }

--- a/api/app/Modules/HR/Infrastructure/Services/EmployeeService.php
+++ b/api/app/Modules/HR/Infrastructure/Services/EmployeeService.php
@@ -8,6 +8,7 @@ use App\Modules\HR\Application\DTOs\CreateEmployeeDTO;
 use App\Modules\HR\Application\DTOs\UpdateEmployeeDTO;
 use App\Events\EmployeeArchived;
 use App\Events\EmployeeCreated;
+use App\Events\EmployeeRoleAssigned;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Infrastructure\Services\TenantCacheService;
 use Illuminate\Support\Arr;
@@ -126,11 +127,22 @@ class EmployeeService
         /** @var array<string, mixed> $payload */
         $this->applyBiometricConsent($payload, $employee);
 
+        $previousManagerRole = $employee->manager_role;
+        $roleChangeRequested = array_key_exists('manager_role', $payload) || array_key_exists('role', $payload);
+
         $employee->fill($payload);
         $employee->save();
 
         if ($employee->company_id !== null) {
             $this->tenantCache->invalidateEmployees($employee->company_id);
+        }
+
+        // PA2-MOB-007 — nominate/revoke RH permissions must leave an audit
+        // trail even when the change is made through the generic employee
+        // update endpoint (e.g. from the manager mobile app) rather than the
+        // dedicated RoleAssignmentController::assign endpoint.
+        if ($roleChangeRequested && $employee->manager_role !== $previousManagerRole) {
+            EmployeeRoleAssigned::dispatch($employee, $actor, $previousManagerRole, $employee->manager_role);
         }
 
         return $employee;

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/RoleAssignmentController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/RoleAssignmentController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Events\EmployeeRoleAssigned;
 use App\Mail\RoleAssignmentMail;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\HR\Infrastructure\Services\RoleInvitationService;
@@ -49,6 +50,9 @@ class RoleAssignmentController extends Controller
         $employee->role = $newRole ? 'manager' : 'employee';
         $employee->manager_role = $newRole;
         $employee->save();
+
+        // PA2-MOB-007 — every nomination/revocation must leave an audit trail.
+        EmployeeRoleAssigned::dispatch($employee, $actor, $previousRole, $newRole);
 
         // Send notification email if role was assigned (not removed)
         if ($newRole && $newRole !== $previousRole) {

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -11,6 +11,7 @@ use App\Events\AttendanceCheckedIn;
 use App\Events\AttendanceCheckedOut;
 use App\Events\EmployeeArchived;
 use App\Events\EmployeeCreated;
+use App\Events\EmployeeRoleAssigned;
 use App\Events\CompanyCreated;
 use App\Events\PayrollValidated;
 use App\Events\SubscriptionPaid;
@@ -32,6 +33,7 @@ class EventServiceProvider extends ServiceProvider
         AbsenceApproved::class => [AuditLogger::class, WebhookListener::class],
         AbsenceRejected::class => [AuditLogger::class, WebhookListener::class],
         PayrollValidated::class => [AuditLogger::class, WebhookListener::class],
+        EmployeeRoleAssigned::class => [AuditLogger::class],
         CompanyCreated::class => [LinkPartnerToNewCompany::class],
         SubscriptionPaid::class => [ProcessCommissionOnPayment::class],
     ];

--- a/api/tests/Feature/RoleAssignmentAuditTest.php
+++ b/api/tests/Feature/RoleAssignmentAuditTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\AuditLog;
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-MOB-007 — Gestion RH mobile: nommer/revoquer RH, permissions, audit.
+ *
+ * The mobile "Team" screen nominates/revokes HR through the generic
+ * PATCH /employees/{id} endpoint, while the legacy web dashboard uses the
+ * dedicated POST /employees/{id}/assign-role endpoint. Both paths must
+ * leave an immutable audit trail entry so a principal manager can review
+ * every permission change on their team.
+ */
+class RoleAssignmentAuditTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_assign_role_endpoint_writes_an_audit_log_entry(): void
+    {
+        $company = Company::factory()->create();
+        $principal = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($principal);
+
+        $response = $this->postJson("/api/v1/employees/{$employee->id}/assign-role", [
+            'manager_role' => 'rh',
+        ]);
+
+        $response->assertOk();
+
+        $log = AuditLog::query()
+            ->where('auditable_type', $employee->getMorphClass())
+            ->where('auditable_id', $employee->id)
+            ->where('action', 'role_assigned')
+            ->first();
+
+        $this->assertNotNull($log, 'Expected a role_assigned audit log entry.');
+        $this->assertSame($principal->id, $log->user_id);
+        $this->assertArrayHasKey('manager_role', $log->old_values);
+        $this->assertNull($log->old_values['manager_role']);
+        $this->assertSame('rh', $log->new_values['manager_role'] ?? null);
+    }
+
+    public function test_revoking_a_role_via_assign_role_endpoint_writes_an_audit_log_entry(): void
+    {
+        $company = Company::factory()->create();
+        $principal = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $hrEmployee = Employee::factory()->managerRh()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($principal);
+
+        $this->postJson("/api/v1/employees/{$hrEmployee->id}/assign-role", [
+            'manager_role' => null,
+        ])->assertOk();
+
+        $log = AuditLog::query()
+            ->where('auditable_type', $hrEmployee->getMorphClass())
+            ->where('auditable_id', $hrEmployee->id)
+            ->where('action', 'role_revoked')
+            ->first();
+
+        $this->assertNotNull($log, 'Expected a role_revoked audit log entry.');
+        $this->assertSame('rh', $log->old_values['manager_role'] ?? null);
+        $this->assertArrayHasKey('manager_role', $log->new_values);
+        $this->assertNull($log->new_values['manager_role']);
+    }
+
+    public function test_nominating_hr_via_the_generic_employee_update_endpoint_also_writes_an_audit_log_entry(): void
+    {
+        // This mirrors the manager mobile app's TeamScreen._toggleHrRole(),
+        // which patches role/manager_role via PATCH /employees/{id} instead
+        // of the dedicated assign-role endpoint.
+        $company = Company::factory()->create();
+        $principal = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($principal);
+
+        $response = $this->patchJson("/api/v1/employees/{$employee->id}", [
+            'role' => 'manager',
+            'manager_role' => 'rh',
+        ]);
+
+        $response->assertOk();
+
+        $log = AuditLog::query()
+            ->where('auditable_type', $employee->getMorphClass())
+            ->where('auditable_id', $employee->id)
+            ->where('action', 'role_assigned')
+            ->first();
+
+        $this->assertNotNull($log, 'Expected a role_assigned audit log entry from the generic update endpoint.');
+        $this->assertSame($principal->id, $log->user_id);
+        $this->assertSame('rh', $log->new_values['manager_role'] ?? null);
+    }
+
+    public function test_revoking_hr_via_the_generic_employee_update_endpoint_also_writes_an_audit_log_entry(): void
+    {
+        $company = Company::factory()->create();
+        $principal = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $hrEmployee = Employee::factory()->managerRh()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($principal);
+
+        $this->patchJson("/api/v1/employees/{$hrEmployee->id}", [
+            'role' => 'employee',
+            'manager_role' => null,
+        ])->assertOk();
+
+        $log = AuditLog::query()
+            ->where('auditable_type', $hrEmployee->getMorphClass())
+            ->where('auditable_id', $hrEmployee->id)
+            ->where('action', 'role_revoked')
+            ->first();
+
+        $this->assertNotNull($log, 'Expected a role_revoked audit log entry from the generic update endpoint.');
+        $this->assertSame('rh', $log->old_values['manager_role'] ?? null);
+    }
+
+    public function test_updating_unrelated_fields_does_not_create_a_role_audit_log_entry(): void
+    {
+        $company = Company::factory()->create();
+        $principal = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($principal);
+
+        $this->patchJson("/api/v1/employees/{$employee->id}", [
+            'phone' => '+213555000111',
+        ])->assertOk();
+
+        $count = AuditLog::query()
+            ->where('auditable_type', $employee->getMorphClass())
+            ->where('auditable_id', $employee->id)
+            ->whereIn('action', ['role_assigned', 'role_revoked'])
+            ->count();
+
+        $this->assertSame(0, $count);
+    }
+
+    public function test_a_non_principal_manager_cannot_assign_roles_and_no_audit_log_is_written(): void
+    {
+        $company = Company::factory()->create();
+        $deptManager = Employee::factory()->managerDept()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($deptManager);
+
+        $this->patchJson("/api/v1/employees/{$employee->id}", [
+            'role' => 'manager',
+            'manager_role' => 'rh',
+        ])->assertUnprocessable();
+
+        $count = AuditLog::query()
+            ->where('auditable_type', $employee->getMorphClass())
+            ->where('auditable_id', $employee->id)
+            ->whereIn('action', ['role_assigned', 'role_revoked'])
+            ->count();
+
+        $this->assertSame(0, $count);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #977 (PA2-MOB-007 — Gestion RH mobile: nommer/revoquer RH, permissions, audit).

Every nomination or revocation of a `manager_role` now leaves an immutable entry in `audit_logs`, recording the previous role, the new role, and the identity of the principal manager who made the change.

## The gap
A dedicated `POST /employees/{id}/assign-role` endpoint (`RoleAssignmentController`) already existed and correctly restricts role changes to principal managers, but it never wrote to the audit trail. Worse, the **manager mobile app's Team screen** (`TeamScreen._toggleHrRole`) nominates/revokes HR through the generic `PATCH /employees/{id}` endpoint instead, which bypassed any audit trail entirely — so the actual mobile flow the acceptance criteria describes had zero audit coverage.

## What's included
- New `App\Events\EmployeeRoleAssigned` event carrying the employee, the acting manager, and the previous/new `manager_role`
- `AuditLogger` listener handles it, writing `action=role_assigned` or `action=role_revoked` with old/new `manager_role` values, reusing the existing `audit_logs` table and `AuditLogController` read API
- `RoleAssignmentController::assign` dispatches the event after updating the employee
- `EmployeeService::update` dispatches the event whenever `manager_role`/`role` actually changes as part of a generic employee update (covers the mobile app's actual call path)
- CHANGELOG entry under Unreleased

## Testing
- New `RoleAssignmentAuditTest` (6 tests) covering: nomination + revocation via both endpoints, no spurious audit entries on unrelated field updates, and rejection of a non-principal manager's attempt (still no audit entry written)
- Verified no regressions: ran `--filter="Employee|Audit|Role"` with and without this change (`git stash`) — identical baseline errors/failures aside from the 4 new tests, which fail without the fix and pass with it