### PR TITLE
fix(ci,security): harden deploy-main.yml against untrusted checkout and cache poisoning

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -23,6 +23,9 @@ jobs:
   prepare:
     name: Prepare deployment context
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     outputs:
       should_deploy: ${{ steps.final.outputs.should_deploy }}
       ref: ${{ steps.context.outputs.ref }}
@@ -87,6 +90,7 @@ jobs:
         with:
           ref: ${{ steps.context.outputs.sha }}
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Resolve parent commit for change detection
         if: steps.context.outputs.should_deploy == 'pending-validation'
@@ -216,6 +220,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     if: needs.prepare.outputs.should_deploy == 'true'
+    permissions:
+      contents: read
 
     steps:
       - name: Validate Render secret
@@ -277,6 +283,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, deploy-api]
     if: needs.prepare.outputs.should_deploy == 'true'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -301,10 +309,51 @@ jobs:
             android_package: com.leopardo.platformadmin
 
     steps:
+      # Defense in depth (CodeQL actions/untrusted-checkout): `needs.prepare.outputs.sha`
+      # is already gated in the `prepare` job to only ever resolve to a SHA whose
+      # upstream workflow_run succeeded, was triggered by a `push` (never a fork
+      # pull_request/pull_request_target), targeted `main`, and ran in this base
+      # repository. CodeQL's actions dataflow analysis cannot see that cross-job
+      # validation, so this job independently re-verifies - right before checkout,
+      # in a privileged (secrets-bearing) context - that the resolved SHA is
+      # actually main itself or an ancestor of main before ever checking it out.
+      - name: Verify deployment SHA is on main before privileged checkout
+        id: verify_sha
+        uses: actions/github-script@v9
+        env:
+          DEPLOY_SHA: ${{ needs.prepare.outputs.sha }}
+        with:
+          script: |
+            const sha = process.env.DEPLOY_SHA;
+            if (!sha) {
+              core.setFailed('No deployment SHA was resolved by the prepare job.');
+              return;
+            }
+
+            const { data } = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `main...${sha}`,
+            });
+
+            core.info(`Comparison of ${sha} against main: status=${data.status}, ahead_by=${data.ahead_by}, behind_by=${data.behind_by}`);
+
+            // "identical" means sha IS the tip of main; "behind" means sha is an
+            // ancestor of main (an older, already-merged commit). Both are safe:
+            // they only ever reference code that a trusted collaborator already
+            // pushed to the protected main branch. "ahead" or "diverged" would mean
+            // the SHA carries commits that are not on main - i.e. potentially
+            // attacker-controlled content smuggled through the workflow_run event -
+            // and must never be checked out here.
+            if (data.status !== 'identical' && data.status !== 'behind') {
+              core.setFailed(`Refusing privileged checkout of ${sha}: it is not main or an ancestor of main (status=${data.status}).`);
+            }
+
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.sha }}
+          persist-credentials: false
 
       - name: Resolve Firebase distribution readiness
         id: firebase_ready


### PR DESCRIPTION
## Summary

Fixes the CodeQL security findings on `.github/workflows/deploy-main.yml` reported in #1317: an `actions/untrusted-checkout` alert (currently open at **critical** severity as alert #28) plus the historical `actions/untrusted-checkout/high` and `actions/cache-poisoning/code-injection` alerts (#1, #2) on the same file.

`deploy-main.yml` runs on `workflow_run` completion, which is a **privileged** trigger: it has access to `secrets.RENDER_DEPLOY_HOOK_URL`, `secrets.FIREBASE_TOKEN`, and per-app Firebase secrets. A privileged workflow that checks out and later executes code from an insufficiently-verified SHA is exactly the "pwn request" pattern CodeQL is designed to catch.

## Root cause

- The `prepare` job already gates `should_deploy` correctly: it only resolves a deployable SHA when the upstream `workflow_run` succeeded, was itself triggered by a `push` (never `pull_request`/`pull_request_target` from a fork), targeted `main`, and ran in this base repository — and it already routes every `github.event.workflow_run.*` value through step `env:` before use (blocking expression/script injection in the cache-poisoning sense).
- However, that validation lives in the `prepare` job. The `distribute-mobile` job (and, to a lesser extent, `deploy-api`) consumes `needs.prepare.outputs.sha` and checks it out directly. CodeQL's actions dataflow analysis is scoped per-job/per-step; it cannot see that the SHA was already vetted in a different job, so it correctly flags the checkout in `distribute-mobile` as unverified from its own vantage point (alert #28, critical).
- None of the three jobs declared explicit least-privilege `permissions:`, relying solely on the workflow-level default. That made the actual trust boundary harder to audit, both for CodeQL and for human reviewers.

## Fix

- **Explicit least-privilege `permissions:` on every job** (`prepare`, `deploy-api`, `distribute-mobile`): `contents: read` everywhere, plus `actions: read` on `prepare` (needed for the `workflow_run` conclusion lookup via `actions/github-script`).
- **`persist-credentials: false`** on both `actions/checkout` steps, so the runner's `GITHUB_TOKEN` is never persisted in git config — reduces blast radius if a later step in the same job is compromised (e.g. a malicious `npm`/`pod`/gradle script during the mobile build).
- **New same-job runtime verification step in `distribute-mobile`**: "Verify deployment SHA is on main before privileged checkout" uses `actions/github-script` + `compareCommitsWithBasehead('main...<sha>')` to confirm the resolved SHA is `main` itself (`identical`) or an ancestor of `main` (`behind`) *immediately before the privileged checkout*, in the same job that has secrets. Any other comparison status (`ahead`/`diverged`) — meaning the SHA carries commits not present on the protected `main` branch — fails the job closed instead of checking it out.

This directly closes the CodeQL-flagged gap: validation is no longer only visible across job boundaries, it is now also independently re-verified at the point of privileged checkout in `distribute-mobile`.

## Verification

- `actionlint` (github.com/rhysd/actionlint) run against the modified file and the full `.github/workflows/` tree: no new findings, no regressions.
- `js-yaml` parse check confirms the modified workflow is structurally valid YAML with the expected job/step shape (`prepare`, `deploy-api`, `distribute-mobile` all present with their new `permissions:` blocks; `distribute-mobile` steps now start with the verification step followed by checkout).
- Reviewed diff line-by-line against the exact CodeQL alert locations (`most_recent_instance.location` for alerts #1, #2, #28 via `gh api repos/.../code-scanning/alerts/<n>`) to confirm the fix targets the actual flagged lines/job.

## Risk / rollback

No behavior change for the happy path: `should_deploy` gating, the Render deploy, and the Firebase distribution flow are unchanged. The only new failure mode is the added verification step failing closed if `needs.prepare.outputs.sha` is ever not `main`/an ancestor of `main` — which is the intended fail-safe behavior, not a regression.

Fixes kitokoh/leopardo-hr#1317
