### PR TITLE
docs(edge): document the role of the three Edge Dockerfiles

### DIFF
--- a/docs/edge-sync/ARCHITECTURE.md
+++ b/docs/edge-sync/ARCHITECTURE.md
@@ -92,11 +92,14 @@ api/app/Modules/EdgeSync/
 ### 3.2 Edge Docker Stack
 ```
 edge/
-├── docker-compose.yml    # Stack complète (api+ui+sync+proxy)
-├── Dockerfile.edge       # Image PHP 8.4 Alpine + SQLite
+├── docker-compose.yml    # Stack complète (api+ui+sync+proxy), utilise Dockerfile.edge
+├── Dockerfile.edge       # Image PHP 8.4 Alpine + SQLite (local/dev, buildée par docker-compose.yml)
+├── Dockerfile.publish    # Image de production publiée sur Docker Hub (buildée par publish.sh)
+├── Dockerfile            # Image FrankenPHP autonome (référence, non branchée dans un script de build)
 ├── Caddyfile.edge        # Reverse proxy
 ├── nginx.edge.conf       # Nginx config interne
 ├── supervisord.edge.conf # Supervisor (php-fpm + nginx)
+├── publish.sh            # Build + push de l'image de production (Dockerfile.publish)
 ├── install.sh            # Script d'installation one-liner
 └── .env.example          # Template configuration
 

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,6 +1,14 @@
 # =============================================================================
-# Leopardo Edge API — Docker image
+# Leopardo Edge API — Docker image (standalone, FrankenPHP)
 # Tag cible : leopardo/edge-api:1.0.0
+#
+# STATUS: standalone reference image, not currently wired into
+# edge/docker-compose.yml (which builds edge-api/edge-ui from Dockerfile.edge)
+# nor into edge/publish.sh (which uses Dockerfile.publish). Build it manually
+# from the repo root if you need the FrankenPHP + embedded PWA variant.
+# See the other Dockerfile* files in this directory for their actual role:
+#   - Dockerfile.edge    -> used by edge/docker-compose.yml (local/dev stack)
+#   - Dockerfile.publish -> used by edge/publish.sh (Docker Hub release image)
 #
 # Build :
 #   docker build -t leopardo/edge-api:1.0.0 -f edge/Dockerfile .

--- a/edge/Dockerfile.edge
+++ b/edge/Dockerfile.edge
@@ -1,5 +1,12 @@
 # ============================================================
 # Leopardo Edge API — Lightweight Laravel for Edge deployment
+#
+# STATUS: this is the ACTIVE Dockerfile for local/dev usage — it is the
+# one built by edge/docker-compose.yml (edge-api and edge-ui services,
+# via `docker compose up` from this directory). See Dockerfile.publish
+# for the production release image built by edge/publish.sh, and
+# Dockerfile (no suffix) for a standalone FrankenPHP reference image
+# that is not currently wired into any build script.
 # ============================================================
 FROM php:8.4-fpm-alpine
 

--- a/edge/Dockerfile.publish
+++ b/edge/Dockerfile.publish
@@ -2,6 +2,12 @@
 # Leopardo Edge API — Production Docker Image
 # Published to: leopardo/edge-api:VERSION
 #
+# STATUS: this is the ACTIVE Dockerfile used by edge/publish.sh to build
+# and push the public leopardo/edge-api image to Docker Hub. See
+# Dockerfile.edge for the local/dev image built by edge/docker-compose.yml,
+# and Dockerfile (no suffix) for a standalone FrankenPHP reference image
+# that is not currently wired into any build script.
+#
 # Build: docker build -f Dockerfile.publish -t leopardo/edge-api:1.0.0 .
 # Push:  docker push leopardo/edge-api:1.0.0
 # ============================================================

--- a/edge/README.md
+++ b/edge/README.md
@@ -52,6 +52,16 @@ docker compose exec edge-api php artisan edge:sync-daemon
 docker compose ps
 ```
 
+## Dockerfiles
+
+This directory has three Dockerfiles with distinct roles — do not assume they are interchangeable:
+
+| File                  | Used by                          | Purpose                                                        |
+|-----------------------|-----------------------------------|-----------------------------------------------------------------|
+| `Dockerfile.edge`     | `edge/docker-compose.yml`         | Local/dev image (`edge-api`, `edge-ui` services), php-fpm + nginx + supervisor |
+| `Dockerfile.publish`  | `edge/publish.sh`                 | Production image published to Docker Hub as `leopardo/edge-api` |
+| `Dockerfile`          | *(not currently wired in)*        | Standalone FrankenPHP + embedded PWA reference image; build manually if needed |
+
 ## Sécurité
 
 - Licence JWT (RS256) signée par Leopardo Cloud


### PR DESCRIPTION
## What Problem This Solves
`edge/Dockerfile`, `edge/Dockerfile.edge`, and `edge/Dockerfile.publish` coexist without any documentation explaining which one is actually used where, which is confusing for anyone touching the Edge Docker stack.

## Why This Change Was Made
Traced each file to its actual consumer:
- `Dockerfile.edge` → built by `edge/docker-compose.yml` for the `edge-api`/`edge-ui` services (local/dev stack).
- `Dockerfile.publish` → built by `edge/publish.sh` for the production image pushed to Docker Hub as `leopardo/edge-api`.
- `Dockerfile` (no suffix) → a standalone FrankenPHP + embedded PWA reference image that is **not** referenced by any build script, docker-compose file, or CI workflow today.

Added a STATUS header comment to each Dockerfile, a summary table to `edge/README.md`, and updated the directory listing in `docs/edge-sync/ARCHITECTURE.md` to reflect this.

## User Impact
Documentation-only change, no behavior change. Removes ambiguity for future contributors/agents working on the Edge stack.

## Evidence
- `grep -rln "Dockerfile.edge" .` → only `edge/docker-compose.yml` and `docs/edge-sync/ARCHITECTURE.md`.
- `grep -rln "Dockerfile.publish" .` → only `edge/publish.sh`.
- No other script/workflow references the bare `edge/Dockerfile`.

Fixes #1295