### PR TITLE
PA2-COUNTRY-002: seed default schedule from country rules on company provisioning

### DIFF
--- a/api/app/Modules/HR/Infrastructure/Services/SectorTemplateService.php
+++ b/api/app/Modules/HR/Infrastructure/Services/SectorTemplateService.php
@@ -5,21 +5,103 @@ declare(strict_types=1);
 namespace App\Modules\HR\Infrastructure\Services;
 
 use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Payroll\Domain\Contracts\CountryRulesInterface;
+use App\Modules\Payroll\Infrastructure\Services\PayrollCalculator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class SectorTemplateService
 {
-    /**
-     * @param Company $company
-     * @return void
-     */
+    public function __construct(
+        private readonly PayrollCalculator $payrollCalculator = new PayrollCalculator,
+    ) {}
+
     public function applyTemplate(Company $company): void
     {
         $sector = strtolower($company->sector ?? 'standard');
 
         $this->seedAbsenceTypes($company->id, $sector);
         $this->seedPositions($company->id, $sector);
+        $this->seedDefaultSchedule($company);
+    }
+
+    /**
+     * PA2-COUNTRY-002: the company creation flow already derives currency
+     * and timezone from the chosen country (see CountryDefaults), but was
+     * missing the "HR rule model" part of the acceptance criteria: a new
+     * company had no default work Schedule at all, so attendance/overtime
+     * calculations had nothing to fall back on until a manager manually
+     * created one from scratch with generic 9-to-5/Mon-Fri values that may
+     * not match local labor law (e.g. France's 35h week, Tunisia's Sunday
+     * rest day, Morocco's 44h threshold).
+     *
+     * This seeds one `is_default` Schedule per new company, using the
+     * country's own CountryRulesInterface (weeklyRestDays(),
+     * overtimeThresholdWeeklyHours()) so the starting point already
+     * matches that country's standard labor-code baseline. Managers can
+     * still edit/replace it afterwards via the Schedule CRUD API.
+     *
+     * Idempotent: does nothing if a default schedule already exists for
+     * this company (e.g. re-applying the template, or a schedule created
+     * by another provisioning path first).
+     */
+    private function seedDefaultSchedule(Company $company): void
+    {
+        if (! $this->sharedTableExists('schedules')) {
+            return;
+        }
+
+        $alreadyHasDefault = DB::table($this->tenantTable('schedules'))
+            ->where('company_id', $company->id)
+            ->where('is_default', true)
+            ->exists();
+
+        if ($alreadyHasDefault) {
+            return;
+        }
+
+        $countryCode = strtoupper((string) ($company->country ?? ''));
+        $restDays = [7]; // Sunday-only fallback, matching most supported countries.
+        $overtimeThresholdWeekly = 40.0;
+
+        try {
+            $rules = $this->payrollCalculator->getRules($countryCode);
+            $restDays = $this->normalizeRestDays($rules);
+            $overtimeThresholdWeekly = $rules->overtimeThresholdWeeklyHours();
+        } catch (\InvalidArgumentException) {
+            // Country not registered in PayrollCalculator's rules map yet:
+            // keep the generic Sunday-rest/40h fallback above rather than
+            // failing company provisioning over a missing country ruleset.
+        }
+
+        $workDays = array_values(array_diff([1, 2, 3, 4, 5, 6, 7], $restDays));
+        $overtimeThresholdDaily = round($overtimeThresholdWeekly / max(count($workDays), 1), 2);
+
+        DB::table($this->tenantTable('schedules'))->insert([
+            'company_id' => $company->id,
+            'name' => 'Horaire standard',
+            'start_time' => '08:00:00',
+            'end_time' => '17:00:00',
+            'break_minutes' => 60,
+            'work_days' => json_encode($workDays),
+            'rest_days' => json_encode($restDays),
+            'late_tolerance_minutes' => 15,
+            'overtime_threshold_daily' => $overtimeThresholdDaily,
+            'overtime_threshold_weekly' => $overtimeThresholdWeekly,
+            'is_default' => true,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function normalizeRestDays(CountryRulesInterface $rules): array
+    {
+        $restDays = array_values(array_unique(array_map('intval', $rules->weeklyRestDays())));
+        $restDays = array_values(array_filter($restDays, static fn (int $day): bool => $day >= 1 && $day <= 7));
+
+        return $restDays === [] ? [7] : $restDays;
     }
 
     private function seedAbsenceTypes(string $companyId, string $sector): void
@@ -162,4 +244,3 @@ class SectorTemplateService
         return (bool) ($result->exists ?? false);
     }
 }
-

--- a/api/tests/Feature/PlatformCompanyProvisioningTest.php
+++ b/api/tests/Feature/PlatformCompanyProvisioningTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use App\Mail\UserInvitationMail;
 use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Mail\UserInvitationMail;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -185,6 +185,61 @@ class PlatformCompanyProvisioningTest extends TestCase
             ]);
     }
 
+    public function test_company_creation_seeds_default_schedule_from_country_rules(): void
+    {
+        // PA2-COUNTRY-002: choosing a country should not only derive
+        // currency/timezone but also seed a default Schedule matching that
+        // country's labor-code baseline (e.g. France: 35h/week, Saturday +
+        // Sunday rest; Tunisia: 48h/week, Sunday rest only).
+        Mail::fake();
+
+        DB::table('plans')->insert([
+            'id' => 3,
+            'name' => 'Starter',
+            'price_monthly' => 29,
+            'price_yearly' => 290,
+            'trial_days' => 14,
+            'is_active' => true,
+        ]);
+
+        $superAdmin = SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => 'admin-schedule@leopardo-rh.com',
+            'password_hash' => Hash::make('admin'),
+        ]);
+
+        $response = $this
+            ->actingAs($superAdmin, 'super_admin_api')
+            ->postJson('/api/v1/platform/companies', [
+                'name' => 'Societe France',
+                'sector' => 'Industrie',
+                'country' => 'FR',
+                'city' => 'Paris',
+                'email' => 'contact@societe-france.fr',
+                'plan_id' => 3,
+                'manager_first_name' => 'Camille',
+                'manager_last_name' => 'Dubois',
+                'manager_email' => 'camille.dubois@societe-france.fr',
+            ]);
+
+        $response->assertCreated();
+        $companyId = $response->json('data.company.id');
+
+        DB::statement('SET search_path TO shared_tenants,public');
+
+        $schedule = DB::table('schedules')
+            ->where('company_id', $companyId)
+            ->where('is_default', true)
+            ->first();
+
+        DB::statement('SET search_path TO public');
+
+        $this->assertNotNull($schedule, 'Expected a default Schedule to be seeded for the new company.');
+        $this->assertSame([6, 7], json_decode($schedule->rest_days, true));
+        $this->assertSame([1, 2, 3, 4, 5], json_decode($schedule->work_days, true));
+        $this->assertEquals(35.0, (float) $schedule->overtime_threshold_weekly);
+    }
+
     public function test_super_admin_api_login_returns_token(): void
     {
         $superAdmin = SuperAdmin::query()->create([
@@ -204,4 +259,3 @@ class PlatformCompanyProvisioningTest extends TestCase
         $response->assertJsonPath('token_type', 'Bearer');
     }
 }
-


### PR DESCRIPTION
Closes #1029

## Problem
PA2-COUNTRY-002 acceptance criteria: choosing a country/language for a new company should derive currency, timezone, AND the HR rule model. Currency/timezone were already handled via `CountryDefaults`, but no default work `Schedule` was ever created during provisioning — new companies had nothing to fall back on for attendance/overtime calculations until a manager manually built one with generic 9-to-5 Mon-Fri values that may not match local labor law.

## Fix
`SectorTemplateService::applyTemplate()` now also seeds one `is_default` Schedule per new company, derived from that country's own `CountryRulesInterface` (`weeklyRestDays()`, `overtimeThresholdWeeklyHours()`) via `PayrollCalculator::getRules()`. Falls back to a generic Sunday-rest/40h schedule for any country not yet registered in the payroll rules map, and is idempotent (skips if a default schedule already exists for the company).

Covers both provisioning paths that call `applyTemplate()`: `CompanyProvisioningService::provisionSharedCompany()` (super-admin creation and approved `CompanyRequest` flows).

## Testing
Added `test_company_creation_seeds_default_schedule_from_country_rules` asserting a France-based company gets a 35h/week, Saturday+Sunday-rest default schedule matching `FrancePayrollRules`.

Ran full `PlatformCompanyProvisioningTest` suite against Postgres locally: 5/5 passing. Also ran the broader Schedule/Payroll/Provisioning/Trial test filter; confirmed the 31 pre-existing failures there are unchanged/pre-existing on `main` (unrelated DB-isolation issue in this sandbox, not caused by this change).