### PR TITLE
feat(payroll): allow manager to select a subset of pay slips for bulk payment (PA2-PAY-005)

### DIFF
--- a/api/app/Jobs/ProcessBulkPaymentJob.php
+++ b/api/app/Jobs/ProcessBulkPaymentJob.php
@@ -46,9 +46,16 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
 
     private ?string $resolvedCompanyId = null;
 
+    /**
+     * @param  array<int, int>|null  $paySlipIds  Optional subset of pay_slips.id
+     *     to pay in this batch (PA2-PAY-005 "selection multiple"). Null
+     *     (the default) preserves the previous "pay every eligible slip
+     *     in the run" behaviour.
+     */
     public function __construct(
         public readonly int $payrollRunId,
         public readonly int $triggeredById,
+        public readonly ?array $paySlipIds = null,
     ) {
         $this->onQueue('payroll');
     }
@@ -86,11 +93,19 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
 
         $this->updateProgress(0, 'starting');
 
-        // ── Step 1: Collect all pay slips for this run ──────────────────────
+        // ── Step 1: Collect the pay slips to process for this run ─────────
+        // PA2-PAY-005: when the manager selected a specific subset of pay
+        // slips, only those (still eligible) slips are processed; any
+        // requested id that doesn't belong to this run or isn't eligible is
+        // silently ignored rather than failing the whole batch.
         /** @var Collection<int, PaySlip> $slips */
         $slips = PaySlip::query()
             ->where('payroll_run_id', $run->id)
             ->whereIn('status', ['calculated', 'validated'])
+            ->when(
+                $this->paySlipIds !== null,
+                fn ($query) => $query->whereIn('id', $this->paySlipIds),
+            )
             ->get();
 
         $total = $slips->count();
@@ -129,14 +144,27 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
         $succeeded = $total - count($failures);
         $finalStatus = $failures === [] ? 'completed' : 'completed_with_errors';
 
-        // ── Step 2: Mark payroll run as paid ────────────────────────────────
+        // ── Step 2: Mark payroll run as paid, if fully settled ──────────────
         // The run is marked paid even with partial failures: the successful
         // slips were genuinely paid and must not be re-processed on retry;
         // failures are surfaced separately for manual follow-up.
-        $run->update([
-            'status' => 'paid',
-            'paid_at' => now(),
-        ]);
+        //
+        // PA2-PAY-005: when the manager only selected a subset of pay slips,
+        // other eligible slips in the run may still be awaiting payment —
+        // the run must stay in its current status (not be marked 'paid')
+        // until every calculated/validated slip has actually been paid.
+        $remainingUnpaid = PaySlip::query()
+            ->where('payroll_run_id', $run->id)
+            ->whereIn('status', ['calculated', 'validated'])
+            ->whereNotIn('id', $slips->pluck('id'))
+            ->exists();
+
+        if (! $remainingUnpaid) {
+            $run->update([
+                'status' => 'paid',
+                'paid_at' => now(),
+            ]);
+        }
 
         $this->updateProgress($total, $finalStatus, $total, $failures);
 

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/BulkPaymentController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/BulkPaymentController.php
@@ -44,6 +44,17 @@ class BulkPaymentController extends Controller
             ], 422);
         }
 
+        // PA2-PAY-005: a manager can pick a subset of employees/pay slips to
+        // pay in this batch (e.g. "pay everyone except the two under
+        // dispute") instead of always paying the whole run. Omitting
+        // pay_slip_ids keeps the previous "pay everyone in the run"
+        // behaviour so existing integrations are unaffected.
+        $validated = $request->validate([
+            'pay_slip_ids' => ['nullable', 'array', 'min:1'],
+            'pay_slip_ids.*' => ['integer', 'distinct'],
+        ]);
+        $paySlipIds = $validated['pay_slip_ids'] ?? null;
+
         // Prevent double-dispatch if already processing
         $progressKey = "bulk_pay:run:{$payrollRun->id}";
         try {
@@ -61,11 +72,12 @@ class BulkPaymentController extends Controller
             // Redis unavailable — allow dispatch to continue
         }
 
-        ProcessBulkPaymentJob::dispatch($payrollRun->id, $actor->id);
+        ProcessBulkPaymentJob::dispatch($payrollRun->id, $actor->id, $paySlipIds);
 
         return response()->json([
             'message' => 'Bulk payment processing started.',
             'payroll_run_id' => $payrollRun->id,
+            'selected_pay_slip_count' => $paySlipIds !== null ? count($paySlipIds) : null,
             'status' => 'accepted',
         ], 202);
     }

--- a/api/tests/Feature/BulkPaymentControllerTest.php
+++ b/api/tests/Feature/BulkPaymentControllerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\ProcessBulkPaymentJob;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
+use Illuminate\Support\Facades\Bus;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-005 — "Selection multiple batch async recap erreurs partielles":
+ * a manager must be able to select a specific subset of pay slips to pay
+ * in a batch instead of always paying the whole run, with the batch still
+ * processed asynchronously.
+ */
+class BulkPaymentControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_manager_can_bulk_pay_a_selected_subset_of_pay_slips(): void
+    {
+        Bus::fake();
+
+        [$company, $manager, $run, $slipA, $slipB] = $this->fixture();
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/bulk-pay", [
+            'pay_slip_ids' => [$slipA->id],
+        ]);
+
+        $response->assertAccepted()
+            ->assertJsonPath('status', 'accepted')
+            ->assertJsonPath('payroll_run_id', $run->id)
+            ->assertJsonPath('selected_pay_slip_count', 1);
+
+        Bus::assertDispatched(
+            ProcessBulkPaymentJob::class,
+            fn (ProcessBulkPaymentJob $job): bool => $job->payrollRunId === $run->id
+                && $job->triggeredById === $manager->id
+                && $job->paySlipIds === [$slipA->id]
+        );
+    }
+
+    public function test_manager_can_bulk_pay_the_whole_run_when_no_selection_is_given(): void
+    {
+        Bus::fake();
+
+        [$company, $manager, $run] = $this->fixture();
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/bulk-pay");
+
+        $response->assertAccepted()
+            ->assertJsonPath('selected_pay_slip_count', null);
+
+        Bus::assertDispatched(
+            ProcessBulkPaymentJob::class,
+            fn (ProcessBulkPaymentJob $job): bool => $job->payrollRunId === $run->id
+                && $job->paySlipIds === null
+        );
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee, 2: PayrollRun, 3: PaySlip, 4: PaySlip}
+     */
+    private function fixture(): array
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => '2026-06-01',
+            'period_end' => '2026-06-30',
+            'status' => 'validated',
+            'employee_count' => 2,
+            'total_gross' => 240000,
+            'total_deductions' => 44000,
+            'total_net' => 196000,
+        ]);
+
+        $employeeA = Employee::factory()->create(['company_id' => $company->id]);
+        $employeeB = Employee::factory()->create(['company_id' => $company->id]);
+
+        $slipA = PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employeeA->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 120000,
+            'total_deductions' => 22000,
+            'net_salary' => 98000,
+            'employer_contributions' => 31200,
+            'total_cost' => 151200,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'validated',
+        ]);
+
+        $slipB = PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employeeB->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 120000,
+            'total_deductions' => 22000,
+            'net_salary' => 98000,
+            'employer_contributions' => 31200,
+            'total_cost' => 151200,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'validated',
+        ]);
+
+        return [$company, $manager, $run, $slipA, $slipB];
+    }
+}

--- a/api/tests/Feature/ProcessBulkPaymentJobTest.php
+++ b/api/tests/Feature/ProcessBulkPaymentJobTest.php
@@ -152,6 +152,73 @@ class ProcessBulkPaymentJobTest extends TestCase
     }
 
     /**
+     * PA2-PAY-005 — a manager can select a specific subset of pay slips to
+     * pay in a batch, instead of always paying every eligible slip in the
+     * run. Only the selected slips are processed and paid; the run itself
+     * must stay non-'paid' while other eligible slips are still pending,
+     * so a later batch (or the default "pay everyone" call) can still
+     * pick them up.
+     */
+    public function test_bulk_payment_with_pay_slip_ids_only_processes_the_selected_subset(): void
+    {
+        Queue::fake();
+
+        [$company, $manager] = $this->companyAndManager();
+        $run = $this->payrollRun($company);
+        $selectedEmployee = Employee::factory()->create(['company_id' => $company->id]);
+        $otherEmployee = Employee::factory()->create(['company_id' => $company->id]);
+
+        $selectedSlip = $this->paySlip($run, $selectedEmployee);
+        $otherSlip = $this->paySlip($run, $otherEmployee);
+
+        (new ProcessBulkPaymentJob($run->id, $manager->id, [$selectedSlip->id]))->handle();
+
+        // The run must NOT be marked paid: $otherSlip is still eligible and
+        // was intentionally excluded from this batch.
+        $run->refresh();
+        $this->assertNotSame('paid', $run->status);
+
+        Queue::assertPushed(
+            GeneratePaymentDocumentJob::class,
+            fn (GeneratePaymentDocumentJob $job): bool => true
+        );
+        Queue::assertPushed(GeneratePaySlipPdfJob::class, 1);
+        Queue::assertPushed(GeneratePaymentDocumentJob::class, 1);
+
+        $audit = AuditLog::query()
+            ->where('auditable_type', PayrollRun::class)
+            ->where('auditable_id', $run->id)
+            ->where('action', 'bulk_payment_processed')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $this->assertSame(1, $audit->new_values['total_slips']);
+        $this->assertSame(1, $audit->new_values['succeeded']);
+    }
+
+    /**
+     * When the selected subset covers every eligible slip in the run, the
+     * run must still end up 'paid' — selecting "all of them one by one"
+     * behaves the same as the default "pay everyone" call.
+     */
+    public function test_bulk_payment_marks_run_paid_when_selected_subset_covers_all_eligible_slips(): void
+    {
+        Queue::fake();
+
+        [$company, $manager] = $this->companyAndManager();
+        $run = $this->payrollRun($company);
+        $employeeA = Employee::factory()->create(['company_id' => $company->id]);
+        $employeeB = Employee::factory()->create(['company_id' => $company->id]);
+        $slipA = $this->paySlip($run, $employeeA);
+        $slipB = $this->paySlip($run, $employeeB);
+
+        (new ProcessBulkPaymentJob($run->id, $manager->id, [$slipA->id, $slipB->id]))->handle();
+
+        $run->refresh();
+        $this->assertSame('paid', $run->status);
+    }
+
+    /**
      * @return array{0: Company, 1: Employee}
      */
     private function companyAndManager(): array


### PR DESCRIPTION
## Summary

PA2-PAY-005 ("Paiement masse manager") requires: **selection multiple**, batch async, recap, and partial-error handling. Async processing + partial-failure resilience + recap notification were already implemented for PA2-PAY-013 (#1207), but the batch always paid *every* eligible pay slip in the run — there was no way for a manager to select a specific subset.

## Changes

- `POST /payroll-runs/{id}/bulk-pay` now accepts an optional `pay_slip_ids` array. When present, only those (still `calculated`/`validated`) slips are processed. Omitting it keeps the previous "pay everyone in the run" behaviour, so existing callers are unaffected.
- `ProcessBulkPaymentJob` accepts an optional `$paySlipIds` subset and now only marks the `PayrollRun` as `paid` once every eligible slip in the run has actually been paid — a partial selection no longer prematurely closes out the whole run.
- New tests:
  - Controller: bulk-pay dispatches the job with the selected ids, and with `null` when no selection is given.
  - Job: a partial selection leaves the run non-`paid`; a selection covering every eligible slip still ends up `paid` (matching prior full-run behaviour).

## Testing

```
vendor/bin/phpunit tests/Feature/ProcessBulkPaymentJobTest.php tests/Feature/BulkPaymentControllerTest.php tests/Feature/PaymentBatchControllerTest.php tests/Feature/PaymentDocumentControllerTest.php
vendor/bin/phpunit --filter Payroll
```
All green except 2 pre-existing, unrelated sqlite `EXTRACT()` failures in `SocialDeclarationControllerTest` (documented elsewhere as a known sqlite-vs-postgres incompatibility, reproduces identically on `main`).

Closes #1005