### PR TITLE
fix(migrations): restauration du search_path — flakiness coverage gate (issue #1490)

### DIFF
--- a/api/database/migrations/public/2026_07_23_000001_create_failed_jobs_table.php
+++ b/api/database/migrations/public/2026_07_23_000001_create_failed_jobs_table.php
@@ -30,32 +30,47 @@ return new class extends Migration
 
     public function up(): void
     {
+        // Issue #1490 : ne JAMAIS laisser fuir `SET search_path TO public` dans
+        // la session — les migrations tenant exécutées ensuite dans la même
+        // session créeraient leurs tables dans `public` au lieu du schéma
+        // tenant (shared_tenants), d'où les `relation "companies" does not
+        // exist` intermittents sur la gate de coverage (runs 2026-07-25).
+        $previousPath = DB::selectOne('SHOW search_path')->search_path;
         DB::statement('SET search_path TO public');
 
-        if (Schema::hasTable('failed_jobs')) {
-            return;
-        }
-
         try {
-            Schema::create('failed_jobs', function (Blueprint $table) {
-                $table->id();
-                $table->string('uuid')->unique();
-                $table->text('connection');
-                $table->text('queue');
-                $table->longText('payload');
-                $table->longText('exception');
-                $table->timestampTz('failed_at')->useCurrent();
-            });
-        } catch (QueryException $exception) {
-            if ($exception->getCode() !== '42P07') {
-                throw $exception;
+            if (Schema::hasTable('failed_jobs')) {
+                return;
             }
+
+            try {
+                Schema::create('failed_jobs', function (Blueprint $table) {
+                    $table->id();
+                    $table->string('uuid')->unique();
+                    $table->text('connection');
+                    $table->text('queue');
+                    $table->longText('payload');
+                    $table->longText('exception');
+                    $table->timestampTz('failed_at')->useCurrent();
+                });
+            } catch (QueryException $exception) {
+                if ($exception->getCode() !== '42P07') {
+                    throw $exception;
+                }
+            }
+        } finally {
+            DB::statement('SET search_path TO '.$previousPath);
         }
     }
 
     public function down(): void
     {
+        $previousPath = DB::selectOne('SHOW search_path')->search_path;
         DB::statement('SET search_path TO public');
-        Schema::dropIfExists('failed_jobs');
+        try {
+            Schema::dropIfExists('failed_jobs');
+        } finally {
+            DB::statement('SET search_path TO '.$previousPath);
+        }
     }
 };

--- a/api/database/migrations/public/2026_07_25_000001_create_scheduled_task_runs_table.php
+++ b/api/database/migrations/public/2026_07_25_000001_create_scheduled_task_runs_table.php
@@ -30,30 +30,45 @@ return new class extends Migration
 
     public function up(): void
     {
+        // Issue #1490 : ne jamais laisser fuir `SET search_path TO public` dans
+        // la session — la phase de migrations tenant de la même session doit
+        // garder son search_path (`shared_tenants` en CI) intact, sinon les
+        // résolutions `relation "companies" does not exist` intermittentes
+        // apparaissent (gate de coverage, runs 2026-07-25).
+        $previousPath = DB::selectOne('SHOW search_path')->search_path;
         DB::statement('SET search_path TO public');
 
-        if (Schema::hasTable('scheduled_task_runs')) {
-            return;
+        try {
+            if (Schema::hasTable('scheduled_task_runs')) {
+                return;
+            }
+
+            Schema::create('scheduled_task_runs', function (Blueprint $table): void {
+                $table->id();
+                $table->string('name', 190)->unique();
+                $table->timestampTz('started_at')->nullable();
+                $table->timestampTz('finished_at')->nullable();
+                $table->integer('runtime_ms')->nullable();
+                $table->string('status', 20)->default('unknown');
+                $table->integer('exit_code')->nullable();
+                $table->text('output')->nullable();
+                $table->timestamps();
+
+                $table->index('status');
+            });
+        } finally {
+            DB::statement('SET search_path TO '.$previousPath);
         }
-
-        Schema::create('scheduled_task_runs', function (Blueprint $table): void {
-            $table->id();
-            $table->string('name', 190)->unique();
-            $table->timestampTz('started_at')->nullable();
-            $table->timestampTz('finished_at')->nullable();
-            $table->integer('runtime_ms')->nullable();
-            $table->string('status', 20)->default('unknown');
-            $table->integer('exit_code')->nullable();
-            $table->text('output')->nullable();
-            $table->timestamps();
-
-            $table->index('status');
-        });
     }
 
     public function down(): void
     {
+        $previousPath = DB::selectOne('SHOW search_path')->search_path;
         DB::statement('SET search_path TO public');
-        Schema::dropIfExists('scheduled_task_runs');
+        try {
+            Schema::dropIfExists('scheduled_task_runs');
+        } finally {
+            DB::statement('SET search_path TO '.$previousPath);
+        }
     }
 };


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1490
**Category:** Bug Fix

## 🚀 Changes Description

**Cause racine (analyse statique)** : les migrations `public` font `SET search_path TO public` **sans restauration**. Or `RefreshTenantDatabase` exécute `migrate:fresh --path public` puis `migrate --path tenant` **dans la même session** : la fuite du search_path vers `public` contredit l'invariant documenté « CI runs tenant migrations with search_path=shared_tenants only » (commentaire de la migration tenant 2026_07_23_000003), d'où les `SQLSTATE[42P01] relation \"companies\" does not exist` intermittents (runs main 2026-07-25, apparus le jour de l'ajout de failed_jobs le 07-23).

**Correctifs :**
- `2026_07_23_000001_create_failed_jobs_table.php` : sauvegarde/restauration du search_path (`up` + `down`, try/finally).
- `2026_07_25_000001_create_scheduled_task_runs_table.php` : idem (réécriture complète).
- `2026_07_23_000003_platform_impersonation_sessions_table.php` : **inchangée** (aucun SET search_path réel).

## 🗺️ Surfaces touchees
- [x] API (database/migrations)

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels / limites
- Pas de base PostgreSQL dans l'environnement d'audit : le fix est validé statiquement (équilibre des blocs, try/finally, restaurations). **À confirmer par 10 runs consécutifs de la gate de coverage.**
- 10 autres migrations public (avril-mai) partagent le même motif de fuite mais préexistaient au flake : follow-up proposé (voir issue).

## 🛡 Quality Checklist
- [x] Code Quality: try/finally systématiques, restauration du chemin précédent
- [x] Testing: CI à confirmer (10 runs)
- [x] Verification: analyse statique + recoupement avec la doc PILOT_RELEASE_GO_NOGO_CHECKLIST.md
- [x] Security: aucun impact