### PR TITLE
feat(payroll): generate bank export files asynchronously (PA2-PAY-014)

### DIFF
--- a/api/app/Http/Resources/Api/V1/BankExportResource.php
+++ b/api/app/Http/Resources/Api/V1/BankExportResource.php
@@ -20,6 +20,7 @@ class BankExportResource extends JsonResource
             'payroll_run_id' => $this->payroll_run_id,
             'format' => $this->format,
             'file_path' => $this->file_path,
+            'error_message' => $this->error_message,
             'total_amount' => $this->total_amount,
             'transfer_count' => $this->transfer_count,
             'status' => $this->status,
@@ -31,4 +32,3 @@ class BankExportResource extends JsonResource
         ];
     }
 }
-

--- a/api/app/Jobs/GenerateBankExportJob.php
+++ b/api/app/Jobs/GenerateBankExportJob.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Contracts\Queue\TenantScopedJob;
+use App\Jobs\Middleware\EnsureTenantContext;
+use App\Modules\Payroll\Domain\Models\BankExport;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Infrastructure\Services\BankExportGenerator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * PA2-PAY-014 — Bordereaux (bank transfer files) generated outside the HTTP
+ * request/response cycle.
+ *
+ * `BankExportController::generate()` used to build the whole file (SEPA
+ * XML, CCP Algerie, CPA/BNA, or generic CSV) synchronously, which blocks the
+ * manager's client until every pay slip line has been rendered — this does
+ * not scale for large payroll runs. This job mirrors the async
+ * `GeneratePaymentDocumentJob`/`GeneratePaySlipPdfJob` pending -> generating
+ * -> generated/failed pattern: the controller now creates a `pending`
+ * `BankExport` row immediately and dispatches this job to do the actual
+ * work on the `documents` queue.
+ */
+class GenerateBankExportJob implements ShouldQueue, TenantScopedJob
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 120;
+
+    private ?string $resolvedCompanyId = null;
+
+    public function __construct(public readonly int $bankExportId)
+    {
+        $this->onQueue('documents');
+    }
+
+    public function tenantCompanyId(): ?string
+    {
+        if ($this->resolvedCompanyId !== null) {
+            return $this->resolvedCompanyId;
+        }
+
+        /** @var BankExport|null $export */
+        $export = BankExport::query()->withoutGlobalScopes()->find($this->bankExportId);
+
+        return $this->resolvedCompanyId = $export?->company_id;
+    }
+
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new EnsureTenantContext];
+    }
+
+    public function handle(BankExportGenerator $generator): void
+    {
+        /** @var BankExport|null $export */
+        $export = BankExport::query()->withoutGlobalScopes()->find($this->bankExportId);
+
+        if ($export === null) {
+            Log::warning("GenerateBankExportJob: BankExport #{$this->bankExportId} not found.");
+
+            return;
+        }
+
+        $export->forceFill(['status' => 'generating', 'error_message' => null])->save();
+
+        try {
+            /** @var PayrollRun|null $run */
+            $run = PayrollRun::query()->withoutGlobalScopes()->find($export->payroll_run_id);
+
+            if ($run === null) {
+                throw new \RuntimeException("PayrollRun #{$export->payroll_run_id} not found for BankExport #{$export->id}.");
+            }
+
+            $format = $export->format ?? 'csv_generic';
+            $content = $generator->generate($run, $format);
+            $extension = $generator->fileExtension($format);
+
+            $filePath = sprintf(
+                'bank_exports/%s_%s_%s.%s',
+                $export->company_id,
+                $run->period_start->format('Y_m'),
+                $format,
+                $extension
+            );
+
+            Storage::disk('local')->put($filePath, $content);
+
+            $totalAmount = $run->paySlips()->where('status', 'validated')->sum('net_salary');
+            $transferCount = $run->paySlips()->where('status', 'validated')->count();
+
+            $export->forceFill([
+                'status' => 'generated',
+                'file_path' => $filePath,
+                'total_amount' => round((float) $totalAmount, 2),
+                'transfer_count' => $transferCount,
+                'generated_at' => now(),
+                'error_message' => null,
+            ])->save();
+        } catch (Throwable $e) {
+            $export->forceFill([
+                'status' => 'failed',
+                'error_message' => $e->getMessage(),
+            ])->save();
+
+            report($e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return [
+            'bank_export:'.$this->bankExportId,
+            'queue:documents',
+        ];
+    }
+}

--- a/api/app/Modules/Payroll/Domain/Models/BankExport.php
+++ b/api/app/Modules/Payroll/Domain/Models/BankExport.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Payroll\Domain\Models;
 
 use App\Traits\BelongsToCompany;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -12,9 +13,10 @@ use Illuminate\Support\Carbon;
 /**
  * @property int $id
  * @property int|null $payroll_run_id
- * @property int|null $company_id
+ * @property string|null $company_id
  * @property string|null $format
  * @property string|null $file_path
+ * @property string|null $error_message
  * @property float $total_amount
  * @property int $transfer_count
  * @property string $status
@@ -22,14 +24,27 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $sent_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @mixin \Illuminate\Database\Eloquent\Builder<static>
+ *
+ * @mixin Builder<static>
  */
 class BankExport extends Model
 {
     use BelongsToCompany;
 
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_GENERATING = 'generating';
+
+    public const STATUS_GENERATED = 'generated';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_SENT = 'sent';
+
+    public const STATUS_CONFIRMED = 'confirmed';
+
     protected $fillable = [
-        'payroll_run_id', 'company_id', 'format', 'file_path',
+        'payroll_run_id', 'company_id', 'format', 'file_path', 'error_message',
         'total_amount', 'transfer_count', 'status',
         'generated_at', 'sent_at',
     ];

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/BankExportController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/BankExportController.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\BankExportResource;
+use App\Jobs\GenerateBankExportJob;
 use App\Modules\Payroll\Domain\Models\BankExport;
-use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
-use App\Modules\Payroll\Infrastructure\Services\BankExportGenerator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -36,36 +36,29 @@ class BankExportController extends Controller
             'format' => 'required|in:sepa_xml,ccp_dz,virement_ma,csv_generic',
         ]);
 
-        $generator = new BankExportGenerator;
         $format = $validated['format'];
-        $content = $generator->generate($payrollRun, $format);
-        $extension = $generator->fileExtension($format);
 
-        $fileName = sprintf('bank_exports/%s_%s_%s.%s',
-            $payrollRun->company_id,
-            $payrollRun->period_start->format('Y_m'),
-            $format,
-            $extension
-        );
-
-        Storage::disk('local')->put($fileName, $content);
-
-        $totalAmount = $payrollRun->paySlips()->where('status', 'validated')->sum('net_salary');
-
+        // PA2-PAY-014: the file itself (SEPA XML / CCP Algerie / CPA/BNA /
+        // CSV) is never rendered inside the HTTP request anymore — it does
+        // not scale for large payroll runs. Create a `pending` BankExport
+        // row immediately and let GenerateBankExportJob (queue `documents`)
+        // do the actual work, mirroring GeneratePaymentDocumentJob's
+        // pending -> generating -> generated/failed lifecycle.
         $export = BankExport::create([
             'payroll_run_id' => $payrollRun->id,
             'company_id' => $payrollRun->company_id,
             'format' => $format,
-            'file_path' => $fileName,
-            'total_amount' => round($totalAmount, 2),
-            'transfer_count' => $payrollRun->paySlips()->where('status', 'validated')->count(),
-            'status' => 'generated',
-            'generated_at' => now(),
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_PENDING,
         ]);
+
+        GenerateBankExportJob::dispatch($export->id);
 
         return (new BankExportResource($export))
             ->response()
-            ->setStatusCode(201);
+            ->setStatusCode(202);
     }
 
     public function show(Request $request, BankExport $bankExport): JsonResponse
@@ -95,11 +88,19 @@ class BankExportController extends Controller
             abort(403);
         }
 
-        if (! Storage::disk('local')->exists($bankExport->file_path)) {
+        if ($bankExport->status !== BankExport::STATUS_GENERATED && $bankExport->status !== BankExport::STATUS_SENT && $bankExport->status !== BankExport::STATUS_CONFIRMED) {
+            return response()->json([
+                'message' => $bankExport->status === BankExport::STATUS_FAILED
+                    ? 'Bank export generation failed: '.($bankExport->error_message ?? 'unknown error.')
+                    : 'Bank export is still being generated. Please try again shortly.',
+                'status' => $bankExport->status,
+            ], 409);
+        }
+
+        if ($bankExport->file_path === null || ! Storage::disk('local')->exists($bankExport->file_path)) {
             return response()->json(['message' => 'Export file not found.'], 404);
         }
 
         return Storage::disk('local')->download($bankExport->file_path);
     }
 }
-

--- a/api/database/migrations/tenant/2026_07_25_000002_make_bank_exports_generation_async.php
+++ b/api/database/migrations/tenant/2026_07_25_000002_make_bank_exports_generation_async.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-PAY-014 — Bordereaux (bank exports) PDFs/files hors requete HTTP.
+ *
+ * `BankExportController::generate()` used to build the whole bank-transfer
+ * file (SEPA XML / CCP Algerie / CPA / BNA / CSV) synchronously inside the
+ * HTTP request, which does not scale for large payroll runs and blocks the
+ * manager's mobile/web client until the whole file is rendered and written
+ * to disk. This migration makes `bank_exports.status` support an async
+ * pending/generating/failed lifecycle instead of just generated/sent/confirmed,
+ * makes `file_path` nullable (no file exists yet while pending/generating),
+ * and adds `error_message` for failed jobs — mirroring the existing
+ * `payment_documents` pending -> generating -> available/failed pattern
+ * (see 2026_06_01_000001_create_payment_documents_table.php).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('bank_exports')) {
+            return;
+        }
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE bank_exports DROP CONSTRAINT IF EXISTS bank_exports_status_check');
+            DB::statement(
+                'ALTER TABLE bank_exports ADD CONSTRAINT bank_exports_status_check '.
+                "CHECK (status IN ('pending', 'generating', 'generated', 'failed', 'sent', 'confirmed'))"
+            );
+            DB::statement('ALTER TABLE bank_exports ALTER COLUMN file_path DROP NOT NULL');
+            DB::statement("ALTER TABLE bank_exports ALTER COLUMN status SET DEFAULT 'pending'");
+        }
+        // Note: SQLite (used by default in local/unit test runs) has no
+        // NOT NULL/CHECK constraint enforcement issue here since
+        // Schema::create() on that driver never enforced the original
+        // `file_path` NOT NULL as strictly; no DBAL-dependent ->change()
+        // is used so this migration works without doctrine/dbal installed.
+
+        if (! Schema::hasColumn('bank_exports', 'error_message')) {
+            Schema::table('bank_exports', function (Blueprint $table) {
+                $table->text('error_message')->nullable()->after('file_path');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('bank_exports')) {
+            return;
+        }
+
+        if (Schema::hasColumn('bank_exports', 'error_message')) {
+            Schema::table('bank_exports', function (Blueprint $table) {
+                $table->dropColumn('error_message');
+            });
+        }
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE bank_exports DROP CONSTRAINT IF EXISTS bank_exports_status_check');
+            DB::statement(
+                'ALTER TABLE bank_exports ADD CONSTRAINT bank_exports_status_check '.
+                "CHECK (status IN ('generated', 'sent', 'confirmed'))"
+            );
+            DB::statement("ALTER TABLE bank_exports ALTER COLUMN status SET DEFAULT 'generated'");
+        }
+    }
+};

--- a/api/tests/Feature/BankExportControllerTest.php
+++ b/api/tests/Feature/BankExportControllerTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\GenerateBankExportJob;
+use App\Modules\Payroll\Domain\Models\BankExport;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-014 — bank export generation must never block the HTTP request:
+ * generate() only creates a `pending` BankExport row and dispatches
+ * GenerateBankExportJob; the file itself is produced asynchronously.
+ */
+class BankExportControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_generate_creates_pending_export_and_dispatches_job_without_building_file(): void
+    {
+        Queue::fake();
+
+        [$company, $manager, $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson("/api/v1/payroll-runs/{$run->id}/bank-export", [
+            'format' => 'sepa_xml',
+        ]);
+
+        $response->assertStatus(202)
+            ->assertJsonPath('data.status', BankExport::STATUS_PENDING)
+            ->assertJsonPath('data.file_path', null);
+
+        $export = BankExport::query()->where('payroll_run_id', $run->id)->first();
+
+        $this->assertNotNull($export);
+        $this->assertSame(BankExport::STATUS_PENDING, $export->status);
+        $this->assertNull($export->file_path);
+
+        Queue::assertPushed(GenerateBankExportJob::class, fn (GenerateBankExportJob $job): bool => $job->bankExportId === $export->id);
+    }
+
+    public function test_generate_requires_manager_role(): void
+    {
+        Queue::fake();
+
+        [$company, , $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        Sanctum::actingAs($employee);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/bank-export", [
+            'format' => 'csv_generic',
+        ])->assertForbidden();
+    }
+
+    public function test_generate_rejects_payroll_run_from_another_company(): void
+    {
+        Queue::fake();
+
+        [$company, $manager, $employee] = $this->actors();
+        [, $slip] = $this->payrollSlip($company, $employee);
+
+        [$foreignCompany, , $foreignEmployee] = $this->actors();
+        [$foreignRun] = $this->payrollSlip($foreignCompany, $foreignEmployee);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson("/api/v1/payroll-runs/{$foreignRun->id}/bank-export", [
+            'format' => 'csv_generic',
+        ])->assertNotFound();
+    }
+
+    public function test_generate_rejects_payroll_run_not_yet_validated(): void
+    {
+        Queue::fake();
+
+        [$company, $manager, $employee] = $this->actors();
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'status' => 'draft',
+            'employee_count' => 1,
+            'total_gross' => 120000,
+            'total_deductions' => 22000,
+            'total_net' => 98000,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/bank-export", [
+            'format' => 'csv_generic',
+        ])->assertStatus(422);
+
+        Queue::assertNotPushed(GenerateBankExportJob::class);
+    }
+
+    public function test_show_returns_export_status_and_error_message(): void
+    {
+        [$company, $manager, $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        $export = BankExport::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'format' => 'sepa_xml',
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_FAILED,
+            'error_message' => 'Bank export generator crashed.',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson("/api/v1/bank-exports/{$export->id}")
+            ->assertOk()
+            ->assertJsonPath('data.status', BankExport::STATUS_FAILED)
+            ->assertJsonPath('data.error_message', 'Bank export generator crashed.');
+    }
+
+    public function test_download_while_generating_returns_conflict(): void
+    {
+        [$company, $manager, $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        $export = BankExport::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'format' => 'sepa_xml',
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_GENERATING,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson("/api/v1/bank-exports/{$export->id}/download")
+            ->assertStatus(409)
+            ->assertJsonPath('status', BankExport::STATUS_GENERATING);
+    }
+
+    public function test_download_after_failure_returns_conflict_with_error_message(): void
+    {
+        [$company, $manager, $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        $export = BankExport::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'format' => 'sepa_xml',
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_FAILED,
+            'error_message' => 'Disk full.',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson("/api/v1/bank-exports/{$export->id}/download")
+            ->assertStatus(409)
+            ->assertJsonPath('status', BankExport::STATUS_FAILED);
+    }
+
+    public function test_download_generated_export_streams_the_file(): void
+    {
+        Storage::fake('local');
+
+        [$company, $manager, $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        $path = 'bank_exports/'.$company->id.'_2026_05_sepa_xml.xml';
+        Storage::disk('local')->put($path, '<Document></Document>');
+
+        $export = BankExport::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'format' => 'sepa_xml',
+            'file_path' => $path,
+            'total_amount' => 98000,
+            'transfer_count' => 1,
+            'status' => BankExport::STATUS_GENERATED,
+            'generated_at' => now(),
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->get("/api/v1/bank-exports/{$export->id}/download")
+            ->assertOk();
+    }
+
+    public function test_show_rejects_bank_export_from_another_company(): void
+    {
+        [$company, $manager, $employee] = $this->actors();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        [$foreignCompany, , $foreignEmployee] = $this->actors();
+        [$foreignRun] = $this->payrollSlip($foreignCompany, $foreignEmployee);
+
+        $foreignExport = BankExport::query()->create([
+            'payroll_run_id' => $foreignRun->id,
+            'company_id' => $foreignCompany->id,
+            'format' => 'sepa_xml',
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_PENDING,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->getJson("/api/v1/bank-exports/{$foreignExport->id}")->assertNotFound();
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee, 2: Employee}
+     */
+    private function actors(): array
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => fake()->unique()->safeEmail(),
+        ]);
+
+        return [$company, $manager, $employee];
+    }
+
+    /**
+     * @return array{0: PayrollRun, 1: PaySlip}
+     */
+    private function payrollSlip(Company $company, Employee $employee): array
+    {
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'status' => 'validated',
+            'employee_count' => 1,
+            'total_gross' => 120000,
+            'total_deductions' => 22000,
+            'total_net' => 98000,
+        ]);
+
+        $slip = PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 120000,
+            'total_deductions' => 22000,
+            'net_salary' => 98000,
+            'employer_contributions' => 31200,
+            'total_cost' => 151200,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'validated',
+        ]);
+
+        return [$run, $slip];
+    }
+}

--- a/api/tests/Feature/GenerateBankExportJobTest.php
+++ b/api/tests/Feature/GenerateBankExportJobTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Jobs\GenerateBankExportJob;
+use App\Modules\Payroll\Domain\Models\BankExport;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
+use App\Modules\Payroll\Infrastructure\Services\BankExportGenerator;
+use Illuminate\Support\Facades\Storage;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-PAY-014 — GenerateBankExportJob::handle() exercised directly, since
+ * BankExportControllerTest only asserts the job is dispatched (Queue::fake).
+ * Verifies the pending -> generating -> generated/failed lifecycle, that
+ * the file is actually written to disk, and that a failure is recorded on
+ * the BankExport row with error_message instead of leaving it stuck as
+ * "generating".
+ */
+class GenerateBankExportJobTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+        Storage::fake('local');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_job_generates_csv_file_and_marks_export_generated(): void
+    {
+        [$company, $employee] = $this->companyAndEmployee();
+        [$run] = $this->payrollSlip($company, $employee);
+
+        $export = BankExport::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'format' => 'csv_generic',
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_PENDING,
+        ]);
+
+        (new GenerateBankExportJob($export->id))->handle(app(BankExportGenerator::class));
+
+        $export->refresh();
+
+        $this->assertSame(BankExport::STATUS_GENERATED, $export->status);
+        $this->assertNotNull($export->file_path);
+        $this->assertNotNull($export->generated_at);
+        $this->assertNull($export->error_message);
+        $this->assertSame(1, $export->transfer_count);
+        $this->assertSame(98000.0, (float) $export->total_amount);
+
+        $this->assertTrue(Storage::disk('local')->exists($export->file_path));
+    }
+
+    public function test_job_marks_export_failed_and_rethrows_when_payroll_run_is_missing(): void
+    {
+        [$company] = $this->companyAndEmployee();
+
+        $export = BankExport::query()->create([
+            'payroll_run_id' => 999_999,
+            'company_id' => $company->id,
+            'format' => 'csv_generic',
+            'file_path' => null,
+            'total_amount' => 0,
+            'transfer_count' => 0,
+            'status' => BankExport::STATUS_PENDING,
+        ]);
+
+        $thrown = null;
+
+        try {
+            (new GenerateBankExportJob($export->id))->handle(app(BankExportGenerator::class));
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected the job to rethrow the missing payroll run failure.');
+
+        $export->refresh();
+
+        $this->assertSame(BankExport::STATUS_FAILED, $export->status);
+        $this->assertNotNull($export->error_message);
+        $this->assertNull($export->file_path);
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee}
+     */
+    private function companyAndEmployee(): array
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => fake()->unique()->safeEmail(),
+        ]);
+
+        return [$company, $employee];
+    }
+
+    /**
+     * @return array{0: PayrollRun, 1: PaySlip}
+     */
+    private function payrollSlip(Company $company, Employee $employee): array
+    {
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'status' => 'validated',
+            'employee_count' => 1,
+            'total_gross' => 120000,
+            'total_deductions' => 22000,
+            'total_net' => 98000,
+        ]);
+
+        $slip = PaySlip::query()->create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 120000,
+            'total_deductions' => 22000,
+            'net_salary' => 98000,
+            'employer_contributions' => 31200,
+            'total_cost' => 151200,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'validated',
+        ]);
+
+        return [$run, $slip];
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -1319,6 +1319,28 @@ trait CreatesMvpSchema
             });
         }
 
+        // PA2-PAY-014: bank export status now supports the async
+        // pending -> generating -> generated/failed lifecycle (previously
+        // only generated/sent/confirmed), file_path is nullable while no
+        // file has been produced yet, and error_message records job
+        // failures (see 2026_07_25_000002_make_bank_exports_generation_async.php).
+        if (! Schema::hasTable($this->moduleTable('bank_exports'))) {
+            Schema::create($this->moduleTable('bank_exports'), function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('payroll_run_id');
+                $table->uuid('company_id')->nullable()->index();
+                $table->string('format', 20)->default('csv_generic');
+                $table->string('file_path', 500)->nullable();
+                $table->decimal('total_amount', 16, 2)->default(0);
+                $table->unsignedInteger('transfer_count')->default(0);
+                $table->string('status', 20)->default('pending');
+                $table->text('error_message')->nullable();
+                $table->timestampTz('generated_at')->nullable();
+                $table->timestampTz('sent_at')->nullable();
+                $table->timestampsTz();
+            });
+        }
+
         if (! Schema::hasTable($this->moduleTable('payment_batches'))) {
             Schema::create($this->moduleTable('payment_batches'), function (Blueprint $table): void {
                 $table->id();
@@ -1906,6 +1928,7 @@ trait CreatesMvpSchema
         DB::statement('DROP TABLE IF EXISTS "payment_confirmations"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "payment_items"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "payment_batches"'.$cascade);
+        DB::statement('DROP TABLE IF EXISTS "bank_exports"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "payment_documents"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "pay_slips"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "privacy_requests"'.$cascade);


### PR DESCRIPTION
## Summary

Closes #1047

Bank export files (SEPA XML, CCP Algerie, CPA/BNA, generic CSV) were previously rendered synchronously inside `BankExportController::generate()`, blocking the manager's client until the whole file had been built and written to disk. This does not scale for large payroll runs.

## Changes

- Add `GenerateBankExportJob` (queue: `documents`), mirroring the existing `GeneratePaymentDocumentJob`/`GeneratePaySlipPdfJob` `pending -> generating -> generated/failed` lifecycle.
- `BankExportController::generate()` now creates a `pending` `BankExport` row immediately, dispatches the job, and returns `202 Accepted` instead of `201` with a fully generated file.
- Extend `BankExport` status lifecycle (`pending`, `generating`, `generated`, `failed`, `sent`, `confirmed`); make `file_path` nullable and add `error_message` via a new migration (pgsql `CHECK` constraint + column changes, no `doctrine/dbal` dependency).
- `BankExportController::download()` now returns `409` with the export status while pending/generating, or the error message on failure, instead of a bare `404`.
- Expose `error_message` on `BankExportResource`.
- Add feature tests for the controller (generate/show/download across all statuses, tenant isolation, role checks) and for `GenerateBankExportJob::handle()` (success path writes the file and totals; failure path marks the export failed and rethrows).
- Extend the `CreatesMvpSchema` test fixture with a `bank_exports` table matching the new async schema.

## Testing

- `php artisan test --filter=BankExport` — 16 passed (49 assertions), pgsql driver.
- `php artisan test --filter=Payroll` — 129 passed, 1 pre-existing unrelated failure (`PayrollCountryRulesTest::morocco_and_tunisia...`, confirmed failing on `main` before this change too — PA2-COUNTRY-012 placeholder text).
- `vendor/bin/pint` applied to all touched files.
- `vendor/bin/phpstan analyse` on touched files: no new issues beyond pre-existing baseline patterns already present elsewhere in the codebase (missing iterable value types on Resources, mixed-array offset access on `$validated[...]`).