### PR TITLE
feat(attendance): audit-log offline kiosk sync punches (PA2-ATT-001)

### DIFF
--- a/api/app/Modules/Attendance/Infrastructure/Services/AttendanceService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/AttendanceService.php
@@ -230,6 +230,13 @@ class AttendanceService
                 ], $this->buildPunchMeta($company, $employee, $dto, 'external_check_out')),
             ])->save();
 
+            // PA2-ATT-001 - the offline/external kiosk sync path must be
+            // auditable exactly like the direct mobile check-in/check-out
+            // endpoints: dispatch the same domain event so AuditLogger
+            // records who/when an external punch closed a session, instead
+            // of this path silently bypassing the audit trail.
+            AttendanceCheckedOut::dispatch($log);
+
             return $log;
         }
 
@@ -257,7 +264,7 @@ class AttendanceService
             $status = $lateMinutes > 0 ? 'late' : 'ontime';
         }
 
-        return AttendanceLog::query()->create([
+        $log = AttendanceLog::query()->create([
             'company_id' => $employee->company_id,
             'employee_id' => $employee->id,
             'schedule_id' => $schedule?->id,
@@ -277,6 +284,13 @@ class AttendanceService
             'gps_lng' => $dto->gps_lng,
             'punch_meta' => $this->buildPunchMeta($company, $employee, $dto, 'external_check_in'),
         ]);
+
+        // PA2-ATT-001 - same rationale as the check_out branch above: an
+        // offline-synced external check-in must leave the same audit trail
+        // as a direct mobile check-in.
+        AttendanceCheckedIn::dispatch($log);
+
+        return $log;
     }
 
     public function recalculateLog(AttendanceLog $log): AttendanceLog

--- a/api/tests/Feature/KioskMultiEventPunchTest.php
+++ b/api/tests/Feature/KioskMultiEventPunchTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Core\Auth\Domain\Models\AuditLog;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -122,6 +124,63 @@ class KioskMultiEventPunchTest extends TestCase
             'employee_id' => $employee->id,
             'external_event_id' => 'evt-mission-002',
             'work_type' => 'mission',
+        ]);
+    }
+
+    public function test_kiosk_offline_sync_writes_an_audit_log_row_per_punch(): void
+    {
+        // PA2-ATT-001 - the multi-event punch model must be auditable on
+        // every entry point, including the offline kiosk sync path
+        // (AttendanceService::importExternalPunch()), which previously
+        // never dispatched AttendanceCheckedIn/AttendanceCheckedOut and was
+        // therefore invisible to the existing AuditLogger listener that
+        // already covers the direct mobile check-in/check-out endpoints.
+        [$manager, $employee] = $this->seedCompanyManagerAndBiometricEmployee();
+        [$deviceCode, $syncToken] = $this->registerKiosk($manager);
+
+        $this->withHeader('X-Kiosk-Token', $syncToken)
+            ->postJson('/api/v1/kiosks/'.$deviceCode.'/sync', [
+                'events' => [
+                    [
+                        'identifier' => 'FP-001',
+                        'action' => 'check_in',
+                        'occurred_at' => '2026-04-19T08:00:00Z',
+                        'external_event_id' => 'evt-audit-001',
+                        'biometric_type' => 'fingerprint',
+                        'work_type' => 'mission',
+                    ],
+                    [
+                        'identifier' => 'FP-001',
+                        'action' => 'check_out',
+                        'occurred_at' => '2026-04-19T17:00:00Z',
+                        'external_event_id' => 'evt-audit-002',
+                        'biometric_type' => 'fingerprint',
+                        'work_type' => 'mission',
+                    ],
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.processed_count', 2);
+
+        DB::statement('SET search_path TO shared_tenants,public');
+
+        $log = AttendanceLog::query()->where('employee_id', $employee->id)->firstOrFail();
+
+        // The check-in creates the row ("created"), the check-out later
+        // updates the same row ("updated") — one audit_logs row per event,
+        // matching the direct mobile check-in/check-out behaviour.
+        $this->assertSame(
+            2,
+            AuditLog::query()->where('auditable_id', $log->id)->count(),
+            'Expected one audit_logs row for the offline check-in and one for the offline check-out.'
+        );
+        $this->assertDatabaseHas('audit_logs', [
+            'auditable_id' => $log->id,
+            'action' => 'checked_in',
+        ]);
+        $this->assertDatabaseHas('audit_logs', [
+            'auditable_id' => $log->id,
+            'action' => 'checked_out',
         ]);
     }
 


### PR DESCRIPTION
Closes #1016

## Problem
`AttendanceLog`'s direct mobile check-in/check-out endpoints already write an `audit_logs` row on every transition via the existing `AuditLogger` listener (subscribed to `AttendanceCheckedIn`/`AttendanceCheckedOut`). The offline kiosk sync path (`AttendanceService::importExternalPunch()`, used by `KioskAttendanceService::syncPunches()` for biometric/QR punches synced after connectivity is restored) never dispatched either event, so it silently bypassed the audit trail entirely — a real gap for exactly the kind of sensitive, delayed, device-attributed punch data PA2-ATT-001's explicit "audit" acceptance criterion is meant to cover.

## Fix
`AttendanceService::importExternalPunch()` now dispatches `AttendanceCheckedIn` on the create branch and `AttendanceCheckedOut` on the check_out branch, matching the exact same events already dispatched by the direct `checkIn()`/`checkOut()` methods, so the existing `AuditLogger` listener picks up offline-synced punches with zero additional wiring.

## Tests
New test in `KioskMultiEventPunchTest` asserts one `audit_logs` row (`action=checked_in`) for the offline check-in event and one (`action=checked_out`) for the offline check-out event on the same `attendance_logs` row.

Verified locally against a real PostgreSQL 17 instance (matching CI's `postgres:16` service, since this suite relies on `SET search_path` and is not sqlite-compatible):
- `php artisan test tests/Feature/KioskMultiEventPunchTest.php` — 6/6 green, including the new audit test and all 5 pre-existing PA2-ATT-010 cases unmodified
- `php artisan test tests/Feature/Attendance tests/Unit/AttendanceServiceTest.php tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php` — 58/58 green
- `php artisan test tests/Unit/AuditLoggerListenerTest.php tests/Feature/AuditLogExportTest.php` — 8/8 green, no regression on the existing audit-log listener/export surface
- `vendor/bin/pint --test` on both touched files: clean
- `vendor/bin/phpstan analyse --configuration=phpstan-modules.neon app/Modules/Attendance`: no errors
- Confirmed the 2 `CheckInTest`/`CheckOutTest` failures under the default sqlite `:memory:` config are pre-existing (identical failure on `main` via `git stash`), unrelated to this change.