### PR TITLE
ci: remove dead develop/staging branch triggers after trunk-based migration

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,7 +19,7 @@ name: Actionlint
 on:
   pull_request:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'

--- a/.github/workflows/backend-jobs-ci.yml
+++ b/.github/workflows/backend-jobs-ci.yml
@@ -3,7 +3,7 @@ name: Backend Jobs CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'api/app/Jobs/**'
       - 'api/app/Listeners/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL - Leopardo RH
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -10,7 +10,7 @@ name: Backend Coverage Gate
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -3,7 +3,7 @@ name: Mobile Apps CI - Flutter
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'front/mobile_apps/**'
       - 'dev-hub/tools/validate-mobile-apps-split.ps1'
@@ -19,7 +19,7 @@ on:
       - 'dev-hub/tools/mobile-workflow-contracts.json'
       - '.github/workflows/mobile-apps-ci.yml'
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'front/mobile_apps/**'
       - 'dev-hub/tools/validate-mobile-apps-split.ps1'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -3,9 +3,9 @@ name: Secret Scan
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   push:
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,14 @@ name: Tests - Leopardo RH
 on:
   workflow_dispatch:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - 'api/**'
       - 'front/admin-dashboard/**'
       - '.github/workflows/tests.yml'
       - '.github/workflows/phpstan-baseline.yml'
   push:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - 'api/**'
       - 'front/admin-dashboard/**'

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -3,12 +3,12 @@ name: Web CI - Leopardo Admin
 on:
   workflow_dispatch:
   push:
-    branches: [main, develop, staging]
+    branches: [main]
     paths:
       - 'front/admin-dashboard/**'
       - '.github/workflows/web-ci.yml'
   pull_request:
-    branches: [main, develop, staging]
+    branches: [main]
     paths:
       - 'front/admin-dashboard/**'
       - '.github/workflows/web-ci.yml'


### PR DESCRIPTION
## What Problem This Solves
Several workflow files still declared `branches: [main, develop]` (or `staging`) triggers even though the repo migrated to a trunk-based model on `main` — `develop` and `staging` no longer exist. This was dead, misleading configuration that contradicted the branch model.

## Why This Change Was Made
Cleaned up the `branches:` filters in the affected workflows to only reference `main`, matching the actual branch model used by the repo today.

## User Impact
No behavior change for CI on `main` (that trigger still fires as before). Removes confusing dead configuration for contributors reading the workflow files.

## Evidence
- Confirmed via `gh api repos/kitokoh/leopardo-hr/branches` that only `main` (plus short-lived feature/fix branches) exists.
- Ran `actionlint .github/workflows/*.yml` after the change — exits 0, no new errors.

Fixes #1312