### PR TITLE
feat(crm): expose lead source, note and conversion summary on platform pipeline

### DIFF
--- a/api/app/Core/Tenant/Domain/Models/CompanyRequest.php
+++ b/api/app/Core/Tenant/Domain/Models/CompanyRequest.php
@@ -31,6 +31,8 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User|null $user
+ * @property-read string $source
+ * @property-read string|null $note
  * @mixin \Illuminate\Database\Eloquent\Builder<static>
  */
 class CompanyRequest extends Model
@@ -81,5 +83,37 @@ class CompanyRequest extends Model
     public function isPending(): bool
     {
         return $this->status === 'pending';
+    }
+
+    /**
+     * PA2-ADM-004: acquisition channel of this lead, resolved from the
+     * structured `signup_payload.source` captured by the self-service
+     * trial flow, falling back to a legacy `description` marker
+     * ("... — source: X") and finally to a generic label for requests
+     * created by the manager-initiated company request flow.
+     */
+    public function getSourceAttribute(): string
+    {
+        $payload = $this->signup_payload;
+        if (is_array($payload) && ! empty($payload['source']) && is_string($payload['source'])) {
+            return $payload['source'];
+        }
+
+        $description = (string) ($this->description ?? '');
+        if (preg_match('/source:\s*([^\r\n]+)/i', $description, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        return $this->user_id !== null ? 'manager_request' : 'direct';
+    }
+
+    /**
+     * PA2-ADM-004: short note shown on the CRM pipeline card — prefers the
+     * admin's own note, falling back to the lead's own description/notes
+     * so the platform team always has context even before reviewing.
+     */
+    public function getNoteAttribute(): ?string
+    {
+        return $this->admin_notes ?: ($this->notes ?: $this->description);
     }
 }

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCrmPipelineController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformCrmPipelineController.php
@@ -25,11 +25,17 @@ class PlatformCrmPipelineController extends Controller
         ];
 
         foreach ($requests as $request) {
+            // PA2-ADM-004: the pipeline card must surface the lead's
+            // acquisition source and an admin-facing note, in addition to
+            // status and conversion state, so the platform team can act
+            // on a lead without opening the full detail view.
             $data = [
                 'id' => $request->id,
                 'company_name' => $request->company_name,
                 'email' => $request->email,
                 'sector' => $request->sector,
+                'source' => $request->source,
+                'note' => $request->note,
                 'created_at' => $request->created_at,
                 'status' => $request->status,
                 'company' => $request->approvedCompany ? [
@@ -54,8 +60,22 @@ class PlatformCrmPipelineController extends Controller
             }
         }
 
+        // PA2-ADM-004: expose an explicit conversion summary (lead -> trial
+        // -> paying client) so the admin UI does not have to recompute
+        // ratios client-side from the four raw buckets.
+        $totalLeads = $requests->count();
+        $convertedToTrial = count($pipeline['trials']) + count($pipeline['active']);
+        $convertedToActive = count($pipeline['active']);
+
         return new JsonResponse([
             'data' => $pipeline,
+            'meta' => [
+                'total_leads' => $totalLeads,
+                'conversion' => [
+                    'lead_to_trial_rate' => $totalLeads > 0 ? round($convertedToTrial / $totalLeads, 4) : 0.0,
+                    'lead_to_client_rate' => $totalLeads > 0 ? round($convertedToActive / $totalLeads, 4) : 0.0,
+                ],
+            ],
         ]);
     }
 

--- a/api/tests/Feature/PlatformCrmPipelineApiTest.php
+++ b/api/tests/Feature/PlatformCrmPipelineApiTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\CompanyRequest;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * PA2-ADM-004: the CRM pipeline endpoint must surface each lead's status,
+ * acquisition source, an admin-facing note, and an explicit conversion
+ * summary (lead -> trial -> paying client), not just the raw bucket
+ * split it returned before.
+ */
+class PlatformCrmPipelineApiTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+        $this->setUpCompanyRequestTable();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownCompanyRequestTable();
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_pipeline_exposes_status_source_note_and_conversion_summary(): void
+    {
+        $superAdmin = SuperAdmin::query()->create([
+            'name' => 'Platform Admin',
+            'email' => 'admin@leopardo-rh.com',
+            'password_hash' => Hash::make('admin'),
+        ]);
+
+        // Pending lead captured via the self-service trial signup form,
+        // with a structured source in signup_payload (new format).
+        CompanyRequest::query()->create([
+            'company_name' => 'Terrain Plus',
+            'sector' => 'BTP',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'lead@terrain-plus.dz',
+            'status' => 'pending',
+            'signup_payload' => ['source' => 'signup_form'],
+        ]);
+
+        // Pending lead captured via the legacy description marker format.
+        CompanyRequest::query()->create([
+            'company_name' => 'Chantier Nord',
+            'sector' => 'BTP',
+            'country' => 'DZ',
+            'city' => 'Oran',
+            'email' => 'lead@chantier-nord.dz',
+            'status' => 'pending',
+            'description' => 'Self-service trial signup pending verification — source: demo_form',
+            'admin_notes' => null,
+        ]);
+
+        // Approved request whose company is still in trial.
+        $trialCompany = Company::query()->create([
+            'name' => 'Trial Co',
+            'slug' => 'trial-co',
+            'sector' => 'Services',
+            'email' => 'trial@co.dz',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'trial',
+            'subscription_start' => now()->toDateString(),
+            'subscription_end' => now()->addDays(20)->toDateString(),
+            'plan_id' => 1,
+        ]);
+
+        CompanyRequest::query()->create([
+            'company_name' => 'Trial Co',
+            'sector' => 'Services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'trial@co.dz',
+            'status' => 'approved',
+            'approved_company_id' => $trialCompany->id,
+            'admin_notes' => 'Client pilote a suivre de pres.',
+        ]);
+
+        // Approved request whose company converted to a paying client.
+        $activeCompany = Company::query()->create([
+            'name' => 'Active Co',
+            'slug' => 'active-co',
+            'sector' => 'Services',
+            'email' => 'active@co.dz',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+            'subscription_start' => now()->subDays(40)->toDateString(),
+            'subscription_end' => now()->addDays(320)->toDateString(),
+            'plan_id' => 1,
+        ]);
+
+        CompanyRequest::query()->create([
+            'company_name' => 'Active Co',
+            'sector' => 'Services',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'active@co.dz',
+            'status' => 'approved',
+            'approved_company_id' => $activeCompany->id,
+        ]);
+
+        $response = $this
+            ->actingAs($superAdmin, 'super_admin_api')
+            ->getJson('/api/v1/platform/crm/pipeline');
+
+        $response->assertOk();
+
+        // Status buckets still hold the right counts.
+        $response->assertJsonCount(2, 'data.leads');
+        $response->assertJsonCount(1, 'data.trials');
+        $response->assertJsonCount(1, 'data.active');
+
+        $leads = $response->json('data.leads');
+        $signupLead = collect($leads)->firstWhere('company_name', 'Terrain Plus');
+        $demoLead = collect($leads)->firstWhere('company_name', 'Chantier Nord');
+
+        // Source resolved from signup_payload (new format).
+        $this->assertSame('signup_form', $signupLead['source']);
+        // Source resolved from the legacy description marker.
+        $this->assertSame('demo_form', $demoLead['source']);
+
+        $trials = $response->json('data.trials');
+        $this->assertSame('Client pilote a suivre de pres.', $trials[0]['note']);
+
+        // Conversion summary: 4 total leads, 2 converted to trial+active,
+        // 1 converted all the way to an active paying client.
+        $response->assertJsonPath('meta.total_leads', 4);
+        $response->assertJsonPath('meta.conversion.lead_to_trial_rate', 0.5);
+        $response->assertJsonPath('meta.conversion.lead_to_client_rate', 0.25);
+    }
+
+    private function setUpCompanyRequestTable(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+
+            return;
+        }
+
+        if (! Schema::hasTable('company_requests')) {
+            Schema::create('company_requests', function (Blueprint $table): void {
+                $table->id();
+                $table->foreignId('user_id')->nullable();
+                $table->string('company_name');
+                $table->string('sector')->nullable();
+                $table->string('country')->nullable();
+                $table->string('city')->nullable();
+                $table->string('email')->nullable();
+                $table->string('phone')->nullable();
+                $table->text('notes')->nullable();
+                $table->text('description')->nullable();
+                $table->string('status')->default('pending');
+                $table->uuid('approved_company_id')->nullable();
+                $table->text('admin_notes')->nullable();
+                $table->timestamp('reviewed_at')->nullable();
+                $table->json('signup_payload')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    private function tearDownCompanyRequestTable(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO public');
+
+            return;
+        }
+
+        Schema::dropIfExists('company_requests');
+    }
+}

--- a/front/admin-dashboard/src/views/crm/CrmPipelineView.vue
+++ b/front/admin-dashboard/src/views/crm/CrmPipelineView.vue
@@ -12,6 +12,22 @@
       </button>
     </div>
 
+    <!-- PA2-ADM-004: explicit lead -> trial -> client conversion summary -->
+    <div v-if="!isLoading && !errorMessage" class="grid grid-cols-1 gap-4 sm:grid-cols-3 shrink-0">
+      <div class="card p-4">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Leads totaux</p>
+        <p class="mt-1 text-2xl font-black text-slate-900 dark:text-white">{{ meta.total_leads }}</p>
+      </div>
+      <div class="card p-4">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Taux lead -> essai</p>
+        <p class="mt-1 text-2xl font-black text-emerald-600">{{ formatRate(meta.conversion.lead_to_trial_rate) }}</p>
+      </div>
+      <div class="card p-4">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Taux lead -> client payant</p>
+        <p class="mt-1 text-2xl font-black text-blue-600">{{ formatRate(meta.conversion.lead_to_client_rate) }}</p>
+      </div>
+    </div>
+
     <div v-if="isLoading" class="flex-1 flex items-center justify-center p-6 text-sm text-gray-500">
       Chargement du pipeline...
     </div>
@@ -35,6 +51,10 @@
           <div v-for="item in pipeline.leads" :key="item.id" class="bg-white dark:bg-slate-900 p-4 rounded-lg shadow-sm border border-slate-200 dark:border-slate-800 hover:border-brand-500 transition-colors cursor-pointer" @click="openRequest(item.id)">
             <h3 class="font-bold text-slate-900 dark:text-white">{{ item.company_name }}</h3>
             <p class="text-xs text-slate-500 mt-1">{{ item.sector || 'Secteur non précisé' }}</p>
+            <span class="inline-block mt-2 text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400">
+              {{ formatSource(item.source) }}
+            </span>
+            <p v-if="item.note" class="text-xs text-slate-400 mt-2 line-clamp-2">{{ item.note }}</p>
             <div class="mt-3 flex items-center justify-between">
               <span class="text-xs text-slate-400">{{ formatDate(item.created_at) }}</span>
             </div>
@@ -60,6 +80,10 @@
           <div v-for="item in pipeline.trials" :key="item.id" class="bg-white dark:bg-slate-900 p-4 rounded-lg shadow-sm border border-emerald-100 dark:border-emerald-900/50 hover:border-brand-500 transition-colors cursor-pointer" @click="openCompany(item.company.id)">
             <h3 class="font-bold text-slate-900 dark:text-white">{{ item.company_name }}</h3>
             <p class="text-xs text-slate-500 mt-1">{{ item.email }}</p>
+            <span class="inline-block mt-2 text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400">
+              {{ formatSource(item.source) }}
+            </span>
+            <p v-if="item.note" class="text-xs text-slate-400 mt-2 line-clamp-2">{{ item.note }}</p>
             <div class="mt-3 flex items-center justify-between">
               <span class="text-xs font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">{{ item.company.days_left }}j restants</span>
             </div>
@@ -84,6 +108,10 @@
         <div class="flex-1 p-3 space-y-3 overflow-y-auto">
           <div v-for="item in pipeline.active" :key="item.id" class="bg-white dark:bg-slate-900 p-4 rounded-lg shadow-sm border border-blue-100 dark:border-blue-900/50 hover:border-brand-500 transition-colors cursor-pointer" @click="openCompany(item.company.id)">
             <h3 class="font-bold text-slate-900 dark:text-white">{{ item.company_name }}</h3>
+            <span class="inline-block mt-2 text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400">
+              {{ formatSource(item.source) }}
+            </span>
+            <p v-if="item.note" class="text-xs text-slate-400 mt-2 line-clamp-2">{{ item.note }}</p>
             <div class="mt-3 flex items-center justify-between">
               <span class="text-xs font-medium text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">Actif</span>
             </div>
@@ -139,6 +167,24 @@ const pipeline = ref({
   active: [],
   rejected: []
 })
+// PA2-ADM-004: conversion summary served alongside the raw pipeline buckets.
+const meta = ref({
+  total_leads: 0,
+  conversion: {
+    lead_to_trial_rate: 0,
+    lead_to_client_rate: 0
+  }
+})
+
+const SOURCE_LABELS = {
+  signup_form: 'Inscription',
+  demo_form: 'Demande de démo',
+  contact_form: 'Contact',
+  newsletter_form: 'Newsletter',
+  self_service_trial: 'Essai self-service',
+  manager_request: 'Demande manager',
+  direct: 'Direct'
+}
 
 async function loadPipeline() {
   isLoading.value = true
@@ -147,12 +193,28 @@ async function loadPipeline() {
   try {
     const response = await api.get('/platform/crm/pipeline')
     pipeline.value = response.data?.data || { leads: [], trials: [], active: [], rejected: [] }
+    meta.value = response.data?.meta || {
+      total_leads: 0,
+      conversion: { lead_to_trial_rate: 0, lead_to_client_rate: 0 }
+    }
   } catch (error) {
     console.error('Failed to load CRM pipeline:', error)
     errorMessage.value = 'Impossible de charger le pipeline CRM.'
   } finally {
     isLoading.value = false
   }
+}
+
+function formatRate(rate) {
+  return new Intl.NumberFormat(toIntlLocale(localeStore.current), {
+    style: 'percent',
+    maximumFractionDigits: 1
+  }).format(rate || 0)
+}
+
+function formatSource(source) {
+  if (!source) return SOURCE_LABELS.direct
+  return SOURCE_LABELS[source] || source
 }
 
 function openRequest(id) {


### PR DESCRIPTION
Closes #968 (PA2-ADM-004).

## Problem
The platform CRM pipeline endpoint (`GET /platform/crm/pipeline`) only returned the four raw status buckets (leads/trials/active/rejected). It never exposed each lead's acquisition **source** or admin **note**, and did not compute a **conversion** summary, even though the ticket's acceptance criteria explicitly asked for "Leads visibles statut source note conversion client".

## Changes
- `CompanyRequest`: added `source`/`note` accessors. `source` resolves from the structured `signup_payload.source` written by the self-service trial flow, falls back to the legacy `description` marker (`... — source: X`) used by older requests, and defaults to `manager_request`/`direct`. `note` prefers `admin_notes`, falling back to the lead's own `notes`/`description`.
- `PlatformCrmPipelineController`: every pipeline item now includes `source`/`note`; response also returns `meta.total_leads` and `meta.conversion` (lead→trial and lead→client rates).
- `CrmPipelineView.vue` (admin-dashboard): renders a source badge + note excerpt on lead/trial/active cards, and a 3-tile conversion summary header above the board.
- New test `PlatformCrmPipelineApiTest` covering both source-resolution paths and the conversion math.

## Testing
- `php vendor/bin/phpunit tests/Feature/PlatformCrmPipelineApiTest.php` → passes (1 test, 10 assertions).
- `npx eslint src/views/crm/CrmPipelineView.vue` → no new warnings (pre-existing unrelated warning confirmed present on `main` too).
- `php -l` on all changed PHP files → no syntax errors.
