### PR TITLE
ci: bump actions/cache to v6 in setup-backend-db composite action

### DIFF
--- a/.github/actions/setup-backend-db/action.yml
+++ b/.github/actions/setup-backend-db/action.yml
@@ -85,7 +85,7 @@ runs:
       run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Composer dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: composer-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles(format('{0}/composer.lock', inputs.working-directory)) }}


### PR DESCRIPTION
## What Problem This Solves
`.github/workflows/tests.yml` uses `actions/cache@v6` for the Composer cache step, but the composite action `.github/actions/setup-backend-db/action.yml` still pinned `actions/cache@v4` for the same kind of caching need, which produced a real CI deprecation warning (Node.js 20 deprecated, actions/cache@v4 forced onto Node 24).

## Why This Change Was Made
Bumped `actions/cache@v4` to `@v6` in the composite action so it matches the version already used elsewhere in the pipeline.

## User Impact
No functional CI change; removes a spurious Node.js 20 deprecation warning from future runs using this composite action.

## Evidence
- `grep -rn "actions/cache@" .github/` now shows `@v6` consistently across `tests.yml` and `setup-backend-db/action.yml`.
- `actionlint .github/workflows/*.yml` passes (exit 0).

Fixes #1311