### PR TITLE
feat(vitrine): show a real product screenshot in the homepage hero (PA2-MKT-001)

### DIFF
--- a/front/web/src/app/(landing)/page.tsx
+++ b/front/web/src/app/(landing)/page.tsx
@@ -16,6 +16,7 @@ import {
   LaunchOperatingSystemSection,
   // Phase-3 sections — no more Legacy prefixes
   HeroSection,
+  HeroProductVisual,
   FAQSection,
   CTASection,
   ProblemSection,
@@ -82,6 +83,12 @@ export default function LandingPage() {
           animated
           quickTrialForm={
             <QuickTrialEmailForm locale={locale} copy={copy.heroQuickTrial} />
+          }
+          visual={
+            <HeroProductVisual
+              src="/screenshots/web-dashboard.png"
+              alt={copy.hero.visualAlt ?? 'Leopardo HR admin dashboard screenshot'}
+            />
           }
         />
 

--- a/front/web/src/modules/vitrine/components/sections/HeroProductVisual.tsx
+++ b/front/web/src/modules/vitrine/components/sections/HeroProductVisual.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Image from 'next/image';
+
+export interface HeroProductVisualProps {
+  /** Screenshot served from `front/web/public/screenshots` (real product UI, not a mockup). */
+  src: string;
+  alt: string;
+}
+
+/**
+ * Browser-chrome frame around a real product screenshot, shown directly in
+ * the hero (above the fold) so a visitor sees actual product UI before
+ * scrolling or leaving an email (PA2-MKT-001).
+ */
+export function HeroProductVisual({ src, alt }: HeroProductVisualProps) {
+  return (
+    <div className="relative mx-auto w-full max-w-4xl">
+      <div className="absolute -inset-4 bg-gradient-to-r from-emerald-500/10 to-cyan-500/10 rounded-3xl blur-2xl" />
+      <div className="relative rounded-2xl border border-slate-200/80 dark:border-slate-800/80 bg-slate-900 shadow-2xl overflow-hidden">
+        <div className="flex items-center gap-1.5 h-8 px-4 bg-slate-800 dark:bg-slate-800">
+          <span className="w-2.5 h-2.5 rounded-full bg-red-500/60" />
+          <span className="w-2.5 h-2.5 rounded-full bg-amber-500/60" />
+          <span className="w-2.5 h-2.5 rounded-full bg-green-500/60" />
+        </div>
+        <div className="relative aspect-[16/9] bg-slate-950">
+          <Image
+            src={src}
+            alt={alt}
+            fill
+            priority
+            sizes="(max-width: 768px) 100vw, 896px"
+            className="object-cover object-top"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/web/src/modules/vitrine/components/sections/HeroSection.tsx
+++ b/front/web/src/modules/vitrine/components/sections/HeroSection.tsx
@@ -161,6 +161,18 @@ export function HeroSection({
           {/* Optional quick-trial inline form (e.g. QuickTrialEmailForm with source=hero_email_trial) */}
           {quickTrialForm}
 
+          {/* Real product visual — proves the product exists before the visitor scrolls (PA2-MKT-001) */}
+          {visual && (
+            <motion.div
+              initial={animated ? { opacity: 0, y: 40, scale: 0.97 } : {}}
+              animate={animated ? { opacity: 1, y: 0, scale: 1 } : {}}
+              transition={{ duration: 1, delay: 0.6, ease: [0.22, 1, 0.36, 1] }}
+              className="mt-16 max-w-4xl mx-auto"
+            >
+              {visual}
+            </motion.div>
+          )}
+
           {/* Stats */}
           {stats && stats.length > 0 && (
             <motion.div

--- a/front/web/src/modules/vitrine/components/sections/__tests__/HeroProductVisual.test.tsx
+++ b/front/web/src/modules/vitrine/components/sections/__tests__/HeroProductVisual.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { HeroProductVisual } from '../HeroProductVisual';
+
+/**
+ * PA2-MKT-001 — the hero must show a real product screenshot instead of
+ * leaving the visitor with only copy before the email capture.
+ */
+describe('HeroProductVisual', () => {
+  it('renders the real product screenshot with the provided alt text', () => {
+    render(
+      <HeroProductVisual
+        src="/screenshots/web-dashboard.png"
+        alt="Leopardo HR admin dashboard screenshot"
+      />
+    );
+
+    const image = screen.getByAltText('Leopardo HR admin dashboard screenshot');
+    expect(image).toBeInTheDocument();
+    expect(image.tagName.toLowerCase()).toBe('img');
+  });
+});

--- a/front/web/src/modules/vitrine/components/sections/__tests__/imports.test.ts
+++ b/front/web/src/modules/vitrine/components/sections/__tests__/imports.test.ts
@@ -9,6 +9,11 @@ describe('Phase 3 Components - Imports', () => {
     expect(HeroSection).toBeDefined();
   });
 
+  it('should import HeroProductVisual', () => {
+    const { HeroProductVisual } = require('../HeroProductVisual');
+    expect(HeroProductVisual).toBeDefined();
+  });
+
   it('should import FeatureCard and FeaturesSection', () => {
     const { FeatureCard } = require('../FeatureCard');
     const { FeaturesSection } = require('../FeaturesSection');
@@ -57,6 +62,7 @@ describe('Phase 3 Components - Imports', () => {
   it('should export all components from index', () => {
     const exports = require('../index');
     expect(exports.HeroSection).toBeDefined();
+    expect(exports.HeroProductVisual).toBeDefined();
     expect(exports.FeatureCard).toBeDefined();
     expect(exports.FeaturesSection).toBeDefined();
     expect(exports.PricingCard).toBeDefined();

--- a/front/web/src/modules/vitrine/components/sections/index.ts
+++ b/front/web/src/modules/vitrine/components/sections/index.ts
@@ -1,5 +1,6 @@
 // Hero Section
 export { HeroSection, type HeroSectionProps } from './HeroSection';
+export { HeroProductVisual, type HeroProductVisualProps } from './HeroProductVisual';
 
 // Problem & Solution Components
 export { ProblemSection, type ProblemSectionProps, type ProblemItem } from './ProblemSection';

--- a/front/web/src/modules/vitrine/lib/vitrine-locale.ts
+++ b/front/web/src/modules/vitrine/lib/vitrine-locale.ts
@@ -49,6 +49,7 @@ type LandingCopy = {
     secondaryCta: string
     mobileBadge?: string
     downloadCta?: string
+    visualAlt?: string
     stats: HeroStat[]
   }
   heroQuickTrial: {
@@ -169,6 +170,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
       subtitleTail: 'pour transformer vos operations quotidiennes sans la complexite d\'un ERP.',
       mobileBadge: 'Disponible sur mobile',
       downloadCta: 'Telecharger les apps',
+      visualAlt: 'Capture du tableau de bord admin Leopardo RH',
       primaryCta: 'Essai gratuit 30 jours',
       secondaryCta: 'Voir la demo',
       stats: [
@@ -312,6 +314,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
       subtitleTail: 'to transform your daily operations without the complexity of a heavy ERP.',
       mobileBadge: 'Available on mobile',
       downloadCta: 'Download the apps',
+      visualAlt: 'Leopardo HR admin dashboard screenshot',
       primaryCta: 'Start 30-day free trial',
       secondaryCta: 'Watch demo',
       stats: [
@@ -455,6 +458,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
       subtitleTail: 'agir ERP olmadan saha pilotu baslatmaniz icin.',
       mobileBadge: 'Mobilde kullanilabilir',
       downloadCta: 'Uygulamalari indir',
+      visualAlt: 'Leopardo IK yonetici paneli ekran goruntusu',
       primaryCta: '30 gun ucretsiz deneyin',
       secondaryCta: 'Demoyu izle',
       stats: [
@@ -598,6 +602,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
       subtitleTail: 'لتشغيل تجربة ميدانية بدون نظام ERP ثقيل.',
       mobileBadge: 'متاح على الجوال',
       downloadCta: 'تحميل التطبيقات',
+      visualAlt: 'لقطة شاشة للوحة تحكم الإدارة في ليوباردو للموارد البشرية',
       primaryCta: 'ابدأ تجربة 30 يوما',
       secondaryCta: 'شاهد العرض',
       stats: [


### PR DESCRIPTION
## Summary

Closes #948

The Phase-3 `HeroSection` component already accepted a `visual` prop in its interface, but the JSX never rendered it anywhere, so no page ever showed a product visual above the fold. Visitors had to scroll past the hero, problem/solution and features sections before reaching `ProductScreenshots` to see any real UI, working against the acceptance criteria for a hero with visible product proof.

## Changes

- Render `visual` inside `HeroSection` with a subtle entrance animation, placed between the quick-trial form and the stats grid.
- Add `HeroProductVisual`: a browser-chrome frame around a real product screenshot (`next/image`), reusing the existing `/screenshots/web-dashboard.png` asset already wired into `ProductScreenshots`.
- Wire `HeroProductVisual` into the homepage `HeroSection` usage and add a localized `visualAlt` string (fr/en/tr/ar) to `vitrine-locale.ts`.
- Export `HeroProductVisual` from the sections barrel and cover it in the Phase 3 imports test.
- Add a focused test asserting the real screenshot renders with its accessible alt text.

CTAs already point at existing, non-dead `/signup` and `/demo` routes; no change needed there.

## Testing

- `npx tsc --noEmit` — clean.
- `npx eslint` on touched files — clean.
- `npx jest src/modules/vitrine` — 8 suites / 237 tests passed.
- `npx jest` (full project) — 8 suites / 237 tests passed.