### PR TITLE
fix(mobile): renommer 24 constructeurs de widgets + GlassGlassCard inexistante (issues #1482 #1483)

### DIFF
--- a/front/mobile_apps/leopardo_employee/lib/features/home/screens/home_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/home/screens/home_screen.dart
@@ -262,7 +262,7 @@ class _QuickActionsGrid extends StatelessWidget {
           physics: const NeverScrollableScrollPhysics(),
           children:
               actions
-                  .map((action) => _QuickActionGlassCard(action: action))
+                  .map((action) => _QuickActionCard(action: action))
                   .toList(),
         );
       },
@@ -271,7 +271,7 @@ class _QuickActionsGrid extends StatelessWidget {
 }
 
 class _QuickActionCard extends StatelessWidget {
-  const _QuickActionGlassCard({required this.action});
+  const _QuickActionCard({required this.action});
 
   final MobileQuickAction action;
 
@@ -305,7 +305,7 @@ class _ModulesScroller extends StatelessWidget {
       child: Row(
         children: [
           for (final module in modules) ...[
-            _ModuleGlassCard(module: module),
+            _ModuleCard(module: module),
             const SizedBox(width: 10),
           ],
         ],
@@ -315,7 +315,7 @@ class _ModulesScroller extends StatelessWidget {
 }
 
 class _ModuleCard extends StatelessWidget {
-  const _ModuleGlassCard({required this.module});
+  const _ModuleCard({required this.module});
 
   final MobileModule module;
 

--- a/front/mobile_apps/leopardo_employee/lib/features/home/screens/modules_hub_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/home/screens/modules_hub_screen.dart
@@ -94,7 +94,7 @@ class ModulesHubScreen extends ConsumerWidget {
               itemCount: activeModules.length,
               itemBuilder: (context, index) {
                 final module = activeModules[index];
-                return _ModuleGlassCard(
+                return _ModuleCard(
                   module: module,
                   onTap: module.isActive
                       ? () => context.push(module.route!)
@@ -129,7 +129,7 @@ class ModulesHubScreen extends ConsumerWidget {
 }
 
 class _ModuleCard extends StatelessWidget {
-  const _ModuleGlassCard({required this.module, required this.onTap});
+  const _ModuleCard({required this.module, required this.onTap});
 
   final MobileModule module;
   final VoidCallback? onTap;

--- a/front/mobile_apps/leopardo_employee/lib/features/payrolls/screens/payroll_list_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/payrolls/screens/payroll_list_screen.dart
@@ -131,11 +131,11 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
                   children: [
                     Padding(
                       padding: const EdgeInsets.only(bottom: 16),
-                      child: _BalanceGlassCard(balanceAsync: balanceAsync),
+                      child: _BalanceCard(balanceAsync: balanceAsync),
                     ),
                     Padding(
                       padding: const EdgeInsets.only(bottom: 16),
-                      child: _PaymentDocumentsGlassCard(
+                      child: _PaymentDocumentsCard(
                         documentsAsync: documentsAsync,
                         downloadingId: _downloadingDocumentId,
                         onDownload: _downloadPaymentDocument,
@@ -226,9 +226,9 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.all(20),
             children: [
-              _BalanceGlassCard(balanceAsync: balanceAsync),
+              _BalanceCard(balanceAsync: balanceAsync),
               const SizedBox(height: 16),
-              _PaymentDocumentsGlassCard(
+              _PaymentDocumentsCard(
                 documentsAsync: documentsAsync,
                 downloadingId: _downloadingDocumentId,
                 onDownload: _downloadPaymentDocument,
@@ -245,9 +245,9 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.all(20),
             children: [
-              _BalanceGlassCard(balanceAsync: balanceAsync),
+              _BalanceCard(balanceAsync: balanceAsync),
               const SizedBox(height: 16),
-              _PaymentDocumentsGlassCard(
+              _PaymentDocumentsCard(
                 documentsAsync: documentsAsync,
                 downloadingId: _downloadingDocumentId,
                 onDownload: _downloadPaymentDocument,
@@ -266,7 +266,7 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
 }
 
 class _PaymentDocumentsCard extends StatelessWidget {
-  const _PaymentDocumentsGlassCard({
+  const _PaymentDocumentsCard({
     required this.documentsAsync,
     required this.downloadingId,
     required this.onDownload,
@@ -409,7 +409,7 @@ class _PaymentDocumentTile extends StatelessWidget {
 }
 
 class _BalanceCard extends StatelessWidget {
-  const _BalanceGlassCard({required this.balanceAsync});
+  const _BalanceCard({required this.balanceAsync});
 
   final AsyncValue<PayrollBalance> balanceAsync;
 

--- a/front/mobile_apps/leopardo_employee/lib/features/personal_space/screens/personal_space_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/personal_space/screens/personal_space_screen.dart
@@ -44,7 +44,7 @@ class PersonalSpaceScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            _ActionGlassCard(
+            _ActionCard(
               title: 'CrÃ©er mon entreprise',
               description:
                   'Envoyez une demande pour enregistrer votre entreprise sur Leopardo RH.',
@@ -53,7 +53,7 @@ class PersonalSpaceScreen extends ConsumerWidget {
               onTap: () => context.push('/company-request'),
             ),
             const SizedBox(height: 16),
-            _ActionGlassCard(
+            _ActionCard(
               title: 'Rejoindre une Ã©quipe',
               description:
                   'Attendez que votre employeur vous invite via votre email : ${employee?.email}',
@@ -83,7 +83,7 @@ class _ActionCard extends StatelessWidget {
   final Color color;
   final VoidCallback onTap;
 
-  const _ActionGlassCard({
+  const _ActionCard({
     required this.title,
     required this.description,
     required this.icon,

--- a/front/mobile_apps/leopardo_employee/lib/features/profile/screens/profile_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/profile/screens/profile_screen.dart
@@ -48,9 +48,9 @@ class ProfileScreen extends ConsumerWidget {
               children: [
                 _ProfileHeader(employee: employee),
                 const SizedBox(height: 20),
-                _ProfileDetailsGlassCard(employee: employee),
+                _ProfileDetailsCard(employee: employee),
                 const SizedBox(height: 20),
-                _ProfileLanguageGlassCard(
+                _ProfileLanguageCard(
                   employee: employee,
                   languageLabels: _languageLabels,
                 ),
@@ -136,7 +136,7 @@ class _ProfileHeader extends StatelessWidget {
 }
 
 class _ProfileDetailsCard extends StatelessWidget {
-  const _ProfileDetailsGlassCard({required this.employee});
+  const _ProfileDetailsCard({required this.employee});
 
   final Employee employee;
 
@@ -229,7 +229,7 @@ class _ProfileInfoRow extends StatelessWidget {
 }
 
 class _ProfileLanguageCard extends ConsumerStatefulWidget {
-  const _ProfileLanguageGlassCard({
+  const _ProfileLanguageCard({
     required this.employee,
     required this.languageLabels,
   });

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/attendance_mode_picker_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/attendance_mode_picker_screen.dart
@@ -146,7 +146,7 @@ class _AttendanceModePickerScreenState
                 separatorBuilder: (_, __) => const SizedBox(height: 12),
                 itemBuilder: (context, index) {
                   final mode = _modes[index];
-                  return _ModeGlassCard(
+                  return _ModeCard(
                     modeId: mode['id'] as String,
                     label: mode['label'] as String,
                     icon: mode['icon'] as IconData,
@@ -242,7 +242,7 @@ class _ModeCard extends StatelessWidget {
   static const Color _muted = AppColors.mobileDarkMuted;
   static const Color _border = AppColors.mobileDarkBorder;
 
-  const _ModeGlassCard({
+  const _ModeCard({
     required this.modeId,
     required this.label,
     required this.icon,

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/background_permission_onboarding_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/background_permission_onboarding_screen.dart
@@ -133,17 +133,17 @@ class _BackgroundPermissionOnboardingScreenState
               const SizedBox(height: 24),
 
               // Steps
-              _StepGlassCard(
+              _StepCard(
                 step: '1',
                 text: 'Appuyez sur "Ouvrir les paramÃ¨tres" ci-dessous',
               ),
               const SizedBox(height: 10),
-              _StepGlassCard(
+              _StepCard(
                 step: '2',
                 text: 'Touchez "Autorisations" â†’ "Position"',
               ),
               const SizedBox(height: 10),
-              _StepGlassCard(
+              _StepCard(
                 step: '3',
                 text: 'SÃ©lectionnez "Toujours autoriser"',
               ),
@@ -196,7 +196,7 @@ class _BackgroundPermissionOnboardingScreenState
 }
 
 class _StepCard extends StatelessWidget {
-  const _StepGlassCard({required this.step, required this.text});
+  const _StepCard({required this.step, required this.text});
   final String step;
   final String text;
 

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
@@ -108,7 +108,7 @@ class _SmartAttendanceScreenState extends ConsumerState<SmartAttendanceScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
       children: [
         // Section mode effectif
-        _ModeStatusGlassCard(
+        _ModeStatusCard(
           effectiveMode: effectiveMode,
           config: config,
           canChangeMode: canChangeMode,
@@ -119,7 +119,7 @@ class _SmartAttendanceScreenState extends ConsumerState<SmartAttendanceScreen> {
 
         // Section statut zone GPS (visible uniquement en mode GPS auto)
         if (effectiveMode == 'gps_auto') ...[
-          _GpsZoneStatusGlassCard(
+          _GpsZoneStatusCard(
             config: config,
             sessionState: sessionState,
             onStartMonitoring: () async {
@@ -170,7 +170,7 @@ class _SmartAttendanceScreenState extends ConsumerState<SmartAttendanceScreen> {
           ...sessionState.recentSessions.take(10).map(
                 (session) => Padding(
                   padding: const EdgeInsets.only(bottom: 10),
-                  child: _SessionGlassCard(session: session),
+                  child: _SessionCard(session: session),
                 ),
               ),
 
@@ -211,7 +211,7 @@ class _ModeStatusCard extends StatelessWidget {
   static const Color _border = AppColors.mobileDarkBorder;
   static const Color _accent = AppColors.mobileAccentBlue;
 
-  const _ModeStatusGlassCard({
+  const _ModeStatusCard({
     required this.effectiveMode,
     required this.config,
     required this.canChangeMode,
@@ -362,7 +362,7 @@ class _GpsZoneStatusCard extends StatelessWidget {
   static const Color _red = AppColors.mobileAccentRedLight;
   static const Color _accent = AppColors.mobileAccentBlue;
 
-  const _GpsZoneStatusGlassCard({
+  const _GpsZoneStatusCard({
     required this.config,
     required this.sessionState,
     required this.onStartMonitoring,
@@ -543,7 +543,7 @@ class _SessionCard extends StatelessWidget {
   static const Color _muted = AppColors.mobileDarkMuted;
   static const Color _border = AppColors.mobileDarkBorder;
 
-  const _SessionGlassCard({required this.session});
+  const _SessionCard({required this.session});
 
   Color get _statusColor {
     switch (session.status) {

--- a/front/mobile_apps/leopardo_employee/lib/features/user_auth/screens/user_home_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/user_auth/screens/user_home_screen.dart
@@ -154,7 +154,7 @@ class UserHomeScreen extends ConsumerWidget {
         Row(
           children: [
             Expanded(
-              child: _QuickActionGlassCard(
+              child: _QuickActionCard(
                 icon: Icons.door_sliding_outlined,
                 label: 'Placard',
                 color: AppColors.cabinet,
@@ -166,7 +166,7 @@ class UserHomeScreen extends ConsumerWidget {
             ),
             const SizedBox(width: 12),
             Expanded(
-              child: _QuickActionGlassCard(
+              child: _QuickActionCard(
                 icon: Icons.business_outlined,
                 label: 'Creer entreprise',
                 color: AppColors.ia,
@@ -193,7 +193,7 @@ class _QuickActionCard extends StatelessWidget {
   final Color color;
   final VoidCallback onTap;
 
-  const _QuickActionGlassCard({
+  const _QuickActionCard({
     required this.icon,
     required this.label,
     required this.color,

--- a/front/mobile_apps/leopardo_manager/lib/features/home/screens/home_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/home/screens/home_screen.dart
@@ -105,7 +105,7 @@ class HomeScreen extends ConsumerWidget {
                     _ModulesScroller(modules: activeModules),
                     if (canManageTeam) ...[
                       const SizedBox(height: 20),
-                      const _ManagerDigestGlassCard(),
+                      const _ManagerDigestCard(),
                     ],
                   ],
                 ),
@@ -182,7 +182,7 @@ class _HeroHeader extends StatelessWidget {
       'fr_FR',
     ).add_d().add_MMMM().format(DateTime.now());
 
-    return GlassGlassCard(
+    return GlassCard(
       padding: const EdgeInsets.all(20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -272,7 +272,7 @@ class _QuickActionsGrid extends StatelessWidget {
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
           children: actions
-              .map((action) => _QuickActionGlassCard(action: action))
+              .map((action) => _QuickActionCard(action: action))
               .toList(),
         );
       },
@@ -281,7 +281,7 @@ class _QuickActionsGrid extends StatelessWidget {
 }
 
 class _QuickActionCard extends StatelessWidget {
-  const _QuickActionGlassCard({required this.action});
+  const _QuickActionCard({required this.action});
 
   final MobileQuickAction action;
 
@@ -294,7 +294,7 @@ class _QuickActionCard extends StatelessWidget {
     return InkWell(
       borderRadius: BorderRadius.circular(16),
       onTap: () => context.push(action.route),
-      child: GlassGlassCard(
+      child: GlassCard(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -357,7 +357,7 @@ class _ModulesScroller extends StatelessWidget {
       child: Row(
         children: [
           for (final module in modules) ...[
-            _ModuleGlassCard(module: module),
+            _ModuleCard(module: module),
             const SizedBox(width: 10),
           ],
         ],
@@ -367,7 +367,7 @@ class _ModulesScroller extends StatelessWidget {
 }
 
 class _ModuleCard extends StatelessWidget {
-  const _ModuleGlassCard({required this.module});
+  const _ModuleCard({required this.module});
 
   final MobileModule module;
 
@@ -380,7 +380,7 @@ class _ModuleCard extends StatelessWidget {
     return InkWell(
       onTap: module.isActive ? () => context.push(module.route!) : null,
       borderRadius: BorderRadius.circular(24),
-      child: GlassGlassCard(
+      child: GlassCard(
         width: 206,
         padding: const EdgeInsets.all(18),
         child: Column(
@@ -478,7 +478,7 @@ class ManagerDigest {
 }
 
 class _ManagerDigestCard extends ConsumerWidget {
-  const _ManagerDigestGlassCard();
+  const _ManagerDigestCard();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -487,7 +487,7 @@ class _ManagerDigestCard extends ConsumerWidget {
     final digest = ref.watch(managerDigestProvider);
     final resolvedDigest = digest.asData?.value;
 
-    return GlassGlassCard(
+    return GlassCard(
       padding: const EdgeInsets.all(20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/front/mobile_apps/leopardo_manager/lib/features/home/screens/modules_hub_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/home/screens/modules_hub_screen.dart
@@ -94,7 +94,7 @@ class ModulesHubScreen extends ConsumerWidget {
               itemCount: activeModules.length,
               itemBuilder: (context, index) {
                 final module = activeModules[index];
-                return _ModuleGlassCard(
+                return _ModuleCard(
                   module: module,
                   onTap: module.isActive
                       ? () => context.push(module.route!)
@@ -129,7 +129,7 @@ class ModulesHubScreen extends ConsumerWidget {
 }
 
 class _ModuleCard extends StatelessWidget {
-  const _ModuleGlassCard({required this.module, required this.onTap});
+  const _ModuleCard({required this.module, required this.onTap});
 
   final MobileModule module;
   final VoidCallback? onTap;

--- a/front/mobile_apps/leopardo_manager/lib/features/modules/screens/modules_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/modules/screens/modules_screen.dart
@@ -130,7 +130,7 @@ class _EvaluationsTab extends ConsumerWidget {
               }
 
               final item = items[isManager ? index - 1 : index];
-              return _EvaluationGlassCard(
+              return _EvaluationCard(
                 item: item,
                 isManager: isManager,
                 onAction: () => _showEvaluationActions(context, ref, item),
@@ -243,7 +243,7 @@ class _EvaluationsTab extends ConsumerWidget {
 }
 
 class _EvaluationCard extends StatelessWidget {
-  const _EvaluationGlassCard({
+  const _EvaluationCard({
     required this.item,
     required this.isManager,
     required this.onAction,
@@ -780,7 +780,7 @@ class _NotificationsTab extends ConsumerWidget {
               }
 
               final item = items[index - 1];
-              return _NotificationGlassCard(
+              return _NotificationCard(
                 item: item,
                 onTap: () => _showNotificationActions(context, ref, item),
               );
@@ -852,7 +852,7 @@ class _NotificationsTab extends ConsumerWidget {
 }
 
 class _NotificationCard extends StatelessWidget {
-  const _NotificationGlassCard({required this.item, required this.onTap});
+  const _NotificationCard({required this.item, required this.onTap});
 
   final AppNotification item;
   final VoidCallback onTap;

--- a/front/mobile_apps/leopardo_manager/lib/features/payrolls/screens/payroll_list_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/payrolls/screens/payroll_list_screen.dart
@@ -148,7 +148,7 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.all(20),
             children: [
-              _SummaryGlassCard(summaryAsync: summaryAsync),
+              _SummaryCard(summaryAsync: summaryAsync),
               const SizedBox(height: 16),
               Text(
                 'Bulletins recents',
@@ -247,7 +247,7 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.all(20),
             children: [
-              _SummaryGlassCard(summaryAsync: summaryAsync),
+              _SummaryCard(summaryAsync: summaryAsync),
               const SizedBox(height: 120),
               const Center(
                 child: CircularProgressIndicator(
@@ -260,7 +260,7 @@ class _PayrollListScreenState extends ConsumerState<PayrollListScreen> {
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.all(20),
             children: [
-              _SummaryGlassCard(summaryAsync: summaryAsync),
+              _SummaryCard(summaryAsync: summaryAsync),
               const SizedBox(height: 120),
               Text(
                 e.toString(),
@@ -440,7 +440,7 @@ class _PaymentDocumentTile extends StatelessWidget {
 }
 
 class _SummaryCard extends StatelessWidget {
-  const _SummaryGlassCard({required this.summaryAsync});
+  const _SummaryCard({required this.summaryAsync});
 
   final AsyncValue<PayrollMobileSummary> summaryAsync;
 

--- a/front/mobile_apps/leopardo_manager/lib/features/personal_space/screens/personal_space_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/personal_space/screens/personal_space_screen.dart
@@ -44,7 +44,7 @@ class PersonalSpaceScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 32),
-            _ActionGlassCard(
+            _ActionCard(
               title: 'CrÃ©er mon entreprise',
               description:
                   'Envoyez une demande pour enregistrer votre entreprise sur Leopardo RH.',
@@ -53,7 +53,7 @@ class PersonalSpaceScreen extends ConsumerWidget {
               onTap: () => context.push('/company-request'),
             ),
             const SizedBox(height: 16),
-            _ActionGlassCard(
+            _ActionCard(
               title: 'Rejoindre une Ã©quipe',
               description:
                   'Attendez que votre employeur vous invite via votre email : ${employee?.email}',
@@ -83,7 +83,7 @@ class _ActionCard extends StatelessWidget {
   final Color color;
   final VoidCallback onTap;
 
-  const _ActionGlassCard({
+  const _ActionCard({
     required this.title,
     required this.description,
     required this.icon,

--- a/front/mobile_apps/leopardo_manager/lib/features/tasks/screens/task_list_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/tasks/screens/task_list_screen.dart
@@ -62,7 +62,7 @@ class TaskListScreen extends ConsumerWidget {
             return ListView.builder(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 120),
               itemCount: tasks.length,
-              itemBuilder: (_, index) => _TaskGlassCard(task: tasks[index]),
+              itemBuilder: (_, index) => _TaskCard(task: tasks[index]),
             );
           },
         ),
@@ -84,7 +84,7 @@ class TaskListScreen extends ConsumerWidget {
 }
 
 class _TaskCard extends StatelessWidget {
-  const _TaskGlassCard({required this.task});
+  const _TaskCard({required this.task});
 
   final Task task;
 

--- a/front/mobile_apps/leopardo_manager/lib/features/user_auth/screens/user_home_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/user_auth/screens/user_home_screen.dart
@@ -154,7 +154,7 @@ class UserHomeScreen extends ConsumerWidget {
         Row(
           children: [
             Expanded(
-              child: _QuickActionGlassCard(
+              child: _QuickActionCard(
                 icon: Icons.door_sliding_outlined,
                 label: 'Placard',
                 color: AppColors.cabinet,
@@ -166,7 +166,7 @@ class UserHomeScreen extends ConsumerWidget {
             ),
             const SizedBox(width: 12),
             Expanded(
-              child: _QuickActionGlassCard(
+              child: _QuickActionCard(
                 icon: Icons.business_outlined,
                 label: 'Creer entreprise',
                 color: AppColors.ia,
@@ -193,7 +193,7 @@ class _QuickActionCard extends StatelessWidget {
   final Color color;
   final VoidCallback onTap;
 
-  const _QuickActionGlassCard({
+  const _QuickActionCard({
     required this.icon,
     required this.label,
     required this.color,


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Fixes #1483, Closes #1482
**Category:** Bug Fix

## 🚀 Changes Description

Correction du breakage mobile introduit par #1431 (refonte glass) : les apps leopardo_employee et leopardo_manager ne compilent plus.

- **24 constructeurs mal nommés** : la classe `_XCard` déclarait un constructeur `_XGlassCard(...)` (Dart interdit : ctor ≠ classe). Renommés pour correspondre à leur classe. (L'issue #1482 en listait 23 — le 24e, `_ManagerDigestGlassCard` dans home_screen du manager, n'était pas répertorié.)
- **`GlassGlassCard` inexistante ×4** : remplacée par la vraie `GlassCard` (leopardo_core) dans home_screen du manager (l.185/297/383/490).
- Les helpers `_build*GlassCard` / `_metricGlassCard` (fonctions définies ET appelées avec le même nom) sont **volontairement non touchés** : ils compilent.

## 🗺️ Surfaces touchees
- [x] Mobile (`front/mobile_apps/*`)
- [ ] CI / GitHub Actions
- [ ] API / Web / Admin / Docs

## 🔌 Contrat API
- [x] Aucun changement de contrat API dans cette PR.

## ⚠️ Risques residuels
- Pas de SDK Flutter dans l'environnement d'audit : vérification par `flutter analyze` + builds en CI (job mobile-apps-ci). Les renames sont mécaniques (64 remplacements, 16 fichiers) et vérifiés par script (0 ctor désaligné restant dans les 6 apps).

## 🛡 Quality Checklist
- [x] Code Quality: renommage mécanique conforme au pattern existant
- [ ] Testing: CI mobile (flutter analyze + builds) — SDK absent localement
- [x] Verification: 0 constructeur désaligné restant (script), 0 GlassGlassCard
- [x] Documentation: n/a (fix)
- [x] Security: aucun impact
- [x] Breaking Changes: aucun (identifiants privés, scope fichier)