### PR TITLE
ci(kiosk): zkteco-kiosk intégré — package.json, tests i18n, workflow CI (issue #1501)

### DIFF
--- a/.github/workflows/kiosk-ci.yml
+++ b/.github/workflows/kiosk-ci.yml
@@ -1,0 +1,41 @@
+name: Kiosk CI — ZKTeco Kiosk
+
+# Issue #1501 : le kiosque était hors écosystème (aucun package.json,
+# aucun lint/test/CI). Ce workflow couvre front/zkteco-kiosk/**.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'front/zkteco-kiosk/**'
+  push:
+    branches: [main]
+    paths:
+      - 'front/zkteco-kiosk/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  kiosk-ci:
+    name: Lint + i18n tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Lint (node --check)
+        working-directory: front/zkteco-kiosk
+        run: npm run lint
+
+      - name: i18n parity & usage tests
+        working-directory: front/zkteco-kiosk
+        run: npm test

--- a/front/zkteco-kiosk/package.json
+++ b/front/zkteco-kiosk/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "zkteco-kiosk",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Leopardo RH — ZKTeco biometric kiosk (vanilla JS, dependency-free)",
+  "type": "module",
+  "scripts": {
+    "lint": "node --check app.js && node --check admin.js && node --check i18n.js",
+    "test": "node tests/i18n.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/front/zkteco-kiosk/tests/i18n.test.mjs
+++ b/front/zkteco-kiosk/tests/i18n.test.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/* zkteco-kiosk — tests i18n (issue #1501).
+ *
+ * Sans dépendance : vérifie que
+ *   1. chaque langue supportée a un catalogue complet (parité de clés),
+ *   2. chaque `data-i18n="KEY"` / `data-i18n-*="KEY"` utilisé dans les
+ *      pages HTML existe dans les 4 catalogues,
+ *   3. chaque `t('KEY')` utilisé dans app.js/admin.js existe aussi.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const i18nSource = readFileSync(join(root, 'i18n.js'), 'utf8');
+
+// Shim `window` (avec un DOM minimal : l'init d'i18n.js touche document)
+const window = {
+  document: {
+    documentElement: { dir: '', setAttribute() {}, getAttribute: () => null },
+    querySelectorAll: () => [],
+    querySelector: () => null,
+    createElement: () => ({ style: {}, value: '', addEventListener() {} }),
+  },
+};
+global.window = window;
+eval(i18nSource); // eslint-disable-line no-eval
+const KioskI18n = window.KioskI18n;
+if (!KioskI18n) {
+  console.error('❌ KioskI18n introuvable après évaluation de i18n.js');
+  process.exit(1);
+}
+
+const CATALOG = KioskI18n._catalog || extractCatalog();
+function extractCatalog() {
+  // Fallback : ré-évaluer en capturant le CATALOG via une sonde
+  const probe = {};
+  global.window = probe;
+  const src = i18nSource.replace('})(window);', '})(globalThis);');
+  const m = src.match(/var CATALOG = (\{[\s\S]*?\n  \});/);
+  if (!m) throw new Error('CATALOG introuvable');
+  return Function('"use strict"; return (' + m[1] + ');')();
+}
+
+const supported = KioskI18n.supported;
+const langKeys = {};
+let errors = 0;
+
+for (const lang of supported) {
+  const keys = Object.keys(CATALOG[lang] || {});
+  langKeys[lang] = new Set(keys);
+  if (keys.length === 0) {
+    console.error(`❌ Catalogue vide pour "${lang}"`);
+    errors++;
+  }
+}
+
+// 1. Parité des clés entre langues
+const ref = supported[0];
+for (const lang of supported.slice(1)) {
+  const missing = [...langKeys[ref]].filter((k) => !langKeys[lang].has(k));
+  const extra = [...langKeys[lang]].filter((k) => !langKeys[ref].has(k));
+  if (missing.length) { console.error(`❌ [${lang}] clés manquantes vs ${ref}: ${missing.join(', ')}`); errors++; }
+  if (extra.length) { console.error(`❌ [${lang}] clés en trop vs ${ref}: ${extra.join(', ')}`); errors++; }
+}
+
+// 2. data-i18n* dans les pages
+for (const page of ['index.html', 'admin.html']) {
+  const html = readFileSync(join(root, page), 'utf8');
+  for (const key of html.matchAll(/data-i18n(?:-placeholder|-aria-label)?="([^"]+)"/g)) {
+    if (!langKeys[ref].has(key[1])) {
+      console.error(`❌ ${page}: clé i18n inconnue "${key[1]}"`);
+      errors++;
+    }
+  }
+}
+
+// 3. t('KEY') dans les JS
+for (const js of ['app.js', 'admin.js']) {
+  const code = readFileSync(join(root, js), 'utf8');
+  for (const key of code.matchAll(/\bt\(\s*'([^']+)'\s*(?:,|\()/g)) {
+    if (!langKeys[ref].has(key[1])) {
+      console.error(`❌ ${js}: clé i18n inconnue "${key[1]}"`);
+      errors++;
+    }
+  }
+}
+
+// 4. RTL
+if (!KioskI18n.isRtl('ar')) {
+  console.error('❌ ar doit être RTL');
+  errors++;
+}
+
+if (errors) {
+  console.error(`\n✖ ${errors} problème(s) i18n`);
+  process.exit(1);
+}
+console.log(`✓ i18n OK : ${supported.length} langues (${supported.join(',')}), ${langKeys[ref].size} clés, parité + usage vérifiés.`);


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** Closes #1501
**Category:** Enhancement / CI

## 🚀 Changes Description

Le kiosque ZKTeco (vanilla JS, sans dépendance) était **hors écosystème** : aucun `package.json`, aucun lint/test/CI.

- **`package.json`** : scripts `lint` (`node --check` sur app.js/admin.js/i18n.js) et `test` (tests i18n).
- **`tests/i18n.test.mjs`** (sans dépendance) : parité des 4 catalogues (fr/en/tr/ar, **128 clés**), usage `data-i18n` dans index.html/admin.html, usage `t('…')` dans app.js/admin.js, RTL pour ar.
- **`.github/workflows/kiosk-ci.yml`** : lint + tests sur tout changement de `front/zkteco-kiosk/**` (+ workflow_dispatch).

**Vérifié localement (node 24) :** lint exit 0, test ✓ « 4 langues, 128 clés, parité + usage vérifiés ».

## 🗺️ Surfaces touchees
- [x] Kiosk (`front/zkteco-kiosk`)
- [x] CI / GitHub Actions

## 🔌 Contrat API
- [x] Aucun changement de contrat API.

## ⚠️ Risques residuels
- Le test évalue i18n.js avec un stub DOM minimal (pas de navigateur) : couvre la structure du catalogue, pas le rendu.
- La i18n-enterprise garde sa couverture (parité dev-hub).

## 🛡 Quality Checklist
- [x] Testing: tests i18n exécutés localement (verts)
- [x] Verification: lint node --check OK
- [x] Security: aucun impact