### PR TITLE
ci(fix-composer-lock): généraliser le hack one-off en workflow manuel documenté (issue #1500)

### DIFF
--- a/.github/workflows/fix-composer-lock.yml
+++ b/.github/workflows/fix-composer-lock.yml
@@ -1,11 +1,11 @@
 name: Fix — Regenerate composer.lock
 
+# Généralisé depuis un hack one-off (branche aléatoire
+# feat/growth-module-6687823184469251636, issue #1500) vers un outil manuel
+# documenté : utilisé pour régénérer composer.lock lors d'advisories de
+# sécurité (ex. guzzle/phpseclib, #1463). À lancer via workflow_dispatch.
 on:
   workflow_dispatch:
-  push:
-    branches: [ feat/growth-module-6687823184469251636 ]
-    paths:
-      - 'api/composer.json'
 
 permissions:
   contents: write


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1500
**Category:** Refactor

## 🚀 Changes Description

`fix-composer-lock.yml` ne se déclenchait que sur push d'une branche aléatoire (`feat/growth-module-6687823184469251636`), ce qui le rendait inutile après merge (#1500).

- Trigger push retiré ; le workflow est désormais **`workflow_dispatch` uniquement** (manuel).
- Commentaire d'en-tête ajouté : contexte (advisories guzzle/phpseclib #1463), usage.
- README workflows le décrivait déjà comme « Manuel » → aligné avec la réalité.

## 🗺️ Surfaces touchees
- [x] CI / GitHub Actions

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- Aucun : le workflow est explicitement manuel, plus rien ne se déclenche tout seul.

## 🛡 Quality Checklist
- [x] Code Quality: YAML validé
- [x] Verification: déclencheur unique workflow_dispatch
- [x] Documentation: en-tête de fichier + README cohérents
- [x] Security: permissions inchangées (contents: write — nécessaire au commit du lock)