### PR TITLE
fix(ci): avoid bash unbound-variable crash in PHPStan baseline delta guard

### DIFF
--- a/dev-hub/tools/check-phpstan-baseline-delta.sh
+++ b/dev-hub/tools/check-phpstan-baseline-delta.sh
@@ -106,7 +106,7 @@ if [ ${#touched_php_files[@]} -eq 0 ]; then
   exit 0
 fi
 
-declare -A touched_modules
+declare -A touched_modules=()
 
 for f in "${touched_php_files[@]}"; do
   rel="${f#"${API_DIR}"/}"


### PR DESCRIPTION
## Problem
`dev-hub/tools/check-phpstan-baseline-delta.sh` (PA2-ARCH-005, part of the Module Structure Validator workflow) declares its `touched_modules` associative array with a bare `declare -A touched_modules`. Under `set -u`, reading `${#touched_modules[@]}` on an array that was never assigned a key throws `unbound variable` and fails the job — independent of whether the PR's actual changes are fine.

This affects any PR whose diff only touches legacy `api/app/Http` or `api/app/Services` files (outside the `Core/<X>`, `Modules/<X>`, `Shared` module boundary the script buckets by), since `touched_modules` is then never populated. Observed on PR #1362.

## Fix
Initialize the array as `declare -A touched_modules=()`. Bash treats this as already-set, so `${#touched_modules[@]}` reads 0 safely under `set -u` instead of crashing. Behavior is otherwise unchanged (still short-circuits with the existing informational message when no module-scoped PHP file was touched).

## Verification
Ran the script directly against PR #1362's base/head SHAs:
```
$ bash dev-hub/tools/check-phpstan-baseline-delta.sh 178f6c8a... 5fa369c4... api
This diff only touches legacy app/Http, app/Services or non-module code — no per-module baseline to check (see PHPSTAN_BASELINE_REDUCTION_PLAN.md Phase 3).
exit: 0
```
Previously this crashed with `line 120: touched_modules: unbound variable`.