### PR TITLE
feat(attendance): employees can view anomalies on their own attendance day

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/MeController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/MeController.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\AttendanceTodayResource;
 use App\Modules\Attendance\Domain\Models\AttendanceLog;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Modules\Attendance\Infrastructure\Services\AttendanceAnomalyService;
+use App\Modules\Attendance\Interfaces\Api\V1\Requests\AttendanceAnomaliesRequest;
 use App\Modules\Planning\Infrastructure\Services\EstimationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -111,6 +113,28 @@ class MeController extends Controller
                 'month' => $month,
             ]),
         ]);
+    }
+
+    /**
+     * PA2-ATT-004 - Self-service anomaly view: an employee can see anomalies
+     * detected on their own attendance logs (late arrivals, missing
+     * check-outs, excessive overtime, etc.) without needing manager
+     * privileges. Always force-scoped to the caller's own employee_id so a
+     * regular employee can never read another employee's anomalies through
+     * this endpoint.
+     */
+    public function attendanceAnomalies(AttendanceAnomaliesRequest $request, AttendanceAnomalyService $anomalyService): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        $this->authorize('viewOwnAnomalies', AttendanceLog::class);
+
+        $filters = array_merge($request->validated(), ['employee_id' => $employee->id]);
+
+        return new JsonResponse(
+            $anomalyService->summarize($employee->company_id, $filters, null)
+        );
     }
 }
 

--- a/api/app/Policies/AttendancePolicy.php
+++ b/api/app/Policies/AttendancePolicy.php
@@ -22,6 +22,17 @@ class AttendancePolicy
         return $actor->isManager();
     }
 
+    /**
+     * PA2-ATT-004 - Every authenticated employee may view anomalies detected
+     * on their own attendance logs (late arrivals, missing check-outs, etc.).
+     * This is intentionally unrestricted by role: it only ever surfaces the
+     * caller's own records, scoped by employee_id in the controller/service.
+     */
+    public function viewOwnAnomalies(Employee $actor): bool
+    {
+        return true;
+    }
+
     public function viewForEmployee(Employee $actor, Employee $target): bool
     {
         if ($actor->id === $target->id) {

--- a/api/routes/modules/rh.php
+++ b/api/routes/modules/rh.php
@@ -65,6 +65,7 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
     Route::get('/me/daily-summary', [MeController::class, 'dailySummary']);
     Route::get('/me/quick-estimate', [MeController::class, 'quickEstimate']);
     Route::get('/me/monthly-summary', [MeController::class, 'monthlySummary']);
+    Route::get('/me/attendance-anomalies', [MeController::class, 'attendanceAnomalies']); // PA2-ATT-004
     Route::get('/me/balance', [PayrollCycleController::class, 'myBalance']);
     Route::get('/me/ledger', [LedgerController::class, 'myLedger']); // PA2-PAY-007
 

--- a/api/tests/Feature/Attendance/MyAttendanceAnomaliesTest.php
+++ b/api/tests/Feature/Attendance/MyAttendanceAnomaliesTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
+use Illuminate\Support\Carbon;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-ATT-004 - Self-service anomaly view: a plain employee (no manager
+ * role) can see anomalies detected on their own attendance logs, but never
+ * on a colleague's.
+ */
+class MyAttendanceAnomaliesTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_employee_can_view_their_own_attendance_anomalies(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+        ]);
+        $colleague = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+        ]);
+
+        app()->instance('current_company', $company);
+
+        AttendanceLog::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-06',
+            'check_in' => Carbon::parse('2026-05-06 08:35:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-06 17:00:00', 'UTC'),
+            'late_minutes' => 20,
+            'status' => 'late',
+        ]);
+
+        // Colleague's own late arrival must never leak into this employee's
+        // self-service anomaly view.
+        AttendanceLog::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $colleague->id,
+            'date' => '2026-05-06',
+            'check_in' => Carbon::parse('2026-05-06 09:10:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-06 17:00:00', 'UTC'),
+            'late_minutes' => 55,
+            'status' => 'late',
+        ]);
+
+        app()->forgetInstance('current_company');
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson('/api/v1/me/attendance-anomalies?date_from=2026-05-06&date_to=2026-05-06');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.summary.total', 1);
+        $response->assertJsonPath('data.summary.by_type.late_arrival', 1);
+        $response->assertJsonPath('data.summary.business_impact.late_minutes', 20);
+        $response->assertJsonCount(1, 'data.items');
+    }
+
+    public function test_employee_cannot_view_another_employees_anomalies_via_employee_id_override(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+        ]);
+        $colleague = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+        ]);
+
+        app()->instance('current_company', $company);
+        AttendanceLog::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $colleague->id,
+            'date' => '2026-05-06',
+            'check_in' => Carbon::parse('2026-05-06 09:10:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-06 17:00:00', 'UTC'),
+            'late_minutes' => 55,
+            'status' => 'late',
+        ]);
+        app()->forgetInstance('current_company');
+
+        Sanctum::actingAs($employee);
+
+        // Attempting to pass another employee's id must be ignored: the
+        // controller always force-overrides employee_id with the caller's
+        // own id, so this must return zero anomalies for $employee.
+        $response = $this->getJson('/api/v1/me/attendance-anomalies?employee_id='.$colleague->id.'&date_from=2026-05-06&date_to=2026-05-06');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.summary.total', 0);
+        $response->assertJsonCount(0, 'data.items');
+    }
+
+    public function test_employee_with_no_anomalies_gets_an_empty_report(): void
+    {
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+        ]);
+
+        app()->instance('current_company', $company);
+        AttendanceLog::factory()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => '2026-05-06',
+            'check_in' => Carbon::parse('2026-05-06 08:00:00', 'UTC'),
+            'check_out' => Carbon::parse('2026-05-06 17:00:00', 'UTC'),
+        ]);
+        app()->forgetInstance('current_company');
+
+        Sanctum::actingAs($employee);
+
+        $response = $this->getJson('/api/v1/me/attendance-anomalies?date_from=2026-05-06&date_to=2026-05-06');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.summary.total', 0);
+        $response->assertJsonCount(0, 'data.items');
+    }
+}

--- a/front/mobile_apps/leopardo_employee/lib/features/attendance/data/attendance_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/attendance/data/attendance_repository.dart
@@ -5,6 +5,7 @@ import 'package:leopardo_core/models/daily_summary.dart';
 import 'package:leopardo_core/models/monthly_summary.dart';
 import 'package:leopardo_core/core/api/api_exceptions.dart';
 import 'package:hive/hive.dart';
+import 'package:leopardo_employee/features/attendance/models/attendance_anomaly.dart';
 
 class AttendanceRepository {
   final ApiClient apiClient;
@@ -228,6 +229,37 @@ class AttendanceRepository {
       queryParameters: {'from': fmt(from), 'to': fmt(to)},
     );
     return MonthlySummary.fromJson(extractDataMap(response.data));
+  }
+
+  /// PA2-ATT-004 - Anomalies detected on the caller's own attendance logs
+  /// (late arrivals, missing check-outs, excessive overtime, etc.) for the
+  /// given period. Defaults to the current calendar month so the day-detail
+  /// sheet can flag anything unusual for the visible week/day.
+  Future<AttendanceAnomalyReport> getMyAnomalies({
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    String fmt(DateTime d) =>
+        '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+    try {
+      final response = await apiClient.requestWithRetry(
+        '/me/attendance-anomalies',
+        maxRetriesOverride: 0,
+        timeoutOverride: _readTimeout,
+        queryParameters: {
+          'date_from': fmt(from),
+          'date_to': fmt(to),
+          'per_page': 100,
+        },
+      );
+      final data = _dataMap(response.data);
+      return AttendanceAnomalyReport.fromJson(data);
+    } catch (_) {
+      // Anomalies are a non-blocking enrichment of the day-detail view; a
+      // failure here must never prevent the employee from seeing their own
+      // punches, breaks and gains.
+      return AttendanceAnomalyReport.empty;
+    }
   }
 
   Future<List<AttendanceLog>> getHistory(int year, int month) async {

--- a/front/mobile_apps/leopardo_employee/lib/features/attendance/models/attendance_anomaly.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/attendance/models/attendance_anomaly.dart
@@ -1,0 +1,87 @@
+/// PA2-ATT-004 - Self-service anomaly models for the employee day-detail view.
+///
+/// Mirrors the shape returned by `GET /me/attendance-anomalies`, which is a
+/// company-independent, employee-scoped alias of the manager anomaly report
+/// (`AttendanceAnomalyService::summarize`) filtered to the caller's own
+/// `employee_id`.
+class AttendanceAnomaly {
+  const AttendanceAnomaly({
+    required this.type,
+    required this.severity,
+    required this.title,
+    required this.date,
+    required this.requiresManagerAction,
+    required this.recommendedAction,
+  });
+
+  final String type;
+  final String severity;
+  final String title;
+  final String date;
+  final bool requiresManagerAction;
+  final String recommendedAction;
+
+  factory AttendanceAnomaly.fromJson(Map<String, dynamic> json) {
+    return AttendanceAnomaly(
+      type: json['type']?.toString() ?? 'unknown',
+      severity: json['severity']?.toString() ?? 'info',
+      title: json['title']?.toString() ?? 'Anomalie',
+      date: json['date']?.toString() ?? '',
+      requiresManagerAction: json['requires_manager_action'] == true,
+      recommendedAction: json['recommended_action']?.toString() ?? '',
+    );
+  }
+}
+
+class AttendanceAnomalyReport {
+  const AttendanceAnomalyReport({
+    required this.total,
+    required this.critical,
+    required this.warning,
+    required this.info,
+    required this.items,
+  });
+
+  final int total;
+  final int critical;
+  final int warning;
+  final int info;
+  final List<AttendanceAnomaly> items;
+
+  static const empty = AttendanceAnomalyReport(
+    total: 0,
+    critical: 0,
+    warning: 0,
+    info: 0,
+    items: [],
+  );
+
+  factory AttendanceAnomalyReport.fromJson(Map<String, dynamic> json) {
+    final summary = json['summary'] is Map
+        ? (json['summary'] as Map).cast<String, dynamic>()
+        : const <String, dynamic>{};
+    final rawItems = json['items'] as List? ?? const [];
+
+    return AttendanceAnomalyReport(
+      total: _asInt(summary['total']),
+      critical: _asInt(summary['critical']),
+      warning: _asInt(summary['warning']),
+      info: _asInt(summary['info']),
+      items: rawItems
+          .whereType<Map>()
+          .map((e) => AttendanceAnomaly.fromJson(e.cast<String, dynamic>()))
+          .toList(),
+    );
+  }
+
+  /// Anomalies detected on a specific calendar day (`yyyy-MM-dd`).
+  List<AttendanceAnomaly> forDate(String dateKey) {
+    return items.where((item) => item.date == dateKey).toList();
+  }
+}
+
+int _asInt(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value?.toString() ?? '') ?? 0;
+}

--- a/front/mobile_apps/leopardo_employee/lib/features/attendance/providers/attendance_provider.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/attendance/providers/attendance_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:leopardo_employee/features/attendance/data/attendance_repository.dart';
+import 'package:leopardo_employee/features/attendance/models/attendance_anomaly.dart';
 import 'package:leopardo_core/models/attendance_log.dart';
 import 'package:leopardo_core/models/daily_summary.dart';
 import 'package:leopardo_core/models/monthly_summary.dart';
@@ -362,4 +363,16 @@ final todayTasksProvider = FutureProvider<List<Map<String, dynamic>>>((
 ) async {
   final repo = ref.watch(attendanceRepositoryProvider);
   return await repo.getTodayTasks();
+});
+
+/// PA2-ATT-004 - Anomalies detected on the caller's own attendance logs for
+/// the calendar month containing [date]. Non-blocking: repository swallows
+/// network errors and returns an empty report so the day-detail view never
+/// fails to render because of this enrichment.
+final monthlyAnomaliesProvider =
+    FutureProvider.family<AttendanceAnomalyReport, DateTime>((ref, date) async {
+  final repo = ref.watch(attendanceRepositoryProvider);
+  final from = DateTime(date.year, date.month, 1);
+  final to = DateTime(date.year, date.month + 1, 0);
+  return await repo.getMyAnomalies(from: from, to: to);
 });

--- a/front/mobile_apps/leopardo_employee/lib/features/attendance/screens/attendance_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/attendance/screens/attendance_screen.dart
@@ -10,6 +10,7 @@ import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/widgets/pulse_button.dart';
 import 'package:leopardo_employee/core/providers/core_providers.dart';
 import 'package:leopardo_employee/features/attendance/providers/attendance_provider.dart';
+import 'package:leopardo_employee/features/attendance/models/attendance_anomaly.dart';
 import 'package:leopardo_employee/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_core/models/attendance_log.dart';
 
@@ -1021,80 +1022,94 @@ class _AttendanceScreenState extends ConsumerState<AttendanceScreen> {
         minChildSize: 0.42,
         maxChildSize: 0.92,
         builder: (context, controller) => SafeArea(
-          child: ListView(
-            controller: controller,
-            padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
-            children: [
-              const _SheetHandle(),
-              const SizedBox(height: 16),
-              _SheetHeader(
-                title: 'Details de la journee',
-                subtitle: DateFormat(
-                  'EEEE d MMMM yyyy',
-                  'fr_FR',
-                ).format(day.date),
-              ),
-              const SizedBox(height: 16),
-              Row(
+          child: Consumer(
+            builder: (context, ref, _) {
+              final anomaliesAsync =
+                  ref.watch(monthlyAnomaliesProvider(day.date));
+              final dayAnomalies = anomaliesAsync.maybeWhen(
+                data: (report) => report.forDate(_dateKey(day.date)),
+                orElse: () => const <AttendanceAnomaly>[],
+              );
+              return ListView(
+                controller: controller,
+                padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
                 children: [
-                  Expanded(
-                    child: _DetailMetric(
-                      label: 'Temps travaille',
-                      value: day.hoursFormatted,
-                      color: AppColors.mobileDarkTextSoft,
+                  const _SheetHandle(),
+                  const SizedBox(height: 16),
+                  _SheetHeader(
+                    title: 'Details de la journee',
+                    subtitle: DateFormat(
+                      'EEEE d MMMM yyyy',
+                      'fr_FR',
+                    ).format(day.date),
+                  ),
+                  if (dayAnomalies.isNotEmpty) ...[
+                    const SizedBox(height: 14),
+                    ...dayAnomalies.map(_AnomalyTile.new),
+                  ],
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _DetailMetric(
+                          label: 'Temps travaille',
+                          value: day.hoursFormatted,
+                          color: AppColors.mobileDarkTextSoft,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: _DetailMetric(
+                          label: 'Heures supp',
+                          value: day.overtimeFormatted,
+                          color: AppColors.rh,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _DetailMetric(
+                          label: 'Pauses',
+                          value: '${day.breakMinutes} min',
+                          color: AppColors.warning,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: _DetailMetric(
+                          label: 'Gain estime',
+                          value:
+                              '${day.estimatedEarnings.toStringAsFixed(0)} $currency',
+                          color: AppColors.rh,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 18),
+                  const Text(
+                    'Pointages',
+                    style: TextStyle(
+                      color: _secondary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0.6,
                     ),
                   ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: _DetailMetric(
-                      label: 'Heures supp',
-                      value: day.overtimeFormatted,
-                      color: AppColors.rh,
-                    ),
-                  ),
+                  const SizedBox(height: 10),
+                  if (day.sessions.isEmpty)
+                    const _SheetMessage(
+                      icon: Icons.event_busy_outlined,
+                      title: 'Aucune session',
+                      body: 'Cette journee ne contient pas encore de pointage.',
+                    )
+                  else
+                    ...day.sessions.map(_SessionDetailTile.new),
                 ],
-              ),
-              const SizedBox(height: 10),
-              Row(
-                children: [
-                  Expanded(
-                    child: _DetailMetric(
-                      label: 'Pauses',
-                      value: '${day.breakMinutes} min',
-                      color: AppColors.warning,
-                    ),
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: _DetailMetric(
-                      label: 'Gain estime',
-                      value:
-                          '${day.estimatedEarnings.toStringAsFixed(0)} $currency',
-                      color: AppColors.rh,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 18),
-              const Text(
-                'Pointages',
-                style: TextStyle(
-                  color: _secondary,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0.6,
-                ),
-              ),
-              const SizedBox(height: 10),
-              if (day.sessions.isEmpty)
-                const _SheetMessage(
-                  icon: Icons.event_busy_outlined,
-                  title: 'Aucune session',
-                  body: 'Cette journee ne contient pas encore de pointage.',
-                )
-              else
-                ...day.sessions.map(_SessionDetailTile.new),
-            ],
+              );
+            },
           ),
         ),
       ),
@@ -1376,6 +1391,84 @@ class _ActionTile extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// PA2-ATT-004 - Single anomaly row shown at the top of the day-detail sheet
+/// so an employee can see, in their own words, what looked unusual about a
+/// given day (late arrival, missing check-out, excessive overtime, etc.)
+/// without needing to ask a manager.
+class _AnomalyTile extends StatelessWidget {
+  final AttendanceAnomaly anomaly;
+
+  const _AnomalyTile(this.anomaly);
+
+  Color get _color {
+    switch (anomaly.severity) {
+      case 'critical':
+        return AppColors.danger;
+      case 'warning':
+        return AppColors.warning;
+      default:
+        return AppColors.mobileDarkTextSoft;
+    }
+  }
+
+  IconData get _icon {
+    switch (anomaly.severity) {
+      case 'critical':
+        return Icons.error_outline;
+      case 'warning':
+        return Icons.warning_amber_outlined;
+      default:
+        return Icons.info_outline;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.32)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(_icon, size: 18, color: color),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  anomaly.title,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                if (anomaly.recommendedAction.isNotEmpty) ...[
+                  const SizedBox(height: 3),
+                  Text(
+                    anomaly.recommendedAction,
+                    style: const TextStyle(
+                      color: _AttendanceScreenState._muted,
+                      fontSize: 11.5,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
Implements PA2-ATT-004: an employee opening the "day details" sheet in the
attendance screen could see punches, breaks, overtime and estimated gains,
but never any anomaly detected on that day (late arrival, missing
check-out, excessive overtime, etc.) — that view was manager-only via
`GET /attendance/anomalies`.

## Changes
- **API**
  - `AttendancePolicy::viewOwnAnomalies` — new policy gate, unrestricted by
    role since it only ever authorizes viewing the caller's own records.
  - `MeController::attendanceAnomalies` — self-service endpoint that reuses
    `AttendanceAnomalyService::summarize`, force-overriding `employee_id` to
    the authenticated employee's own id so it can never be used to read a
    colleague's anomalies.
  - Route: `GET /me/attendance-anomalies`.
- **Mobile (leopardo_employee)**
  - New `AttendanceAnomaly` / `AttendanceAnomalyReport` models.
  - `AttendanceRepository.getMyAnomalies()` (fails soft to an empty report;
    anomalies are a non-blocking enrichment).
  - `monthlyAnomaliesProvider` (Riverpod, keyed by month).
  - Day-detail bottom sheet now shows an anomaly banner (title +
    recommended action, color-coded by severity) above the existing
    metrics/session list when the viewed day has any.
- **Tests**
  - `MyAttendanceAnomaliesTest`: self-scoping, `employee_id` override
    protection, empty-report case.

Closes #1019