### PR TITLE
fix(edge): schedule edge:monitor to detect silent nodes and expiring licenses

### DIFF
--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -42,6 +42,22 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('attendance:auto-close')->hourly();
         // PA2-PAY-012 — Nightly progressive payroll pre-calculation
         $schedule->command('payroll:precalculate')->dailyAt('02:00');
+        // Audit Mobile+Edge 2026-07-26 (issue #1288) — Edge node silence /
+        // license-expiry monitoring was implemented but never scheduled; a
+        // silent/offline Edge node at a client site (or an expiring/expired
+        // offline license) went completely unnoticed in production.
+        //
+        // NOTE: two competing monitoring commands exist for historical
+        // reasons — edge:monitor (Eloquent EdgeNode model, matches the
+        // canonical UUID schema actually created in production) and
+        // edge:detect-silent-nodes (raw DB::table('edge_nodes') query on
+        // legacy bigint columns like node_id/alert_muted that do not exist
+        // in the canonical schema). Only edge:monitor is schedule-safe here;
+        // scheduling edge:detect-silent-nodes as-is would fail every run
+        // with a "column does not exist" SQL error. See issue #1291 for the
+        // schema unification work and docs/audits/AUDIT_MOBILE_EDGE_2026-07-26.md
+        // sections 1.3 and 1.4.
+        $schedule->command('edge:monitor')->everyThirtyMinutes()->withoutOverlapping();
     })
     ->withRouting(
         api: __DIR__.'/../routes/api.php',


### PR DESCRIPTION
## What Problem This Solves
Two Edge monitoring commands (`edge:monitor`, `edge:detect-silent-nodes`) exist with docblocks claiming they run on a schedule, but neither was ever registered in `bootstrap/app.php`'s `withSchedule()`. In production, a silent/offline Edge node at a client site — or an expiring/expired offline license — went completely unnoticed with no automated alert.

## Why This Change Was Made
`edge:monitor` is the command scheduled here because it uses the Eloquent `EdgeNode` model against the canonical UUID schema that Laravel actually creates in production (confirmed by inspecting `api/app/Modules/EdgeSync/database/migrations/2026_06_29_000001_create_edge_sync_tables.php`).

`edge:detect-silent-nodes` was **not** scheduled because it runs a raw `DB::table('edge_nodes')` query against legacy bigint columns (`node_id`, `alert_muted`, `last_alert_sent_at`) that do not exist in the canonical schema — scheduling it as-is would fail every run with a SQL 'column does not exist' error. Unifying the two competing `edge_nodes` schemas is tracked separately in #1291; once that's resolved, `edge:detect-silent-nodes` (5-min granularity) could replace or complement `edge:monitor` (30-min, but also handles license expiry).

## User Impact
Client sites running an Edge node will now get an automatic email alert within 30 minutes of the node going silent, or when an offline license is expiring within 7 days / has expired — instead of silent, undetected outages.

## Evidence
```diff
+ $schedule->command('edge:monitor')->everyThirtyMinutes()->withoutOverlapping();
```
Verified `edge:monitor` queries columns that exist in the canonical migration (`status`, `last_seen_at`, `company` relation) — see `api/app/Console/Commands/MonitorEdgeNodesCommand.php` and `api/app/Modules/EdgeSync/Domain/Models/EdgeNode.php`.

Fixes kitokoh/leopardo-hr#1288