### PR TITLE
fix(security): replace $guarded = [] with explicit $fillable on 13 Eloquent models

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -5,6 +5,11 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+- **Mass-assignment hardening on 13 Eloquent models** — replaced `protected $guarded = [];` with explicit `protected $fillable = [...]` allow-lists on `AttendanceLog`, `ApprovalRequest`, `ApprovalWorkflow`, `ApprovalDecision`, `KioskAnnouncement`, `AttendanceCorrectionRequest`, `AttendanceKiosk`, `BiometricEnrollmentRequest`, `ZktecoDevice`, `ZktecoSyncLog`, `CalendarEvent`, `CalendarConnection` (Attendance module) and `ScheduledTaskRun` (Platform module)
+  - No known active exploit today (all write paths already used explicit field lists), but `$guarded = []` removed Laravel's mass-assignment safety net for any future `Model::create($request->all())`-style shortcut
+  - Allow-lists built from each model's actual migration columns and real write call sites; no behavior change — existing test suite passes identically before/after
+
 ### Added
 - **Employee-manager discussion threads (PA2-COMM-002)** : fil de discussion privé entre un employé et son manager
   - Modèles `ConversationThread` / `ConversationMessage` (scopés par tenant via `BelongsToCompany`)

--- a/api/app/Modules/Attendance/Domain/Models/ApprovalDecision.php
+++ b/api/app/Modules/Attendance/Domain/Models/ApprovalDecision.php
@@ -22,7 +22,14 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class ApprovalDecision extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'approval_request_id',
+        'level',
+        'approver_id',
+        'decision',
+        'comment',
+        'decided_at',
+    ];
 
     public const UPDATED_AT = null;
 

--- a/api/app/Modules/Attendance/Domain/Models/ApprovalRequest.php
+++ b/api/app/Modules/Attendance/Domain/Models/ApprovalRequest.php
@@ -26,7 +26,15 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  */
 class ApprovalRequest extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'workflow_id',
+        'approvable_type',
+        'approvable_id',
+        'requester_id',
+        'current_level',
+        'status',
+    ];
 
     /** @return BelongsTo<ApprovalWorkflow, $this> */
     public function workflow(): BelongsTo

--- a/api/app/Modules/Attendance/Domain/Models/ApprovalWorkflow.php
+++ b/api/app/Modules/Attendance/Domain/Models/ApprovalWorkflow.php
@@ -20,7 +20,15 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ApprovalWorkflow extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'name',
+        'model_type',
+        'levels',
+        'auto_approve_below',
+        'escalation_hours',
+        'active',
+    ];
 
     protected $casts = [
         'levels' => 'array',

--- a/api/app/Modules/Attendance/Domain/Models/AttendanceCorrectionRequest.php
+++ b/api/app/Modules/Attendance/Domain/Models/AttendanceCorrectionRequest.php
@@ -25,7 +25,18 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class AttendanceCorrectionRequest extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'employee_id',
+        'attendance_log_id',
+        'date',
+        'requested_check_in',
+        'requested_check_out',
+        'reason',
+        'status',
+        'reviewed_by',
+        'reviewed_at',
+    ];
 
     protected $casts = [
         'date' => 'date',

--- a/api/app/Modules/Attendance/Domain/Models/AttendanceKiosk.php
+++ b/api/app/Modules/Attendance/Domain/Models/AttendanceKiosk.php
@@ -26,7 +26,18 @@ class AttendanceKiosk extends Model
 {
     use BelongsToCompany;
 
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'name',
+        'location_label',
+        'device_code',
+        'status',
+        'biometric_mode',
+        'trusted_device_label',
+        'sync_token_hash',
+        'last_seen_at',
+        'last_sync_at',
+    ];
 
     protected $casts = [
         'last_seen_at' => 'datetime',

--- a/api/app/Modules/Attendance/Domain/Models/AttendanceLog.php
+++ b/api/app/Modules/Attendance/Domain/Models/AttendanceLog.php
@@ -43,7 +43,32 @@ class AttendanceLog extends Model
     use BelongsToCompany;
     use HasFactory;
 
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'employee_id',
+        'schedule_id',
+        'date',
+        'session_number',
+        'check_in',
+        'check_out',
+        'method',
+        'source_device_code',
+        'external_event_id',
+        'biometric_type',
+        'synced_from_offline',
+        'work_type',
+        'punch_note',
+        'punch_meta',
+        'punch_photo_path',
+        'status',
+        'hours_worked',
+        'overtime_hours',
+        'late_minutes',
+        'gps_lat',
+        'gps_lng',
+        'corrected_by',
+        'correction_note',
+    ];
 
     protected $casts = [
         'date'                 => 'date',

--- a/api/app/Modules/Attendance/Domain/Models/BiometricEnrollmentRequest.php
+++ b/api/app/Modules/Attendance/Domain/Models/BiometricEnrollmentRequest.php
@@ -14,6 +14,22 @@ class BiometricEnrollmentRequest extends Model
 {
     use BelongsToCompany;
 
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'employee_id',
+        'approver_employee_id',
+        'status',
+        'requested_face_enabled',
+        'requested_fingerprint_enabled',
+        'requested_face_reference_path',
+        'requested_fingerprint_reference_path',
+        'requested_fingerprint_device_id',
+        'request_source',
+        'employee_note',
+        'manager_note',
+        'submitted_at',
+        'approved_at',
+        'rejected_at',
+    ];
 }
 

--- a/api/app/Modules/Attendance/Domain/Models/CalendarConnection.php
+++ b/api/app/Modules/Attendance/Domain/Models/CalendarConnection.php
@@ -23,7 +23,18 @@ use Illuminate\Database\Eloquent\Model;
  */
 class CalendarConnection extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'employee_id',
+        'provider',
+        'access_token',
+        'refresh_token',
+        'calendar_id',
+        'token_expires_at',
+        'sync_leaves',
+        'sync_training',
+        'is_active',
+        'last_synced_at',
+    ];
 
     protected $casts = [
         'token_expires_at' => 'datetime',

--- a/api/app/Modules/Attendance/Domain/Models/CalendarEvent.php
+++ b/api/app/Modules/Attendance/Domain/Models/CalendarEvent.php
@@ -20,7 +20,19 @@ use Illuminate\Database\Eloquent\Model;
  */
 class CalendarEvent extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'employee_id',
+        'external_event_id',
+        'provider',
+        'title',
+        'description',
+        'starts_at',
+        'ends_at',
+        'all_day',
+        'source_type',
+        'source_id',
+        'sync_status',
+    ];
 
     protected $casts = [
         'starts_at' => 'datetime',

--- a/api/app/Modules/Attendance/Domain/Models/KioskAnnouncement.php
+++ b/api/app/Modules/Attendance/Domain/Models/KioskAnnouncement.php
@@ -11,6 +11,14 @@ use Illuminate\Database\Eloquent\Model;
  */
 class KioskAnnouncement extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'title',
+        'body',
+        'priority',
+        'is_active',
+        'starts_at',
+        'expires_at',
+    ];
 }
 

--- a/api/app/Modules/Attendance/Domain/Models/ZktecoDevice.php
+++ b/api/app/Modules/Attendance/Domain/Models/ZktecoDevice.php
@@ -11,6 +11,23 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ZktecoDevice extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'company_id',
+        'serial_number',
+        'name',
+        'ip_address',
+        'port',
+        'protocol',
+        'location_label',
+        'status',
+        'model',
+        'firmware_version',
+        'employee_capacity',
+        'fingerprint_capacity',
+        'face_capacity',
+        'capabilities',
+        'last_heartbeat_at',
+        'last_sync_at',
+    ];
 }
 

--- a/api/app/Modules/Attendance/Domain/Models/ZktecoSyncLog.php
+++ b/api/app/Modules/Attendance/Domain/Models/ZktecoSyncLog.php
@@ -11,6 +11,16 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ZktecoSyncLog extends Model
 {
-    protected $guarded = [];
+    protected $fillable = [
+        'zkteco_device_id',
+        'direction',
+        'sync_type',
+        'records_count',
+        'errors_count',
+        'status',
+        'error_message',
+        'started_at',
+        'completed_at',
+    ];
 }
 

--- a/api/app/Modules/Platform/Domain/Models/ScheduledTaskRun.php
+++ b/api/app/Modules/Platform/Domain/Models/ScheduledTaskRun.php
@@ -31,7 +31,15 @@ class ScheduledTaskRun extends Model
 
     protected $table = 'scheduled_task_runs';
 
-    protected $guarded = [];
+    protected $fillable = [
+        'name',
+        'started_at',
+        'finished_at',
+        'runtime_ms',
+        'status',
+        'exit_code',
+        'output',
+    ];
 
     protected $casts = [
         'started_at' => 'datetime',


### PR DESCRIPTION
Closes #1313

## What Problem This Solves
13 Eloquent models declared `protected $guarded = [];`, which is equivalent to `$fillable = ['*']` and disables Laravel's mass-assignment protection entirely. This is defense-in-depth debt: no active exploit exists today (every write path already used explicit field lists), but it removes a safety net against future `Model::create($request->all())`-style regressions that would silently accept any client-supplied column (e.g. `id`, `company_id`, `status`).

## Why This Change Was Made
Replaced `$guarded = []` with explicit `protected $fillable = [...]` allow-lists on all 13 models listed in the issue:
- `AttendanceLog`, `ApprovalRequest`, `ApprovalWorkflow`, `ApprovalDecision`, `KioskAnnouncement`, `AttendanceCorrectionRequest`, `AttendanceKiosk`, `BiometricEnrollmentRequest`, `ZktecoDevice`, `ZktecoSyncLog`, `CalendarEvent`, `CalendarConnection` (all under `app/Modules/Attendance/Domain/Models/`)
- `ScheduledTaskRun` (`app/Modules/Platform/Domain/Models/`)

Each allow-list was built by cross-referencing:
1. The model's actual migration-defined columns (excluding primary key/timestamps).
2. Every real `::create()`, `::updateOrCreate()`, `->fill()`, and `->update()` call site across the codebase for that model, to make sure no legitimately-written field was dropped.

One inconsistency found and fixed along the way: `AttendanceLog` had a `gps_accuracy` cast/PHPDoc entry with no matching database column (it's actually only ever stored inside the `punch_meta` JSON blob) — this was excluded from `$fillable` since it isn't a real column.

## User Impact
None — this is a no-behavior-change hardening. No new mass-assignment errors were introduced: every existing write path already has its fields listed.

## Evidence
- `php artisan test` (full suite) produces byte-identical results before and after this change: **243 failed, 1 risky, 11 skipped, 1363 passed** on both `main` and this branch. All 243 pre-existing failures are unrelated SQLite-dialect issues (e.g. `EXTRACT(MONTH ...)` not supported by SQLite, date-format string mismatches) that also fail on `main` without this patch.
- `php -l` clean on all 13 modified model files.
- Verified via `git stash`/`git stash pop` A-B comparison that failure counts are identical with and without the patch applied.

Fixes kitokoh/leopardo-hr#1313