### PR TITLE
fix(mobile): wire up OfflineSyncService.init() in leopardo_employee

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/services/offline_sync_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/services/offline_sync_service.dart
@@ -11,9 +11,19 @@ class OfflineSyncService {
 
   OfflineSyncService(this.apiClient, this.connectivity);
 
+  bool _initialized = false;
+
   Future<void> init() async {
-    _offlineBox = await Hive.openBox<Map<dynamic, dynamic>>('offline_punches');
-    
+    // Guard against being called more than once for the same instance
+    // (e.g. logout followed by a fresh login in the same app session):
+    // without this, each call would attach another connectivity listener.
+    if (_initialized) return;
+    _initialized = true;
+
+    _offlineBox = Hive.isBoxOpen('offline_punches')
+        ? Hive.box<Map<dynamic, dynamic>>('offline_punches')
+        : await Hive.openBox<Map<dynamic, dynamic>>('offline_punches');
+
     // Listen to network changes
     _connectivitySub = connectivity.onConnectivityChanged.listen((List<ConnectivityResult> results) {
       if (results.any((result) => result != ConnectivityResult.none)) {

--- a/front/mobile_apps/leopardo_employee/lib/app.dart
+++ b/front/mobile_apps/leopardo_employee/lib/app.dart
@@ -240,6 +240,10 @@ class LeopardoApp extends ConsumerWidget {
               .read(pushNotificationServiceProvider)
               .initialize(apiClient: ref.read(apiClientProvider)),
         );
+        // Replay any check-in/check-out saved offline while unauthenticated
+        // or disconnected (issue #1290): without this the offline_punches
+        // Hive box is never drained.
+        unawaited(ref.read(offlineSyncServiceProvider).init());
       }
     });
 

--- a/front/mobile_apps/leopardo_employee/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_employee/lib/core/providers/core_providers.dart
@@ -1,6 +1,8 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
 import 'package:leopardo_core/core/location/attendance_location_service.dart';
+import 'package:leopardo_core/core/services/offline_sync_service.dart';
 import 'package:leopardo_core/core/services/push_notification_service.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
@@ -42,6 +44,16 @@ final pushNotificationServiceProvider = Provider<PushNotificationService>((
   ref,
 ) {
   return PushNotificationService();
+});
+
+/// Replays the `offline_punches` Hive box written by [AttendanceRepository]
+/// (see issue #1290) whenever connectivity comes back. Without this, offline
+/// check-in/check-out attempts stay stuck in Hive forever.
+final offlineSyncServiceProvider = Provider<OfflineSyncService>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  final service = OfflineSyncService(apiClient, Connectivity());
+  ref.onDispose(service.dispose);
+  return service;
 });
 
 final attendanceLocationServiceProvider = Provider<AttendanceLocationService>((

--- a/front/mobile_apps/leopardo_employee/pubspec.yaml
+++ b/front/mobile_apps/leopardo_employee/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   shimmer: ^3.0.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  connectivity_plus: ^7.3.0
   path_provider: ^2.1.3
   image_picker: ^1.2.3
   local_auth: ^3.0.2


### PR DESCRIPTION
## What Problem This Solves
`AttendanceRepository.checkIn()/checkOut()` in `leopardo_employee` already falls back to writing failed punches into a Hive box named `offline_punches`, but `OfflineSyncService` — the service meant to drain that box once connectivity returns — was never instantiated anywhere in the app. `grep -rln "OfflineSyncService(" front/mobile_apps` only matched its own class definition in `leopardo_core`.

## Why This Change Was Made
- Added an `offlineSyncServiceProvider` (Riverpod) in `leopardo_employee` that builds an `OfflineSyncService` bound to the existing `apiClientProvider` and a real `Connectivity()` instance.
- Call `offlineSyncServiceProvider.init()` from `LeopardoApp`'s `build()`, triggered the same way push notifications already are (on the employee auth state transitioning to a logged-in employee) — replaying a punch requires an authenticated API client anyway.
- Made `OfflineSyncService.init()` idempotent (guard flag + reuse an already-open Hive box) so repeated logout/login cycles in the same app session don't stack multiple connectivity listeners.
- Added `connectivity_plus` as an explicit direct dependency in `leopardo_employee`'s `pubspec.yaml` (previously only pulled in transitively via `leopardo_core`; it's already resolved in `pubspec.lock`, no version bump needed).

## User Impact
Without this wiring, a punch made offline (weak signal, tunnel, basement, etc.) stayed stuck in the local `offline_punches` Hive box forever — unrecorded, unpaid work time that would silently disappear if the employee ever uninstalled the app. Now the queue actually drains as soon as connectivity (and an authenticated session) is available.

## Evidence
Flutter/Dart tooling is not available in this execution environment, so this was verified by manual code review (brace-balance check on every touched file, cross-referencing the exact Hive box name/payload shape between `AttendanceRepository` and `OfflineSyncService`, and confirming `connectivity_plus` is already present in `pubspec.lock` via the `leopardo_core` transitive dependency). CI's Flutter analyze/build job on this PR is the authoritative check.

Fixes #1290