### PR TITLE
fix(mobile): use real Cloud-issued edgeNodeId in SyncService push/pull

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/offline/README.md
+++ b/front/mobile_apps/leopardo_core/lib/offline/README.md
@@ -33,6 +33,10 @@ final syncService = SyncService(
   dio: Dio(),
   edgeBaseUrl: 'http://leopardo.local:7878',
   cloudBaseUrl: 'https://api.leopardo.app',
+  // Cloud-issued UUID for this Edge node (distinct from edgeToken).
+  // Obtained at enrollment together with the token — see the
+  // `install_command` returned by `POST /api/v1/edge` (Cloud admin API).
+  edgeNodeId: prefs.getString('edge_node_id') ?? '',
   edgeToken: prefs.getString('edge_token') ?? '',
 );
 syncService.start();

--- a/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
@@ -17,7 +17,8 @@ class SyncService {
   final Dio _dio;
   final String _edgeBaseUrl;   // e.g. http://leopardo.local:7878
   final String _cloudBaseUrl;  // e.g. https://api.leopardo.app
-  final String _edgeToken;
+  final String _edgeNodeId;    // Cloud-issued UUID for this Edge node
+  final String _edgeToken;     // Bearer secret, distinct from _edgeNodeId
 
   SyncMode _currentMode = SyncMode.offline;
   Timer? _syncTimer;
@@ -32,11 +33,13 @@ class SyncService {
     required Dio dio,
     required String edgeBaseUrl,
     required String cloudBaseUrl,
+    required String edgeNodeId,
     required String edgeToken,
   })  : _db = db,
         _dio = dio,
         _edgeBaseUrl = edgeBaseUrl,
         _cloudBaseUrl = cloudBaseUrl,
+        _edgeNodeId = edgeNodeId,
         _edgeToken = edgeToken;
 
   /// Initialise connectivity monitoring + periodic sync.
@@ -137,9 +140,12 @@ class SyncService {
         }).toList();
 
         try {
-          final target = _currentMode == SyncMode.cloud
-              ? '$_cloudBaseUrl/api/v1/edge-node/${_edgeToken.substring(0, 8)}/push'
-              : '$_edgeBaseUrl/api/v1/edge/push';
+          // Both the Cloud API and the local Edge node instance expose the
+          // same EdgeSync module routes (the Edge box runs the same Laravel
+          // app image), so the path is identical — only the base URL and
+          // the real edgeNodeId (a Cloud-issued UUID, distinct from the
+          // bearer edgeToken) differ.
+          final target = '${_activeBaseUrl()}/api/v1/edge-node/$_edgeNodeId/push';
 
           await _dio.post(
             target,
@@ -170,11 +176,13 @@ class SyncService {
     return SyncResult.success(sent: sent, failed: failed);
   }
 
+  /// The Cloud or Edge base URL currently in use, matching [_currentMode].
+  String _activeBaseUrl() =>
+      _currentMode == SyncMode.cloud ? _cloudBaseUrl : _edgeBaseUrl;
+
   Future<void> _pullDelta() async {
     try {
-      final url = _currentMode == SyncMode.cloud
-          ? '$_cloudBaseUrl/api/v1/edge-node/${_edgeToken.substring(0, 8)}/pull'
-          : '$_edgeBaseUrl/api/v1/edge/pull';
+      final url = '${_activeBaseUrl()}/api/v1/edge-node/$_edgeNodeId/pull';
 
       final response = await _dio.get(
         url,


### PR DESCRIPTION
## Problem
`SyncService` (leopardo_core offline module) used `_edgeToken.substring(0, 8)` as the `{nodeId}` path segment when calling the Cloud sync endpoints. The Cloud-side node id is a full UUID assigned at Edge node registration (`EdgeNodeController::store()`), not the first 8 characters of the bearer token — every push/pull call would 404 as soon as the offline module is wired into an app.

The local Edge-mode target was also wrong: it pointed at `$_edgeBaseUrl/api/v1/edge/push`, a route that doesn't exist. The Edge box runs the exact same Laravel app image as the Cloud API (see `edge/docker-compose.yml` + the EdgeSync module routes), so both Cloud and Edge modes should hit the same `api/v1/edge-node/{nodeId}/push` and `.../pull` paths — only the base URL and the real node id differ.

## Fix
- Added a required `edgeNodeId` constructor parameter, distinct from the existing `edgeToken`, obtained at enrollment (the `install_command`/response returned by `POST /api/v1/edge` on the Cloud admin API already includes the real node UUID).
- Introduced `_activeBaseUrl()` to pick Cloud vs Edge base URL based on `_currentMode`, used consistently for both push and pull.
- Updated the offline module README's integration example.

## Verification
No Dart/Flutter toolchain available in this environment to run `flutter analyze`/tests, so this was reviewed manually — the diff is small, mechanical, and doesn't change any other call sites (no other code in the repo instantiates this `SyncService`).

Fixes #1293