### PR TITLE
feat(vitrine): wire NEXT_PUBLIC_ENABLE_{ANALYTICS,FORMS,BLOG} feature flags

### DIFF
--- a/front/web/.env.local.example
+++ b/front/web/.env.local.example
@@ -27,8 +27,16 @@ NEXT_PUBLIC_ADMIN_URL=https://admin.leopardo-rh.com
 NEXT_PUBLIC_ENVIRONMENT=production
 
 # --- Feature flags vitrine ---
+# NEXT_PUBLIC_ENABLE_ANALYTICS: gates loading of GA4/Mixpanel scripts in
+#   app/layout.tsx. `false` (default) means no analytics script is injected
+#   even if NEXT_PUBLIC_GA_ID/NEXT_PUBLIC_MIXPANEL_TOKEN are set below.
 NEXT_PUBLIC_ENABLE_ANALYTICS=false
+# NEXT_PUBLIC_ENABLE_FORMS: gates the /api/forms/{contact,demo,newsletter,signup}
+#   routes. `false` makes them return HTTP 503 (FORMS_DISABLED) instead of
+#   capturing a lead.
 NEXT_PUBLIC_ENABLE_FORMS=true
+# NEXT_PUBLIC_ENABLE_BLOG: gates the /blog route (404 when disabled) and hides
+#   the Blog link from the Navbar/Footer.
 NEXT_PUBLIC_ENABLE_BLOG=false
 NEXT_PUBLIC_ENABLE_ERROR_TRACKING=false
 

--- a/front/web/src/app/(landing)/blog/layout.tsx
+++ b/front/web/src/app/(landing)/blog/layout.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { generateMetadata as generateSEOMetadata } from '@/modules/vitrine/lib/seo';
 import { pageMetadata } from '@/modules/vitrine/lib/seo';
+import { getEnvConfig } from '@/modules/vitrine/lib/env';
 
 export const metadata: Metadata = generateSEOMetadata({
   title: pageMetadata.blog.title,
@@ -16,5 +18,12 @@ export default function BlogLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // The blog route is only served when NEXT_PUBLIC_ENABLE_BLOG is enabled.
+  // Previously this flag was defined but never read anywhere, so the route
+  // was always built and served regardless of its value (issue #1305).
+  if (!getEnvConfig().enableBlog) {
+    notFound();
+  }
+
   return children;
 }

--- a/front/web/src/app/api/forms/_lib/lead-capture.ts
+++ b/front/web/src/app/api/forms/_lib/lead-capture.ts
@@ -1,6 +1,34 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 type MarketingLeadType = 'signup' | 'demo_request' | 'newsletter' | 'contact';
+
+/**
+ * Whether marketing forms are enabled for the vitrine, mirroring
+ * `NEXT_PUBLIC_ENABLE_FORMS` (see `modules/vitrine/lib/env.ts`). Read
+ * directly from `process.env` here (not `getEnvConfig()`) because this
+ * runs in the Next.js API route runtime, not the vitrine module tree.
+ * Defaults to enabled to preserve current behavior when unset.
+ */
+export function areFormsEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_FORMS !== 'false';
+}
+
+/**
+ * Standard 503 response returned by every `/api/forms/*` route when
+ * `NEXT_PUBLIC_ENABLE_FORMS=false` (issue #1305: the flag was previously
+ * defined but never enforced anywhere, so submissions always succeeded
+ * regardless of its value).
+ */
+export function formsDisabledResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      success: false,
+      message: 'Les formulaires sont temporairement desactives.',
+      error: 'FORMS_DISABLED',
+    },
+    { status: 503 }
+  );
+}
 
 export type MarketingLeadPayload = {
   type: MarketingLeadType;

--- a/front/web/src/app/api/forms/contact/route.ts
+++ b/front/web/src/app/api/forms/contact/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { captureMarketingLead, getClientIp } from '../_lib/lead-capture';
+import { areFormsEnabled, captureMarketingLead, formsDisabledResponse, getClientIp } from '../_lib/lead-capture';
 import { RateLimiter, sanitizeEmail, sanitizeInput } from '@/modules/vitrine/lib/validation';
 
 const rateLimiter = new RateLimiter(5, 15 * 60 * 1000);
@@ -18,6 +18,10 @@ const contactSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  if (!areFormsEnabled()) {
+    return formsDisabledResponse();
+  }
+
   try {
     const ip = getClientIp(request);
 

--- a/front/web/src/app/api/forms/demo/route.ts
+++ b/front/web/src/app/api/forms/demo/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { captureMarketingLead, getClientIp } from '../_lib/lead-capture';
+import { areFormsEnabled, captureMarketingLead, formsDisabledResponse, getClientIp } from '../_lib/lead-capture';
 import { RateLimiter, sanitizeEmail, sanitizeInput } from '@/modules/vitrine/lib/validation';
 
 const rateLimiter = new RateLimiter(5, 15 * 60 * 1000);
@@ -20,6 +20,10 @@ const demoSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  if (!areFormsEnabled()) {
+    return formsDisabledResponse();
+  }
+
   try {
     const ip = getClientIp(request);
 

--- a/front/web/src/app/api/forms/newsletter/route.ts
+++ b/front/web/src/app/api/forms/newsletter/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { captureMarketingLead, getClientIp } from '../_lib/lead-capture';
+import { areFormsEnabled, captureMarketingLead, formsDisabledResponse, getClientIp } from '../_lib/lead-capture';
 import { RateLimiter, sanitizeEmail } from '@/modules/vitrine/lib/validation';
 
 const rateLimiter = new RateLimiter(10, 15 * 60 * 1000);
@@ -14,6 +14,10 @@ const newsletterSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  if (!areFormsEnabled()) {
+    return formsDisabledResponse();
+  }
+
   try {
     const ip = getClientIp(request);
 

--- a/front/web/src/app/api/forms/signup/route.ts
+++ b/front/web/src/app/api/forms/signup/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { captureMarketingLead, getClientIp } from '../_lib/lead-capture';
+import { areFormsEnabled, captureMarketingLead, formsDisabledResponse, getClientIp } from '../_lib/lead-capture';
 import { RateLimiter, sanitizeEmail, sanitizeInput } from '@/modules/vitrine/lib/validation';
 
 const rateLimiter = new RateLimiter(5, 15 * 60 * 1000);
@@ -25,6 +25,10 @@ const signupSchema = z.object({
 const LEOPARDO_API_URL = process.env.LEOPARDO_API_URL || 'https://gestionemployerbackend.onrender.com';
 
 export async function POST(request: NextRequest) {
+  if (!areFormsEnabled()) {
+    return formsDisabledResponse();
+  }
+
   try {
     const ip = getClientIp(request);
 

--- a/front/web/src/app/layout.tsx
+++ b/front/web/src/app/layout.tsx
@@ -74,8 +74,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const gaId = process.env.NEXT_PUBLIC_GA_ID;
-  const mixpanelToken = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
+  // Analytics scripts (GA4, Mixpanel) are only loaded when the vitrine
+  // feature flag is explicitly enabled. Previously `gaId`/`mixpanelToken`
+  // were read and injected independently of `NEXT_PUBLIC_ENABLE_ANALYTICS`,
+  // so setting the flag to `false` (its documented default) had no effect
+  // on whether these third-party trackers actually loaded (issue #1305).
+  const analyticsEnabled = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
+  const gaId = analyticsEnabled ? process.env.NEXT_PUBLIC_GA_ID : undefined;
+  const mixpanelToken = analyticsEnabled ? process.env.NEXT_PUBLIC_MIXPANEL_TOKEN : undefined;
 
   return (
     <html lang="fr" suppressHydrationWarning>

--- a/front/web/src/modules/vitrine/components/Footer.tsx
+++ b/front/web/src/modules/vitrine/components/Footer.tsx
@@ -10,6 +10,7 @@ const SOCIAL_LINKS = [
   { label: 'Gh', href: 'https://github.com/kitokoh/leopardo-hr', title: 'GitHub' },
 ]
 import { NewsletterForm } from './NewsletterForm'
+import { getEnvConfig } from '../lib/env'
 
 function getFooterHref(sectionIndex: number, linkIndex: number): string {
   const key = `${sectionIndex}-${linkIndex}`
@@ -50,6 +51,9 @@ function getFooterHref(sectionIndex: number, linkIndex: number): string {
 export function Footer() {
   const { copy, locale, options } = useVitrineLocale()
   const activeLocale = options.find((option) => option.value === locale)
+  // The Blog link ('1-2' -> /blog) is hidden when NEXT_PUBLIC_ENABLE_BLOG is
+  // disabled, since the route itself now 404s in that case (issue #1305).
+  const { enableBlog } = getEnvConfig()
 
   return (
     <footer className="relative bg-white dark:bg-slate-950 border-t border-slate-200/80 dark:border-slate-800/80">
@@ -90,6 +94,7 @@ export function Footer() {
               <ul className="space-y-2.5">
                 {section.links.map((link, linkIndex) => {
                   const href = getFooterHref(index, linkIndex)
+                  if (href === '/blog' && !enableBlog) return null
 
                   return (
                     <li key={`${section.title}-link-${linkIndex}`}>

--- a/front/web/src/modules/vitrine/components/Navbar.tsx
+++ b/front/web/src/modules/vitrine/components/Navbar.tsx
@@ -25,6 +25,7 @@ import {
   X,
 } from 'lucide-react'
 import { useVitrineLocale } from '../lib/vitrine-locale'
+import { getEnvConfig } from '../lib/env'
 
 type Props = {
   isDark: boolean
@@ -52,6 +53,25 @@ type NavEntry = NavLink | NavDropdown
 
 function isDropdown(entry: NavEntry): entry is NavDropdown {
   return 'items' in entry
+}
+
+// Hide the Blog link when NEXT_PUBLIC_ENABLE_BLOG is disabled (issue #1305):
+// the route itself now returns 404 in that case (see blog/layout.tsx), so
+// the nav must not keep pointing at it.
+function filterNavEntries(entries: NavEntry[]): NavEntry[] {
+  const { enableBlog } = getEnvConfig()
+  if (enableBlog) return entries
+
+  return entries.reduce<NavEntry[]>((acc, entry) => {
+    if (!isDropdown(entry)) {
+      acc.push(entry)
+      return acc
+    }
+
+    const items = entry.items.filter((item) => item.href !== '/blog')
+    if (items.length > 0) acc.push({ ...entry, items })
+    return acc
+  }, [])
 }
 
 const navByLocale: Record<string, NavEntry[]> = {
@@ -214,7 +234,7 @@ export function Navbar({ isDark, onToggleDark }: Props) {
   const [openDropdown, setOpenDropdown] = useState<string | null>(null)
   const dropdownTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { copy, locale, options, setLocale } = useVitrineLocale()
-  const entries = navByLocale[locale] ?? navByLocale.fr
+  const entries = filterNavEntries(navByLocale[locale] ?? navByLocale.fr)
 
   useEffect(() => {
     const handler = () => setScrolled(window.scrollY > 40)


### PR DESCRIPTION
## What Problem This Solves
`front/web/src/modules/vitrine/lib/env.ts` defines and reads `NEXT_PUBLIC_ENABLE_BLOG`, `NEXT_PUBLIC_ENABLE_FORMS`, `NEXT_PUBLIC_ENABLE_ANALYTICS`, but no file in the app ever calls `getEnvConfig()` to condition rendering/behavior on them:
- `/blog` was always built and served regardless of `NEXT_PUBLIC_ENABLE_BLOG` (default `false`).
- GA4/Mixpanel scripts in `app/layout.tsx` were loaded based on `NEXT_PUBLIC_GA_ID`/`NEXT_PUBLIC_MIXPANEL_TOKEN` directly, independent of `NEXT_PUBLIC_ENABLE_ANALYTICS`.
- `NEXT_PUBLIC_ENABLE_FORMS` had no effect at all on `/api/forms/*`.

Anyone relying on these flags to disable a feature was getting a false sense of control.

## Why This Change Was Made (Option A from the issue: wire the flags for real)
- `app/layout.tsx`: only read `NEXT_PUBLIC_GA_ID`/`NEXT_PUBLIC_MIXPANEL_TOKEN` (and therefore only inject the GA4/Mixpanel `<Script>` tags) when `NEXT_PUBLIC_ENABLE_ANALYTICS=true`.
- `app/(landing)/blog/layout.tsx`: call `notFound()` for `/blog` and all nested routes (including `/blog/[slug]`, which is nested under this layout) when `NEXT_PUBLIC_ENABLE_BLOG` is not enabled.
- `Navbar.tsx` / `Footer.tsx`: hide the Blog nav entry and footer link when the blog flag is disabled, since the route itself now 404s in that case.
- `api/forms/_lib/lead-capture.ts`: added `areFormsEnabled()` / `formsDisabledResponse()` helpers; wired into the `contact`, `demo`, `newsletter` and `signup` routes so `NEXT_PUBLIC_ENABLE_FORMS=false` makes them return HTTP 503 `FORMS_DISABLED` instead of silently capturing a lead. Defaults to enabled (`!== 'false'`) so unset env vars keep current production behavior.
- `.env.local.example`: documented the actual effect of each flag inline.

## User Impact
The three feature flags now do what their name implies. Operators can safely turn off the blog, marketing forms, or analytics via env vars without needing a code change, and no longer get a false sense of security from a flag that silently did nothing.

## Evidence
- `npm run build` (Next.js 16, Turbopack): compiles successfully, all 65 routes generated including `/blog` and `/blog/[slug]`.
- Manual verification with `npm run start`:
  - `GET /blog` → `404` with default `NEXT_PUBLIC_ENABLE_BLOG=false`.
  - `GET /contact` → `200` (unaffected page).
  - `POST /api/forms/newsletter` with `NEXT_PUBLIC_ENABLE_FORMS=false` → `{"success":false,"message":"...","error":"FORMS_DISABLED"}`.
- `npx eslint` on all changed files: clean, no warnings/errors.
- `npx tsc --noEmit`: no new errors.

Fixes kitokoh/leopardo-hr#1305