### PR TITLE
docs(ci): fix stale architecture CI/CD doc (scanner, branch model, PHPStan levels, coverage)

### DIFF
--- a/docs/ARCHITECTURE_CICD.md
+++ b/docs/ARCHITECTURE_CICD.md
@@ -1,29 +1,36 @@
 # Architecture CI/CD — Leopardo RH
 
-> Dernière mise à jour : 2026-07-01
+> Dernière mise à jour : 2026-07-26
 
 ## Vue d'ensemble
 
+Le repo est en **trunk-based development** : il n'existe pas de branche `develop` ni de
+branche `staging` (vérifié via `git ls-remote` — seules `main` et des branches
+`feature/*`/`fix/*` courte durée de vie existent). Tout part de branches courtes
+fusionnées dans `main` par PR (branche protégée), et les déploiements staging/production
+sont enchaînés automatiquement après les checks CI sur `main` via `workflow_run`
+(pas de push direct déclenchant un déploiement) :
+
 ```
-git push
+PR → merge sur main
     │
-    ├─ develop → staging deploy (auto)
-    └─ main    → production deploy (auto)
+    ├─ workflow_run("Tests - Leopardo RH" sur main) → deploy-staging.yml → Render staging
+    └─ workflow_run("Tests - Leopardo RH" / "Web CI - Leopardo Admin") → deploy-main.yml → Render production
 ```
 
 ## Workflows GitHub Actions
 
 | Workflow | Déclencheur | Rôle |
 |----------|-------------|------|
-| `tests.yml` | PR + push develop/main | Tests PHP + couverture |
-| `coverage-gate.yml` | PR develop/main (api/) | Gate couverture min 65% |
+| `tests.yml` | PR + push main | Tests PHP + couverture |
+| `coverage-gate.yml` | PR main (api/) | Gate couverture min (voir "Gates de qualité") |
 | `mobile-apps-ci.yml` | PR + push (front/mobile_apps/) | Tests Flutter + analyze |
 | `web-ci.yml` | PR + push (front/web/) | Build Next.js + lint |
 | `openapi-ci.yml` | PR + push (api/openapi/) | Validation spec OpenAPI |
-| `architecture-check.yml` | PR | Vérification DDD boundaries |
-| `deploy-staging.yml` | push develop | Deploy staging Render |
-| `deploy-main.yml` | push main | Deploy production Render |
-| `secret-scan.yml` | PR | Scan fuites secrets (GitLeaks) |
+| `architecture-check.yml` | PR | Vérification DDD boundaries + PHPStan modules/strict |
+| `deploy-staging.yml` | `workflow_run` sur "Tests - Leopardo RH" (branche main) | Deploy staging Render |
+| `deploy-main.yml` | `workflow_run` sur "Tests - Leopardo RH" / "Web CI - Leopardo Admin" | Deploy production Render |
+| `secret-scan.yml` | PR | Scan fuites secrets (TruffleHog) |
 | `codeql.yml` | schedule + PR | Analyse sécurité statique |
 
 ## Environnements
@@ -65,8 +72,19 @@ git push
 ## Gates de qualité
 
 ### Backend
-- **PHPStan** niveau 6 — bloquant
-- **Coverage minimum** : 65% (variable `BACKEND_COVERAGE_MIN`)
+- **PHPStan** : 3 configurations distinctes coexistent (voir `api/phpstan*.neon`) :
+
+  | Config | Niveau | Job CI | Bloquant ? |
+  |--------|--------|--------|------------|
+  | `phpstan-modules.neon` | 5 | `architecture-check.yml` (job `phpstan-modules`) | Oui — requis en branch protection |
+  | `phpstan.neon` | `max` | non exécuté en CI actuellement | — |
+  | `phpstan-strict.neon` | 8 | `architecture-check.yml` (`continue-on-error`) | Non — informatif seulement |
+
+- **Coverage minimum** : `BACKEND_COVERAGE_MIN` (variable GitHub). Défaut actuel
+  (`DEFAULT_BACKEND_COVERAGE_MIN`) = **60%** à la fois dans `tests.yml` et
+  `coverage-gate.yml` (les deux workflows sont alignés depuis la résolution de
+  l'issue #1310). La cible "ratchet" (à relever progressivement) mentionnée dans
+  `coverage-gate.yml` est 65%, mais ce n'est pas (encore) la valeur par défaut appliquée.
 - **Tests** : PHPUnit 11 sur PostgreSQL 16
 
 ### Mobile
@@ -85,6 +103,8 @@ RENDER_SERVICE_ID_WORKER # ID du Background Worker
 SENTRY_AUTH_TOKEN        # Upload sourcemaps
 ```
 
+Voir aussi `docs/CI_CD_SECRETS.md` pour le détail complet des secrets et de leur rotation.
+
 ## Architecture Redis
 
 Toutes les queues partagent la même instance Upstash Redis (TLS).
@@ -98,10 +118,19 @@ Priority par queue :
 
 ## Modèle de branches
 
+Le repo suit un modèle **trunk-based** : il n'y a pas de branche `develop`/`staging`
+longue durée (vérifié via `git ls-remote` — seule `main` persiste, le reste sont des
+branches de travail courtes). Le staging est déployé automatiquement depuis `main`
+après CI verte (voir "Vue d'ensemble" ci-dessus), pas via une branche dédiée.
+
 ```
-main       ← production (protégée, PR obligatoires)
-develop    ← staging (intégration continue)
-feat/*     ← fonctionnalités
-fix/*      ← corrections de bugs
-hotfix/*   ← correctifs urgents prod
+main            ← production ET source du deploy staging (protégée, PR obligatoires)
+feature/issue-N ← travail sur une issue GitHub spécifique
+fix/*           ← corrections de bugs
+hotfix/*        ← correctifs urgents prod
 ```
+
+> Historique : une précédente version de ce document décrivait un modèle `main`
+> (production) / `develop` (staging) avec push direct déclenchant les déploiements.
+> Ce modèle a été abandonné (migration vers trunk-based) et n'est plus représentatif
+> du fonctionnement actuel du CI/CD ; conservé ici uniquement à titre de contexte.


### PR DESCRIPTION
## What Problem This Solves
`docs/ARCHITECTURE_CICD.md` (last updated 2026-07-01) had several factual inaccuracies vs the current codebase and CI config.

## Why This Change Was Made
1. Secret scanner is TruffleHog (`secret-scan.yml`), not GitLeaks.
2. There is no `develop`/`staging` branch (verified via `git ls-remote`) - repo is trunk-based on `main`; staging and production deploys are both triggered via `workflow_run` after CI passes on `main`, not push to a dedicated branch.
3. "PHPStan niveau 6 - bloquant" was wrong; there are 3 separate configs (`phpstan-modules.neon` level 5 blocking, `phpstan.neon` level max not run in CI, `phpstan-strict.neon` level 8 continue-on-error).
4. `BACKEND_COVERAGE_MIN` default is 60 in both `tests.yml` and `coverage-gate.yml` (aligned since #1310); 65 is a ratchet target, not the current default.

## User Impact
Engineers reading this doc now get accurate CI/CD architecture info instead of a stale/misleading branch model and gate description.

## Evidence
- grep -n trufflehog .github/workflows/secret-scan.yml -> confirms TruffleHog usage.
- git ls-remote --heads origin -> only main + short-lived feature/*/fix/* branches, no develop.
- grep -n level api/phpstan*.neon -> modules=5, base=max, strict=8.
- grep -rn BACKEND_COVERAGE_MIN .github/workflows/*.yml -> both default to 60.

Fixes #1309