### PR TITLE
feat(notifications): add mark-all-read to web dashboard inbox

### DIFF
--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -117,6 +117,19 @@ export default function DashboardLayout({
     setUnreadCount((count) => Math.max(0, count - 1));
   };
 
+  const markAllNotificationsRead = async () => {
+    if (unreadCount === 0) {
+      return;
+    }
+
+    await apiFetch('/notifications/read-all', {
+      method: 'PUT',
+    });
+
+    setNotificationPreview((items) => items.map((item) => ({ ...item, is_read: true })));
+    setUnreadCount(0);
+  };
+
   const [showWizard, setShowWizard] = useState(false);
 
   useEffect(() => {
@@ -286,7 +299,18 @@ export default function DashboardLayout({
                 <div className="absolute right-0 top-12 z-20 w-80 rounded-lg border border-slate-200 bg-white p-3 shadow-xl">
                   <div className="flex items-center justify-between border-b border-slate-100 pb-2">
                     <p className="text-sm font-bold text-slate-900">Notifications</p>
-                    <span className="text-xs font-semibold text-slate-500">{unreadCount} non lue(s)</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-semibold text-slate-500">{unreadCount} non lue(s)</span>
+                      {unreadCount > 0 ? (
+                        <button
+                          type="button"
+                          className="text-xs font-semibold text-brand-600 transition hover:text-brand-800"
+                          onClick={() => void markAllNotificationsRead()}
+                        >
+                          Tout marquer lu
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                   <div className="mt-2 max-h-80 space-y-2 overflow-auto">
                     {notificationPreview.length > 0 ? notificationPreview.map((notification) => (


### PR DESCRIPTION
Closes #1052

The in-app notification inbox (PA2-COMM-001 acceptance criteria: notifications and messages listable, read/unread, tenant-scoped) was already implemented end to end:
- API: `GET /notifications`, `GET /notifications/unread`, `PUT /notifications/{id}/read`, `PUT /notifications/read-all`, `DELETE /notifications/{id}`, all tenant/employee scoped with an `unread_count` meta.
- Mobile (employee/manager/hr): full notification list screens + repository already calling `read-all`.
- Web dashboard: header bell with unread badge, dropdown preview, per-item mark-read.

The one gap was the web dashboard dropdown missing a bulk mark-all-read action that mobile already had. This PR adds it.

## Changes
- Added `markAllNotificationsRead` wired to the existing `PUT /notifications/read-all` endpoint.
- Added a 'Tout marquer lu' button in the notification dropdown header, shown only when `unreadCount > 0`.

## Testing
- Manual code review; no `node_modules` installed in this sandbox to run `next build`/lint.
- Change is additive and scoped to a single component; no existing behavior altered.