### PR TITLE
feat(support): add pilot client support center (PA2-COMM-012)

### DIFF
--- a/api/app/Modules/Platform/Domain/Models/PlatformSupportMessage.php
+++ b/api/app/Modules/Platform/Domain/Models/PlatformSupportMessage.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Domain\Models;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * PA2-COMM-012 — One message in a `PlatformSupportTicket` conversation
+ * thread, authored either by the tenant employee who opened the ticket (or a
+ * teammate replying on it) or by a platform super-admin. Exactly one of
+ * `author_employee_id` / `author_super_admin_id` is set.
+ *
+ * @property int $id
+ * @property int $platform_support_ticket_id
+ * @property int|null $author_employee_id
+ * @property int|null $author_super_admin_id
+ * @property string $body
+ * @property Carbon|null $created_at
+ * @property-read PlatformSupportTicket $ticket
+ * @property-read Employee|null $authorEmployee
+ * @property-read SuperAdmin|null $authorSuperAdmin
+ *
+ * @mixin Builder<static>
+ */
+class PlatformSupportMessage extends Model
+{
+    protected $table = 'platform_support_messages';
+
+    public const UPDATED_AT = null;
+
+    protected $fillable = [
+        'platform_support_ticket_id',
+        'author_employee_id',
+        'author_super_admin_id',
+        'body',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    /** @return BelongsTo<PlatformSupportTicket, $this> */
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(PlatformSupportTicket::class, 'platform_support_ticket_id');
+    }
+
+    /** @return BelongsTo<Employee, $this> */
+    public function authorEmployee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'author_employee_id');
+    }
+
+    /** @return BelongsTo<SuperAdmin, $this> */
+    public function authorSuperAdmin(): BelongsTo
+    {
+        return $this->belongsTo(SuperAdmin::class, 'author_super_admin_id');
+    }
+
+    public function isFromPlatform(): bool
+    {
+        return $this->author_super_admin_id !== null;
+    }
+}

--- a/api/app/Modules/Platform/Domain/Models/PlatformSupportTicket.php
+++ b/api/app/Modules/Platform/Domain/Models/PlatformSupportTicket.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Domain\Models;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * PA2-COMM-012 — Pilot client support ticket/conversation opened by a tenant
+ * manager or employee and triaged by a platform super-admin (status +
+ * priority), mirroring `PlatformAnnouncement` (PA2-COMM-005): this table
+ * lives in the `public` schema because a ticket is owned by the platform,
+ * not by a single tenant's own database scope.
+ *
+ * @property int $id
+ * @property string $company_id
+ * @property int $created_by_employee_id
+ * @property string $subject
+ * @property string $category
+ * @property string $priority
+ * @property string $status
+ * @property int|null $assigned_super_admin_id
+ * @property Carbon|null $last_message_at
+ * @property Carbon|null $resolved_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Company $company
+ * @property-read Employee $createdBy
+ * @property-read SuperAdmin|null $assignedSuperAdmin
+ * @property-read Collection<int, PlatformSupportMessage> $messages
+ *
+ * @mixin Builder<static>
+ */
+class PlatformSupportTicket extends Model
+{
+    protected $table = 'platform_support_tickets';
+
+    protected $fillable = [
+        'company_id',
+        'created_by_employee_id',
+        'subject',
+        'category',
+        'priority',
+        'status',
+        'assigned_super_admin_id',
+        'last_message_at',
+        'resolved_at',
+    ];
+
+    protected $casts = [
+        'last_message_at' => 'datetime',
+        'resolved_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public const CATEGORY_GENERAL = 'general';
+
+    public const CATEGORY_BILLING = 'billing';
+
+    public const CATEGORY_TECHNICAL = 'technical';
+
+    public const CATEGORY_ONBOARDING = 'onboarding';
+
+    public const CATEGORY_OTHER = 'other';
+
+    public const PRIORITY_LOW = 'low';
+
+    public const PRIORITY_NORMAL = 'normal';
+
+    public const PRIORITY_HIGH = 'high';
+
+    public const PRIORITY_URGENT = 'urgent';
+
+    public const STATUS_OPEN = 'open';
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_RESOLVED = 'resolved';
+
+    public const STATUS_CLOSED = 'closed';
+
+    /** @return list<string> */
+    public static function categories(): array
+    {
+        return [
+            self::CATEGORY_GENERAL,
+            self::CATEGORY_BILLING,
+            self::CATEGORY_TECHNICAL,
+            self::CATEGORY_ONBOARDING,
+            self::CATEGORY_OTHER,
+        ];
+    }
+
+    /** @return list<string> */
+    public static function priorities(): array
+    {
+        return [self::PRIORITY_LOW, self::PRIORITY_NORMAL, self::PRIORITY_HIGH, self::PRIORITY_URGENT];
+    }
+
+    /** @return list<string> */
+    public static function statuses(): array
+    {
+        return [self::STATUS_OPEN, self::STATUS_PENDING, self::STATUS_RESOLVED, self::STATUS_CLOSED];
+    }
+
+    /** @return BelongsTo<Company, $this> */
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class, 'company_id');
+    }
+
+    /** @return BelongsTo<Employee, $this> */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'created_by_employee_id');
+    }
+
+    /** @return BelongsTo<SuperAdmin, $this> */
+    public function assignedSuperAdmin(): BelongsTo
+    {
+        return $this->belongsTo(SuperAdmin::class, 'assigned_super_admin_id');
+    }
+
+    /** @return HasMany<PlatformSupportMessage, $this> */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(PlatformSupportMessage::class, 'platform_support_ticket_id')->orderBy('created_at');
+    }
+
+    public function isOpenForReplies(): bool
+    {
+        return in_array($this->status, [self::STATUS_OPEN, self::STATUS_PENDING], true);
+    }
+}

--- a/api/app/Modules/Platform/Infrastructure/Services/PlatformSupportTicketService.php
+++ b/api/app/Modules/Platform/Infrastructure/Services/PlatformSupportTicketService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Infrastructure\Services;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Modules\Platform\Domain\Models\PlatformSupportMessage;
+use App\Modules\Platform\Domain\Models\PlatformSupportTicket;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * PA2-COMM-012 — Pilot client support center.
+ *
+ * Centralizes the small set of state transitions around a support ticket
+ * (open, reply, triage, resolve) so both the tenant-facing controller and
+ * the platform admin controller share the same rules instead of duplicating
+ * `last_message_at` bookkeeping and status guards.
+ */
+class PlatformSupportTicketService
+{
+    public function openTicket(
+        Employee $author,
+        string $subject,
+        string $category,
+        string $body,
+        string $priority = PlatformSupportTicket::PRIORITY_NORMAL,
+    ): PlatformSupportTicket {
+        return DB::transaction(function () use ($author, $subject, $category, $body, $priority): PlatformSupportTicket {
+            $now = now();
+
+            /** @var PlatformSupportTicket $ticket */
+            $ticket = PlatformSupportTicket::query()->create([
+                'company_id' => $author->company_id,
+                'created_by_employee_id' => $author->id,
+                'subject' => $subject,
+                'category' => $category,
+                'priority' => $priority,
+                'status' => PlatformSupportTicket::STATUS_OPEN,
+                'last_message_at' => $now,
+            ]);
+
+            PlatformSupportMessage::query()->create([
+                'platform_support_ticket_id' => $ticket->id,
+                'author_employee_id' => $author->id,
+                'body' => $body,
+                'created_at' => $now,
+            ]);
+
+            return $ticket;
+        });
+    }
+
+    public function replyAsEmployee(PlatformSupportTicket $ticket, Employee $author, string $body): PlatformSupportMessage
+    {
+        return DB::transaction(function () use ($ticket, $author, $body): PlatformSupportMessage {
+            $message = PlatformSupportMessage::query()->create([
+                'platform_support_ticket_id' => $ticket->id,
+                'author_employee_id' => $author->id,
+                'body' => $body,
+                'created_at' => now(),
+            ]);
+
+            $ticket->forceFill([
+                'last_message_at' => $message->created_at,
+                // A tenant reply reopens the conversation for the platform
+                // team if it had been marked as merely "pending" a client
+                // answer; a resolved/closed ticket must be reopened
+                // explicitly by triage instead of silently by a stray reply.
+                'status' => $ticket->status === PlatformSupportTicket::STATUS_PENDING
+                    ? PlatformSupportTicket::STATUS_OPEN
+                    : $ticket->status,
+            ])->save();
+
+            return $message;
+        });
+    }
+
+    public function replyAsSuperAdmin(PlatformSupportTicket $ticket, SuperAdmin $author, string $body): PlatformSupportMessage
+    {
+        return DB::transaction(function () use ($ticket, $author, $body): PlatformSupportMessage {
+            $message = PlatformSupportMessage::query()->create([
+                'platform_support_ticket_id' => $ticket->id,
+                'author_super_admin_id' => $author->id,
+                'body' => $body,
+                'created_at' => now(),
+            ]);
+
+            $ticket->forceFill([
+                'last_message_at' => $message->created_at,
+                // A platform reply moves an open ticket to "pending" (i.e.
+                // waiting on the client) unless triage already resolved or
+                // closed it in the same request.
+                'status' => $ticket->status === PlatformSupportTicket::STATUS_OPEN
+                    ? PlatformSupportTicket::STATUS_PENDING
+                    : $ticket->status,
+            ])->save();
+
+            return $message;
+        });
+    }
+
+    public function triage(
+        PlatformSupportTicket $ticket,
+        ?string $status,
+        ?string $priority,
+        ?int $assignedSuperAdminId,
+    ): PlatformSupportTicket {
+        $updates = [];
+
+        if ($status !== null) {
+            $updates['status'] = $status;
+            $updates['resolved_at'] = in_array($status, [PlatformSupportTicket::STATUS_RESOLVED, PlatformSupportTicket::STATUS_CLOSED], true)
+                ? ($ticket->resolved_at ?? now())
+                : null;
+        }
+
+        if ($priority !== null) {
+            $updates['priority'] = $priority;
+        }
+
+        if ($assignedSuperAdminId !== null) {
+            $updates['assigned_super_admin_id'] = $assignedSuperAdminId;
+        }
+
+        if ($updates !== []) {
+            $ticket->forceFill($updates)->save();
+        }
+
+        return $ticket->refresh();
+    }
+}

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformSupportTicketController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformSupportTicketController.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
+
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Http\Controllers\Controller;
+use App\Modules\Platform\Domain\Models\PlatformSupportTicket;
+use App\Modules\Platform\Infrastructure\Services\PlatformSupportTicketService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * PA2-COMM-012 — Pilot client support center, platform-admin side.
+ *
+ * Lets a super-admin see every tenant's support conversations, filter by
+ * status/priority, reply, and triage (status, priority, assignment).
+ */
+class PlatformSupportTicketController extends Controller
+{
+    public function __construct(private readonly PlatformSupportTicketService $ticketService) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'status' => ['nullable', 'string', Rule::in(PlatformSupportTicket::statuses())],
+            'priority' => ['nullable', 'string', Rule::in(PlatformSupportTicket::priorities())],
+            'company_id' => ['nullable', 'uuid'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $query = PlatformSupportTicket::query()
+            ->with(['company:id,name', 'createdBy:id,first_name,last_name,email', 'assignedSuperAdmin:id,name'])
+            ->withCount('messages')
+            ->orderByRaw("CASE priority WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END")
+            ->orderByDesc('last_message_at');
+
+        if (isset($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
+        if (isset($validated['priority'])) {
+            $query->where('priority', $validated['priority']);
+        }
+        if (isset($validated['company_id'])) {
+            $query->where('company_id', $validated['company_id']);
+        }
+
+        $tickets = $query->paginate((int) ($validated['per_page'] ?? 25));
+
+        $statusCounts = PlatformSupportTicket::query()
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        return response()->json([
+            'data' => $tickets->getCollection()->map(fn (PlatformSupportTicket $t): array => $this->summaryPayload($t))->values(),
+            'meta' => [
+                'current_page' => $tickets->currentPage(),
+                'last_page' => $tickets->lastPage(),
+                'total' => $tickets->total(),
+                'status_counts' => [
+                    'open' => (int) ($statusCounts['open'] ?? 0),
+                    'pending' => (int) ($statusCounts['pending'] ?? 0),
+                    'resolved' => (int) ($statusCounts['resolved'] ?? 0),
+                    'closed' => (int) ($statusCounts['closed'] ?? 0),
+                ],
+            ],
+        ]);
+    }
+
+    public function show(PlatformSupportTicket $supportTicket): JsonResponse
+    {
+        $supportTicket->load([
+            'company:id,name',
+            'createdBy:id,first_name,last_name,email',
+            'assignedSuperAdmin:id,name',
+            'messages.authorEmployee:id,first_name,last_name',
+            'messages.authorSuperAdmin:id,name',
+        ]);
+
+        return response()->json(['data' => $this->detailPayload($supportTicket)]);
+    }
+
+    public function reply(Request $request, PlatformSupportTicket $supportTicket): JsonResponse
+    {
+        /** @var SuperAdmin $actor */
+        $actor = $request->user('super_admin_api');
+
+        $validated = $request->validate([
+            'message' => ['required', 'string', 'max:5000'],
+        ]);
+
+        $this->ticketService->replyAsSuperAdmin($supportTicket, $actor, $validated['message']);
+
+        return response()->json([
+            'data' => $this->detailPayload($supportTicket->refresh()->load([
+                'company:id,name',
+                'createdBy:id,first_name,last_name,email',
+                'assignedSuperAdmin:id,name',
+                'messages.authorEmployee:id,first_name,last_name',
+                'messages.authorSuperAdmin:id,name',
+            ])),
+        ]);
+    }
+
+    public function triage(Request $request, PlatformSupportTicket $supportTicket): JsonResponse
+    {
+        /** @var SuperAdmin $actor */
+        $actor = $request->user('super_admin_api');
+
+        $validated = $request->validate([
+            'status' => ['nullable', 'string', Rule::in(PlatformSupportTicket::statuses())],
+            'priority' => ['nullable', 'string', Rule::in(PlatformSupportTicket::priorities())],
+            'assign_to_me' => ['nullable', 'boolean'],
+        ]);
+
+        $ticket = $this->ticketService->triage(
+            ticket: $supportTicket,
+            status: $validated['status'] ?? null,
+            priority: $validated['priority'] ?? null,
+            assignedSuperAdminId: ($validated['assign_to_me'] ?? false) ? $actor->id : null,
+        );
+
+        return response()->json(['data' => $this->summaryPayload($ticket->load(['company:id,name', 'assignedSuperAdmin:id,name']))]);
+    }
+
+    /** @return array<string, mixed> */
+    private function summaryPayload(PlatformSupportTicket $ticket): array
+    {
+        return [
+            'id' => $ticket->id,
+            'subject' => $ticket->subject,
+            'category' => $ticket->category,
+            'priority' => $ticket->priority,
+            'status' => $ticket->status,
+            'messages_count' => $ticket->messages_count ?? 0,
+            'company' => $ticket->company ? [
+                'id' => $ticket->company->id,
+                'name' => $ticket->company->name,
+            ] : null,
+            'created_by' => $ticket->createdBy ? [
+                'id' => $ticket->createdBy->id,
+                'name' => trim($ticket->createdBy->first_name.' '.$ticket->createdBy->last_name),
+                'email' => $ticket->createdBy->email,
+            ] : null,
+            'assigned_super_admin' => $ticket->assignedSuperAdmin ? [
+                'id' => $ticket->assignedSuperAdmin->id,
+                'name' => $ticket->assignedSuperAdmin->name,
+            ] : null,
+            'last_message_at' => $ticket->last_message_at?->toIso8601String(),
+            'created_at' => $ticket->created_at?->toIso8601String(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function detailPayload(PlatformSupportTicket $ticket): array
+    {
+        return [
+            ...$this->summaryPayload($ticket),
+            'messages' => $ticket->messages->map(fn ($message): array => [
+                'id' => $message->id,
+                'body' => $message->body,
+                'from_platform' => $message->isFromPlatform(),
+                'author_name' => $message->isFromPlatform()
+                    ? $message->authorSuperAdmin?->name
+                    : trim((string) $message->authorEmployee?->first_name.' '.(string) $message->authorEmployee?->last_name),
+                'created_at' => $message->created_at?->toIso8601String(),
+            ])->values(),
+        ];
+    }
+}

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/SupportTicketController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/SupportTicketController.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Interfaces\Api\V1\Controllers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Http\Controllers\Controller;
+use App\Modules\Platform\Domain\Models\PlatformSupportTicket;
+use App\Modules\Platform\Infrastructure\Services\PlatformSupportTicketService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * PA2-COMM-012 — Tenant-facing side of the pilot support center: a manager
+ * or employee can open a support ticket and reply on their own company's
+ * tickets. Triage (status/priority/assignment) is platform-admin-only, see
+ * PlatformSupportTicketController.
+ */
+class SupportTicketController extends Controller
+{
+    public function __construct(private readonly PlatformSupportTicketService $ticketService) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $validated = $request->validate([
+            'status' => ['nullable', 'string', Rule::in(PlatformSupportTicket::statuses())],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:50'],
+        ]);
+
+        $query = PlatformSupportTicket::query()
+            ->where('company_id', $actor->company_id)
+            ->withCount('messages')
+            ->orderByDesc('last_message_at');
+
+        if (isset($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
+
+        $tickets = $query->paginate((int) ($validated['per_page'] ?? 20));
+
+        return response()->json([
+            'data' => $tickets->getCollection()->map(fn (PlatformSupportTicket $t): array => $this->summaryPayload($t))->values(),
+            'meta' => [
+                'current_page' => $tickets->currentPage(),
+                'last_page' => $tickets->lastPage(),
+                'total' => $tickets->total(),
+            ],
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $validated = $request->validate([
+            'subject' => ['required', 'string', 'max:200'],
+            'category' => ['required', 'string', Rule::in(PlatformSupportTicket::categories())],
+            'priority' => ['nullable', 'string', Rule::in(PlatformSupportTicket::priorities())],
+            'message' => ['required', 'string', 'max:5000'],
+        ]);
+
+        $ticket = $this->ticketService->openTicket(
+            author: $actor,
+            subject: $validated['subject'],
+            category: $validated['category'],
+            body: $validated['message'],
+            priority: $validated['priority'] ?? PlatformSupportTicket::PRIORITY_NORMAL,
+        );
+
+        return response()->json(['data' => $this->detailPayload($ticket->load('messages'))], 201);
+    }
+
+    public function show(Request $request, PlatformSupportTicket $supportTicket): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        $this->ensureCompanyOwnsTicket($supportTicket, $actor);
+
+        return response()->json([
+            'data' => $this->detailPayload($supportTicket->load(['messages.authorEmployee:id,first_name,last_name'])),
+        ]);
+    }
+
+    public function reply(Request $request, PlatformSupportTicket $supportTicket): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        $this->ensureCompanyOwnsTicket($supportTicket, $actor);
+
+        if ($supportTicket->status === PlatformSupportTicket::STATUS_CLOSED) {
+            throw ValidationException::withMessages([
+                'status' => ['This ticket is closed. Open a new ticket if you need further help.'],
+            ]);
+        }
+
+        $validated = $request->validate([
+            'message' => ['required', 'string', 'max:5000'],
+        ]);
+
+        $this->ticketService->replyAsEmployee($supportTicket, $actor, $validated['message']);
+
+        return response()->json([
+            'data' => $this->detailPayload($supportTicket->refresh()->load('messages')),
+        ]);
+    }
+
+    private function ensureCompanyOwnsTicket(PlatformSupportTicket $ticket, Employee $actor): void
+    {
+        if ($ticket->company_id !== $actor->company_id) {
+            abort(404);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function summaryPayload(PlatformSupportTicket $ticket): array
+    {
+        return [
+            'id' => $ticket->id,
+            'subject' => $ticket->subject,
+            'category' => $ticket->category,
+            'priority' => $ticket->priority,
+            'status' => $ticket->status,
+            'messages_count' => $ticket->messages_count ?? 0,
+            'last_message_at' => $ticket->last_message_at?->toIso8601String(),
+            'created_at' => $ticket->created_at?->toIso8601String(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function detailPayload(PlatformSupportTicket $ticket): array
+    {
+        return [
+            'id' => $ticket->id,
+            'subject' => $ticket->subject,
+            'category' => $ticket->category,
+            'priority' => $ticket->priority,
+            'status' => $ticket->status,
+            'last_message_at' => $ticket->last_message_at?->toIso8601String(),
+            'created_at' => $ticket->created_at?->toIso8601String(),
+            'messages' => $ticket->messages->map(fn ($message): array => [
+                'id' => $message->id,
+                'body' => $message->body,
+                'from_platform' => $message->isFromPlatform(),
+                'created_at' => $message->created_at?->toIso8601String(),
+            ])->values(),
+        ];
+    }
+}

--- a/api/database/migrations/public/2026_07_25_000002_create_platform_support_tickets_table.php
+++ b/api/database/migrations/public/2026_07_25_000002_create_platform_support_tickets_table.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PA2-COMM-012 — Pilot client support center.
+ *
+ * Lets a tenant manager/employee open a support conversation with the
+ * Leopardo platform team, and lets a super-admin triage it (status +
+ * priority) from the admin web console. Mirrors the `platform_announcements`
+ * pattern (PA2-COMM-005): these tables live in the `public` schema because a
+ * ticket is owned by the platform, not by a single tenant's own database
+ * scope, even though every ticket references a tenant `company_id`.
+ *
+ * A ticket has many messages (the conversation thread); the tenant author
+ * and the platform admin(s) exchange messages on the same ticket, which is
+ * simpler than modelling a generic multi-participant conversation for a
+ * pilot-scale support surface.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('platform_support_tickets')) {
+            Schema::create('platform_support_tickets', function (Blueprint $table): void {
+                $table->id();
+                $table->uuid('company_id');
+                $table->unsignedInteger('created_by_employee_id');
+                $table->string('subject', 200);
+                $table->string('category', 30)->default('general');
+                $table->string('priority', 20)->default('normal');
+                $table->string('status', 20)->default('open');
+                $table->unsignedInteger('assigned_super_admin_id')->nullable();
+                $table->timestampTz('last_message_at')->nullable();
+                $table->timestampTz('resolved_at')->nullable();
+                $table->timestamps();
+
+                $table->index('company_id');
+                $table->index('status');
+                $table->index('priority');
+                $table->index('last_message_at');
+            });
+        }
+
+        if (! Schema::hasTable('platform_support_messages')) {
+            Schema::create('platform_support_messages', function (Blueprint $table): void {
+                $table->id();
+                $table->foreignId('platform_support_ticket_id')
+                    ->references('id')
+                    ->on('platform_support_tickets')
+                    ->cascadeOnDelete();
+                // Either the tenant employee or the platform super-admin
+                // authored this message; exactly one of the two is set.
+                $table->unsignedInteger('author_employee_id')->nullable();
+                $table->unsignedInteger('author_super_admin_id')->nullable();
+                $table->text('body');
+                $table->timestampTz('created_at')->nullable();
+
+                $table->index('platform_support_ticket_id');
+            });
+        }
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement("ALTER TABLE platform_support_tickets ADD CONSTRAINT platform_support_tickets_category_check CHECK (category IN ('general', 'billing', 'technical', 'onboarding', 'other'))");
+            DB::statement("ALTER TABLE platform_support_tickets ADD CONSTRAINT platform_support_tickets_priority_check CHECK (priority IN ('low', 'normal', 'high', 'urgent'))");
+            DB::statement("ALTER TABLE platform_support_tickets ADD CONSTRAINT platform_support_tickets_status_check CHECK (status IN ('open', 'pending', 'resolved', 'closed'))");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('platform_support_messages');
+        Schema::dropIfExists('platform_support_tickets');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -32,6 +32,8 @@ use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCountryDefaultsCo
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformCrmPipelineController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformImpersonationController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformMetricsOverviewController;
+use App\Modules\Platform\Interfaces\Api\V1\Controllers\PlatformSupportTicketController;
+use App\Modules\Platform\Interfaces\Api\V1\Controllers\SupportTicketController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\QueueObservabilityController;
 use App\Modules\Platform\Interfaces\Api\V1\Controllers\TranslationCatalogController;
 use Illuminate\Support\Facades\Route;
@@ -127,6 +129,13 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/company/branding', [CompanyBrandingController::class, 'show']);
         Route::patch('/company/branding', [CompanyBrandingController::class, 'update']);
 
+        // PA2-COMM-012 — Pilot client support center: a manager/employee can
+        // open a support ticket and reply on their own company's tickets.
+        Route::get('/support-tickets', [SupportTicketController::class, 'index']);
+        Route::post('/support-tickets', [SupportTicketController::class, 'store']);
+        Route::get('/support-tickets/{supportTicket}', [SupportTicketController::class, 'show'])->whereNumber('supportTicket');
+        Route::post('/support-tickets/{supportTicket}/reply', [SupportTicketController::class, 'reply'])->whereNumber('supportTicket');
+
         Route::get('/onboarding/checklist', OnboardingChecklistController::class);
     });
 
@@ -193,6 +202,13 @@ Route::prefix('v1')->group(function (): void {
         Route::patch('/company-requests/{id}', [PlatformCompanyRequestController::class, 'updateStatus'])->whereNumber('id');
 
         Route::get('/crm/pipeline', PlatformCrmPipelineController::class);
+
+        // PA2-COMM-012 — Pilot client support center: super-admin triage of
+        // tenant-opened support tickets (status, priority, assignment, reply).
+        Route::get('/support-tickets', [PlatformSupportTicketController::class, 'index']);
+        Route::get('/support-tickets/{supportTicket}', [PlatformSupportTicketController::class, 'show'])->whereNumber('supportTicket');
+        Route::post('/support-tickets/{supportTicket}/reply', [PlatformSupportTicketController::class, 'reply'])->whereNumber('supportTicket');
+        Route::patch('/support-tickets/{supportTicket}/triage', [PlatformSupportTicketController::class, 'triage'])->whereNumber('supportTicket');
 
         // PA2-COMM-005 — Platform-wide announcements (maintenance, feature,
         // incident, action required) broadcast by super-admin to all or a

--- a/api/tests/Feature/PlatformSupportTicketControllerTest.php
+++ b/api/tests/Feature/PlatformSupportTicketControllerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Modules\Platform\Domain\Models\PlatformSupportTicket;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-COMM-012 — Pilot client support center: a tenant manager/employee can
+ * open a support ticket and reply on it; a super-admin can see every
+ * tenant's tickets, reply, and triage (status/priority/assignment).
+ */
+class PlatformSupportTicketControllerTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    private function actingAsSuperAdmin(): SuperAdmin
+    {
+        $superAdmin = SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => 'admin@leopardo.test',
+            'password_hash' => Hash::make('password123'),
+        ]);
+
+        Sanctum::actingAs($superAdmin, ['*'], 'super_admin_api');
+
+        return $superAdmin;
+    }
+
+    public function test_employee_can_open_a_support_ticket_and_see_it_listed(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->postJson('/api/v1/support-tickets', [
+            'subject' => 'Payroll export fails',
+            'category' => 'technical',
+            'priority' => 'high',
+            'message' => 'The payroll export button returns a 500 error since this morning.',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.subject', 'Payroll export fails')
+            ->assertJsonPath('data.status', 'open')
+            ->assertJsonPath('data.priority', 'high')
+            ->assertJsonPath('data.messages.0.from_platform', false);
+
+        $this->assertDatabaseHas('platform_support_tickets', [
+            'company_id' => $company->id,
+            'created_by_employee_id' => $employee->id,
+            'subject' => 'Payroll export fails',
+        ]);
+
+        $this->getJson('/api/v1/support-tickets')
+            ->assertOk()
+            ->assertJsonPath('data.0.subject', 'Payroll export fails')
+            ->assertJsonPath('meta.total', 1);
+    }
+
+    public function test_employee_cannot_see_another_companys_ticket(): void
+    {
+        $companyOne = Company::factory()->create();
+        $companyTwo = Company::factory()->create();
+        $employeeOne = Employee::factory()->manager()->create(['company_id' => $companyOne->id]);
+        $employeeTwo = Employee::factory()->manager()->create(['company_id' => $companyTwo->id]);
+
+        Sanctum::actingAs($employeeOne);
+        $ticketId = $this->postJson('/api/v1/support-tickets', [
+            'subject' => 'Private ticket',
+            'category' => 'general',
+            'message' => 'Only my company should see this.',
+        ])->json('data.id');
+
+        Sanctum::actingAs($employeeTwo);
+        $this->getJson("/api/v1/support-tickets/{$ticketId}")->assertNotFound();
+    }
+
+    public function test_super_admin_can_see_and_triage_a_ticket_from_any_company(): void
+    {
+        $superAdmin = $this->actingAsSuperAdmin();
+
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        Sanctum::actingAs($employee);
+
+        $ticketId = $this->postJson('/api/v1/support-tickets', [
+            'subject' => 'Billing question',
+            'category' => 'billing',
+            'message' => 'Why was I charged twice this month?',
+        ])->json('data.id');
+
+        Sanctum::actingAs($superAdmin, ['*'], 'super_admin_api');
+
+        $this->getJson('/api/v1/platform/support-tickets')
+            ->assertOk()
+            ->assertJsonPath('data.0.subject', 'Billing question')
+            ->assertJsonPath('meta.status_counts.open', 1);
+
+        $reply = $this->postJson("/api/v1/platform/support-tickets/{$ticketId}/reply", [
+            'message' => 'We are looking into the duplicate charge, refund incoming.',
+        ]);
+        $reply->assertOk()
+            ->assertJsonPath('data.status', 'pending')
+            ->assertJsonPath('data.messages.1.from_platform', true);
+
+        $triage = $this->patchJson("/api/v1/platform/support-tickets/{$ticketId}/triage", [
+            'status' => 'resolved',
+            'priority' => 'low',
+            'assign_to_me' => true,
+        ]);
+        $triage->assertOk()
+            ->assertJsonPath('data.status', 'resolved')
+            ->assertJsonPath('data.priority', 'low')
+            ->assertJsonPath('data.assigned_super_admin.id', $superAdmin->id);
+
+        $this->assertDatabaseHas('platform_support_tickets', [
+            'id' => $ticketId,
+            'status' => PlatformSupportTicket::STATUS_RESOLVED,
+            'priority' => PlatformSupportTicket::PRIORITY_LOW,
+            'assigned_super_admin_id' => $superAdmin->id,
+        ]);
+    }
+
+    public function test_employee_reply_reopens_a_pending_ticket(): void
+    {
+        $superAdmin = $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($employee);
+        $ticketId = $this->postJson('/api/v1/support-tickets', [
+            'subject' => 'Login issue',
+            'category' => 'technical',
+            'message' => 'Cannot log in on mobile.',
+        ])->json('data.id');
+
+        Sanctum::actingAs($superAdmin, ['*'], 'super_admin_api');
+        $this->postJson("/api/v1/platform/support-tickets/{$ticketId}/reply", [
+            'message' => 'Can you confirm the app version?',
+        ])->assertOk()->assertJsonPath('data.status', 'pending');
+
+        Sanctum::actingAs($employee);
+        $this->postJson("/api/v1/support-tickets/{$ticketId}/reply", [
+            'message' => 'Version 2.4.1.',
+        ])->assertOk()->assertJsonPath('data.status', 'open');
+    }
+
+    public function test_employee_cannot_reply_on_a_closed_ticket(): void
+    {
+        $superAdmin = $this->actingAsSuperAdmin();
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        Sanctum::actingAs($employee);
+        $ticketId = $this->postJson('/api/v1/support-tickets', [
+            'subject' => 'Closed ticket test',
+            'category' => 'other',
+            'message' => 'Initial message.',
+        ])->json('data.id');
+
+        Sanctum::actingAs($superAdmin, ['*'], 'super_admin_api');
+        $this->patchJson("/api/v1/platform/support-tickets/{$ticketId}/triage", [
+            'status' => 'closed',
+        ])->assertOk();
+
+        Sanctum::actingAs($employee);
+        $this->postJson("/api/v1/support-tickets/{$ticketId}/reply", [
+            'message' => 'Are you still there?',
+        ])->assertUnprocessable();
+    }
+}

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -826,6 +826,38 @@ trait CreatesMvpSchema
             $table->index('company_id');
         });
 
+        // PA2-COMM-012 — Pilot client support center (public schema, not
+        // tenant-scoped; see database/migrations/public/2026_07_25_000002_...).
+        Schema::create('platform_support_tickets', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('company_id');
+            $table->unsignedInteger('created_by_employee_id');
+            $table->string('subject', 200);
+            $table->string('category', 30)->default('general');
+            $table->string('priority', 20)->default('normal');
+            $table->string('status', 20)->default('open');
+            $table->unsignedInteger('assigned_super_admin_id')->nullable();
+            $table->timestampTz('last_message_at')->nullable();
+            $table->timestampTz('resolved_at')->nullable();
+            $table->timestamps();
+
+            $table->index('company_id');
+            $table->index('status');
+            $table->index('priority');
+            $table->index('last_message_at');
+        });
+
+        Schema::create('platform_support_messages', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('platform_support_ticket_id');
+            $table->unsignedInteger('author_employee_id')->nullable();
+            $table->unsignedInteger('author_super_admin_id')->nullable();
+            $table->text('body');
+            $table->timestampTz('created_at')->nullable();
+
+            $table->index('platform_support_ticket_id');
+        });
+
         // PA2-ADM-006 — Secure super-admin impersonation sessions (public
         // schema; see database/migrations/public/2026_07_23_000003_...).
         Schema::create('platform_impersonation_sessions', function (Blueprint $table): void {
@@ -1871,6 +1903,8 @@ trait CreatesMvpSchema
         DB::statement('DROP TABLE IF EXISTS "user_invitations"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "platform_announcement_companies"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "platform_impersonation_sessions"'.$cascade);
+        DB::statement('DROP TABLE IF EXISTS "platform_support_messages"'.$cascade);
+        DB::statement('DROP TABLE IF EXISTS "platform_support_tickets"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "platform_announcements"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "super_admins"'.$cascade);
         DB::statement('DROP TABLE IF EXISTS "personal_access_tokens"'.$cascade);

--- a/front/admin-dashboard/src/components/layout/Sidebar.vue
+++ b/front/admin-dashboard/src/components/layout/Sidebar.vue
@@ -161,7 +161,8 @@ import {
   ArrowDownTrayIcon,
   ChartPieIcon,
   ShieldCheckIcon,
-  FunnelIcon
+  FunnelIcon,
+  LifebuoyIcon
 } from '@heroicons/vue/24/outline'
 import { useAuthStore } from '@/stores/auth'
 import { useDashboardStore } from '@/stores/dashboard'
@@ -291,6 +292,12 @@ const navigation = computed(() => [
     path: '/support',
     icon: ChatBubbleLeftRightIcon,
     badge: dashboardStore.stats.supportTickets
+  },
+  {
+    name: 'support-tickets',
+    title: 'Centre support client',
+    path: '/support-tickets',
+    icon: LifebuoyIcon
   },
   {
     name: 'crm-pipeline',

--- a/front/admin-dashboard/src/router/index.js
+++ b/front/admin-dashboard/src/router/index.js
@@ -116,6 +116,15 @@ const routes = [
         }
       },
       {
+        path: '/support-tickets',
+        name: 'support-tickets',
+        component: () => import('@/views/support/SupportTicketsView.vue'),
+        meta: {
+          title: 'Centre support client',
+          icon: 'LifebuoyIcon'
+        }
+      },
+      {
         path: '/crm/pipeline',
         name: 'crm-pipeline',
         component: () => import('@/views/crm/CrmPipelineView.vue'),

--- a/front/admin-dashboard/src/views/support/SupportTicketsView.vue
+++ b/front/admin-dashboard/src/views/support/SupportTicketsView.vue
@@ -1,0 +1,383 @@
+<template>
+  <div class="space-y-8 animate-fade-in">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 class="text-4xl font-black tracking-tight text-slate-900 dark:text-white">Centre support client</h1>
+        <p class="mt-1 text-slate-500 dark:text-slate-400 font-medium text-lg">
+          Conversations ouvertes par les entreprises clientes, triées par priorité.
+        </p>
+      </div>
+      <button class="btn-secondary py-2.5 shadow-glass-sm" :disabled="isLoading" @click="loadTickets">
+        <ArrowPathIcon class="mr-2 h-4 w-4" :class="{ 'animate-spin': isLoading }" />
+        Actualiser
+      </button>
+    </div>
+
+    <!-- KPI Summary -->
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4 animate-slide-up">
+      <StatsCard title="Ouverts" :value="statusCounts.open" icon="ChatBubbleBottomCenterTextIcon" color="blue" />
+      <StatsCard title="En attente client" :value="statusCounts.pending" icon="ClockIcon" color="yellow" />
+      <StatsCard title="Résolus" :value="statusCounts.resolved" icon="CheckCircleIcon" color="green" />
+      <StatsCard title="Fermés" :value="statusCounts.closed" icon="XCircleIcon" color="red" />
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-5">
+      <!-- Ticket list -->
+      <div class="card lg:col-span-2 animate-slide-up" style="animation-delay: 0.1s">
+        <div class="flex flex-col gap-4 border-b border-slate-200/50 px-6 py-6 dark:border-slate-800/50 bg-slate-50/30 dark:bg-slate-900/20">
+          <div class="flex flex-wrap gap-2 p-1 bg-slate-200/50 dark:bg-slate-800/50 rounded-2xl w-fit">
+            <button
+              v-for="option in statusFilters"
+              :key="option.value"
+              :class="[
+                'px-3 py-1.5 text-xs font-black uppercase tracking-widest transition-all rounded-xl',
+                activeStatus === option.value
+                  ? 'bg-white dark:bg-slate-700 text-brand-600 dark:text-white shadow-glass-sm'
+                  : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+              ]"
+              @click="setStatusFilter(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="option in priorityFilters"
+              :key="option.value"
+              :class="[
+                'px-3 py-1 text-[10px] font-black uppercase tracking-widest rounded-lg border transition',
+                activePriority === option.value
+                  ? 'border-brand-400 bg-brand-50 text-brand-700 dark:bg-brand-900/30 dark:text-brand-300'
+                  : 'border-slate-200 text-slate-500 dark:border-slate-700'
+              ]"
+              @click="setPriorityFilter(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="isLoading && tickets.length === 0" class="flex flex-col items-center justify-center p-16 gap-4">
+          <div class="h-10 w-10 animate-spin rounded-full border-4 border-brand-500 border-t-transparent"></div>
+        </div>
+
+        <div v-else-if="tickets.length === 0" class="p-16 text-center">
+          <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 dark:bg-slate-800 text-slate-400">
+            <InboxIcon class="h-7 w-7" />
+          </div>
+          <p class="mt-4 text-sm font-bold text-slate-400 uppercase tracking-widest">Aucun ticket</p>
+        </div>
+
+        <div v-else class="max-h-[640px] divide-y divide-slate-200/50 overflow-y-auto dark:divide-slate-800/50">
+          <button
+            v-for="ticket in tickets"
+            :key="ticket.id"
+            type="button"
+            class="w-full p-4 text-left transition hover:bg-slate-50/70 dark:hover:bg-slate-800/40"
+            :class="selectedTicket?.id === ticket.id ? 'bg-brand-50/60 dark:bg-brand-900/20' : ''"
+            @click="selectTicket(ticket)"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <p class="truncate text-sm font-bold text-slate-900 dark:text-white">{{ ticket.subject }}</p>
+              <span :class="['shrink-0 rounded-lg border px-2 py-0.5 text-[9px] font-black uppercase tracking-widest', priorityClass(ticket.priority)]">
+                {{ priorityLabel(ticket.priority) }}
+              </span>
+            </div>
+            <p class="mt-1 truncate text-xs font-semibold text-slate-500 dark:text-slate-400">
+              {{ ticket.company?.name || 'Entreprise inconnue' }}
+            </p>
+            <div class="mt-2 flex items-center justify-between">
+              <span :class="['rounded-lg border px-2 py-0.5 text-[9px] font-black uppercase tracking-widest', statusClass(ticket.status)]">
+                {{ statusLabel(ticket.status) }}
+              </span>
+              <span class="text-[10px] font-semibold text-slate-400">{{ formatDate(ticket.last_message_at) }}</span>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <!-- Ticket detail / conversation -->
+      <div class="card lg:col-span-3 animate-slide-up" style="animation-delay: 0.15s">
+        <div v-if="!selectedTicket" class="flex h-full min-h-[400px] items-center justify-center p-16 text-center">
+          <div>
+            <ChatBubbleBottomCenterTextIcon class="mx-auto h-10 w-10 text-slate-300" />
+            <p class="mt-4 text-sm font-bold text-slate-400 uppercase tracking-widest">
+              Sélectionnez un ticket pour voir la conversation
+            </p>
+          </div>
+        </div>
+
+        <div v-else>
+          <div class="flex flex-col gap-4 border-b border-slate-200/50 px-6 py-6 dark:border-slate-800/50">
+            <div class="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white">{{ selectedTicket.subject }}</h2>
+                <p class="mt-1 text-sm font-semibold text-slate-500 dark:text-slate-400">
+                  {{ selectedTicket.company?.name }} · {{ selectedTicket.created_by?.name || 'Contact inconnu' }}
+                </p>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <select
+                  v-model="triageStatus"
+                  class="form-select"
+                  :disabled="isTriaging"
+                  @change="applyTriage"
+                >
+                  <option v-for="s in statusFilters.filter((f) => f.value !== 'all')" :key="s.value" :value="s.value">
+                    {{ s.label }}
+                  </option>
+                </select>
+                <select
+                  v-model="triagePriority"
+                  class="form-select"
+                  :disabled="isTriaging"
+                  @change="applyTriage"
+                >
+                  <option v-for="p in priorityFilters.filter((f) => f.value !== 'all')" :key="p.value" :value="p.value">
+                    {{ p.label }}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div ref="messagesContainer" class="max-h-[420px] space-y-4 overflow-y-auto p-6">
+            <div
+              v-for="message in selectedTicket.messages || []"
+              :key="message.id"
+              :class="['flex', message.from_platform ? 'justify-end' : 'justify-start']"
+            >
+              <div
+                :class="[
+                  'max-w-[75%] rounded-2xl px-4 py-3 text-sm shadow-sm',
+                  message.from_platform
+                    ? 'bg-brand-600 text-white'
+                    : 'bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100'
+                ]"
+              >
+                <p class="whitespace-pre-wrap leading-relaxed">{{ message.body }}</p>
+                <p :class="['mt-1 text-[10px] font-semibold', message.from_platform ? 'text-brand-100' : 'text-slate-400']">
+                  {{ message.author_name || (message.from_platform ? 'Équipe Leopardo' : 'Client') }} · {{ formatDate(message.created_at) }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="border-t border-slate-200/50 p-4 dark:border-slate-800/50">
+            <div class="flex gap-3">
+              <textarea
+                v-model="replyBody"
+                rows="2"
+                class="form-input flex-1 text-sm"
+                placeholder="Répondre au client..."
+                :disabled="isReplying"
+              ></textarea>
+              <button
+                class="btn-primary self-end px-5 py-3"
+                :disabled="isReplying || !replyBody.trim()"
+                @click="sendReply"
+              >
+                <PaperAirplaneIcon class="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { nextTick, onMounted, ref } from 'vue'
+import { useToast } from 'vue-toastification'
+import {
+  ArrowPathIcon,
+  ChatBubbleBottomCenterTextIcon,
+  ClockIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  InboxIcon,
+  PaperAirplaneIcon
+} from '@heroicons/vue/24/outline'
+import api from '@/services/api'
+import StatsCard from '@/components/dashboard/StatsCard.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const toast = useToast()
+const localeStore = useLocaleStore()
+
+const isLoading = ref(false)
+const isReplying = ref(false)
+const isTriaging = ref(false)
+const activeStatus = ref('all')
+const activePriority = ref('all')
+const tickets = ref([])
+const selectedTicket = ref(null)
+const replyBody = ref('')
+const triageStatus = ref('open')
+const triagePriority = ref('normal')
+const statusCounts = ref({ open: 0, pending: 0, resolved: 0, closed: 0 })
+const messagesContainer = ref(null)
+
+const statusFilters = [
+  { value: 'all', label: 'Tous' },
+  { value: 'open', label: 'Ouverts' },
+  { value: 'pending', label: 'En attente' },
+  { value: 'resolved', label: 'Résolus' },
+  { value: 'closed', label: 'Fermés' },
+]
+
+const priorityFilters = [
+  { value: 'all', label: 'Toutes priorités' },
+  { value: 'urgent', label: 'Urgent' },
+  { value: 'high', label: 'Haute' },
+  { value: 'normal', label: 'Normale' },
+  { value: 'low', label: 'Basse' },
+]
+
+async function loadTickets() {
+  isLoading.value = true
+
+  try {
+    const params = {}
+    if (activeStatus.value !== 'all') params.status = activeStatus.value
+    if (activePriority.value !== 'all') params.priority = activePriority.value
+
+    const response = await api.get('/platform/support-tickets', { params })
+    tickets.value = response.data?.data || []
+    statusCounts.value = response.data?.meta?.status_counts || statusCounts.value
+
+    if (selectedTicket.value) {
+      const stillPresent = tickets.value.find((t) => t.id === selectedTicket.value.id)
+      if (!stillPresent) {
+        selectedTicket.value = null
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load support tickets:', error)
+    toast.error('Impossible de charger les tickets de support.')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function selectTicket(ticket) {
+  try {
+    const response = await api.get(`/platform/support-tickets/${ticket.id}`)
+    selectedTicket.value = response.data?.data || ticket
+    triageStatus.value = selectedTicket.value.status
+    triagePriority.value = selectedTicket.value.priority
+    await nextTick()
+    if (messagesContainer.value) {
+      messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
+    }
+  } catch (error) {
+    console.error('Failed to load ticket detail:', error)
+    toast.error('Impossible de charger la conversation.')
+  }
+}
+
+async function sendReply() {
+  if (!selectedTicket.value || !replyBody.value.trim() || isReplying.value) return
+  isReplying.value = true
+
+  try {
+    const response = await api.post(`/platform/support-tickets/${selectedTicket.value.id}/reply`, {
+      message: replyBody.value.trim(),
+    })
+    selectedTicket.value = response.data?.data || selectedTicket.value
+    replyBody.value = ''
+    await loadTickets()
+    await nextTick()
+    if (messagesContainer.value) {
+      messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
+    }
+  } catch (error) {
+    console.error('Failed to reply to ticket:', error)
+    toast.error('Envoi de la réponse impossible.')
+  } finally {
+    isReplying.value = false
+  }
+}
+
+async function applyTriage() {
+  if (!selectedTicket.value || isTriaging.value) return
+  isTriaging.value = true
+
+  try {
+    await api.patch(`/platform/support-tickets/${selectedTicket.value.id}/triage`, {
+      status: triageStatus.value,
+      priority: triagePriority.value,
+    })
+    toast.success('Ticket mis à jour.')
+    await loadTickets()
+  } catch (error) {
+    console.error('Failed to triage ticket:', error)
+    toast.error('Mise à jour du ticket impossible.')
+  } finally {
+    isTriaging.value = false
+  }
+}
+
+function setStatusFilter(status) {
+  activeStatus.value = status
+  loadTickets()
+}
+
+function setPriorityFilter(priority) {
+  activePriority.value = priority
+  loadTickets()
+}
+
+function statusClass(status) {
+  const classes = {
+    open: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300 border-blue-200 dark:border-blue-800',
+    pending: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 border-amber-200 dark:border-amber-800',
+    resolved: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800',
+    closed: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+  }
+  return classes[status] || classes.closed
+}
+
+function statusLabel(status) {
+  const labels = { open: 'Ouvert', pending: 'En attente', resolved: 'Résolu', closed: 'Fermé' }
+  return labels[status] || status
+}
+
+function priorityClass(priority) {
+  const classes = {
+    urgent: 'border-red-300 bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300',
+    high: 'border-orange-300 bg-orange-50 text-orange-700 dark:bg-orange-950/30 dark:text-orange-300',
+    normal: 'border-slate-200 bg-slate-50 text-slate-600 dark:bg-slate-900/40 dark:text-slate-300',
+    low: 'border-slate-200 bg-slate-50 text-slate-400 dark:bg-slate-900/40 dark:text-slate-500',
+  }
+  return classes[priority] || classes.normal
+}
+
+function priorityLabel(priority) {
+  const labels = { urgent: 'Urgent', high: 'Haute', normal: 'Normale', low: 'Basse' }
+  return labels[priority] || priority
+}
+
+function formatDate(value) {
+  if (!value) return 'Non renseigné'
+
+  return new Intl.DateTimeFormat(toIntlLocale(localeStore.current), {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}
+
+onMounted(loadTickets)
+</script>
+
+<style scoped>
+@reference '../../style.css';
+.form-input {
+  @apply block w-full rounded-2xl border border-slate-200 bg-white/50 px-4 py-3 text-slate-900 shadow-sm outline-none transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950/50 dark:text-white backdrop-blur-sm placeholder:text-slate-400 font-medium;
+}
+.form-select {
+  @apply rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs font-bold uppercase tracking-widest text-slate-700 outline-none transition focus:border-brand-500 dark:border-slate-800 dark:bg-slate-950/50 dark:text-slate-200;
+}
+</style>


### PR DESCRIPTION
Closes #1063

Acceptance criteria: `Conversations client platform statut priorite`.

Before this PR, no support ticket/conversation system existed anywhere in the codebase:
- `front/admin-dashboard/src/views/support/SupportView.vue` (the existing `/support` page) manages sales lead qualification via `CompanyRequest`, not client support conversations.
- The only other 'support' references are marketing contact-us links (`/contact?topic=support`).

## API (public schema, mirrors the `PlatformAnnouncement` pattern from PA2-COMM-005)
- `platform_support_tickets` / `platform_support_messages` tables (new public-schema migration).
- `PlatformSupportTicket` / `PlatformSupportMessage` models.
- `PlatformSupportTicketService` centralizes ticket state transitions: open, employee reply reopens a `pending` ticket, platform reply moves an `open` ticket to `pending`, triage sets status/priority/assignment and stamps `resolved_at`.
- Tenant-facing `SupportTicketController` (`/api/v1/support-tickets`): a manager/employee can list their own company's tickets, open a new one, view a thread, and reply (blocked once closed, tenant-isolated by `company_id`).
- Platform-admin `PlatformSupportTicketController` (`/api/v1/platform/support-tickets`): list every tenant's tickets sorted by priority with status counts, view a thread, reply, and triage (status/priority/assign-to-me).
- Feature tests: ticket creation + listing, cross-tenant isolation (404), super-admin reply/triage, employee-reply-reopens-pending, reply-on-closed-ticket rejection.

## Admin web (Vue)
- New `SupportTicketsView.vue`: two-pane ticket list (status + priority filters, KPI counters) and conversation thread with reply box and inline status/priority triage selects.
- New `/support-tickets` route + sidebar entry (`LifebuoyIcon`), kept separate from the existing `/support` sales-lead page.

## Testing
- Manual code review; no PHP CLI or `node_modules` available in this sandbox to run PHPUnit or the Vue build.
- Verified brace/paren balance across all new/modified PHP files and clean `node --check` on the extracted JS from the new router/sidebar/Vue-script changes.
- Added the two new tables to `tests/Support/CreatesMvpSchema.php` (the hand-maintained schema used by `TestCase`) so `PlatformSupportTicketControllerTest` can run against the existing in-memory test schema.