### PR TITLE
Fix #1291: unify edge_nodes schema for platform super-admin routes

### DIFF
--- a/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeController.php
+++ b/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeController.php
@@ -22,14 +22,25 @@ use Illuminate\Support\Facades\Log;
  *   GET  /edge/download/docker-compose.yml → docker-compose pré-configuré
  *   GET  /edge/license-public-key          → clé publique RS256 (PEM)
  *
- * Routes protégées (super_admin_api) :
- *   GET    /platform/edge/nodes              → liste des nœuds
- *   POST   /platform/edge/nodes/{id}/sync   → forcer sync
- *   DELETE /platform/edge/nodes/{id}         → révoquer
- *
  * Routes nœud Edge (token EDGE_TOKEN) :
  *   POST /edge/heartbeat   → heartbeat depuis le nœud
  *   POST /edge/sync        → réception sync depuis le nœud
+ *
+ * NOTE (issue #1291): the platform super-admin node-management endpoints
+ * (`GET/POST/DELETE /platform/edge/nodes*`) used to live on this class as
+ * listNodes()/forceSync()/revokeNode(), built against a legacy bigint
+ * `edge_nodes` schema (columns `node_id`, `pending_count`, `license_valid`,
+ * `alert_muted`, `revoked_at`) that is never actually created in
+ * production — the canonical schema created by
+ * 2026_06_29_000001_create_edge_sync_tables.php (module EdgeSync DDD) uses
+ * a UUID primary key, `slug`, and `metadata` JSON instead, and the legacy
+ * migration (2026_06_30_000001_create_edge_nodes_table.php) neutralizes
+ * itself whenever the canonical table already exists. Any real call to
+ * those three methods would therefore fail with a "column ... does not
+ * exist" SQL error against the tables actually created in every
+ * environment. They have been removed here; the equivalent super-admin
+ * node-management endpoints now live on {@see EdgeNodeController} against
+ * the canonical UUID schema (see routes/api.php `platform/edge/nodes*`).
  */
 class EdgeController extends Controller
 {
@@ -267,61 +278,5 @@ class EdgeController extends Controller
             'status'      => 'ok',
             'server_time' => Carbon::now()->toIso8601String(),
         ]);
-    }
-
-    // =========================================================================
-    // Gestion nœuds (platform super-admin)
-    // =========================================================================
-
-    /** GET /platform/edge/nodes */
-    public function listNodes(): JsonResponse
-    {
-        $nodes = DB::table('edge_nodes as n')
-            ->join('companies as c', 'c.id', '=', 'n.company_id')
-            ->select([
-                'n.id', 'n.node_id', 'n.name', 'n.status',
-                'n.ip_address', 'n.last_seen_at', 'n.pending_count',
-                'n.license_valid', 'n.license_expires_at',
-                'n.alert_muted', 'n.version',
-                'c.name as company_name',
-            ])
-            ->orderBy('n.status')
-            ->orderBy('n.name')
-            ->get();
-
-        return response()->json(['data' => $nodes]);
-    }
-
-    /** POST /platform/edge/nodes/{id}/sync */
-    public function forceSync(int $id): JsonResponse
-    {
-        $node = DB::table('edge_nodes')->find($id);
-        if (! $node) {
-            return response()->json(['error' => 'not_found'], 404);
-        }
-
-        DB::table('edge_nodes')->where('id', $id)->update([
-            'sync_requested_at' => Carbon::now(),
-        ]);
-
-        return response()->json(['status' => 'sync_requested']);
-    }
-
-    /** DELETE /platform/edge/nodes/{id} */
-    public function revokeNode(int $id): JsonResponse
-    {
-        $node = DB::table('edge_nodes')->find($id);
-        if (! $node) {
-            return response()->json(['error' => 'not_found'], 404);
-        }
-
-        DB::table('edge_nodes')->where('id', $id)->update([
-            'status'     => 'revoked',
-            'revoked_at' => Carbon::now(),
-        ]);
-
-        Log::warning('[Edge] Nœud révoqué', ['id' => $id, 'node_id' => $node->node_id ?? '']);
-
-        return response()->json(['status' => 'revoked']);
     }
 }

--- a/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeNodeController.php
+++ b/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeNodeController.php
@@ -234,6 +234,60 @@ class EdgeNodeController extends Controller
         return response()->json($result, $result['valid'] ? 200 : 422);
     }
 
+    // ── Platform Super-Admin Routes (issue #1291) ──────
+    //
+    // These replace the dead legacy EdgeController::listNodes()/forceSync()/
+    // revokeNode() methods, which queried a bigint `edge_nodes` schema
+    // (columns node_id/pending_count/license_valid/alert_muted/revoked_at)
+    // that is never actually created — the real schema (created by
+    // 2026_06_29_000001_create_edge_sync_tables.php) is the UUID/slug one
+    // this controller's EdgeNode model already targets. Cross-tenant here
+    // is intentional: these are platform-wide, super-admin-only endpoints.
+
+    /**
+     * List every Edge node across all tenants (platform overview).
+     * GET /api/v1/platform/edge/nodes
+     */
+    public function listAllNodes(): JsonResponse
+    {
+        $nodes = EdgeNode::with(['company:id,name', 'syncLogs' => fn ($q) => $q->latest()->limit(1)])
+            ->orderByDesc('last_seen_at')
+            ->get()
+            ->map(fn (EdgeNode $node) => array_merge($node->toArray(), [
+                'is_online'     => $node->isOnline(),
+                'license_valid' => $node->isLicenseValid(),
+                'company_name'  => $node->company?->name,
+            ]));
+
+        return response()->json(['data' => $nodes]);
+    }
+
+    /**
+     * Force a manual sync for any tenant's Edge node (platform override).
+     * POST /api/v1/platform/edge/nodes/{nodeId}/sync
+     */
+    public function forceSync(string $nodeId): JsonResponse
+    {
+        $node = EdgeNode::findOrFail($nodeId);
+        $log  = $this->syncEngine->sync($node);
+
+        return response()->json(['data' => $log]);
+    }
+
+    /**
+     * Revoke an Edge node and its active license (platform override).
+     * DELETE /api/v1/platform/edge/nodes/{nodeId}
+     */
+    public function revokeNode(string $nodeId): JsonResponse
+    {
+        $node = EdgeNode::findOrFail($nodeId);
+
+        $node->update(['status' => 'suspended']);
+        $this->licenseService->revokeLicense($node);
+
+        return response()->json(['status' => 'revoked', 'data' => $node->fresh()]);
+    }
+
     // ── Private Helpers ───────────────────────────────────
 
     private function authorizeEdgeToken(Request $request, EdgeNode $node): void

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -11,7 +11,7 @@ use App\Modules\Billing\Interfaces\Api\V1\PlatformCompanySubscriptionController;
 use App\Modules\Billing\Interfaces\Api\V1\PlatformPlanController;
 use App\Modules\Billing\Interfaces\Api\V1\SelfServiceTrialController;
 use App\Modules\Billing\Interfaces\Api\V1\StripeWebhookController;
-use App\Modules\EdgeSync\Interfaces\Api\V1\EdgeController;
+use App\Modules\EdgeSync\Interfaces\Api\V1\EdgeNodeController;
 use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBrandingController;
 use App\Modules\HR\Interfaces\Api\V1\Controllers\PrivacyController;
 use App\Modules\Marketing\Interfaces\Api\V1\Controllers\MarketingLeadController;
@@ -237,11 +237,14 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/impersonations', [PlatformImpersonationController::class, 'store']);
         Route::delete('/impersonations/{session}', [PlatformImpersonationController::class, 'destroy'])->whereNumber('session');
 
-        // Edge node management (super-admin)
+        // Edge node management (super-admin).
+        // Uses EdgeNodeController against the canonical UUID edge_nodes
+        // schema (see issue #1291) — the legacy bigint-schema EdgeController
+        // equivalents were removed because that schema is never created.
         Route::prefix('edge/nodes')->group(function (): void {
-            Route::get('/', [EdgeController::class, 'listNodes']);
-            Route::post('/{id}/sync', [EdgeController::class, 'forceSync'])->whereNumber('id');
-            Route::delete('/{id}', [EdgeController::class, 'revokeNode'])->whereNumber('id');
+            Route::get('/', [EdgeNodeController::class, 'listAllNodes']);
+            Route::post('/{nodeId}/sync', [EdgeNodeController::class, 'forceSync']);
+            Route::delete('/{nodeId}', [EdgeNodeController::class, 'revokeNode']);
         });
     });
 });


### PR DESCRIPTION
Closes #1291

The legacy `EdgeController::listNodes()/forceSync()/revokeNode()` methods queried a bigint `edge_nodes` schema (`node_id`, `pending_count`, `license_valid`, `alert_muted`, `revoked_at`) that is never actually created in any environment: the canonical schema created by `2026_06_29_000001_create_edge_sync_tables.php` uses a UUID primary key, `slug`, and `metadata` JSON, and the legacy migration self-neutralizes when that canonical table exists. Any real call to those three legacy methods would fail with a SQL column-does-not-exist error.

- Removed the dead legacy methods from `EdgeController`.
- Added `listAllNodes()/forceSync()/revokeNode()` to `EdgeNodeController`, operating on the canonical UUID `EdgeNode` model and reusing the existing `SyncEngineService`/`EdgeLicenseService`.
- Repointed `routes/api.php` `platform/edge/nodes*` routes at `EdgeNodeController` (UUID `{nodeId}` param instead of numeric `{id}`).

This matches the existing `EdgeSyncOnReconnectTest` expectations, which already POST to `/api/v1/platform/edge/nodes/{node->id}/sync` using the UUID node id.