### PR TITLE
ci(staging): retirer les fallbacks production — fail-fast sans vrai environnement staging (issue #1485)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ depuis les steps des workflows ci-dessous, pas declenchees directement.
 | Fichier | Déclencheur | Rôle |
 |---|---|---|
 | `deploy-main.yml` | Push → main | Déploiement production (Render) |
-| `deploy-staging.yml` | Push → staging | Déploiement staging |
+| `deploy-staging.yml` | `workflow_run` (Tests sur main) + dispatch | Déploiement staging — **fail-fast si `STAGING_API_URL`/`RENDER_STAGING_DEPLOY_HOOK_URL` absents** (plus aucun fallback prod, issue #1485) |
 | `e2e-staging.yml` | Après deploy-staging | Tests E2E post-déploiement |
 | `mobile-distribute.yml` | Manuel + tags | Distribution APK/IPA |
 | `release.yml` | Tags v*.*.* | Création de release GitHub |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -81,19 +81,31 @@ jobs:
     if: needs.gate.outputs.should_deploy == 'true'
     environment:
       name: staging
-      url: ${{ vars.STAGING_API_URL || 'https://gestionemployerbackend.onrender.com' }}
+      url: ${{ vars.STAGING_API_URL }}
 
     steps:
+      - name: Verify staging environment is configured
+        shell: bash
+        env:
+          STAGING_API_URL: ${{ vars.STAGING_API_URL }}
+          RENDER_STAGING_DEPLOY_HOOK_URL: ${{ secrets.RENDER_STAGING_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${STAGING_API_URL}" ]]; then
+            echo "::error::STAGING_API_URL is not set. Refusing to deploy: without it, this workflow would target the production URL (issue #1485). Configure a real staging environment first."
+            exit 1
+          fi
+          if [[ -z "${RENDER_STAGING_DEPLOY_HOOK_URL}" ]]; then
+            echo "::error::RENDER_STAGING_DEPLOY_HOOK_URL is not set. The production deploy hook is NOT used as a fallback anymore (issue #1485)."
+            exit 1
+          fi
+
       - name: Trigger Render staging deploy
         shell: bash
         env:
-          RENDER_STAGING_HOOK_URL: ${{ secrets.RENDER_STAGING_DEPLOY_HOOK_URL || secrets.RENDER_DEPLOY_HOOK_URL }}
+          RENDER_STAGING_HOOK_URL: ${{ secrets.RENDER_STAGING_DEPLOY_HOOK_URL }}
         run: |
           set -euo pipefail
-          if [[ -z "${RENDER_STAGING_HOOK_URL}" ]]; then
-            echo "::warning::No staging deploy hook configured. Set RENDER_STAGING_DEPLOY_HOOK_URL or RENDER_DEPLOY_HOOK_URL secret."
-            exit 0
-          fi
           echo "Triggering Render staging deployment..."
           curl --fail --silent --show-error --request POST "${RENDER_STAGING_HOOK_URL}"
           echo "Deploy hook triggered successfully."
@@ -101,7 +113,7 @@ jobs:
       - name: Wait for staging health
         shell: bash
         env:
-          STAGING_URL: ${{ vars.STAGING_API_URL || 'https://gestionemployerbackend.onrender.com' }}
+          STAGING_URL: ${{ vars.STAGING_API_URL }}
         run: |
           set -euo pipefail
           URL="${STAGING_URL}/api/v1/health"

--- a/docs/ARCHITECTURE_CICD.md
+++ b/docs/ARCHITECTURE_CICD.md
@@ -45,6 +45,7 @@ PR → merge sur main
 
 ### Staging
 - Même architecture, variables `APP_ENV=staging`
+- **Depuis #1485** : `deploy-staging.yml` échoue (fail-fast) si `STAGING_API_URL` ou `RENDER_STAGING_DEPLOY_HOOK_URL` ne sont pas configurés — les fallbacks vers les valeurs/secret de production ont été retirés. Tant qu'aucune app Render staging réelle n'existe, ce workflow restera rouge sur main (signal volontaire, pas un déploiement masqué de la prod).
 
 ## Variables d'environnement requises
 


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1485
**Category:** Bug Fix

## 🚀 Changes Description

Le workflow `deploy-staging.yml` n'était pas un vrai staging : il utilisait
- **l'URL de production** par défaut (`https://gestionemployerbackend.onrender.com`) pour le healthcheck et l'URL d'environnement (l.84/104),
- **le hook de déploiement de production** (`secrets.RENDER_DEPLOY_HOOK_URL`) comme fallback (l.90).

→ chaque push sur main « déployait le staging »… sur la prod (ou le skip silencieux).

**Changements :**
- Nouvelle étape `Verify staging environment is configured` : fail-fast si `STAGING_API_URL` ou `RENDER_STAGING_DEPLOY_HOOK_URL` sont absents.
- Suppression des deux fallbacks prod (URL + secret). Le healthcheck ne peut plus cibler la prod.
- Doc : `.github/workflows/README.md` + `docs/ARCHITECTURE_CICD.md` alignés (déclencheur réel : workflow_run sur main + dispatch ; exigence de config staging).

## 🗺️ Surfaces touchees
- [x] CI / GitHub Actions (`.github/workflows`)
- [x] Docs uniquement (README workflows, ARCHITECTURE_CICD)

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- Ce workflow sera **rouge** tant qu'aucun vrai environnement staging (app Render + var `STAGING_API_URL` + secret hook) n'existera — c'est voulu (signal explicite plutôt que déploiement masqué de la prod).
- La création de l'environnement staging réel (app Render séparée) reste un travail produit/infra à part, hors scope de cette PR.

## 🛡 Quality Checklist
- [x] Code Quality: YAML validé
- [x] Testing: CI PR (actionlint)
- [x] Verification: 0 référence à l'URL prod ou au secret prod dans le workflow
- [x] Documentation: README workflows + ARCHITECTURE_CICD à jour
- [x] Security: suppression d'un chemin qui pouvait déclencher un déploiement prod
- [x] Breaking Changes: oui, assumé (le workflow échoue sans config staging réelle)