### PR TITLE
ci(security): baseline detect-secrets rendue bloquante en CI (issue #1503)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,3 +25,23 @@ jobs:
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           extra_args: --results=verified,unknown
+
+  detect-secrets:
+    name: detect-secrets Baseline Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install detect-secrets
+        run: python -m pip install --user detect-secrets==1.4.0
+
+      - name: Scan against baseline (issue #1503)
+        # La baseline .secrets.baseline (detect-secrets) était orpheline : elle
+        # n'était consommée que par le hook pre-commit local. Ce job la rend
+        # bloquante en CI : tout secret NEUF (non baseliné) fait échouer le run.
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          detect-secrets scan --baseline .secrets.baseline


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1503
**Category:** Bug Fix

## 🚀 Changes Description

`.secrets.baseline` (detect-secrets v1.4.0, 0 entrée) n'était consommé que par le hook pre-commit local — la CI ne faisait tourner que TruffleHog, et les hooks pre-commit sont `|| true` (non bloquants).

- Nouveau job **`detect-secrets Baseline Scan`** dans `secret-scan.yml` : installe detect-secrets==1.4.0 et scanne contre la baseline ; **tout secret neuf non baseliné fait échouer le run**.
- Les deux outils (TruffleHog + detect-secrets) sont désormais bloquants et complémentaires (heuristiques différentes).

## 🗺️ Surfaces touchees
- [x] CI / GitHub Actions

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- La politique d'exception (ajout d'une entrée à la baseline) reste à documenter — c'est un choix d'équipe ; la baseline est versionnée et la PR qui l'étend est visible en review.

## 🛡 Quality Checklist
- [x] Verification: YAML validé (jobs: trufflehog + detect-secrets)
- [x] Security: détection de secrets renforcée (2 outils bloquants)
- [x] Breaking Changes: non