### PR TITLE
fix(mobile): add offline fallback to leopardo_manager/leopardo_hr check-in/check-out

### DIFF
--- a/front/mobile_apps/leopardo_hr/lib/app.dart
+++ b/front/mobile_apps/leopardo_hr/lib/app.dart
@@ -292,6 +292,10 @@ class LeopardoApp extends ConsumerWidget {
               .read(pushNotificationServiceProvider)
               .initialize(apiClient: ref.read(apiClientProvider)),
         );
+        // Replay any check-in/check-out saved offline while disconnected
+        // (issue #1289): without this the offline_punches Hive box is
+        // never drained.
+        unawaited(ref.read(offlineSyncServiceProvider).init());
       }
     });
 

--- a/front/mobile_apps/leopardo_hr/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_hr/lib/core/providers/core_providers.dart
@@ -1,6 +1,8 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
 import 'package:leopardo_core/core/location/attendance_location_service.dart';
+import 'package:leopardo_core/core/services/offline_sync_service.dart';
 import 'package:leopardo_core/core/services/push_notification_service.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
@@ -44,6 +46,15 @@ final pushNotificationServiceProvider = Provider<PushNotificationService>((
   ref,
 ) {
   return PushNotificationService();
+});
+
+/// Replays the `offline_punches` Hive box written by [AttendanceRepository]
+/// when check-in/check-out fails offline (see issue #1289).
+final offlineSyncServiceProvider = Provider<OfflineSyncService>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  final service = OfflineSyncService(apiClient, Connectivity());
+  ref.onDispose(service.dispose);
+  return service;
 });
 
 final attendanceLocationServiceProvider = Provider<AttendanceLocationService>((

--- a/front/mobile_apps/leopardo_hr/lib/features/attendance/data/attendance_repository.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/attendance/data/attendance_repository.dart
@@ -1,4 +1,6 @@
+import 'package:hive/hive.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_exceptions.dart';
 import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/models/attendance_log.dart';
 import 'package:leopardo_core/models/daily_summary.dart';
@@ -27,19 +29,29 @@ class AttendanceRepository {
     double? gpsLng,
     double? gpsAccuracy,
   }) async {
-    final response = await apiClient.requestWithRetry(
-      '/attendance/check-in',
-      method: 'POST',
-      data: {
-        'device_timezone': _deviceTimezoneContext(),
-        if (gpsLat != null) 'gps_lat': gpsLat,
-        if (gpsLng != null) 'gps_lng': gpsLng,
-        if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
-      },
-      maxRetriesOverride: 0,
-      timeoutOverride: _actionTimeout,
-    );
-    return AttendanceLog.fromJson(_dataMap(response.data));
+    final payload = {
+      'device_timezone': _deviceTimezoneContext(),
+      if (gpsLat != null) 'gps_lat': gpsLat,
+      if (gpsLng != null) 'gps_lng': gpsLng,
+      if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
+    };
+
+    try {
+      final response = await apiClient.requestWithRetry(
+        '/attendance/check-in',
+        method: 'POST',
+        data: payload,
+        maxRetriesOverride: 0,
+        timeoutOverride: _actionTimeout,
+      );
+      return AttendanceLog.fromJson(_dataMap(response.data));
+    } catch (e) {
+      if (_isOfflineError(e)) {
+        await _saveOfflinePunch('check-in', payload);
+        return _offlinePendingLog(checkIn: true);
+      }
+      rethrow;
+    }
   }
 
   Future<AttendanceLog> checkOut({
@@ -47,19 +59,68 @@ class AttendanceRepository {
     double? gpsLng,
     double? gpsAccuracy,
   }) async {
-    final response = await apiClient.requestWithRetry(
-      '/attendance/check-out',
-      method: 'POST',
-      data: {
-        'device_timezone': _deviceTimezoneContext(),
-        if (gpsLat != null) 'gps_lat': gpsLat,
-        if (gpsLng != null) 'gps_lng': gpsLng,
-        if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
-      },
-      maxRetriesOverride: 0,
-      timeoutOverride: _actionTimeout,
+    final payload = {
+      'device_timezone': _deviceTimezoneContext(),
+      if (gpsLat != null) 'gps_lat': gpsLat,
+      if (gpsLng != null) 'gps_lng': gpsLng,
+      if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
+    };
+
+    try {
+      final response = await apiClient.requestWithRetry(
+        '/attendance/check-out',
+        method: 'POST',
+        data: payload,
+        maxRetriesOverride: 0,
+        timeoutOverride: _actionTimeout,
+      );
+      return AttendanceLog.fromJson(_dataMap(response.data));
+    } catch (e) {
+      if (_isOfflineError(e)) {
+        await _saveOfflinePunch('check-out', payload);
+        return _offlinePendingLog(checkIn: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// Mirrors the fallback used by `leopardo_employee`'s
+  /// `AttendanceRepository`: on a network failure, queue the punch in the
+  /// same `offline_punches` Hive box so [OfflineSyncService] (wired up in
+  /// `leopardo_core`) can replay it once connectivity returns, instead of
+  /// letting the raw `ApiException` reach the UI and lose the punch
+  /// (issue #1289).
+  static bool _isOfflineError(Object e) {
+    return e is ApiException &&
+        (e.message.toLowerCase().contains('connexion') ||
+            e.message.toLowerCase().contains('internet'));
+  }
+
+  static Future<void> _saveOfflinePunch(
+    String type,
+    Map<String, dynamic> payload,
+  ) async {
+    final box = Hive.isBoxOpen('offline_punches')
+        ? Hive.box<Map<dynamic, dynamic>>('offline_punches')
+        : await Hive.openBox<Map<dynamic, dynamic>>('offline_punches');
+    await box.add({
+      'type': type,
+      'payload': payload,
+      'timestamp': DateTime.now().toIso8601String(),
+    });
+  }
+
+  static AttendanceLog _offlinePendingLog({required bool checkIn}) {
+    final now = DateTime.now();
+    return AttendanceLog(
+      id: 0,
+      employeeId: 0,
+      date: DateTime(now.year, now.month, now.day),
+      status: 'offline_sync_pending',
+      employeeName: 'Vous',
+      checkIn: checkIn ? now : null,
+      checkOut: checkIn ? null : now,
     );
-    return AttendanceLog.fromJson(_dataMap(response.data));
   }
 
   Future<AttendanceLog> updateAttendanceLog({

--- a/front/mobile_apps/leopardo_hr/pubspec.yaml
+++ b/front/mobile_apps/leopardo_hr/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   shimmer: ^3.0.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  connectivity_plus: ^7.3.0
   path_provider: ^2.1.3
   image_picker: ^1.2.3
   local_auth: ^3.0.2

--- a/front/mobile_apps/leopardo_manager/lib/app.dart
+++ b/front/mobile_apps/leopardo_manager/lib/app.dart
@@ -294,6 +294,10 @@ class LeopardoApp extends ConsumerWidget {
               .read(pushNotificationServiceProvider)
               .initialize(apiClient: ref.read(apiClientProvider)),
         );
+        // Replay any check-in/check-out saved offline while disconnected
+        // (issue #1289): without this the offline_punches Hive box is
+        // never drained.
+        unawaited(ref.read(offlineSyncServiceProvider).init());
       }
     });
 

--- a/front/mobile_apps/leopardo_manager/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_manager/lib/core/providers/core_providers.dart
@@ -1,6 +1,8 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
 import 'package:leopardo_core/core/location/attendance_location_service.dart';
+import 'package:leopardo_core/core/services/offline_sync_service.dart';
 import 'package:leopardo_core/core/services/push_notification_service.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
@@ -44,6 +46,15 @@ final pushNotificationServiceProvider = Provider<PushNotificationService>((
   ref,
 ) {
   return PushNotificationService();
+});
+
+/// Replays the `offline_punches` Hive box written by [AttendanceRepository]
+/// when check-in/check-out fails offline (see issue #1289).
+final offlineSyncServiceProvider = Provider<OfflineSyncService>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  final service = OfflineSyncService(apiClient, Connectivity());
+  ref.onDispose(service.dispose);
+  return service;
 });
 
 final attendanceLocationServiceProvider = Provider<AttendanceLocationService>((

--- a/front/mobile_apps/leopardo_manager/lib/features/attendance/data/attendance_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/attendance/data/attendance_repository.dart
@@ -1,4 +1,6 @@
+import 'package:hive/hive.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
+import 'package:leopardo_core/core/api/api_exceptions.dart';
 import 'package:leopardo_core/core/api/api_payload.dart';
 import 'package:leopardo_core/models/attendance_log.dart';
 import 'package:leopardo_core/models/daily_summary.dart';
@@ -27,19 +29,29 @@ class AttendanceRepository {
     double? gpsLng,
     double? gpsAccuracy,
   }) async {
-    final response = await apiClient.requestWithRetry(
-      '/attendance/check-in',
-      method: 'POST',
-      data: {
-        'device_timezone': _deviceTimezoneContext(),
-        if (gpsLat != null) 'gps_lat': gpsLat,
-        if (gpsLng != null) 'gps_lng': gpsLng,
-        if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
-      },
-      maxRetriesOverride: 0,
-      timeoutOverride: _actionTimeout,
-    );
-    return AttendanceLog.fromJson(_dataMap(response.data));
+    final payload = {
+      'device_timezone': _deviceTimezoneContext(),
+      if (gpsLat != null) 'gps_lat': gpsLat,
+      if (gpsLng != null) 'gps_lng': gpsLng,
+      if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
+    };
+
+    try {
+      final response = await apiClient.requestWithRetry(
+        '/attendance/check-in',
+        method: 'POST',
+        data: payload,
+        maxRetriesOverride: 0,
+        timeoutOverride: _actionTimeout,
+      );
+      return AttendanceLog.fromJson(_dataMap(response.data));
+    } catch (e) {
+      if (_isOfflineError(e)) {
+        await _saveOfflinePunch('check-in', payload);
+        return _offlinePendingLog(checkIn: true);
+      }
+      rethrow;
+    }
   }
 
   Future<AttendanceLog> checkOut({
@@ -47,19 +59,68 @@ class AttendanceRepository {
     double? gpsLng,
     double? gpsAccuracy,
   }) async {
-    final response = await apiClient.requestWithRetry(
-      '/attendance/check-out',
-      method: 'POST',
-      data: {
-        'device_timezone': _deviceTimezoneContext(),
-        if (gpsLat != null) 'gps_lat': gpsLat,
-        if (gpsLng != null) 'gps_lng': gpsLng,
-        if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
-      },
-      maxRetriesOverride: 0,
-      timeoutOverride: _actionTimeout,
+    final payload = {
+      'device_timezone': _deviceTimezoneContext(),
+      if (gpsLat != null) 'gps_lat': gpsLat,
+      if (gpsLng != null) 'gps_lng': gpsLng,
+      if (gpsAccuracy != null) 'gps_accuracy': gpsAccuracy,
+    };
+
+    try {
+      final response = await apiClient.requestWithRetry(
+        '/attendance/check-out',
+        method: 'POST',
+        data: payload,
+        maxRetriesOverride: 0,
+        timeoutOverride: _actionTimeout,
+      );
+      return AttendanceLog.fromJson(_dataMap(response.data));
+    } catch (e) {
+      if (_isOfflineError(e)) {
+        await _saveOfflinePunch('check-out', payload);
+        return _offlinePendingLog(checkIn: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// Mirrors the fallback used by `leopardo_employee`'s
+  /// `AttendanceRepository`: on a network failure, queue the punch in the
+  /// same `offline_punches` Hive box so [OfflineSyncService] (wired up in
+  /// `leopardo_core`) can replay it once connectivity returns, instead of
+  /// letting the raw `ApiException` reach the UI and lose the punch
+  /// (issue #1289).
+  static bool _isOfflineError(Object e) {
+    return e is ApiException &&
+        (e.message.toLowerCase().contains('connexion') ||
+            e.message.toLowerCase().contains('internet'));
+  }
+
+  static Future<void> _saveOfflinePunch(
+    String type,
+    Map<String, dynamic> payload,
+  ) async {
+    final box = Hive.isBoxOpen('offline_punches')
+        ? Hive.box<Map<dynamic, dynamic>>('offline_punches')
+        : await Hive.openBox<Map<dynamic, dynamic>>('offline_punches');
+    await box.add({
+      'type': type,
+      'payload': payload,
+      'timestamp': DateTime.now().toIso8601String(),
+    });
+  }
+
+  static AttendanceLog _offlinePendingLog({required bool checkIn}) {
+    final now = DateTime.now();
+    return AttendanceLog(
+      id: 0,
+      employeeId: 0,
+      date: DateTime(now.year, now.month, now.day),
+      status: 'offline_sync_pending',
+      employeeName: 'Vous',
+      checkIn: checkIn ? now : null,
+      checkOut: checkIn ? null : now,
     );
-    return AttendanceLog.fromJson(_dataMap(response.data));
   }
 
   Future<AttendanceLog> updateAttendanceLog({

--- a/front/mobile_apps/leopardo_manager/pubspec.yaml
+++ b/front/mobile_apps/leopardo_manager/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   shimmer: ^3.0.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  connectivity_plus: ^7.3.0
   path_provider: ^2.1.3
   image_picker: ^1.2.3
   local_auth: ^3.0.2


### PR DESCRIPTION
## What Problem This Solves
Unlike `leopardo_employee` (which already has a basic Hive fallback), `AttendanceRepository.checkIn()/checkOut()` in `leopardo_manager` and `leopardo_hr` called the API directly with no try/catch fallback. A network failure raised an `ApiException` straight to the UI with no local save, so a manager or HR user punching in/out with unreliable connectivity (client site visit, basement, etc.) simply lost that punch — a regression versus the employee app.

## Why This Change Was Made
- Mirrored the exact fallback pattern already used by `leopardo_employee`: on a network-related `ApiException` (message contains 'connexion' or 'internet'), queue the punch into the same `offline_punches` Hive box (same `type`/`payload`/`timestamp` shape) instead of letting the error propagate, and return a synthetic `AttendanceLog` with status `offline_sync_pending` so the UI can reflect that state.
- Wired up `offlineSyncServiceProvider` (`OfflineSyncService` bound to `apiClientProvider` + `Connectivity()`) in both apps' `core_providers.dart`, and call `.init()` from `LeopardoApp`'s `build()` on the auth state transitioning to a logged-in user — same trigger point already used for push notification registration.
- Added `connectivity_plus` as an explicit direct dependency in both `pubspec.yaml` files (already resolved transitively via `leopardo_core`, no `pubspec.lock` changes needed).

## User Impact
Harmonizes offline behavior across the 3 attendance-punching apps (employee/manager/hr) instead of leaving managers/HR without any network-failure safety net for their own check-in/check-out.

## Evidence
Flutter/Dart tooling is not available in this execution environment, so this was verified by manual code review: brace-balance check on every touched file, and cross-referencing the exact Hive box name/payload shape against the existing `leopardo_employee` implementation and the paired PR for #1290 (kitokoh/leopardo-hr#1371) which wires the same `OfflineSyncService` pattern. CI's Flutter analyze/build job on this PR is the authoritative check.

Fixes #1289