### PR TITLE
docs(cicd): docs alignées sur la réalité — 31 pipelines, chemins exacts, badge Codecov mort retiré (issue #1506)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ leopardo-hr/
 ├── postman/                # Collection Postman de l'API
 ├── examples/               # Exemples d'usage du SDK
 ├── assets/ , screenshots/  # Visuels marketing/README (candidats Git LFS — voir docs/architecture/ARCHITECTURE.md)
-└── .github/workflows/      # 25 pipelines CI/CD (voir .github/workflows/README.md pour la cartographie)
+└── .github/workflows/      # 31 pipelines CI/CD (voir .github/workflows/README.md pour la cartographie)
 ```
 
 > Cet arbre doit rester synchronisé avec la structure réelle du repo. En cas de doute, vérifier avec `find . -maxdepth 2 -not -path '*/node_modules/*'`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/kitokoh/leopardo-hr/actions"><img src="https://img.shields.io/github/actions/workflow/status/kitokoh/leopardo-hr/tests.yml?branch=main&style=for-the-badge&logo=github&label=CI/CD" alt="CI Status"></a>
-  <a href="https://codecov.io/gh/kitokoh/leopardo-hr"><img src="https://img.shields.io/codecov/c/github/kitokoh/leopardo-hr?style=for-the-badge&logo=codecov&label=Coverage" alt="Code Coverage"></a>
+  <img src="https://img.shields.io/badge/Coverage-Gate_in_CI-30a14e?style=for-the-badge&logo=php" alt="Coverage Gate">
   <a href="docs/security/SECURITY.md"><img src="https://img.shields.io/badge/Security-Enterprise--Grade-brightgreen?style=for-the-badge&logo=anchor" alt="Security Hardened"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/kitokoh/leopardo-hr?style=for-the-badge&label=License" alt="License"></a>
   <img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4">

--- a/docs/ARCHITECTURE_CICD.md
+++ b/docs/ARCHITECTURE_CICD.md
@@ -25,8 +25,8 @@ PR → merge sur main
 | `tests.yml` | PR + push main | Tests PHP + couverture |
 | `coverage-gate.yml` | PR main (api/) | Gate couverture min (voir "Gates de qualité") |
 | `mobile-apps-ci.yml` | PR + push (front/mobile_apps/) | Tests Flutter + analyze |
-| `web-ci.yml` | PR + push (front/web/) | Build Next.js + lint |
-| `openapi-ci.yml` | PR + push (api/openapi/) | Validation spec OpenAPI |
+| `web-ci.yml` | PR + push (front/admin-dashboard/) | Build + lint admin-dashboard (Vue/Vite) |
+| `openapi-ci.yml` | PR + push (api/openapi.yaml, dev-hub/openapi/) | Validation spec OpenAPI |
 | `architecture-check.yml` | PR | Vérification DDD boundaries + PHPStan modules/strict |
 | `deploy-staging.yml` | `workflow_run` sur "Tests - Leopardo RH" (branche main) | Deploy staging Render |
 | `deploy-main.yml` | `workflow_run` sur "Tests - Leopardo RH" / "Web CI - Leopardo Admin" | Deploy production Render |


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1506
**Category:** Documentation

## 🚀 Changes Description

- `ARCHITECTURE.md` : « 25 pipelines CI/CD » → **31** (comptage réel des fichiers `.github/workflows/*.yml`).
- `docs/ARCHITECTURE_CICD.md` :
  - `web-ci.yml` couvre **front/admin-dashboard/** (Vue/Vite), pas `front/web/` (Next.js) — corrigé.
  - `openapi-ci.yml` couvre **api/openapi.yaml + dev-hub/openapi/** — corrigé.
- `README.md` : le badge Codecov était **mort** (aucun upload Codecov en CI) → remplacé par un badge « Coverage Gate in CI » (le gate existe : coverage-gate.yml).

## 🗺️ Surfaces touchees
- [x] Docs uniquement (ARCHITECTURE.md, docs/ARCHITECTURE_CICD.md, README.md)

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## 🛡 Quality Checklist
- [x] Verification: chemins recoupés avec les workflows réels (paths des triggers)
- [x] Documentation: onboarding fiable