### PR TITLE
ci(architecture): garde anti-interface-orpheline + script dédié (issue #1492)

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Check for orphan (unrouted) controllers
         run: dev-hub/tools/check-unrouted-controllers.sh api
 
+      - name: Check for orphan domain contract interfaces (issue #1492)
+        run: dev-hub/tools/check-orphan-interfaces.sh api
+
       - name: Check newly added files declare strict_types (PA2-ARCH-009)
         env:
           DIFF_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}

--- a/dev-hub/tools/check-orphan-interfaces.sh
+++ b/dev-hub/tools/check-orphan-interfaces.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# check-orphan-interfaces.sh — Détecte les interfaces de contrat DDD sans implémentation.
+#
+# Usage : dev-hub/tools/check-orphan-interfaces.sh [api_dir]
+#   api_dir : racine du backend Laravel (défaut : api)
+#
+# Règle (issue #1492) : chaque interface de `Modules/*/Domain/Contracts/`
+# doit avoir au moins une classe `implements` (dans api/app, y compris hors
+# Modules : ex. app/Services/Payroll/CountryRules implémente
+# Modules/Payroll CountryRulesInterface). Les orphelins CONNUS (liste ci-
+# dessous, au 2026-08-07) sont tolérés ; tout NOUVEL orphelin fait échouer le
+# check : soit l'implémenter, soit assumer via ADR et ajouter à l'allowlist.
+#
+# Exemple : ALLOW_ORPHAN_INTERFACES="MonInterface" \
+#           dev-hub/tools/check-orphan-interfaces.sh
+set -euo pipefail
+
+API_DIR="${1:-api}"
+
+DEFAULT_ALLOW="AttendanceRepositoryInterface InvoiceRepositoryInterface \
+SubscriptionRepositoryInterface DocumentRepositoryInterface FolderRepositoryInterface \
+AccessTokenServiceInterface CameraRepositoryInterface TripRepositoryInterface \
+VehicleRepositoryInterface PartnerRepositoryInterface ContractRepositoryInterface \
+DepartmentRepositoryInterface EmployeeRepositoryInterface NotificationRepositoryInterface \
+OnboardingRepositoryInterface PlanningRepositoryInterface CompanyProvisioningInterface \
+JobPostingRepositoryInterface GeofenceValidatorInterface TrainingRepositoryInterface"
+ALLOW="${ALLOW_ORPHAN_INTERFACES:-${DEFAULT_ALLOW}}"
+
+if [[ ! -d "${API_DIR}/app/Modules" ]]; then
+  echo "::error::${API_DIR}/app/Modules introuvable — API_DIR invalide ?"
+  exit 1
+fi
+
+orphans=()
+for iface in "${API_DIR}"/app/Modules/*/Domain/Contracts/*Interface.php; do
+  [[ -e "${iface}" ]] || continue
+  name="$(basename "${iface}" .php)"
+  # Fichiers contenant à la fois "implements" et le nom de l'interface, hors déclaration elle-même.
+  if rg -l "implements" "${API_DIR}/app" --glob '*.php' 2>/dev/null \
+      | xargs -r rg -l "\b${name}\b" 2>/dev/null \
+      | grep -v "Domain/Contracts" | grep -q .; then
+    : # implémentée
+  else
+    orphans+=("${name} (${iface#${API_DIR}/})")
+  fi
+done
+
+new_orphans=()
+for o in "${orphans[@]:-}"; do
+  short="${o%% *}"
+  if grep -qw "${short}" <<< "${ALLOW}"; then
+    echo "::warning::Orphelin connu (allowlist) : ${o}"
+  else
+    new_orphans+=("${o}")
+  fi
+done
+
+if [[ ${#new_orphans[@]} -gt 0 ]]; then
+  echo "::error::Interfaces de contrat SANS implémentation (NOUVEAUX orphelins) :"
+  printf '::error::  - %s\n' "${new_orphans[@]}"
+  echo "Ajoutez-les à ALLOW_ORPHAN_INTERFACES uniquement si c'est un choix assumé (ADR),"
+  echo "sinon implémentez l'interface (issue #1492)."
+  exit 1
+fi
+
+echo "✓ ${#orphans[@]} orphelin(s) au total (tous dans l'allowlist) — 0 nouveau, OK"
+exit 0


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1492
**Category:** Refactor

## 🚀 Changes Description

- Nouveau script **`dev-hub/tools/check-orphan-interfaces.sh`** : détecte les interfaces de contrat `Modules/*/Domain/Contracts/` sans aucune classe `implements` dans `api/app` (y compris hors Modules).
- **Découverte : 20 orphelins réels** (pas 2 comme estimé dans l'issue) — la plupart des modules (Attendance, Billing, Cabinet, Cameras, Fleet, HR, Notification, Onboarding, Planning, Platform, Recruitment, SmartAttendance, Growth, Training) déclarent des interfaces de repository jamais implémentées. Elles sont dans l'**allowlist** (`DEFAULT_ALLOW`) ; le check ne tolère que celles-là.
- **Tout NOUVEL orphelin fait échouer la CI** : soit implémenter l'interface, soit assumer via ADR et l'ajouter à l'allowlist.
- Step ajouté au job `module-structure-check` de `architecture-check.yml`.
- Tests manuels : repo réel → exit 0 (20 connus) ; interface ajoutée → exit 1.

## 🗺️ Surfaces touchees
- [x] CI / GitHub Actions
- [x] API (dev-hub/tools)

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- Les 20 interfaces orphelines restent déclarées sans implémentation (dette assumée) — l'implémentation par module reste un travail d'équipe (suivi possible dans le corps de l'issue).
- Le détecteur peut rater une implémentation exotique (ex. via class_alias) — conservateur.

## 🛡 Quality Checklist
- [x] Code Quality: script bash testé (2 scénarios)
- [x] Testing: exit codes vérifiés manuellement
- [x] Verification: 20 orphelins identifiés avec chemins exacts
- [x] Security: aucun impact