### PR TITLE
fix(mobile): restore StartupGate loading-state text lost in Lot 2+3 redesign

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/widgets/startup_gate.dart
@@ -176,7 +176,7 @@ class _StartupGateState extends State<StartupGate> {
                               ),
                             ),
                             const SizedBox(height: 12),
-                            if (_startupWarning == null)
+                            if (_startupWarning == null) ...[
                               const SizedBox(
                                 width: 24,
                                 height: 24,
@@ -186,7 +186,20 @@ class _StartupGateState extends State<StartupGate> {
                                     Color(0xFF10B981),
                                   ),
                                 ),
-                              )
+                              ),
+                              const SizedBox(height: 12),
+                              const Text(
+                                'Ouverture de votre espace...',
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Color(
+                                    0xFFBBCABF,
+                                  ), // on-surface-variant
+                                  fontSize: 14,
+                                  height: 1.4,
+                                ),
+                              ),
+                            ]
                             else
                               Text(
                                 _startupWarning!,


### PR DESCRIPTION
## Problem
Commit 6dae229c ("design: refonte visuelle Lot 2+3 - StartupGate premium") dropped the `Ouverture de votre espace...` loading label that used to be shown while the critical startup initializer is running (before any warning/timeout state is reached).

This is currently breaking CI on `main` and on every other open PR via the **Mobile apps split guard** check:
```
Write-Error: .../dev-hub/tools/validate-mobile-runtime-smoke.ps1:23
StartupGate is missing required marker: Ouverture de votre espace...
```

It also silently breaks the existing widget test `renders a visible startup guard before async bootstrap finishes` in `startup_gate_test.dart`, which asserts that exact text is visible while the bootstrap Future is still pending.

## Fix
Restore the loading label under the spinner (only in the "no warning yet" branch), styled to match the existing warning-text branch (same color/size/line-height). The redesigned warning/timeout UI is untouched.

## Verification
- Diff is scoped to the loading branch only; warning/timeout branch unchanged.
- Marker text now matches exactly what `validate-mobile-runtime-smoke.ps1` and `startup_gate_test.dart` expect.
- No Flutter toolchain available in this sandbox to run `flutter test` directly; verified by inline reading of the test expectations against the new widget tree.