### PR TITLE
fix(web): wire eslint-config-next into flat eslint config

### DIFF
--- a/front/web/eslint.config.mjs
+++ b/front/web/eslint.config.mjs
@@ -1,4 +1,5 @@
 import tseslint from "typescript-eslint";
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 
 export default [
   {
@@ -13,6 +14,54 @@ export default [
       "e2e/**",
       "public/**",
     ],
+  },
+  // eslint-config-next is declared as a dependency but was previously never
+  // imported here, so Next.js/React hooks/accessibility rules were silently
+  // never applied despite `npm run lint` reporting 0 errors/warnings.
+  // eslint-config-next@16+ ships ready-to-use flat config arrays, so no
+  // FlatCompat shim is needed.
+  ...nextCoreWebVitals,
+  {
+    // eslint-plugin-react (pulled in transitively by eslint-config-next) reads
+    // the installed React version to enable/disable some legacy-API rules.
+    // Its "detect" mode crashes under ESLint 10's flat-config RuleContext
+    // (no context.getFilename()), so pin the version explicitly instead.
+    settings: {
+      react: { version: "19.2.8" },
+    },
+  },
+  {
+    // eslint-plugin-react-hooks v7 (pulled in by eslint-config-next@16) adds a
+    // new family of React Compiler "readiness" diagnostics (purity,
+    // immutability, set-state-in-effect, incompatible-library, etc.) and
+    // defaults them to "error". These flag long-standing, otherwise correct
+    // Next.js patterns across this codebase (data-fetching useEffect +
+    // setState, `window.location.href = ...` navigation, `Math.random()` for
+    // non-crypto DOM ids, React Hook Form's `watch()`, etc.). Fixing all of
+    // them would require a much larger, dedicated refactor unrelated to this
+    // issue's scope (wiring up eslint-config-next itself), so per the
+    // fallback documented in issue #1306 this is a deliberate, explicit
+    // decision to disable only these specific React-Compiler-readiness
+    // rules for now rather than let them silently block `npm run lint`
+    // (which runs with --max-warnings 0). `rules-of-hooks` and
+    // `exhaustive-deps` — the rules that catch real bugs — remain enabled at
+    // their configured severity. Revisit as a dedicated follow-up if/when
+    // the codebase adopts the React Compiler.
+    rules: {
+      "react-hooks/purity": "off",
+      "react-hooks/immutability": "off",
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/set-state-in-render": "off",
+      "react-hooks/gating": "off",
+      "react-hooks/refs": "off",
+      "react-hooks/config": "off",
+      "react-hooks/globals": "off",
+      "react-hooks/error-boundaries": "off",
+      "react-hooks/static-components": "off",
+      "react-hooks/use-memo": "off",
+      "react-hooks/preserve-manual-memoization": "off",
+      "react-hooks/incompatible-library": "off",
+    },
   },
   ...tseslint.configs.recommended,
   {

--- a/front/web/src/app/(dashboard)/edge-nodes/page.tsx
+++ b/front/web/src/app/(dashboard)/edge-nodes/page.tsx
@@ -5,7 +5,7 @@
 
 'use client';
 
-import { useState, useEffect, useSyncExternalStore } from 'react';
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react';
 import { motion } from 'framer-motion';
 import { Cpu, Plus, RefreshCw, ShieldAlert, Wifi, WifiOff, X } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
@@ -52,13 +52,7 @@ export default function EdgeNodesPage() {
   const [installCommand, setInstallCommand] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchNodes();
-    const interval = setInterval(fetchNodes, 30000); // refresh every 30s
-    return () => clearInterval(interval);
-  }, []);
-
-  async function fetchNodes() {
+  const fetchNodes = useCallback(async () => {
     try {
       const res = await apiFetch('/edge');
       const data = await res.json();
@@ -69,7 +63,13 @@ export default function EdgeNodesPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [labels.loadError]);
+
+  useEffect(() => {
+    fetchNodes();
+    const interval = setInterval(fetchNodes, 30000); // refresh every 30s
+    return () => clearInterval(interval);
+  }, [fetchNodes]);
 
   async function triggerSync(nodeId: string) {
     setSyncing(nodeId);

--- a/front/web/src/app/(dashboard)/smart-attendance/sessions/[id]/page.tsx
+++ b/front/web/src/app/(dashboard)/smart-attendance/sessions/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import Image from 'next/image';
 import { Check, LogIn, LogOut, X } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { ModulePageShell } from '@/components/module-page-shell';
@@ -189,9 +190,11 @@ export default function SmartAttendanceSessionDetailPage() {
             <section className="rounded-2xl border border-app-border bg-white p-6 shadow-sm">
               <div className="flex items-center gap-4">
                 {session.employee_photo ? (
-                  <img
+                  <Image
                     src={session.employee_photo}
                     alt={session.employee_name ?? ''}
+                    width={64}
+                    height={64}
                     className="h-16 w-16 rounded-2xl object-cover"
                   />
                 ) : (

--- a/front/web/src/app/(landing)/about/page.tsx
+++ b/front/web/src/app/(landing)/about/page.tsx
@@ -126,7 +126,7 @@ export default function AboutPage() {
             <div className="prose dark:prose-invert max-w-none">
               <p className="text-lg text-slate-600 dark:text-slate-400 leading-relaxed mb-6">
                 Leopardo a été fondée en 2020 par Ahmed Benali, un entrepreneur passionné qui a constaté que les PME
-                manquaient d'une solution RH complète et abordable. Après avoir géré les ressources humaines avec Excel
+                manquaient d&apos;une solution RH complète et abordable. Après avoir géré les ressources humaines avec Excel
                 pendant des années, il a décidé de créer une plateforme qui changerait tout.
               </p>
               <p className="text-lg text-slate-600 dark:text-slate-400 leading-relaxed mb-6">
@@ -319,7 +319,7 @@ export default function AboutPage() {
               Nous Recrutons!
             </h2>
             <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto mb-8 leading-relaxed">
-              Vous êtes passionné par la technologie et l'innovation? Rejoignez notre équipe et aidez-nous à transformer
+              Vous êtes passionné par la technologie et l&apos;innovation? Rejoignez notre équipe et aidez-nous à transformer
               la gestion RH pour les PME.
             </p>
             <motion.a
@@ -328,7 +328,7 @@ export default function AboutPage() {
               whileTap={{ scale: 0.95 }}
               className="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold transition-colors"
             >
-              Voir les Offres d'Emploi
+              Voir les Offres d&apos;Emploi
               <ArrowRight className="w-5 h-5" />
             </motion.a>
           </motion.div>

--- a/front/web/src/app/(landing)/checkout/page.tsx
+++ b/front/web/src/app/(landing)/checkout/page.tsx
@@ -344,7 +344,7 @@ function PlanSummaryCard({
           <div className="flex items-center gap-2 px-4 py-3 rounded-2xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900/50">
             <Sparkles className="w-4 h-4 text-emerald-600 dark:text-emerald-400 flex-shrink-0" />
             <p className="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
-              {cfg.trialDays} jours gratuits inclus · Aucune CB débitée avant la fin de l'essai
+              {cfg.trialDays} jours gratuits inclus · Aucune CB débitée avant la fin de l&apos;essai
             </p>
           </div>
         )}
@@ -440,11 +440,11 @@ function StepRecap({
 
       {cfg.isFree ? (
         <div className="mt-6 p-4 rounded-2xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-800/50 text-sm text-emerald-800 dark:text-emerald-300">
-          <strong>Plan 100% gratuit.</strong> Aucune carte bancaire requise. Commencez immédiatement, jusqu'à 5 employés.
+          <strong>Plan 100% gratuit.</strong> Aucune carte bancaire requise. Commencez immédiatement, jusqu&apos;à 5 employés.
         </div>
       ) : (
         <div className="mt-6 p-4 rounded-2xl bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900/50 text-sm text-blue-800 dark:text-blue-300">
-          <strong>Essai gratuit de {cfg.trialDays} jours.</strong> Votre carte ne sera débitée qu'après la période d'essai. Annulez à tout moment depuis votre tableau de bord.
+          <strong>Essai gratuit de {cfg.trialDays} jours.</strong> Votre carte ne sera débitée qu&apos;après la période d&apos;essai. Annulez à tout moment depuis votre tableau de bord.
         </div>
       )}
 
@@ -1042,7 +1042,7 @@ function StepPayment({
         <div className="grid grid-cols-2 gap-3">
           <div>
             <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">
-              Date d'expiration
+              Date d&apos;expiration
             </label>
             <input
               type="text"
@@ -1107,7 +1107,7 @@ function StepPayment({
             <span className="font-bold text-emerald-600">{cfg.trialDays} jours</span>
           </div>
           <div className="border-t border-slate-200 dark:border-slate-700 mt-3 pt-3 flex items-center justify-between">
-            <span className="font-bold text-slate-900 dark:text-white">Dû aujourd'hui</span>
+            <span className="font-bold text-slate-900 dark:text-white">Dû aujourd&apos;hui</span>
             <span className="font-black text-lg text-emerald-600">EUR 0,00</span>
           </div>
         </div>
@@ -1130,7 +1130,7 @@ function StepPayment({
           ) : (
             <>
               <Lock className="w-4 h-4" />
-              Démarrer l'essai gratuit — EUR 0,00 dû maintenant
+              Démarrer l&apos;essai gratuit — EUR 0,00 dû maintenant
               <ArrowRight className="w-5 h-5" />
             </>
           )}
@@ -1139,7 +1139,7 @@ function StepPayment({
         <p className="text-center text-xs text-slate-400 dark:text-slate-500">
           En confirmant, vous acceptez nos{' '}
           <Link href="/terms" className="underline underline-offset-2 hover:text-slate-600">
-            conditions d'utilisation
+            conditions d&apos;utilisation
           </Link>{' '}
           et notre{' '}
           <Link href="/privacy" className="underline underline-offset-2 hover:text-slate-600">

--- a/front/web/src/app/(landing)/checkout/success/page.tsx
+++ b/front/web/src/app/(landing)/checkout/success/page.tsx
@@ -172,7 +172,7 @@ function SuccessInner() {
 
             <p className="text-xl text-slate-500 dark:text-slate-400 mb-10 max-w-xl mx-auto leading-relaxed">
               {company ? `${company} — ` : ''} Plan <strong className="text-slate-900 dark:text-white">{plan}</strong>
-              {billing === 'annual' ? ' (annuel)' : ' (mensuel)'}. 30 jours offerts, aucune carte débitée aujourd'hui.
+              {billing === 'annual' ? ' (annuel)' : ' (mensuel)'}. 30 jours offerts, aucune carte débitée aujourd&apos;hui.
             </p>
           </motion.div>
 
@@ -205,11 +205,11 @@ function SuccessInner() {
                 <span className="text-sm font-bold text-slate-900 dark:text-white">{plan}</span>
               </div>
               <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
-                <span className="text-sm text-slate-500 dark:text-slate-400">Période d'essai</span>
+                <span className="text-sm text-slate-500 dark:text-slate-400">Période d&apos;essai</span>
                 <span className="text-sm font-bold text-emerald-600">30 jours gratuits</span>
               </div>
               <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
-                <span className="text-sm text-slate-500 dark:text-slate-400">Débité aujourd'hui</span>
+                <span className="text-sm text-slate-500 dark:text-slate-400">Débité aujourd&apos;hui</span>
                 <span className="text-sm font-black text-emerald-600">EUR 0,00</span>
               </div>
               {isSandbox && (
@@ -250,7 +250,7 @@ function SuccessInner() {
           >
             <Mail className="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0" />
             <p className="text-sm text-blue-800 dark:text-blue-300">
-              <strong>Un email de confirmation</strong> a été envoyé à <strong>{email || 'votre adresse'}</strong> avec vos identifiants d'accès et les instructions de démarrage.
+              <strong>Un email de confirmation</strong> a été envoyé à <strong>{email || 'votre adresse'}</strong> avec vos identifiants d&apos;accès et les instructions de démarrage.
             </p>
           </motion.div>
 

--- a/front/web/src/components/PWAProvider.tsx
+++ b/front/web/src/components/PWAProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const safeLog = (..._args: unknown[]) => {};
 
@@ -108,6 +108,28 @@ export function PWAProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  // Sync pending data when back online
+  const syncPendingData = useCallback(async () => {
+    if (!swRegistration) return;
+
+    try {
+      // Sync forms
+      const syncRegistration = swRegistration as SyncCapableRegistration;
+      if (syncRegistration.sync) {
+        await syncRegistration.sync.register('sync-forms');
+        safeLog('[PWA] Sync forms registered');
+      }
+
+      // Sync analytics
+      if (syncRegistration.sync) {
+        await syncRegistration.sync.register('sync-analytics');
+        safeLog('[PWA] Sync analytics registered');
+      }
+    } catch (error) {
+      safeLog('[PWA] Sync registration failed:', error);
+    }
+  }, [swRegistration]);
+
   // Handle online/offline events
   useEffect(() => {
     const handleOnline = () => {
@@ -128,10 +150,10 @@ export function PWAProvider({ children }: { children: React.ReactNode }) {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, []);
+  }, [syncPendingData]);
 
   // Prompt for installation
-  const promptInstall = async () => {
+  const promptInstall = useCallback(async () => {
     if (!deferredPrompt) {
       safeLog('[PWA] Install prompt not available');
       return;
@@ -145,29 +167,7 @@ export function PWAProvider({ children }: { children: React.ReactNode }) {
     } catch (error) {
       safeLog('[PWA] Installation prompt failed:', error);
     }
-  };
-
-  // Sync pending data when back online
-  const syncPendingData = async () => {
-    if (!swRegistration) return;
-
-    try {
-      // Sync forms
-      const syncRegistration = swRegistration as SyncCapableRegistration;
-      if (syncRegistration.sync) {
-        await syncRegistration.sync.register('sync-forms');
-        safeLog('[PWA] Sync forms registered');
-      }
-
-      // Sync analytics
-      if (syncRegistration.sync) {
-        await syncRegistration.sync.register('sync-analytics');
-        safeLog('[PWA] Sync analytics registered');
-      }
-    } catch (error) {
-      safeLog('[PWA] Sync registration failed:', error);
-    }
-  };
+  }, [deferredPrompt]);
 
   // Expose PWA functions to window
   useEffect(() => {
@@ -178,7 +178,7 @@ export function PWAProvider({ children }: { children: React.ReactNode }) {
       deferredPrompt: !!deferredPrompt,
       swRegistration,
     };
-  }, [deferredPrompt, isInstalled, isOnline, swRegistration]);
+  }, [deferredPrompt, isInstalled, isOnline, promptInstall, swRegistration]);
 
   return <>{children}</>;
 }

--- a/front/web/src/hooks/useIntersectionObserver.ts
+++ b/front/web/src/hooks/useIntersectionObserver.ts
@@ -35,7 +35,8 @@ export function useIntersectionObserver(
   const [hasBeenVisible, setHasBeenVisible] = useState(false);
 
   useEffect(() => {
-    if (!ref.current) return;
+    const element = ref.current;
+    if (!element) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -58,12 +59,10 @@ export function useIntersectionObserver(
       }
     );
 
-    observer.observe(ref.current);
+    observer.observe(element);
 
     return () => {
-      if (ref.current) {
-        observer.unobserve(ref.current);
-      }
+      observer.unobserve(element);
     };
   }, [threshold, root, rootMargin, triggerOnce]);
 
@@ -89,7 +88,8 @@ export function useIntersectionObserverCallback(
   const hasTriggered = useRef(false);
 
   useEffect(() => {
-    if (!ref.current) return;
+    const element = ref.current;
+    if (!element) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -113,12 +113,10 @@ export function useIntersectionObserverCallback(
       }
     );
 
-    observer.observe(ref.current);
+    observer.observe(element);
 
     return () => {
-      if (ref.current) {
-        observer.unobserve(ref.current);
-      }
+      observer.unobserve(element);
     };
   }, [callback, threshold, root, rootMargin, triggerOnce]);
 

--- a/front/web/src/lib/caching-config.ts
+++ b/front/web/src/lib/caching-config.ts
@@ -319,7 +319,7 @@ export function getRevalidationTime(path: string): number {
   return 3600; // Default 1 hour
 }
 
-export default {
+const cachingConfig = {
   cacheHeaders,
   isrConfig,
   compressionConfig,
@@ -332,3 +332,5 @@ export default {
   shouldCache,
   getRevalidationTime,
 };
+
+export default cachingConfig;

--- a/front/web/src/lib/dynamic-imports.tsx
+++ b/front/web/src/lib/dynamic-imports.tsx
@@ -275,7 +275,7 @@ export const bundleOptimization = {
   ],
 };
 
-export default {
+const dynamicImportsConfig = {
   createDynamicComponent,
   lazyLoadSections,
   lazyLoadComponents,
@@ -284,3 +284,5 @@ export default {
   routeCodeSplitting,
   bundleOptimization,
 };
+
+export default dynamicImportsConfig;

--- a/front/web/src/lib/monitoring.ts
+++ b/front/web/src/lib/monitoring.ts
@@ -475,7 +475,7 @@ export const getMonitoringStatus = () => {
   };
 };
 
-export default {
+const monitoringModule = {
   initializeGA4,
   trackPageView,
   trackConversion,
@@ -498,5 +498,6 @@ export default {
   getEnvironment,
   isMonitoringEnabled,
   getMonitoringStatus,
-
 };
+
+export default monitoringModule;

--- a/front/web/src/modules/vitrine/components/forms/NewsletterForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/NewsletterForm.tsx
@@ -123,7 +123,7 @@ export function NewsletterForm({
             icon={<ArrowRight className="w-4 h-4" />}
             iconPosition="right"
           >
-            S'inscrire
+            S&apos;inscrire
           </Button>
         </form>
         {formState.isSuccess && (
@@ -177,7 +177,7 @@ export function NewsletterForm({
               loading={formState.isSubmitting}
               disabled={formState.isSubmitting || formState.isSuccess}
             >
-              S'inscrire
+              S&apos;inscrire
             </Button>
           </form>
         </div>

--- a/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
@@ -230,7 +230,7 @@ export function SignupForm({
               Tester Leopardo avec votre entreprise
             </h2>
             <p className="mb-6 text-sm leading-6 text-slate-600 dark:text-slate-400">
-              Creez votre espace d'essai en 2 minutes. Aucune carte bancaire requise.
+              Creez votre espace d&apos;essai en 2 minutes. Aucune carte bancaire requise.
             </p>
 
             {formState.isError && (
@@ -329,7 +329,7 @@ export function SignupForm({
 
               {role === 'operations' && (
                 <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
-                  Nous preparerons un parcours axe terrain : pointage, taches, kiosk et suivi d'equipe.
+                  Nous preparerons un parcours axe terrain : pointage, taches, kiosk et suivi d&apos;equipe.
                 </div>
               )}
 
@@ -343,9 +343,9 @@ export function SignupForm({
                   {...register('agreeToTerms')}
                 />
                 <label htmlFor="agreeToTerms" className="text-sm text-slate-600 dark:text-slate-400">
-                  J'accepte les{' '}
+                  J&apos;accepte les{' '}
                   <a href="/terms" className="font-semibold text-emerald-600 hover:text-emerald-700">
-                    conditions d'utilisation
+                    conditions d&apos;utilisation
                   </a>{' '}
                   et la{' '}
                   <a href="/privacy" className="font-semibold text-emerald-600 hover:text-emerald-700">
@@ -491,7 +491,7 @@ export function SignupForm({
             </div>
 
             <h2 className="mb-2 text-2xl font-black tracking-tight text-slate-950 dark:text-white">
-              Demande d'essai recue
+              Demande d&apos;essai recue
             </h2>
             <p className="mb-1 text-sm leading-6 text-slate-600 dark:text-slate-400">
               {pendingMessage}
@@ -501,9 +501,9 @@ export function SignupForm({
             </p>
 
             <div className="rounded-xl bg-slate-50 px-4 py-3 text-left text-xs leading-5 text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">
-              Notre systeme de creation d'espace instantane est momentanement
+              Notre systeme de creation d&apos;espace instantane est momentanement
               indisponible (redemarrage serveur). Votre demande est bien
-              enregistree : une personne de l'equipe Leopardo vous contactera
+              enregistree : une personne de l&apos;equipe Leopardo vous contactera
               par email sous 24h ouvrables avec un acces adapte a votre
               contexte.
             </div>
@@ -609,7 +609,7 @@ export function SignupForm({
                     className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
                   >
                     <Download className="h-4 w-4" />
-                    Telecharger l'app
+                    Telecharger l&apos;app
                   </a>
                 </div>
 

--- a/front/web/src/modules/vitrine/components/sections/TestimonialCard.tsx
+++ b/front/web/src/modules/vitrine/components/sections/TestimonialCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Star } from 'lucide-react';
+import Image from 'next/image';
 
 export interface TestimonialCardProps {
   quote: string;
@@ -71,10 +72,12 @@ export function TestimonialCard({
         <div className="flex items-center gap-4">
           {avatar ? (
             <div className="relative w-12 h-12 rounded-full overflow-hidden flex-shrink-0">
-              <img
+              <Image
                 src={avatar}
                 alt={author}
-                className="absolute inset-0 h-full w-full object-cover"
+                fill
+                sizes="48px"
+                className="object-cover"
               />
             </div>
           ) : (


### PR DESCRIPTION
## What Problem This Solves
`front/web/package.json` declares `eslint-config-next` as a dependency, but `eslint.config.mjs` (flat config) only imported `typescript-eslint`. Next.js/React-hooks/accessibility rules were never applied, despite `npm run lint` reporting 0 errors/warnings — a false sense of security.

## Why This Change Was Made
- Imported `eslint-config-next/core-web-vitals` (ready-to-use flat config array on eslint-config-next 16+, no FlatCompat shim needed).
- Pinned `settings.react.version` explicitly — eslint-plugin-react's `detect` mode crashes under ESLint 10's flat-config RuleContext (`context.getFilename is not a function`).
- Fixed every real issue the new rules revealed:
  - `react/no-unescaped-entities`: escaped raw apostrophes with `&apos;` (About, Checkout, Checkout success, NewsletterForm, SignupForm).
  - `import/no-anonymous-default-export`: named the exported config objects in `caching-config.ts`, `dynamic-imports.tsx`, `monitoring.ts`.
  - `@next/next/no-img-element`: replaced `<img>` with `next/image`'s `<Image>` in the smart-attendance session detail page and `TestimonialCard`.
  - `react-hooks/exhaustive-deps`: wrapped `fetchNodes`/`syncPendingData`/`promptInstall` in `useCallback` with correct deps; copied `ref.current` into a local variable before using it in effect cleanups (`useIntersectionObserver`).
- Explicitly disabled (with a documented rationale comment in `eslint.config.mjs`) the new React-Compiler-readiness diagnostics added by `eslint-plugin-react-hooks` v7 (`purity`, `immutability`, `set-state-in-effect`, `incompatible-library`, etc.). These flag long-standing, otherwise-correct Next.js patterns (data-fetching `useEffect` + `setState`, `window.location.href = ...` navigation, etc.) across the whole app. Fixing all of them is a much larger refactor outside this issue's scope. `rules-of-hooks` and `exhaustive-deps` — the rules that catch real bugs — remain fully enabled.

## User Impact
Real Next.js/React-hooks/accessibility lint coverage is now active on `front/web`, closing the gap between the declared dependency and actual enforcement, without breaking the existing build or test suite.

## Evidence
- `npx eslint src --max-warnings 0` → 0 problems.
- `npm run build` → succeeds, 65 routes generated.
- `npx jest` → 14 suites / 267 tests passed.

Fixes #1306