### PR TITLE
fix(edge-sync): route platform edge node endpoints through canonical EdgeNode model

### DIFF
--- a/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeController.php
+++ b/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeController.php
@@ -7,11 +7,11 @@ namespace App\Modules\EdgeSync\Interfaces\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Modules\EdgeSync\Application\Services\EdgeLicenseService;
 use App\Modules\EdgeSync\Application\Services\SyncEngineService;
+use App\Modules\EdgeSync\Domain\Models\EdgeNode;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -30,6 +30,18 @@ use Illuminate\Support\Facades\Log;
  * Routes nœud Edge (token EDGE_TOKEN) :
  *   POST /edge/heartbeat   → heartbeat depuis le nœud
  *   POST /edge/sync        → réception sync depuis le nœud
+ *
+ * NOTE (issue #1291): the platform node-management methods below
+ * (listNodes/forceSync/revokeNode) operate on the canonical EdgeNode
+ * Eloquent model (UUID primary key, `edge_nodes` table created by
+ * App\Modules\EdgeSync\database\migrations\2026_06_29_000001_create_edge_sync_tables).
+ * They previously ran raw DB::table('edge_nodes') queries against a
+ * competing legacy bigint schema (node_id/pending_count/license_valid
+ * columns) that the canonical migration never creates in production,
+ * which made /platform/edge/nodes* fail with "column does not exist"
+ * as soon as the canonical migration ran first. See
+ * database/migrations/tenant/2026_06_30_000001_create_edge_nodes_table.php
+ * for how that legacy migration now self-neutralizes.
  */
 class EdgeController extends Controller
 {
@@ -241,7 +253,16 @@ class EdgeController extends Controller
     // Heartbeat Edge → Cloud
     // =========================================================================
 
-    /** POST /edge/heartbeat */
+    /**
+     * POST /edge/heartbeat
+     *
+     * `node_id` accepts either the canonical EdgeNode UUID or its slug
+     * (both uniquely identify a node). Kept for install scripts that only
+     * know the human-readable slug; nodes provisioned via
+     * EdgeNodeController::store() should prefer
+     * POST /api/v1/edge-node/{nodeId}/heartbeat with their UUID + bearer
+     * token instead, which is the authenticated machine-to-machine route.
+     */
     public function heartbeat(Request $request): JsonResponse
     {
         $validated = $request->validate([
@@ -251,17 +272,26 @@ class EdgeController extends Controller
             'ip_address'    => ['nullable', 'ip'],
         ]);
 
-        DB::table('edge_nodes')
-            ->where('node_id', $validated['node_id'])
-            ->update([
-                'status'        => 'online',
-                'last_seen_at'  => Carbon::now(),
-                'pending_count' => $validated['pending_count'] ?? 0,
-                'version'       => $validated['version'] ?? null,
-                'ip_address'    => $validated['ip_address'] ?? $request->ip(),
-            ]);
+        $node = EdgeNode::query()
+            ->when(
+                \Illuminate\Support\Str::isUuid($validated['node_id']),
+                fn ($query) => $query->where('id', $validated['node_id'])->orWhere('slug', $validated['node_id']),
+                fn ($query) => $query->where('slug', $validated['node_id']),
+            )
+            ->first();
 
-        Log::info('[Edge] Heartbeat reçu', ['node_id' => $validated['node_id']]);
+        if (! $node) {
+            return response()->json(['error' => 'node_not_found'], 404);
+        }
+
+        $node->update([
+            'status'       => 'active',
+            'last_seen_at' => Carbon::now(),
+            'public_ip'    => $validated['ip_address'] ?? $request->ip(),
+            'edge_version' => $validated['version'] ?? $node->edge_version,
+        ]);
+
+        Log::info('[Edge] Heartbeat reçu', ['node_id' => $node->id]);
 
         return response()->json([
             'status'      => 'ok',
@@ -276,51 +306,64 @@ class EdgeController extends Controller
     /** GET /platform/edge/nodes */
     public function listNodes(): JsonResponse
     {
-        $nodes = DB::table('edge_nodes as n')
-            ->join('companies as c', 'c.id', '=', 'n.company_id')
-            ->select([
-                'n.id', 'n.node_id', 'n.name', 'n.status',
-                'n.ip_address', 'n.last_seen_at', 'n.pending_count',
-                'n.license_valid', 'n.license_expires_at',
-                'n.alert_muted', 'n.version',
-                'c.name as company_name',
-            ])
-            ->orderBy('n.status')
-            ->orderBy('n.name')
-            ->get();
+        $nodes = EdgeNode::query()
+            ->with('company')
+            ->withCount(['syncQueue as pending_count' => function ($query) {
+                $query->where('status', 'pending');
+            }])
+            ->orderByDesc('status')
+            ->orderBy('name')
+            ->get()
+            ->map(function (EdgeNode $node) {
+                /** @var \App\Modules\EdgeSync\Domain\Models\EdgeLicense|null $license */
+                $license = $node->license()->latest('expires_at')->first();
+
+                return [
+                    'id'                 => $node->id,
+                    'node_id'            => $node->slug,
+                    'name'               => $node->name,
+                    'status'             => $node->status,
+                    'ip_address'         => $node->public_ip ?? $node->local_ip,
+                    'last_seen_at'       => $node->last_seen_at,
+                    'pending_count'      => $node->pending_count,
+                    'license_valid'      => $license?->isValid() ?? false,
+                    'license_expires_at' => $license?->expires_at ?? $node->license_expires_at,
+                    'alert_muted'        => (bool) ($node->metadata['alert_muted'] ?? false),
+                    'version'            => $node->edge_version,
+                    'company_name'       => $node->company?->name,
+                ];
+            });
 
         return response()->json(['data' => $nodes]);
     }
 
     /** POST /platform/edge/nodes/{id}/sync */
-    public function forceSync(int $id): JsonResponse
+    public function forceSync(string $id): JsonResponse
     {
-        $node = DB::table('edge_nodes')->find($id);
+        $node = EdgeNode::find($id);
         if (! $node) {
             return response()->json(['error' => 'not_found'], 404);
         }
 
-        DB::table('edge_nodes')->where('id', $id)->update([
-            'sync_requested_at' => Carbon::now(),
-        ]);
+        $node->update(['metadata' => array_merge($node->metadata ?? [], [
+            'sync_requested_at' => Carbon::now()->toIso8601String(),
+        ])]);
 
         return response()->json(['status' => 'sync_requested']);
     }
 
     /** DELETE /platform/edge/nodes/{id} */
-    public function revokeNode(int $id): JsonResponse
+    public function revokeNode(string $id): JsonResponse
     {
-        $node = DB::table('edge_nodes')->find($id);
+        $node = EdgeNode::find($id);
         if (! $node) {
             return response()->json(['error' => 'not_found'], 404);
         }
 
-        DB::table('edge_nodes')->where('id', $id)->update([
-            'status'     => 'revoked',
-            'revoked_at' => Carbon::now(),
-        ]);
+        $node->update(['status' => 'revoked']);
+        $this->licenseService->revokeLicense($node);
 
-        Log::warning('[Edge] Nœud révoqué', ['id' => $id, 'node_id' => $node->node_id ?? '']);
+        Log::warning('[Edge] Nœud révoqué', ['id' => $id, 'slug' => $node->slug]);
 
         return response()->json(['status' => 'revoked']);
     }

--- a/api/database/migrations/tenant/2026_06_30_000001_create_edge_nodes_table.php
+++ b/api/database/migrations/tenant/2026_06_30_000001_create_edge_nodes_table.php
@@ -19,11 +19,23 @@ return new class extends Migration
         if (Schema::hasTable('edge_nodes')) {
             // La table edge_nodes est déjà créée par la migration
             // 2026_06_29_000001_create_edge_sync_tables.php (module EdgeSync DDD,
-            // schéma UUID). Cette migration légacy visait un schéma bigint
-            // différent mais n'est reliée à aucune route active
-            // (App\Http\Controllers\Api\V1\EdgeController n'est enregistré
-            // dans aucun fichier de routes). On la neutralise pour éviter le
-            // conflit "relation edge_nodes already exists" en CI/production.
+            // schéma UUID) qui s'exécute toujours avant celle-ci (timestamp
+            // antérieur). Cette migration légacy visait un schéma bigint
+            // différent (node_id/pending_count/license_valid).
+            //
+            // Historique (issue #1291) : App\Modules\EdgeSync\Interfaces\Api\V1\
+            // EdgeController::listNodes/forceSync/revokeNode (routes actives
+            // /platform/edge/nodes*) interrogeaient directement ce schéma
+            // bigint legacy via DB::table('edge_nodes'), ce qui cassait ces
+            // routes en production puisque seul le schéma UUID canonique est
+            // réellement créé. Le correctif consiste à faire passer
+            // EdgeController sur le modèle Eloquent EdgeNode canonique
+            // (App\Modules\EdgeSync\Domain\Models\EdgeNode) plutôt qu'à fusionner
+            // les schémas. Cette migration reste neutralisée pour éviter le
+            // conflit "relation edge_nodes already exists" en CI/production ;
+            // elle est conservée uniquement pour compatibilité avec
+            // d'anciens environnements qui auraient déjà exécuté son up()
+            // avant l'introduction du module EdgeSync DDD.
             return;
         }
 

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -240,8 +240,8 @@ Route::prefix('v1')->group(function (): void {
         // Edge node management (super-admin)
         Route::prefix('edge/nodes')->group(function (): void {
             Route::get('/', [EdgeController::class, 'listNodes']);
-            Route::post('/{id}/sync', [EdgeController::class, 'forceSync'])->whereNumber('id');
-            Route::delete('/{id}', [EdgeController::class, 'revokeNode'])->whereNumber('id');
+            Route::post('/{id}/sync', [EdgeController::class, 'forceSync'])->whereUuid('id');
+            Route::delete('/{id}', [EdgeController::class, 'revokeNode'])->whereUuid('id');
         });
     });
 });

--- a/api/tests/Feature/Edge/EdgePlatformNodeManagementTest.php
+++ b/api/tests/Feature/Edge/EdgePlatformNodeManagementTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Edge;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\SuperAdmin;
+use App\Modules\EdgeSync\Domain\Models\EdgeLicense;
+use App\Modules\EdgeSync\Domain\Models\EdgeNode;
+use App\Modules\EdgeSync\Domain\Models\SyncQueue;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for issue #1291.
+ *
+ * The `/platform/edge/nodes*` super-admin endpoints
+ * (EdgeController::listNodes/forceSync/revokeNode) used to run raw
+ * `DB::table('edge_nodes')` queries against a legacy bigint schema
+ * (node_id/pending_count/license_valid columns) that is never actually
+ * created in production/CI — only the canonical UUID/DDD `edge_nodes`
+ * schema (App\Modules\EdgeSync\Domain\Models\EdgeNode) is. These tests
+ * exercise the endpoints against that canonical schema to make sure
+ * they keep working against the real table shape going forward.
+ */
+class EdgePlatformNodeManagementTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    private Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+
+        $this->company = Company::factory()->create([
+            'schema_name'  => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status'       => 'active',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    private function superAdmin(): SuperAdmin
+    {
+        return SuperAdmin::query()->create([
+            'name'          => 'Platform Admin',
+            'email'         => fake()->unique()->safeEmail(),
+            'password_hash' => Hash::make('password123'),
+        ]);
+    }
+
+    private function actingAsSuperAdmin(): void
+    {
+        Sanctum::actingAs($this->superAdmin(), ['*'], 'super_admin_api');
+    }
+
+    private function createEdgeNode(array $overrides = []): EdgeNode
+    {
+        return EdgeNode::create(array_merge([
+            'company_id'    => $this->company->id,
+            'name'          => 'Kiosque Entrée',
+            'slug'          => 'kiosque-entree-'.fake()->unique()->numberBetween(1000, 999999),
+            'status'        => 'active',
+            'mode'          => 'hybrid',
+            'last_seen_at'  => Carbon::now(),
+            'public_ip'     => '203.0.113.10',
+            'edge_version'  => '1.2.3',
+            'metadata'      => [],
+            'capabilities'  => [],
+        ], $overrides));
+    }
+
+    /**
+     * GET /platform/edge/nodes must read the canonical EdgeNode schema,
+     * not a raw legacy `edge_nodes` bigint table.
+     */
+    public function test_list_nodes_returns_data_from_canonical_schema(): void
+    {
+        $this->actingAsSuperAdmin();
+
+        $node = $this->createEdgeNode(['name' => 'Kiosque Principal']);
+
+        SyncQueue::create([
+            'edge_node_id' => $node->id,
+            'entity_type'  => 'attendance_log',
+            'entity_id'    => (string) fake()->uuid(),
+            'operation'    => 'create',
+            'payload'      => ['foo' => 'bar'],
+            'status'       => 'pending',
+        ]);
+
+        EdgeLicense::create([
+            'company_id'        => $this->company->id,
+            'edge_node_id'      => $node->id,
+            'license_key'       => (string) fake()->uuid(),
+            'signed_payload'    => 'stub-payload',
+            'allowed_features'  => [],
+            'max_employees'     => 50,
+            'issued_at'         => Carbon::now(),
+            'expires_at'        => Carbon::now()->addDays(30),
+            'last_validated_at' => Carbon::now(),
+            'validation_status' => 'valid',
+        ]);
+
+        $response = $this->getJson('/api/v1/platform/edge/nodes')->assertOk();
+
+        $response->assertJsonPath('data.0.id', $node->id);
+        $response->assertJsonPath('data.0.node_id', $node->slug);
+        $response->assertJsonPath('data.0.name', 'Kiosque Principal');
+        $response->assertJsonPath('data.0.pending_count', 1);
+        $response->assertJsonPath('data.0.license_valid', true);
+        $response->assertJsonPath('data.0.company_name', $this->company->name);
+    }
+
+    /**
+     * POST /platform/edge/nodes/{uuid}/sync must accept the node UUID
+     * (not a numeric legacy id) and mark a sync request against the
+     * canonical row.
+     */
+    public function test_force_sync_accepts_node_uuid_and_records_request(): void
+    {
+        $this->actingAsSuperAdmin();
+
+        $node = $this->createEdgeNode();
+
+        $this->postJson("/api/v1/platform/edge/nodes/{$node->id}/sync")
+            ->assertOk()
+            ->assertJsonPath('status', 'sync_requested');
+
+        $node->refresh();
+        $this->assertArrayHasKey('sync_requested_at', $node->metadata);
+    }
+
+    public function test_force_sync_returns_404_for_unknown_node(): void
+    {
+        $this->actingAsSuperAdmin();
+
+        $this->postJson('/api/v1/platform/edge/nodes/'.fake()->uuid().'/sync')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not_found');
+    }
+
+    /**
+     * DELETE /platform/edge/nodes/{uuid} must revoke the canonical
+     * EdgeNode row and its associated license, not a legacy table.
+     */
+    public function test_revoke_node_marks_node_revoked_and_revokes_license(): void
+    {
+        $this->actingAsSuperAdmin();
+
+        $node = $this->createEdgeNode();
+
+        EdgeLicense::create([
+            'company_id'        => $this->company->id,
+            'edge_node_id'      => $node->id,
+            'license_key'       => (string) fake()->uuid(),
+            'signed_payload'    => 'stub-payload',
+            'allowed_features'  => [],
+            'max_employees'     => 50,
+            'issued_at'         => Carbon::now(),
+            'expires_at'        => Carbon::now()->addDays(30),
+            'last_validated_at' => Carbon::now(),
+            'validation_status' => 'valid',
+        ]);
+
+        $this->deleteJson("/api/v1/platform/edge/nodes/{$node->id}")
+            ->assertOk()
+            ->assertJsonPath('status', 'revoked');
+
+        $node->refresh();
+        $this->assertSame('revoked', $node->status);
+
+        $license = EdgeLicense::where('edge_node_id', $node->id)->first();
+        $this->assertSame('revoked', $license->validation_status);
+    }
+
+    /**
+     * POST /edge/heartbeat must accept either the node UUID or its
+     * human-readable slug and update the canonical row.
+     */
+    public function test_heartbeat_accepts_uuid_and_updates_canonical_node(): void
+    {
+        $node = $this->createEdgeNode(['last_seen_at' => Carbon::now()->subHour(), 'status' => 'inactive']);
+
+        $this->postJson('/api/v1/edge/heartbeat', [
+            'node_id'       => $node->id,
+            'pending_count' => 2,
+            'version'       => '9.9.9',
+            'ip_address'    => '198.51.100.5',
+        ])->assertOk()->assertJsonPath('status', 'ok');
+
+        $node->refresh();
+        $this->assertSame('active', $node->status);
+        $this->assertSame('9.9.9', $node->edge_version);
+        $this->assertSame('198.51.100.5', $node->public_ip);
+        $this->assertNotNull($node->last_seen_at);
+    }
+
+    public function test_heartbeat_accepts_slug_identifier(): void
+    {
+        $node = $this->createEdgeNode();
+
+        $this->postJson('/api/v1/edge/heartbeat', [
+            'node_id' => $node->slug,
+        ])->assertOk()->assertJsonPath('status', 'ok');
+
+        $node->refresh();
+        $this->assertSame('active', $node->status);
+    }
+
+    public function test_heartbeat_returns_404_for_unknown_node(): void
+    {
+        $this->postJson('/api/v1/edge/heartbeat', [
+            'node_id' => 'does-not-exist',
+        ])->assertStatus(404)->assertJsonPath('error', 'node_not_found');
+    }
+}


### PR DESCRIPTION
## What Problem This Solves
`/platform/edge/nodes*` (list/forceSync/revokeNode) and `/edge/heartbeat` were querying a legacy bigint `edge_nodes` schema via raw `DB::table('edge_nodes')` calls. That legacy migration (`2026_06_30_000001_create_edge_nodes_table.php`) self-neutralizes (no-op) whenever the canonical UUID/DDD `edge_nodes` table already exists — and it always does, since `2026_06_29_000001_create_edge_sync_tables.php` runs first. So in every real environment (production, CI) the legacy bigint columns never actually exist, and these super-admin platform routes broke outright.

## Why This Change Was Made
Rather than merging two competing schemas, the fix aligns `EdgeController`'s platform node-management methods with the schema that is actually created: the canonical `App\Modules\EdgeSync\Domain\Models\EdgeNode` Eloquent model (UUID primary key).

## User Impact
- Super-admins can once again list Edge nodes, force a sync, and revoke a node from the platform admin UI/API (`GET/POST/DELETE /platform/edge/nodes*`) — these were previously broken against real deployments.
- Revoking a node from the platform now also revokes its `EdgeLicense` (via `EdgeLicenseService`), which the legacy code never did correctly.
- `/edge/heartbeat` no longer crashes (Postgres "invalid input syntax for type uuid") when a node identifies itself by slug instead of UUID.
- Route params for `forceSync`/`revokeNode` now validate as UUIDs (matching the model's real key type) instead of numeric ids.

## Evidence
- Added `tests/Feature/Edge/EdgePlatformNodeManagementTest.php` — 7 new tests covering `listNodes`, `forceSync` (success + 404), `revokeNode` (+ license revocation), and `heartbeat` (UUID, slug, unknown-node 404) against the canonical schema. All pass.
- Full existing Edge/EdgeSync suite still green: `61 passed, 2 skipped` (`tests/Feature/Edge`, `tests/Feature/EdgeSync`) run against Postgres matching CI config.
- `vendor/bin/phpstan analyse --configuration=phpstan-modules.neon`: no errors.
- `php -l` clean on all touched files.

Fixes #1291