### PR TITLE
fix(admin-dashboard): add sidebar navigation links for Edge, Growth, and Predictions views

### DIFF
--- a/front/admin-dashboard/src/components/layout/Sidebar.vue
+++ b/front/admin-dashboard/src/components/layout/Sidebar.vue
@@ -162,7 +162,10 @@ import {
   ChartPieIcon,
   ShieldCheckIcon,
   FunnelIcon,
-  LifebuoyIcon
+  LifebuoyIcon,
+  ServerIcon,
+  ArrowTrendingUpIcon,
+  ChartBarSquareIcon
 } from '@heroicons/vue/24/outline'
 import { useAuthStore } from '@/stores/auth'
 import { useDashboardStore } from '@/stores/dashboard'
@@ -304,6 +307,24 @@ const navigation = computed(() => [
     title: 'Pipeline CRM',
     path: '/crm/pipeline',
     icon: FunnelIcon
+  },
+  {
+    name: 'predictions',
+    title: 'Dashboard Prédictif IA',
+    path: '/predictions',
+    icon: ChartBarSquareIcon
+  },
+  {
+    name: 'growth',
+    title: 'Administration Growth',
+    path: '/growth',
+    icon: ArrowTrendingUpIcon
+  },
+  {
+    name: 'edge',
+    title: 'Edge Nodes',
+    path: '/edge',
+    icon: ServerIcon
   },
   {
     name: 'system',


### PR DESCRIPTION
## What Problem This Solves
`EdgeNodesView` (`/edge`), `GrowthDashboardView` (`/growth`), and `PredictionsView` (`/predictions`) are fully implemented views with real API calls (edge node CRUD, `/platform/growth/partners`, `/v1/predictions/turnover`), but were unreachable from the UI — no entry in `Sidebar.vue`, no `router-link`/`router.push` anywhere else pointed to them. The only way in was typing the URL by hand.

## Why This Change Was Made
Checked the router (`src/router/index.js`) — the three routes exist with no role/permission gating, so they are safe to surface as plain nav entries rather than hiding them behind a feature flag.

## User Impact
Admins can now navigate to Edge Nodes, Growth Administration, and the AI Predictions dashboard directly from the sidebar, using the same title/icon already defined in the router meta for consistency.

## Evidence
```
$ npx vite build --mode production
✓ built in 4.94s
dist/assets/EdgeNodesView-*.js
dist/assets/GrowthDashboardView-*.js
dist/assets/PredictionsView-*.js
```
Build succeeds with the new sidebar entries wired to the existing routes/components.

Fixes kitokoh/leopardo-hr#1303