### PR TITLE
fix(ci,security): add CodeQL-recognized workflow_run repo guard to distribute-mobile (#1396)

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -282,7 +282,25 @@ jobs:
     name: Distribute mobile staging build
     runs-on: ubuntu-latest
     needs: [prepare, deploy-api]
-    if: needs.prepare.outputs.should_deploy == 'true'
+    # actions/untrusted-checkout (issue #1396, alert #29): the previous same-job
+    # guard ("Verify deployment SHA is on main before privileged checkout" below)
+    # is a real runtime check, but it uses a custom actions/github-script snippet
+    # that CodeQL's static control-check recognizer does not match against any
+    # known pattern, so the checkout step stayed flagged as unverified even
+    # after that fix landed. CodeQL *does* recognize a job-level `if:` that
+    # compares github.event.workflow_run.head_repository.full_name to
+    # github.repository as a valid workflow_run repository check, so this
+    # condition adds that exact recognized guard. It is a redundant safety net
+    # in practice - prepare's should_deploy output already gates on this same
+    # comparison (see the "Resolve deployment source" step) - but it makes the
+    # protection visible to CodeQL at the point of privileged checkout instead
+    # of only in an earlier job it cannot see across. workflow_dispatch (manual
+    # deploy from main) has no workflow_run payload, so it is short-circuited
+    # true and unaffected.
+    if: >
+      needs.prepare.outputs.should_deploy == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.head_repository.full_name == github.repository)
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
## Résumé
Corrige les 3 alertes CodeQL untrusted-checkout/cache-poisoning documentées dans #1396 sur `deploy-main.yml`.

## Contexte
Une passe de durcissement précédente (#1366) avait déjà ajouté un garde-fou dans le même job (`distribute-mobile`) : un script `actions/github-script` qui vérifie via `compareCommitsWithBasehead` que `needs.prepare.outputs.sha` est bien `main` ou un ancêtre de `main` avant le checkout privilégié. C'est un vrai contrôle runtime — mais CodeQL ne reconnaît ce genre de logique custom via aucun de ses patterns statiques de "control check" pour `untrusted-checkout`, donc l'alerte #29 restait ouverte malgré tout.

## Root cause identifiée
En inspectant la librairie CodeQL Actions (`ControlChecks.qll`) et la doc query-help officielle, j'ai confirmé que le pattern reconnu pour un job `workflow_run` privilégié est précisément une condition `if:` comparant `github.event.workflow_run.head_repository.full_name` à `github.repository` — c'est littéralement l'exemple "Correct Usage" de la doc GitHub Security Lab pour ce type de déclencheur.

## Fix
- Ajout de cette condition `if:` exacte au niveau du job `distribute-mobile`, court-circuitée pour `workflow_dispatch` (qui n'a pas de payload `workflow_run`).
- C'est une ceinture-et-bretelles en pratique : le job `prepare` fait déjà cette même comparaison pour calculer `should_deploy`. Le changement rend simplement cette protection visible à l'analyse statique de CodeQL directement au point du checkout privilégié, au lieu d'être seulement présente dans un job amont qu'elle ne peut pas traverser.
- Le garde-fou runtime existant (`compareCommitsWithBasehead`) est conservé intact — défense en profondeur.

## Alertes #1 et #2
Ces deux alertes étaient en réalité des doublons obsolètes : elles pointaient sur une ancienne catégorie d'analyse CodeQL (`.github/workflows/codeql.yml:analyze/language:actions`) renommée en `analyze-actions` lors du PR #1354 (19 juillet 2026). Cette ancienne catégorie ne tourne plus jamais, donc GitHub ne pouvait jamais les marquer "fixed" automatiquement, même après correction du code. Vérifié via l'API : le run le plus récent de la catégorie `analyze-actions` actuelle (commit `62b2612e`, 2026-08-01) ne reporte plus qu'un seul résultat — l'alerte #29 ci-dessus. Je les ai dismissées via l'API Code Scanning avec une justification factuelle documentée (`won't fix` + explication).

## Vérification
- [x] `actionlint` (avec shellcheck intégré) passe sans erreur sur le fichier modifié et sur l'ensemble de `.github/workflows/`
- [x] Alertes #1 et #2 : dismissées via l'API avec justification (doublons obsolètes)
- [ ] Alerte #29 : sera confirmée "fixed" par CodeQL après merge sur `main` (nécessite un run de `codeql.yml` sur `main`)
- [x] Le pipeline de déploiement n'est pas cassé : la condition ajoutée est strictement équivalente à la logique déjà appliquée dans `prepare` pour ce même run — aucun changement de comportement pour les déploiements légitimes (push sur main / workflow_dispatch manuel)
- [x] Décision documentée dans le workflow (commentaire explicatif au-dessus de la condition `if:`)

Fixes #1396