### PR TITLE
docs(roadmap): réécrire ROADMAP.md racine, alignée sur la réalité (issue #1505)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,46 +1,31 @@
 # Product Roadmap — Leopardo RH
 
-> ⚠️ **Ce document decrit une trajectoire produit aspirationnelle/marketing.**
-> Pour l'etat operationnel reel, les priorites courantes et les ecarts avec cette roadmap,
-> se referer a [`PILOTAGE.md`](PILOTAGE.md), qui prime en cas de divergence entre les deux documents.
+> ⚠️ **Source de vérité opérationnelle : [`docs/REFERENTIEL_PRODUIT/ROADMAP.md`](docs/REFERENTIEL_PRODUIT/ROADMAP.md)** (séquencement détaillé, horizons) et **[`PILOTAGE.md`](PILOTAGE.md)** (état opérationnel réel, priorités courantes). Ce document est un résumé de statut produit — en cas de divergence, **PILOTAGE.md prime** (issue #1505).
 
-Leopardo RH follows a phased delivery approach, prioritizing stability for SMEs before expanding into advanced enterprise features.
+## 📍 Statut actuel (2026-08)
 
-## 📍 Current Status: Phase 0 (MVP)
-**Status: COMPLETED & STABLE**
-- Core HR management & employee lifecycle.
-- Multi-tenant shared isolation.
-- Native Mobile App (Flutter) for attendance tracking.
-- Basic Payroll Estimation logic.
-- ZKTeco Biometric Kiosk integration.
+Le code sur `main` a dépassé le périmètre MVP initial. Plateforme livrée :
 
----
+- **HR Core** : cycle de vie employé, départements, contrats, RBAC (principal/rh/dept/comptable/superviseur/employee), cabinet documentaire.
+- **Multi-tenant** : isolation **mode `schema`** activée (`search_path` PostgreSQL), onboarding invités, trial guidé.
+- **Paie** : moteur de paie automatisé multi-pays (DZ, MA, FR, TR), bulletins PDF, exports bancaires, avances, prêts, commissions.
+- **Présence & pointage** : mobile géolocalisé, kiosque ZKTeco biométrique, corrections, workflows d'approbation, anomalies.
+- **Mobile** : 6 apps Flutter (employee, manager, hr, marketing, platform_admin + core).
+- **IA** : Leo AI — orchestrateur d'agents, prédictions (absentéisme, turnover), commande vocale, préparation de paie.
+- **Modules Phase 2 livrés** : Billing/abonnements (Stripe, Chargily), Caméras RTSP, Absence avancée (politiques de congés), Fleet, Recrutement, Notifications, Marketing.
+- **Intégrations** : webhooks sortants (endpoints + dispatcher), SSO, ZKTeco, Traccar (GPS).
 
-## 🚀 Phase 1: Foundation Hardening (Q2 2026)
-**Status: IN PROGRESS**
-- [x] Professional Documentation & Open Source Positioning.
-- [ ] Domain-Driven Design (DDD) backend restructuring.
-- [ ] Enterprise-grade security audits and hardening.
-- [ ] Real-time Mobile Experience (RTMX) components.
+## 🚀 Prochaines priorités (extrait)
 
-## 🏗 Phase 2: Modular Expansion (Q3 2026)
-Activation of specialized modules based on customer demand:
-- **Finance & Billing:** Automated invoicing and payment tracking for SMEs.
-- **Security & Vision:** RTSP camera streaming and AI-assisted site monitoring.
-- **Advanced Absence:** Multi-step approval workflows and leave balance policies.
-- **Leo AI (Beta):** Conversation-driven HR assistant for managers.
+1. **Stabilisation** : fermer les issues P0/P1 du backlog GitHub (mobile, CI staging, infra de test).
+2. **Pilotes clients** : 3 pilotes avant ouverture de nouveaux modules Phase 2.
+3. **Enterprise** (12-24 mois) : moteurs de conformité fiscale additionnels, API publique v1 stabilisée, forecasting avancé.
+4. **Écosystème** (24+ mois) : marketplace de modules, SDK ouvert, couche d'identité globale mobile.
 
-## 🏢 Phase 3: Enterprise & Scale (2027)
-- Physical database isolation (Schema Mode) for large corporations.
-- Public API for third-party integrations (Webhooks, SDKs).
-- Multi-country tax compliance engines (Turkey, France, Senegal).
-- Advanced workforce forecasting and performance analytics.
+## 📋 Comment suivre
 
-## 🌍 Phase 4: Platform Ecosystem (2028+)
-- Developer Marketplace for community-built HR modules.
-- Open SDK for custom enterprise extensions.
-- Global identity layer for mobile workforce.
+- Backlog détaillé et issues : **GitHub Issues** (label `P1`/`P2`/`P3`).
+- Séquençage produit : `docs/REFERENTIEL_PRODUIT/ROADMAP.md`.
+- État opérationnel et écarts : `PILOTAGE.md`.
 
----
-
-*This roadmap is subject to change based on community feedback and market needs.*
+*Cette roadmap est sujette à évolution selon les retours clients et de la communauté.*


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1505
**Category:** Documentation

## 🚀 Changes Description

Réécriture de `ROADMAP.md` racine — le document annonçait des items périmés :
- « DDD backend restructuring [ ] » → **fait** (19 modules DDD).
- « Schema Mode (physical isolation) » annoncé futur → **activé** (search_path PostgreSQL, PILOTAGE).
- Phase 2 (Billing, Caméras, Absence avancée, Leo AI) annoncée à venir → **livrée** sur main.

Nouvelle structure : statut actuel vérifié par module (avec évidences dans le code), prochaines priorités, et **source de vérité unique** : `docs/REFERENTIEL_PRODUIT/ROADMAP.md` (séquençage) + `PILOTAGE.md` (état réel), avec lien explicite en tête.

## 🗺️ Surfaces touchees
- [x] Docs uniquement (ROADMAP.md)

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- `docs/REFERENTIEL_PRODUIT/ROADMAP.md` reste la référence détaillée ; à tenir à jour (process, pas de code).

## 🛡 Quality Checklist
- [x] Verification: chaque affirmation recoupée avec le code (modules, TenantManager, PILOTAGE)
- [x] Documentation: roadmap unique et non obsolète