### PR TITLE
fix(mobile): wire leopardo_core offline module into leopardo_employee

### DIFF
--- a/docs/edge-sync/ARCHITECTURE.md
+++ b/docs/edge-sync/ARCHITECTURE.md
@@ -63,6 +63,16 @@ Try Edge (http://leopardo.local)
     → Fail → Mode Offline
 ```
 
+> **Statut de câblage (issue #1287)** : cette détection est effectivement
+> câblée dans `leopardo_employee` (`syncServiceProvider` dans
+> `core/providers/core_providers.dart`, démarré depuis `app.dart` au
+> lancement de l'app). Le mode Edge n'est atteint que si l'utilisateur a
+> renseigné l'URL/UUID/jeton du nœud Edge depuis **Paramètres → Nœud Edge**
+> (`AppPreferences.saveEdgeEnrollment`) — sans cet appairage explicite,
+> l'app oscille simplement entre Cloud et Offline, comme avant. Les apps
+> `manager`, `hr` et `platform_admin` n'ont pas ce besoin produit aujourd'hui
+> et ne sont pas câblées.
+
 ---
 
 ## 3. Structure des Composants

--- a/front/mobile_apps/leopardo_core/lib/core/storage/app_preferences.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/storage/app_preferences.dart
@@ -9,6 +9,9 @@ class AppPreferences {
   static const String _biometricNoteKey = 'settings_biometric_note';
   static const String _preferredLanguageKey = 'settings_preferred_language';
   static const String _isRtlKey = 'settings_is_rtl';
+  static const String _edgeNodeIdKey = 'edge_node_id';
+  static const String _edgeTokenKey = 'edge_token';
+  static const String _edgeBaseUrlKey = 'edge_base_url';
 
   static final Map<String, Object?> _memory = <String, Object?>{};
 
@@ -44,6 +47,36 @@ class AppPreferences {
   String get preferredLanguage =>
       (_read(_preferredLanguageKey, '') as String).trim();
   bool get isRtl => _read(_isRtlKey, false) as bool;
+
+  /// Cloud-issued UUID for this device's paired Edge node (see issue #1287 /
+  /// docs/edge-sync/ARCHITECTURE.md). Empty when the device has never been
+  /// paired with an Edge node — [SyncService] then simply never reaches
+  /// `SyncMode.edge` and behaves as cloud/offline only.
+  String get edgeNodeId => (_read(_edgeNodeIdKey, '') as String).trim();
+
+  /// Bearer secret returned once at Edge node registration
+  /// (`EdgeNodeController::store()`), distinct from [edgeNodeId].
+  String get edgeToken => (_read(_edgeTokenKey, '') as String).trim();
+
+  /// Local network base URL of the paired Edge box, e.g.
+  /// `http://leopardo.local:7878`. Empty means "not configured".
+  String get edgeBaseUrl => (_read(_edgeBaseUrlKey, '') as String).trim();
+
+  Future<void> saveEdgeEnrollment({
+    required String edgeNodeId,
+    required String edgeToken,
+    required String edgeBaseUrl,
+  }) async {
+    await _write(_edgeNodeIdKey, edgeNodeId.trim());
+    await _write(_edgeTokenKey, edgeToken.trim());
+    await _write(_edgeBaseUrlKey, edgeBaseUrl.trim());
+  }
+
+  Future<void> clearEdgeEnrollment() async {
+    await _delete(_edgeNodeIdKey);
+    await _delete(_edgeTokenKey);
+    await _delete(_edgeBaseUrlKey);
+  }
 
   Future<void> saveBiometricSettings({
     required bool biometricEnabled,

--- a/front/mobile_apps/leopardo_core/lib/offline/README.md
+++ b/front/mobile_apps/leopardo_core/lib/offline/README.md
@@ -2,6 +2,14 @@
 
 Support offline-first pour les apps Leopardo RH (employee + manager).
 
+> **Statut (issue #1287)** : ce module est cable dans `leopardo_employee`
+> (`app.dart` + `core/providers/core_providers.dart`). `SyncService` demarre
+> automatiquement au lancement de l app et bascule en mode Edge une fois que
+> l utilisateur a renseigne l URL/identifiant/jeton du noeud Edge dans
+> **Parametres → Noeud Edge**. Les autres apps mobiles (`manager`, `hr`,
+> `platform_admin`) n en ont pas encore besoin cote produit et restent en
+> mode Cloud/Offline (fallback Hive `offline_punches` existant).
+
 ## Architecture
 
 ```
@@ -26,7 +34,8 @@ lib/offline/
 ## Intégration dans une app
 
 ```dart
-// main.dart ou App widget
+// main.dart ou App widget — voir l implementation reelle dans
+// leopardo_employee/lib/core/providers/core_providers.dart (syncServiceProvider)
 final db = EdgeDatabase();
 final syncService = SyncService(
   db: db,
@@ -36,8 +45,9 @@ final syncService = SyncService(
   // Cloud-issued UUID for this Edge node (distinct from edgeToken).
   // Obtained at enrollment together with the token — see the
   // `install_command` returned by `POST /api/v1/edge` (Cloud admin API).
-  edgeNodeId: prefs.getString('edge_node_id') ?? '',
-  edgeToken: prefs.getString('edge_token') ?? '',
+  // Saved via AppPreferences.saveEdgeEnrollment() from Settings.
+  edgeNodeId: preferences.edgeNodeId,
+  edgeToken: preferences.edgeToken,
 );
 syncService.start();
 

--- a/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
@@ -58,15 +58,22 @@ class SyncService {
   }
 
   Future<void> _detectMode() async {
-    // 1. Try Edge node (local network first)
-    final edgeReachable = await _ping('$_edgeBaseUrl/api/edge/health');
+    // 1. Try Edge node (local network first).
+    //
+    // The Edge box runs the same Laravel app image as the Cloud API (see
+    // edge/docker-compose.yml + the EdgeSync module routes), which exposes
+    // the health probe at `api/v1/edge/health` (see
+    // api/app/Modules/EdgeSync/routes/api.php) — not `api/edge/health`,
+    // which does not exist and would always fail the reachability check.
+    final edgeReachable = await _ping('$_edgeBaseUrl/api/v1/edge/health');
     if (edgeReachable) {
       _setMode(SyncMode.edge);
       return;
     }
 
-    // 2. Try Cloud
-    final cloudReachable = await _ping('$_cloudBaseUrl/api/health');
+    // 2. Try Cloud. The Cloud API exposes its liveness probe at
+    // `api/v1/health` (see api/routes/api.php), not `api/health`.
+    final cloudReachable = await _ping('$_cloudBaseUrl/api/v1/health');
     if (cloudReachable) {
       _setMode(SyncMode.cloud);
       return;

--- a/front/mobile_apps/leopardo_core/test/core/storage/app_preferences_edge_test.dart
+++ b/front/mobile_apps/leopardo_core/test/core/storage/app_preferences_edge_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leopardo_core/core/storage/app_preferences.dart';
+
+// Regression test for issue #1287: AppPreferences.edgeNodeId/edgeToken/
+// edgeBaseUrl are the only persisted source SyncService reads to decide
+// whether a device has been paired with a local Edge node. Without a Hive
+// box open, AppPreferences falls back to its static in-memory map, so these
+// getters/setters can be exercised without any Flutter binding/plugin.
+void main() {
+  test('edge enrollment fields default to empty strings when unset', () {
+    final preferences = AppPreferences();
+
+    expect(preferences.edgeNodeId, isEmpty);
+    expect(preferences.edgeToken, isEmpty);
+    expect(preferences.edgeBaseUrl, isEmpty);
+  });
+
+  test('saveEdgeEnrollment persists trimmed values and can be cleared', () async {
+    final preferences = AppPreferences();
+
+    await preferences.saveEdgeEnrollment(
+      edgeNodeId: '  550e8400-e29b-41d4-a716-446655440000  ',
+      edgeToken: '  secret-token  ',
+      edgeBaseUrl: '  http://leopardo.local:7878  ',
+    );
+
+    expect(preferences.edgeNodeId, '550e8400-e29b-41d4-a716-446655440000');
+    expect(preferences.edgeToken, 'secret-token');
+    expect(preferences.edgeBaseUrl, 'http://leopardo.local:7878');
+
+    await preferences.clearEdgeEnrollment();
+
+    expect(preferences.edgeNodeId, isEmpty);
+    expect(preferences.edgeToken, isEmpty);
+    expect(preferences.edgeBaseUrl, isEmpty);
+  });
+}

--- a/front/mobile_apps/leopardo_employee/lib/app.dart
+++ b/front/mobile_apps/leopardo_employee/lib/app.dart
@@ -39,6 +39,7 @@ import 'package:leopardo_employee/features/smart_attendance/screens/smart_attend
 import 'package:leopardo_employee/features/smart_attendance/screens/background_permission_onboarding_screen.dart';
 import 'package:leopardo_employee/features/company_branding/providers/tenant_branding_provider.dart';
 import 'package:leopardo_core/l10n/l10n.dart';
+import 'package:leopardo_employee/offline_wrapper.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
   final authListenable = ValueNotifier<AuthState>(ref.read(authProvider));
@@ -247,6 +248,15 @@ class LeopardoApp extends ConsumerWidget {
       }
     });
 
+    // Edge/Cloud/Offline mode detection (issue #1287): without this,
+    // `leopardo_core/lib/offline/*` (SyncService, EdgeDatabase,
+    // AttendanceOfflineService) stays fully dead code and the app can never
+    // detect or use a locally-paired Edge node. `syncServiceProvider`
+    // itself calls `SyncService.start()` exactly once, the first time it is
+    // read (see core_providers.dart) — watching it here just keeps it alive
+    // for the app's lifetime and exposes it to the status banner below.
+    final syncService = ref.watch(syncServiceProvider);
+
     final router = ref.watch(routerProvider);
     final authState = ref.watch(authProvider);
     final preferences = ref.watch(appPreferencesProvider);
@@ -295,7 +305,10 @@ class LeopardoApp extends ConsumerWidget {
       builder: (context, child) {
         return Directionality(
           textDirection: isRtl ? TextDirection.rtl : TextDirection.ltr,
-          child: child ?? const SizedBox.shrink(),
+          child: OfflineWrapper(
+            syncService: syncService,
+            child: child ?? const SizedBox.shrink(),
+          ),
         );
       },
       localeResolutionCallback: (requestedLocale, supportedLocales) {

--- a/front/mobile_apps/leopardo_employee/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_employee/lib/core/providers/core_providers.dart
@@ -1,4 +1,5 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:leopardo_core/core/api/api_client.dart';
 import 'package:leopardo_core/core/location/attendance_location_service.dart';
@@ -6,6 +7,9 @@ import 'package:leopardo_core/core/services/offline_sync_service.dart';
 import 'package:leopardo_core/core/services/push_notification_service.dart';
 import 'package:leopardo_core/core/storage/app_preferences.dart';
 import 'package:leopardo_core/core/storage/secure_storage.dart';
+import 'package:leopardo_core/offline/database/edge_database.dart';
+import 'package:leopardo_core/offline/services/attendance_offline_service.dart';
+import 'package:leopardo_core/offline/services/sync_service.dart';
 import 'package:leopardo_employee/features/auth/data/auth_repository.dart';
 import 'package:leopardo_employee/features/attendance/data/attendance_repository.dart';
 import 'package:leopardo_employee/features/settings/data/settings_repository.dart';
@@ -54,6 +58,49 @@ final offlineSyncServiceProvider = Provider<OfflineSyncService>((ref) {
   final service = OfflineSyncService(apiClient, Connectivity());
   ref.onDispose(service.dispose);
   return service;
+});
+
+/// Local SQLite (Drift) database used by the Edge/offline module
+/// (see issue #1287 — `leopardo_core/lib/offline/*` was previously never
+/// wired into any app). Long-lived: closed only when the app itself exits.
+final edgeDatabaseProvider = Provider<EdgeDatabase>((ref) {
+  return EdgeDatabase();
+});
+
+/// Detects Cloud / local-Edge-network / fully-offline connectivity and
+/// syncs the Edge SQLite queue accordingly. Only reaches [SyncMode.edge]
+/// once the device has been paired with an Edge node from Settings (see
+/// [AppPreferences.edgeNodeId]); otherwise it simply oscillates between
+/// cloud and offline, same as before this module existed.
+final syncServiceProvider = Provider<SyncService>((ref) {
+  final preferences = ref.watch(appPreferencesProvider);
+  final db = ref.watch(edgeDatabaseProvider);
+  final service = SyncService(
+    db: db,
+    dio: Dio(),
+    edgeBaseUrl: preferences.edgeBaseUrl.isNotEmpty
+        ? preferences.edgeBaseUrl
+        : 'http://leopardo.local:7878',
+    cloudBaseUrl: ApiClient.resolveBaseUrl().replaceFirst('/api/v1', ''),
+    edgeNodeId: preferences.edgeNodeId,
+    edgeToken: preferences.edgeToken,
+  );
+  service.start();
+  ref.onDispose(service.stop);
+  return service;
+});
+
+/// Offline-first check-in/check-out backed by [EdgeDatabase] + [SyncService]
+/// (see issue #1287). Distinct from [offlineSyncServiceProvider], which only
+/// drains the legacy Hive `offline_punches` fallback queue.
+final attendanceOfflineServiceProvider = Provider<AttendanceOfflineService>((
+  ref,
+) {
+  return AttendanceOfflineService(
+    db: ref.watch(edgeDatabaseProvider),
+    syncService: ref.watch(syncServiceProvider),
+    dio: Dio(),
+  );
 });
 
 final attendanceLocationServiceProvider = Provider<AttendanceLocationService>((

--- a/front/mobile_apps/leopardo_employee/lib/features/settings/screens/settings_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/settings/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui' show PlatformDispatcher;
 
@@ -15,6 +16,8 @@ import 'package:leopardo_core/models/notification_preferences.dart';
 import 'package:leopardo_employee/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_employee/features/settings/data/biometric_enrollment.dart';
 import 'package:leopardo_employee/features/settings/data/settings_repository.dart';
+import 'package:leopardo_core/core/storage/app_preferences.dart';
+import 'package:leopardo_core/offline/services/sync_service.dart';
 import 'package:local_auth/local_auth.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
@@ -44,6 +47,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   final TextEditingController _fingerprintDeviceController =
       TextEditingController();
   final TextEditingController _companyQrController = TextEditingController();
+  final TextEditingController _edgeNodeIdController = TextEditingController();
+  final TextEditingController _edgeTokenController = TextEditingController();
+  final TextEditingController _edgeBaseUrlController = TextEditingController();
   static const Map<String, String> _languageLabels = {
     'fr': 'Francais',
     'ar': 'العربية',
@@ -60,6 +66,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   bool _fingerprintEnabled = false;
   bool _faceEnabled = false;
   bool _attendanceConsent = false;
+  bool _edgeSaving = false;
   File? _selectedFaceImage;
   BiometricEnrollment? _latestEnrollment;
   String _selectedLanguage = 'fr';
@@ -89,6 +96,46 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         : (_languageLabels.containsKey(deviceLanguage) ? deviceLanguage : 'fr');
     _loadLocalSettings();
     _loadEnrollmentStatus();
+    _loadEdgeSettings();
+  }
+
+  void _loadEdgeSettings() {
+    final preferences = ref.read(appPreferencesProvider);
+    _edgeNodeIdController.text = preferences.edgeNodeId;
+    _edgeTokenController.text = preferences.edgeToken;
+    _edgeBaseUrlController.text = preferences.edgeBaseUrl;
+  }
+
+  Future<void> _saveEdgeSettings(BuildContext context) async {
+    setState(() => _edgeSaving = true);
+    try {
+      await ref.read(appPreferencesProvider).saveEdgeEnrollment(
+            edgeNodeId: _edgeNodeIdController.text,
+            edgeToken: _edgeTokenController.text,
+            edgeBaseUrl: _edgeBaseUrlController.text,
+          );
+      // Re-run mode detection immediately so the sync banner reflects the
+      // newly paired Edge node without waiting for the next periodic tick
+      // or connectivity change (see issue #1287).
+      unawaited(ref.read(syncServiceProvider).syncNow());
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Parametres Edge enregistres.')),
+      );
+    } finally {
+      if (mounted) setState(() => _edgeSaving = false);
+    }
+  }
+
+  Future<void> _clearEdgeSettings(BuildContext context) async {
+    await ref.read(appPreferencesProvider).clearEdgeEnrollment();
+    _edgeNodeIdController.clear();
+    _edgeTokenController.clear();
+    _edgeBaseUrlController.clear();
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Appairage Edge supprime.')),
+    );
   }
 
   Future<void> _loadLocalSettings() async {
@@ -132,6 +179,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _biometricNoteController.dispose();
     _fingerprintDeviceController.dispose();
     _companyQrController.dispose();
+    _edgeNodeIdController.dispose();
+    _edgeTokenController.dispose();
+    _edgeBaseUrlController.dispose();
     super.dispose();
   }
 
@@ -172,6 +222,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           _buildPasswordSection(context, authState),
           const SizedBox(height: 20),
           _buildBiometricSection(context),
+          const SizedBox(height: 20),
+          _buildEdgeSection(context),
           const SizedBox(height: 28),
           _buildLogoutSection(context),
           SizedBox(height: MediaQuery.of(context).padding.bottom + 8),
@@ -999,6 +1051,111 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             style: AppTypography.caption.copyWith(
               color: MobileSurface.secondary,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEdgeSection(BuildContext context) {
+    final syncService = ref.watch(syncServiceProvider);
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: MobileSurface.cardDecoration(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const MobileIconBubble(
+                icon: Icons.lan_rounded,
+                color: AppColors.info,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Noeud Edge (reseau local)',
+                      style: AppTypography.subtitle.copyWith(
+                        color: MobileSurface.text,
+                      ),
+                    ),
+                    Text(
+                      'Optionnel: pointer vers un serveur Edge installe sur site pour pointer sans Internet.',
+                      style: AppTypography.caption.copyWith(
+                        color: MobileSurface.secondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          StreamBuilder<SyncMode>(
+            stream: syncService.modeStream,
+            initialData: syncService.currentMode,
+            builder: (context, snapshot) {
+              final mode = snapshot.data ?? SyncMode.offline;
+              final label = switch (mode) {
+                SyncMode.cloud => 'Connecte au Cloud',
+                SyncMode.edge => 'Connecte au noeud Edge local',
+                SyncMode.offline => 'Hors ligne',
+              };
+              return Text(
+                'Statut actuel: $label',
+                style: AppTypography.bodySmall.copyWith(
+                  color: MobileSurface.secondary,
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: 14),
+          TextField(
+            controller: _edgeBaseUrlController,
+            decoration: const InputDecoration(
+              labelText: 'Adresse du noeud Edge',
+              hintText: 'http://leopardo.local:7878',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _edgeNodeIdController,
+            decoration: const InputDecoration(
+              labelText: 'Identifiant du noeud (UUID)',
+              hintText: 'Fourni par votre administrateur',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _edgeTokenController,
+            obscureText: true,
+            decoration: const InputDecoration(
+              labelText: 'Jeton Edge',
+              hintText: 'Fourni une seule fois a l enregistrement',
+            ),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton(
+                  onPressed:
+                      _edgeSaving ? null : () => _saveEdgeSettings(context),
+                  child: Text(
+                    _edgeSaving ? 'Enregistrement...' : 'Enregistrer',
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              OutlinedButton(
+                onPressed: () => _clearEdgeSettings(context),
+                child: const Text('Retirer'),
+              ),
+            ],
           ),
         ],
       ),


### PR DESCRIPTION
## What Problem This Solves
`SyncService`, `EdgeDatabase`, `AttendanceOfflineService`, `OfflineTokenService`, `OfflineWrapper`, `LiveSyncStatusBanner` (`front/mobile_apps/leopardo_core/lib/offline/*`) were not imported by any of the 4 Flutter apps' `main.dart`/`app.dart`. `OfflineWrapper` itself was used by no screen. `docs/edge-sync/ARCHITECTURE.md` and `edge/README.md` describe automatic Edge/Cloud/Offline mode detection on mobile that did not exist in practice.

## Why This Change Was Made
- Added `syncServiceProvider`, `edgeDatabaseProvider`, `attendanceOfflineServiceProvider` (Riverpod) to `leopardo_employee`'s `core_providers.dart`, wiring the real `SyncService`/`EdgeDatabase`/`AttendanceOfflineService` classes from `leopardo_core`.
- `LeopardoApp` now watches `syncServiceProvider` (which calls `SyncService.start()` once) and wraps its `MaterialApp.router` body in the existing `OfflineWrapper`, so the sync status banner (offline/edge banners) is visible app-wide.
- Added `AppPreferences.edgeNodeId`/`edgeToken`/`edgeBaseUrl` + `saveEdgeEnrollment`/`clearEdgeEnrollment` as the persisted source of truth for pairing a device with a local Edge node, and a new **Settings → Noeud Edge** section so a real user can actually enter/clear that pairing (previously nothing in the codebase ever wrote these values).
- Fixed `SyncService._detectMode()`: it pinged `$_edgeBaseUrl/api/edge/health` and `$_cloudBaseUrl/api/health`, neither of which exists (`api/app/Modules/EdgeSync/routes/api.php` exposes `api/v1/edge/health`; `api/routes/api.php` exposes `v1/health` under the `api` prefix, i.e. `api/v1/health`). Without this fix, automatic mode detection could never succeed even after wiring the module in — it would always fall through to Offline.
- Documented the actual wiring scope (leopardo_employee only — manager/hr/platform_admin keep their existing Hive-based offline fallback and have no current product need for local Edge pairing) in the offline module README and `docs/edge-sync/ARCHITECTURE.md`.

## User Impact
The employee app can now genuinely detect and use a locally-paired Edge node (once an admin/employee pairs it from Settings), matching what client-facing docs already promised. Previously this was 100% dead code with health-check URLs that would 404 even if someone had wired it in manually.

## Evidence
No Dart/Flutter toolchain is available in this execution environment (checked: no `flutter`/`dart` binary). Verified by:
- Brace/paren balance check on every touched file (all matched).
- Cross-referencing every new import against the actual public API of `leopardo_core`'s offline module (constructor params, method names) file-by-file.
- Verifying the Edge/Cloud health route paths directly against `api/app/Modules/EdgeSync/routes/api.php` and `api/routes/api.php`.
- Added a new unit test (`front/mobile_apps/leopardo_core/test/core/storage/app_preferences_edge_test.dart`) for the new `AppPreferences` edge-enrollment getters/setters, following the existing Hive-memory-fallback pattern used by other `AppPreferences` fields — this test needs no plugin bindings and should run under CI's Flutter test job.
- Relying on CI's Flutter analyze/build/test job as the authoritative check.

Fixes #1287