### PR TITLE
fix(admin-dashboard): honor BASE_URL in Playwright staging E2E run (issue #1066)

### DIFF
--- a/front/admin-dashboard/playwright.config.js
+++ b/front/admin-dashboard/playwright.config.js
@@ -1,5 +1,18 @@
 import { defineConfig } from '@playwright/test'
 
+// PA2-QA-001 — Smoke login across the 5 surfaces (API, employee/manager
+// mobile, platform admin, admin web, kiosk).
+//
+// .github/workflows/e2e-staging.yml runs this suite against the real
+// deployed staging URL by exporting BASE_URL (see the front/web project's
+// own convention in front/web/playwright.config.ts). This config used to
+// only read PLAYWRIGHT_BASE_URL, so the "staging" admin-dashboard smoke job
+// silently ignored BASE_URL, always fell back to 127.0.0.1:4173, and spun up
+// a fresh local dev server instead of testing staging — the CI job passed
+// without ever exercising the real deployed admin login flow.
+const baseURL = process.env.BASE_URL || process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:4173'
+const shouldStartLocalServer = !process.env.BASE_URL && !process.env.PLAYWRIGHT_BASE_URL
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
@@ -12,16 +25,18 @@ export default defineConfig({
       ]
     : 'list',
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:4173',
+    baseURL,
     headless: true,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
-  webServer: {
-    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
-    url: 'http://127.0.0.1:4173/login',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: shouldStartLocalServer
+    ? {
+        command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+        url: 'http://127.0.0.1:4173/login',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      }
+    : undefined,
 })


### PR DESCRIPTION
## Ticket
PA2-QA-001 — Smoke login across the 5 surfaces (API, employee/manager mobile, platform admin, admin web, kiosk).

## Bug

`.github/workflows/e2e-staging.yml`'s `e2e-admin-dashboard` job exports `BASE_URL` to point the admin dashboard's Playwright suite at the real deployed staging URL — the exact same env var `front/web/playwright.config.ts` already reads for its own staging smoke run.

However, `front/admin-dashboard/playwright.config.js` only ever read `PLAYWRIGHT_BASE_URL`. It never looked at `BASE_URL`, so on every CI run:

- the config silently fell back to the local default `http://127.0.0.1:4173`
- the `webServer` block booted a brand-new local Vite dev server
- the whole "staging smoke" job ran entirely against localhost, never touching the deployed admin login flow it was supposed to validate

The job reported green without ever exercising staging — a false sense of coverage for the admin web login surface specifically called out in PA2-QA-001's acceptance criteria.

## Fix

- `playwright.config.js` now resolves `baseURL` from `BASE_URL` first, then `PLAYWRIGHT_BASE_URL`, then the local default — matching `front/web`'s convention.
- The local `webServer` bootstrap is skipped whenever either env var points at a real target, so the suite hits that URL directly instead of racing its own freshly-started dev server on the same machine.

## Testing

- Ran the full existing e2e suite locally with no env var set (default local mode): 36 passed, 4 pre-existing skips unrelated to this change.
- Started a second local admin-dashboard dev server on a different port to emulate "staging", ran the suite with `BASE_URL` pointed at it, and confirmed (via absence of `[WebServer]` boot logs) that Playwright correctly skipped its own server and hit the target URL directly.
- `eslint` clean on the changed file; pre-existing (unrelated) prettier formatting warning on this file predates this change.

Closes #1066