### PR TITLE
test(phpunit): config alignée sur la vraie base pgsql + rapport de coverage (issue #1488)

### DIFF
--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -17,14 +17,29 @@
             <directory>app</directory>
         </include>
     </source>
+    <coverage>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false" showOnlySummary="true"/>
+        </report>
+    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <!-- Issue #1488 : la config DB de test réelle est pgsql (voir .env.testing
+             et tests/TestCase::configureTestingDatabaseConnection()).
+             L'ancien binôme sqlite/:memory: était contredit par le TestCase et
+             n'était jamais utilisé. Valeurs non forcées : l'env du runner prime. -->
+        <env name="DB_CONNECTION" value="pgsql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="5432"/>
+        <env name="DB_DATABASE" value="leopardo_test"/>
+        <env name="DB_USERNAME" value="leopardo_user"/>
+        <env name="DB_PASSWORD" value="leopardo_pass_test"/>
+        <env name="DB_SEARCH_PATH" value="shared_tenants,public"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1488
**Category:** Bug Fix

## 🚀 Changes Description

`api/phpunit.xml` déclarait `DB_CONNECTION=sqlite` + `:memory:` alors que :
- `tests/TestCase::configureTestingDatabaseConnection()` force **pgsql** (database.default = pgsql) ;
- `api/.env.testing` porte déjà la vraie config pgsql (`leopardo_test`, `shared_tenants,public`).

La config sqlite n'était **jamais utilisée** → fausse information pour quiconque lance les tests localement.

**Changements :**
- phpunit.xml : `DB_CONNECTION=pgsql` + host/port/db/user/pass/search_path alignés sur .env.testing (valeurs **non forcées** : l'env du runner prime, aucun breaking pour la CI).
- Bloc `<coverage>` ajouté (clover + texte) → `phpunit --coverage-text` produit un % localement (le seuil reste piloté par coverage-gate.yml).
- Segmentation : les testsuites `Unit`/`Feature` existent déjà (`--testsuite Unit`) — documenté dans le commit.

## 🗺️ Surfaces touchees
- [x] API (phpunit.xml)

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- Lancer phpunit localement nécessite un PostgreSQL joignable (127.0.0.1 ou host `pgsql` en docker) — comportement déjà imposé par le TestCase, désormais explicite.
- Les `->group()` par module restent absents (dette documentée) ; les testsuites couvrent déjà la segmentation unit/feature.

## 🛡 Quality Checklist
- [x] Verification: XML valide ; config alignée sur .env.testing
- [x] Testing: la CI backend validera (même config effective qu'avant, seule la déclaration change)
- [x] Security: aucun impact