### PR TITLE
feat(notifications): Twilio-backed SMS and WhatsApp providers (PA2-JOB-003)

### DIFF
--- a/api/app/Modules/Notification/Infrastructure/Services/CommunicationService.php
+++ b/api/app/Modules/Notification/Infrastructure/Services/CommunicationService.php
@@ -13,6 +13,8 @@ use App\Modules\Notification\Domain\Models\Notification;
 use App\Modules\Notification\Domain\Models\NotificationPreference;
 use App\Modules\Notification\Infrastructure\Services\Providers\AuditMessageProvider;
 use App\Modules\Notification\Infrastructure\Services\Providers\MailMessageProvider;
+use App\Modules\Notification\Infrastructure\Services\Providers\TwilioSmsMessageProvider;
+use App\Modules\Notification\Infrastructure\Services\Providers\TwilioWhatsAppMessageProvider;
 use App\Support\I18nCatalog;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -370,6 +372,25 @@ class CommunicationService
             return new MailMessageProvider(
                 (int) config('communication.email_retry.max_attempts', 3),
                 (int) config('communication.email_retry.base_delay_ms', 500),
+            );
+        }
+
+        // PA2-JOB-003 - Twilio-backed SMS/WhatsApp providers. Both reuse the
+        // same bounded caller-side retry policy as email (PA2-COMM-007) via
+        // RetryableMessageProviderInterface; each provider itself no-ops
+        // (status `skipped`) when its own credentials are not configured,
+        // so an incomplete environment never throws here.
+        if ($channel === 'sms' && $configured === 'twilio') {
+            return new TwilioSmsMessageProvider(
+                (int) config('communication.sms_retry.max_attempts', 3),
+                (int) config('communication.sms_retry.base_delay_ms', 500),
+            );
+        }
+
+        if ($channel === 'whatsapp' && $configured === 'twilio') {
+            return new TwilioWhatsAppMessageProvider(
+                (int) config('communication.whatsapp_retry.max_attempts', 3),
+                (int) config('communication.whatsapp_retry.base_delay_ms', 500),
             );
         }
 

--- a/api/app/Modules/Notification/Infrastructure/Services/Providers/TwilioSmsMessageProvider.php
+++ b/api/app/Modules/Notification/Infrastructure/Services/Providers/TwilioSmsMessageProvider.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Notification\Infrastructure\Services\Providers;
+
+use App\Contracts\Communication\MessageProviderInterface;
+use App\Contracts\Communication\RetryableMessageProviderInterface;
+use App\Core\Auth\Domain\Models\Employee;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * PA2-JOB-003 - Production SMS channel provider for `CommunicationService`,
+ * backed by the Twilio Messages REST API.
+ *
+ * - Same contract as every other channel provider: `CommunicationService`
+ *   only knows `MessageProviderInterface`, not that Twilio is underneath.
+ * - Retry: opts into `RetryableMessageProviderInterface` so a transient
+ *   network/5xx failure is retried by the caller with backoff, mirroring
+ *   `MailMessageProvider` (PA2-COMM-007).
+ * - Skips silently (status `skipped`) when the employee has no usable
+ *   phone number or when Twilio credentials are not configured, so a
+ *   misconfigured environment never blocks the rest of the notification
+ *   fan-out.
+ */
+class TwilioSmsMessageProvider implements MessageProviderInterface, RetryableMessageProviderInterface
+{
+    public function __construct(
+        private readonly int $maxAttempts = 3,
+        private readonly int $baseRetryDelayMs = 500,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function send(Employee $employee, string $title, string $body, array $metadata = []): string
+    {
+        $to = $this->resolvePhoneNumber($employee);
+
+        if ($to === null) {
+            Log::info('Communication SMS dispatch skipped: no usable phone number', [
+                'employee_id' => $employee->id,
+            ]);
+
+            return 'skipped';
+        }
+
+        $credentials = $this->credentials();
+
+        if ($credentials === null) {
+            Log::warning('Communication SMS dispatch skipped: Twilio credentials not configured');
+
+            return 'skipped';
+        }
+
+        [$accountSid, $authToken, $from] = $credentials;
+
+        try {
+            $response = Http::asForm()
+                ->withBasicAuth($accountSid, $authToken)
+                ->post("https://api.twilio.com/2010-04-01/Accounts/{$accountSid}/Messages.json", [
+                    'From' => $from,
+                    'To' => $to,
+                    'Body' => $this->composeMessage($title, $body),
+                ]);
+
+            if ($response->successful()) {
+                return 'queued';
+            }
+
+            Log::warning('Twilio SMS API error', [
+                'employee_id' => $employee->id,
+                'status' => $response->status(),
+                'response' => $response->json(),
+            ]);
+
+            throw new RuntimeException('Twilio SMS API returned HTTP '.$response->status());
+        } catch (Throwable $exception) {
+            Log::warning('Communication SMS dispatch attempt failed', [
+                'employee_id' => $employee->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        }
+    }
+
+    public function maxAttempts(): int
+    {
+        return max(1, $this->maxAttempts);
+    }
+
+    public function retryDelayMs(int $attempt): int
+    {
+        // Exponential backoff: baseDelay * 2^(attempt-1).
+        return $this->baseRetryDelayMs * (2 ** max(0, $attempt - 1));
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string}|null
+     */
+    private function credentials(): ?array
+    {
+        $accountSid = config('services.twilio.account_sid');
+        $authToken = config('services.twilio.auth_token');
+        $from = config('services.twilio.from');
+
+        if (! is_string($accountSid) || $accountSid === ''
+            || ! is_string($authToken) || $authToken === ''
+            || ! is_string($from) || $from === '') {
+            return null;
+        }
+
+        return [$accountSid, $authToken, $from];
+    }
+
+    private function resolvePhoneNumber(Employee $employee): ?string
+    {
+        $phone = $employee->phone ?? $employee->personal_phone ?? null;
+
+        if (! is_string($phone) || trim($phone) === '') {
+            return null;
+        }
+
+        return trim($phone);
+    }
+
+    private function composeMessage(string $title, string $body): string
+    {
+        if ($title === '') {
+            return $body;
+        }
+
+        return $title.': '.$body;
+    }
+}

--- a/api/app/Modules/Notification/Infrastructure/Services/Providers/TwilioWhatsAppMessageProvider.php
+++ b/api/app/Modules/Notification/Infrastructure/Services/Providers/TwilioWhatsAppMessageProvider.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Notification\Infrastructure\Services\Providers;
+
+use App\Contracts\Communication\MessageProviderInterface;
+use App\Contracts\Communication\RetryableMessageProviderInterface;
+use App\Core\Auth\Domain\Models\Employee;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * PA2-JOB-003 - Production WhatsApp channel provider for
+ * `CommunicationService`, backed by Twilio's WhatsApp-enabled Messages
+ * REST API (Twilio acts as the WhatsApp Business Cloud API gateway).
+ *
+ * - Same contract/retry shape as `TwilioSmsMessageProvider`, kept as a
+ *   separate class because WhatsApp numbers need the `whatsapp:` scheme
+ *   prefix on both `From` and `To` and use a distinct configured sender.
+ * - Skips silently when the employee has no usable phone number or the
+ *   WhatsApp sender is not configured, so a misconfigured environment
+ *   never blocks the rest of the notification fan-out.
+ */
+class TwilioWhatsAppMessageProvider implements MessageProviderInterface, RetryableMessageProviderInterface
+{
+    private const WHATSAPP_SCHEME = 'whatsapp:';
+
+    public function __construct(
+        private readonly int $maxAttempts = 3,
+        private readonly int $baseRetryDelayMs = 500,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function send(Employee $employee, string $title, string $body, array $metadata = []): string
+    {
+        $to = $this->resolvePhoneNumber($employee);
+
+        if ($to === null) {
+            Log::info('Communication WhatsApp dispatch skipped: no usable phone number', [
+                'employee_id' => $employee->id,
+            ]);
+
+            return 'skipped';
+        }
+
+        $credentials = $this->credentials();
+
+        if ($credentials === null) {
+            Log::warning('Communication WhatsApp dispatch skipped: Twilio WhatsApp credentials not configured');
+
+            return 'skipped';
+        }
+
+        [$accountSid, $authToken, $from] = $credentials;
+
+        try {
+            $response = Http::asForm()
+                ->withBasicAuth($accountSid, $authToken)
+                ->post("https://api.twilio.com/2010-04-01/Accounts/{$accountSid}/Messages.json", [
+                    'From' => $this->withWhatsAppScheme($from),
+                    'To' => $this->withWhatsAppScheme($to),
+                    'Body' => $this->composeMessage($title, $body),
+                ]);
+
+            if ($response->successful()) {
+                return 'queued';
+            }
+
+            Log::warning('Twilio WhatsApp API error', [
+                'employee_id' => $employee->id,
+                'status' => $response->status(),
+                'response' => $response->json(),
+            ]);
+
+            throw new RuntimeException('Twilio WhatsApp API returned HTTP '.$response->status());
+        } catch (Throwable $exception) {
+            Log::warning('Communication WhatsApp dispatch attempt failed', [
+                'employee_id' => $employee->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        }
+    }
+
+    public function maxAttempts(): int
+    {
+        return max(1, $this->maxAttempts);
+    }
+
+    public function retryDelayMs(int $attempt): int
+    {
+        // Exponential backoff: baseDelay * 2^(attempt-1).
+        return $this->baseRetryDelayMs * (2 ** max(0, $attempt - 1));
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string}|null
+     */
+    private function credentials(): ?array
+    {
+        $accountSid = config('services.twilio.account_sid');
+        $authToken = config('services.twilio.auth_token');
+        $from = config('services.twilio.whatsapp_from');
+
+        if (! is_string($accountSid) || $accountSid === ''
+            || ! is_string($authToken) || $authToken === ''
+            || ! is_string($from) || $from === '') {
+            return null;
+        }
+
+        return [$accountSid, $authToken, $from];
+    }
+
+    private function resolvePhoneNumber(Employee $employee): ?string
+    {
+        $phone = $employee->phone ?? $employee->personal_phone ?? null;
+
+        if (! is_string($phone) || trim($phone) === '') {
+            return null;
+        }
+
+        return trim($phone);
+    }
+
+    private function withWhatsAppScheme(string $number): string
+    {
+        if (str_starts_with($number, self::WHATSAPP_SCHEME)) {
+            return $number;
+        }
+
+        return self::WHATSAPP_SCHEME.$number;
+    }
+
+    private function composeMessage(string $title, string $body): string
+    {
+        if ($title === '') {
+            return $body;
+        }
+
+        return $title.': '.$body;
+    }
+}

--- a/api/config/communication.php
+++ b/api/config/communication.php
@@ -17,6 +17,12 @@ return [
     'providers' => [
         'email' => env('COMMUNICATION_EMAIL_PROVIDER', 'mail'),
         'push' => env('COMMUNICATION_PUSH_PROVIDER', 'firebase'),
+        // PA2-JOB-003 - real Twilio-backed SMS/WhatsApp providers now exist
+        // (see Notification/Infrastructure/Services/Providers) but default
+        // to the safe audit-only fallback, same as an unset/unknown provider
+        // name. Operators opt in explicitly via
+        // COMMUNICATION_SMS_PROVIDER=twilio / COMMUNICATION_WHATSAPP_PROVIDER=twilio
+        // plus the TWILIO_* credentials once a real account is available.
         'sms' => env('COMMUNICATION_SMS_PROVIDER', 'audit'),
         'whatsapp' => env('COMMUNICATION_WHATSAPP_PROVIDER', 'audit'),
     ],
@@ -49,6 +55,27 @@ return [
     'email_retry' => [
         'max_attempts' => (int) env('COMMUNICATION_EMAIL_MAX_ATTEMPTS', 3),
         'base_delay_ms' => (int) env('COMMUNICATION_EMAIL_RETRY_BASE_DELAY_MS', 500),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | SMS / WhatsApp provider retry (PA2-JOB-003)
+    |--------------------------------------------------------------------------
+    |
+    | Same bounded caller-side retry policy as `email_retry` above, applied
+    | by `CommunicationService` to the Twilio-backed SMS and WhatsApp
+    | providers.
+    |
+    */
+
+    'sms_retry' => [
+        'max_attempts' => (int) env('COMMUNICATION_SMS_MAX_ATTEMPTS', 3),
+        'base_delay_ms' => (int) env('COMMUNICATION_SMS_RETRY_BASE_DELAY_MS', 500),
+    ],
+
+    'whatsapp_retry' => [
+        'max_attempts' => (int) env('COMMUNICATION_WHATSAPP_MAX_ATTEMPTS', 3),
+        'base_delay_ms' => (int) env('COMMUNICATION_WHATSAPP_RETRY_BASE_DELAY_MS', 500),
     ],
 
     'public_metadata_keys' => [

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -36,6 +36,17 @@ return [
         'credentials' => env('FIREBASE_SERVICE_ACCOUNT_JSON'),
     ],
 
+    // PA2-JOB-003 - Twilio credentials shared by the SMS and WhatsApp
+    // Cloud API-compatible communication providers. `whatsapp_from` is the
+    // Twilio WhatsApp-enabled sender number (E.164, e.g. "whatsapp:+14155238886");
+    // `from` is the plain SMS sender number.
+    'twilio' => [
+        'account_sid' => env('TWILIO_ACCOUNT_SID'),
+        'auth_token' => env('TWILIO_AUTH_TOKEN'),
+        'from' => env('TWILIO_SMS_FROM'),
+        'whatsapp_from' => env('TWILIO_WHATSAPP_FROM'),
+    ],
+
     'stripe' => [
         'secret' => env('STRIPE_SECRET_KEY'),
         'webhook_secret' => env('STRIPE_WEBHOOK_SECRET'),

--- a/api/tests/Feature/CommunicationServiceTest.php
+++ b/api/tests/Feature/CommunicationServiceTest.php
@@ -182,6 +182,56 @@ class CommunicationServiceTest extends TestCase
     }
 
     /**
+     * PA2-JOB-003 — when an operator opts into the real Twilio-backed
+     * providers (`COMMUNICATION_SMS_PROVIDER=twilio` /
+     * `COMMUNICATION_WHATSAPP_PROVIDER=twilio` plus TWILIO_* credentials),
+     * `CommunicationService` actually calls the Twilio REST API instead of
+     * the audit-only fallback.
+     */
+    public function test_sms_and_whatsapp_dispatch_via_twilio_when_configured(): void
+    {
+        config()->set('communication.providers.sms', 'twilio');
+        config()->set('communication.providers.whatsapp', 'twilio');
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.from', '+15550001111');
+        config()->set('services.twilio.whatsapp_from', 'whatsapp:+14155238886');
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.twilio.com/*' => \Illuminate\Support\Facades\Http::response(['sid' => 'SM123'], 201),
+        ]);
+
+        $employee = $this->employee();
+        NotificationPreference::query()->create([
+            'company_id' => $employee->company_id,
+            'employee_id' => $employee->id,
+            'app_enabled' => true,
+            'sms_enabled' => true,
+            'whatsapp_enabled' => true,
+            'categories' => ['payroll' => true],
+        ]);
+
+        $result = app(CommunicationService::class)->notifyEmployee($employee, 'payroll_ready', [], ['sms', 'whatsapp']);
+
+        $this->assertSame('queued', $result['results']['sms']);
+        $this->assertSame('queued', $result['results']['whatsapp']);
+        $this->assertDatabaseHas('communication_events', [
+            'employee_id' => $employee->id,
+            'channel' => 'sms',
+            'status' => 'queued',
+            'provider' => 'twilio',
+        ]);
+        $this->assertDatabaseHas('communication_events', [
+            'employee_id' => $employee->id,
+            'channel' => 'whatsapp',
+            'status' => 'queued',
+            'provider' => 'twilio',
+        ]);
+
+        \Illuminate\Support\Facades\Http::assertSentCount(2);
+    }
+
+    /**
      * PA2-COMM-007 — a transient email transport failure is retried up to
      * `communication.email_retry.max_attempts` before recording a final
      * `failed` audit event, instead of failing on the very first attempt.

--- a/api/tests/Unit/Providers/TwilioSmsMessageProviderTest.php
+++ b/api/tests/Unit/Providers/TwilioSmsMessageProviderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Providers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Notification\Infrastructure\Services\Providers\TwilioSmsMessageProvider;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-JOB-003 - Production SMS provider: verifies the actual Twilio REST
+ * call, the missing-phone-number skip, the missing-credentials skip, and
+ * that a transport/API failure propagates as an exception (so
+ * `CommunicationService::dispatchWithRetry()` can retry it) instead of
+ * being swallowed here.
+ */
+class TwilioSmsMessageProviderTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_send_posts_to_twilio_messages_api_with_composed_body(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.from', '+15550001111');
+
+        Http::fake([
+            'api.twilio.com/*' => Http::response(['sid' => 'SM123'], 201),
+        ]);
+
+        $employee = $this->employee(['phone' => '+15551234567']);
+        $provider = new TwilioSmsMessageProvider;
+
+        $status = $provider->send($employee, 'Payslip ready', 'Your payslip for July is ready.');
+
+        $this->assertSame('queued', $status);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.twilio.com/2010-04-01/Accounts/AC_test_sid/Messages.json'
+                && $request['From'] === '+15550001111'
+                && $request['To'] === '+15551234567'
+                && $request['Body'] === 'Payslip ready: Your payslip for July is ready.';
+        });
+    }
+
+    public function test_send_is_skipped_when_employee_has_no_phone_number(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.from', '+15550001111');
+
+        Http::fake();
+
+        $employee = $this->employee(['phone' => null, 'personal_phone' => null]);
+        $provider = new TwilioSmsMessageProvider;
+
+        $status = $provider->send($employee, 'Title', 'Body');
+
+        $this->assertSame('skipped', $status);
+        Http::assertNothingSent();
+    }
+
+    public function test_send_is_skipped_when_twilio_credentials_are_not_configured(): void
+    {
+        config()->set('services.twilio.account_sid', null);
+        config()->set('services.twilio.auth_token', null);
+        config()->set('services.twilio.from', null);
+
+        Http::fake();
+
+        $employee = $this->employee(['phone' => '+15551234567']);
+        $provider = new TwilioSmsMessageProvider;
+
+        $status = $provider->send($employee, 'Title', 'Body');
+
+        $this->assertSame('skipped', $status);
+        Http::assertNothingSent();
+    }
+
+    public function test_send_throws_for_the_caller_to_retry_on_twilio_error_response(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.from', '+15550001111');
+
+        Http::fake([
+            'api.twilio.com/*' => Http::response(['message' => 'Invalid number'], 400),
+        ]);
+
+        $employee = $this->employee(['phone' => '+15551234567']);
+        $provider = new TwilioSmsMessageProvider;
+
+        $this->expectException(RuntimeException::class);
+
+        $provider->send($employee, 'Title', 'Body');
+    }
+
+    public function test_max_attempts_and_retry_delay_use_configured_values(): void
+    {
+        $provider = new TwilioSmsMessageProvider(4, 250);
+
+        $this->assertSame(4, $provider->maxAttempts());
+        $this->assertSame(250, $provider->retryDelayMs(1));
+        $this->assertSame(500, $provider->retryDelayMs(2));
+        $this->assertSame(1000, $provider->retryDelayMs(3));
+    }
+
+    private function employee(array $attributes = []): Employee
+    {
+        $company = Company::factory()->create();
+
+        return Employee::factory()->create(array_merge([
+            'company_id' => $company->id,
+        ], $attributes));
+    }
+}

--- a/api/tests/Unit/Providers/TwilioWhatsAppMessageProviderTest.php
+++ b/api/tests/Unit/Providers/TwilioWhatsAppMessageProviderTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Providers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Notification\Infrastructure\Services\Providers\TwilioWhatsAppMessageProvider;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-JOB-003 - Production WhatsApp provider: verifies the actual Twilio
+ * REST call with the `whatsapp:` scheme applied to both From/To, the
+ * missing-phone-number skip, the missing-credentials skip, and that a
+ * transport/API failure propagates as an exception (so
+ * `CommunicationService::dispatchWithRetry()` can retry it) instead of
+ * being swallowed here.
+ */
+class TwilioWhatsAppMessageProviderTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_send_posts_to_twilio_messages_api_with_whatsapp_scheme(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.whatsapp_from', 'whatsapp:+14155238886');
+
+        Http::fake([
+            'api.twilio.com/*' => Http::response(['sid' => 'SM123'], 201),
+        ]);
+
+        $employee = $this->employee(['phone' => '+15551234567']);
+        $provider = new TwilioWhatsAppMessageProvider;
+
+        $status = $provider->send($employee, 'Payslip ready', 'Your payslip for July is ready.');
+
+        $this->assertSame('queued', $status);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.twilio.com/2010-04-01/Accounts/AC_test_sid/Messages.json'
+                && $request['From'] === 'whatsapp:+14155238886'
+                && $request['To'] === 'whatsapp:+15551234567'
+                && $request['Body'] === 'Payslip ready: Your payslip for July is ready.';
+        });
+    }
+
+    public function test_send_does_not_double_prefix_a_number_already_scoped(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.whatsapp_from', 'whatsapp:+14155238886');
+
+        Http::fake([
+            'api.twilio.com/*' => Http::response(['sid' => 'SM123'], 201),
+        ]);
+
+        $employee = $this->employee(['phone' => 'whatsapp:+15551234567']);
+        $provider = new TwilioWhatsAppMessageProvider;
+
+        $provider->send($employee, 'Title', 'Body');
+
+        Http::assertSent(function ($request) {
+            return $request['To'] === 'whatsapp:+15551234567';
+        });
+    }
+
+    public function test_send_is_skipped_when_employee_has_no_phone_number(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.whatsapp_from', 'whatsapp:+14155238886');
+
+        Http::fake();
+
+        $employee = $this->employee(['phone' => null, 'personal_phone' => null]);
+        $provider = new TwilioWhatsAppMessageProvider;
+
+        $status = $provider->send($employee, 'Title', 'Body');
+
+        $this->assertSame('skipped', $status);
+        Http::assertNothingSent();
+    }
+
+    public function test_send_is_skipped_when_twilio_whatsapp_credentials_are_not_configured(): void
+    {
+        config()->set('services.twilio.account_sid', null);
+        config()->set('services.twilio.auth_token', null);
+        config()->set('services.twilio.whatsapp_from', null);
+
+        Http::fake();
+
+        $employee = $this->employee(['phone' => '+15551234567']);
+        $provider = new TwilioWhatsAppMessageProvider;
+
+        $status = $provider->send($employee, 'Title', 'Body');
+
+        $this->assertSame('skipped', $status);
+        Http::assertNothingSent();
+    }
+
+    public function test_send_throws_for_the_caller_to_retry_on_twilio_error_response(): void
+    {
+        config()->set('services.twilio.account_sid', 'AC_test_sid');
+        config()->set('services.twilio.auth_token', 'test_token');
+        config()->set('services.twilio.whatsapp_from', 'whatsapp:+14155238886');
+
+        Http::fake([
+            'api.twilio.com/*' => Http::response(['message' => 'Invalid number'], 400),
+        ]);
+
+        $employee = $this->employee(['phone' => '+15551234567']);
+        $provider = new TwilioWhatsAppMessageProvider;
+
+        $this->expectException(RuntimeException::class);
+
+        $provider->send($employee, 'Title', 'Body');
+    }
+
+    public function test_max_attempts_and_retry_delay_use_configured_values(): void
+    {
+        $provider = new TwilioWhatsAppMessageProvider(4, 250);
+
+        $this->assertSame(4, $provider->maxAttempts());
+        $this->assertSame(250, $provider->retryDelayMs(1));
+        $this->assertSame(500, $provider->retryDelayMs(2));
+        $this->assertSame(1000, $provider->retryDelayMs(3));
+    }
+
+    private function employee(array $attributes = []): Employee
+    {
+        $company = Company::factory()->create();
+
+        return Employee::factory()->create(array_merge([
+            'company_id' => $company->id,
+        ], $attributes));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #997 (PA2-JOB-003 - "Communication multi-canal": Email/SMS/WhatsApp providers, quotas, quiet hours).

`CommunicationService` already had solid quota enforcement, quiet-hours logic, retry/backoff, and a production email provider (`MailMessageProvider`, PA2-COMM-007). SMS and WhatsApp, however, only had the log-only `AuditMessageProvider` stub - no real provider existed anywhere in the codebase.

This PR adds real production providers for both channels, following the exact same pattern as `MailMessageProvider`.

## Changes
- **`TwilioSmsMessageProvider`** and **`TwilioWhatsAppMessageProvider`** (`app/Modules/Notification/Infrastructure/Services/Providers/`): implement `MessageProviderInterface` + `RetryableMessageProviderInterface`, calling the Twilio Messages REST API directly over `Illuminate\Support\Facades\Http` (no new SDK dependency, consistent with `PushNotificationService`'s HTTP client pattern).
  - Resolve the employee's `phone`/`personal_phone`; skip safely (`status = 'skipped'`) when there's no usable number.
  - Skip safely when Twilio credentials aren't configured, so an incomplete environment never blocks the rest of the notification fan-out.
  - WhatsApp provider applies the `whatsapp:` scheme to both `From`/`To` and uses a distinct configured sender (`TWILIO_WHATSAPP_FROM`), without double-prefixing numbers that already carry the scheme.
  - On API/transport failure, both throw so `CommunicationService`'s existing bounded retry-with-backoff logic can retry them, matching email's behavior.
- **`config/services.php`**: new `twilio` block (`account_sid`, `auth_token`, `from`, `whatsapp_from`).
- **`config/communication.php`**: new `sms_retry` / `whatsapp_retry` sections (mirroring `email_retry`). Provider selection stays **opt-in**: `COMMUNICATION_SMS_PROVIDER` / `COMMUNICATION_WHATSAPP_PROVIDER` still default to `audit`, so no existing environment's behavior changes until an operator explicitly sets `=twilio` plus real credentials.
- **`CommunicationService::providerFor()`**: wires the two new providers when the corresponding channel is configured as `twilio`.

## Tests
- `tests/Unit/Providers/TwilioSmsMessageProviderTest.php` - happy path (verifies the exact Twilio REST call/body), missing-phone skip, missing-credentials skip, API-error-propagates-for-retry, retry backoff math.
- `tests/Unit/Providers/TwilioWhatsAppMessageProviderTest.php` - same coverage plus the `whatsapp:` scheme/no-double-prefix behavior.
- `tests/Feature/CommunicationServiceTest.php` - new integration test proving the opt-in Twilio path actually calls the Twilio API end-to-end through `CommunicationService::notifyEmployee()`; all previously existing tests still pass unmodified in behavior (audit-only fallback is untouched).

```
Tests:    13 passed (40 assertions)   # CommunicationServiceTest
Tests:    11 passed (23 assertions)   # Twilio provider unit tests
```

Unrelated pre-existing failures in this test run (`PushNotificationServiceTest`, `EdgeSilentNodeDetectionTest`, `PredictionControllerTest`) are due to SQLite not supporting `EXTRACT(... FROM ...)` used elsewhere in the codebase - confirmed present on `main` before this change (verified via `git stash`), not introduced by this PR.