### PR TITLE
chore(security): clés Google retirées de l'arbre — stub + secret CI (issue #1467)

### DIFF
--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -172,6 +172,23 @@ jobs:
         working-directory: ${{ matrix.project.path }}
         run: flutter pub get --offline || flutter pub get
 
+      - name: Restore Firebase config from secret (issue #1467)
+        # google-services.json n'est PLUS committé (clé API réelle exposée) :
+        # un stub à clés factices est versionné pour les builds locaux/forks ;
+        # le fichier réel est restauré depuis le secret GOOGLE_SERVICES_JSON.
+        shell: bash
+        run: |
+          if [[ -n "${GOOGLE_SERVICES_JSON}" ]]; then
+            for target in front/mobile_apps/leopardo_employee front/mobile_apps/leopardo_hr front/mobile_apps/leopardo_manager front/mobile_apps/leopardo_platform_admin; do
+              printf '%s' "${GOOGLE_SERVICES_JSON}" > "${target}/android/app/google-services.json"
+            done
+            echo "Firebase config restaurée depuis le secret."
+          else
+            echo "::warning::GOOGLE_SERVICES_JSON non défini — build avec le stub (clés factices)."
+          fi
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
       - name: Build debug APK
         working-directory: ${{ matrix.project.path }}
         run: flutter build apk --debug --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}

--- a/.github/workflows/mobile-distribute-main.yml
+++ b/.github/workflows/mobile-distribute-main.yml
@@ -100,6 +100,7 @@ jobs:
           PROJECT_PATH: ${{ matrix.app.project_path }}
           APP_NAME: ${{ matrix.app.name }}
           ANDROID_PACKAGE: ${{ matrix.app.android_package }}
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           set -euo pipefail
           READY=true
@@ -112,6 +113,11 @@ jobs:
             READY=false
           fi
           CONFIG_FILE="${PROJECT_PATH}/android/app/google-services.json"
+          if [[ -n "${GOOGLE_SERVICES_JSON}" ]]; then
+            mkdir -p "$(dirname "${CONFIG_FILE}")"
+            printf '%s' "${GOOGLE_SERVICES_JSON}" > "${CONFIG_FILE}"
+            echo "Firebase config restaurée depuis le secret (issue #1467)."
+          fi
           if [[ ! -f "${CONFIG_FILE}" ]]; then
             echo "Missing Firebase config: ${CONFIG_FILE}. Skipping ${{ matrix.app.name }} Firebase distribution."
             READY=false

--- a/.github/workflows/mobile-distribute.yml
+++ b/.github/workflows/mobile-distribute.yml
@@ -172,9 +172,15 @@ jobs:
           ANDROID_PACKAGE: ${{ matrix.app.android_package }}
           FIREBASE_APP_ID: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || matrix.app.name == 'platform_admin' && secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID || secrets.FIREBASE_APP_ID_HR }}
           FIREBASE_APP_ID_SECRET_NAME: ${{ matrix.app.firebase_secret }}
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           set -euo pipefail
           CONFIG_FILE="${PROJECT_PATH}/android/app/google-services.json"
+          if [[ -n "${GOOGLE_SERVICES_JSON}" ]]; then
+            mkdir -p "$(dirname "${CONFIG_FILE}")"
+            printf '%s' "${GOOGLE_SERVICES_JSON}" > "${CONFIG_FILE}"
+            echo "Firebase config restaurée depuis le secret (issue #1467)."
+          fi
           if [[ ! -f "${CONFIG_FILE}" ]]; then
             echo "Missing Firebase config: ${CONFIG_FILE}"
             echo "Run dev-hub/tools/install-mobile-firebase-configs.ps1 with matching Firebase app IDs."

--- a/docs/security/RUNBOOK_SECRET_ROTATION_PURGE.md
+++ b/docs/security/RUNBOOK_SECRET_ROTATION_PURGE.md
@@ -5,6 +5,27 @@
 > (fenêtre de maintenance), validée par le propriétaire du repo, et réalisée en
 > coordination avec les hébergeurs (Render, Upstash, Firebase).
 
+## Statut 2026-08-09 — Clés Google (issue #1467, partiel)
+
+Les 4 `google-services.json` committés (projet Firebase `leopardo-rh`, une seule
+clé API partagée `AIzaSyCYauGS…`) ont été **retirés de l'arbre git** et remplacés
+par un **stub à clés factices** versionné (`AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000`).
+Les builds CI restaurent le fichier réel depuis le secret Actions
+`GOOGLE_SERVICES_JSON` (mobile-apps-ci.yml, mobile-distribute.yml,
+mobile-distribute-main.yml).
+
+Restant (action humaine) :
+1. **Rotation de la clé API Google** dans la console Firebase (la clé committée
+   reste exploitable depuis l'historique git et les alertes Secret Scanning).
+2. Purge de l'historique git (cf. section purge plus bas) — les 4 fichiers
+   concernés + le secret Redis (#1472).
+3. Après purge, résoudre les 2 alertes GitHub Secret Scanning (google_api_key).
+
+Local : `dev-hub/tools/install-mobile-firebase-configs.ps1` (télécharge les
+fichiers réels depuis Firebase) puis build — les fichiers réels ne doivent
+jamais être commités.
+
+
 ## Périmètre des secrets exposés (au 2026-08-07)
 
 | Secret | Où | Statut |

--- a/front/mobile_apps/leopardo_employee/android/app/google-services.json
+++ b/front/mobile_apps/leopardo_employee/android/app/google-services.json
@@ -1,1 +1,182 @@
-{"project_info":{"project_number":"201283742683","project_id":"leopardo-rh","storage_bucket":"leopardo-rh.firebasestorage.app"},"client":[{"client_info":{"mobilesdk_app_id":"1:201283742683:android:0f417d1a89347a92fdd5fe","android_client_info":{"package_name":"com.leopardo.employee"}},"oauth_client":[{"client_id":"201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.employee","certificate_hash":"e2f8db522b29b0d308793ee9f4a397b3c0643e9e"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:3d02836dee65e8f8fdd5fe","android_client_info":{"package_name":"com.leopardo.manager"}},"oauth_client":[{"client_id":"201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.manager","certificate_hash":"6480d1a63d320670a16c49881e9594d89accf243"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:32f913a4d2937ebcfdd5fe","android_client_info":{"package_name":"com.leopardo.platformadmin"}},"oauth_client":[{"client_id":"201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.platformadmin","certificate_hash":"efe50bb78c09f421c07292778652d4db67ef24c0"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:98120a33d1309f03fdd5fe","android_client_info":{"package_name":"com.leopardo.rh"}},"oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}}],"configuration_version":"1"}
+{
+  "project_info": {
+    "project_number": "201283742683",
+    "project_id": "leopardo-rh",
+    "storage_bucket": "leopardo-rh.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.employee"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.employee",
+            "certificate_hash": "e2f8db522b29b0d308793ee9f4a397b3c0643e9e"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.manager"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.manager",
+            "certificate_hash": "6480d1a63d320670a16c49881e9594d89accf243"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.platformadmin"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.platformadmin",
+            "certificate_hash": "efe50bb78c09f421c07292778652d4db67ef24c0"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.rh"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/front/mobile_apps/leopardo_hr/android/app/google-services.json
+++ b/front/mobile_apps/leopardo_hr/android/app/google-services.json
@@ -1,1 +1,182 @@
-{"project_info":{"project_number":"201283742683","project_id":"leopardo-rh","storage_bucket":"leopardo-rh.firebasestorage.app"},"client":[{"client_info":{"mobilesdk_app_id":"1:201283742683:android:0f417d1a89347a92fdd5fe","android_client_info":{"package_name":"com.leopardo.employee"}},"oauth_client":[{"client_id":"201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.employee","certificate_hash":"e2f8db522b29b0d308793ee9f4a397b3c0643e9e"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:3d02836dee65e8f8fdd5fe","android_client_info":{"package_name":"com.leopardo.manager"}},"oauth_client":[{"client_id":"201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.manager","certificate_hash":"6480d1a63d320670a16c49881e9594d89accf243"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:32f913a4d2937ebcfdd5fe","android_client_info":{"package_name":"com.leopardo.platformadmin"}},"oauth_client":[{"client_id":"201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.platformadmin","certificate_hash":"efe50bb78c09f421c07292778652d4db67ef24c0"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:98120a33d1309f03fdd5fe","android_client_info":{"package_name":"com.leopardo.rh"}},"oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}}],"configuration_version":"1"}
+{
+  "project_info": {
+    "project_number": "201283742683",
+    "project_id": "leopardo-rh",
+    "storage_bucket": "leopardo-rh.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.employee"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.employee",
+            "certificate_hash": "e2f8db522b29b0d308793ee9f4a397b3c0643e9e"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.manager"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.manager",
+            "certificate_hash": "6480d1a63d320670a16c49881e9594d89accf243"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.platformadmin"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.platformadmin",
+            "certificate_hash": "efe50bb78c09f421c07292778652d4db67ef24c0"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.rh"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/front/mobile_apps/leopardo_manager/android/app/google-services.json
+++ b/front/mobile_apps/leopardo_manager/android/app/google-services.json
@@ -1,1 +1,182 @@
-{"project_info":{"project_number":"201283742683","project_id":"leopardo-rh","storage_bucket":"leopardo-rh.firebasestorage.app"},"client":[{"client_info":{"mobilesdk_app_id":"1:201283742683:android:0f417d1a89347a92fdd5fe","android_client_info":{"package_name":"com.leopardo.employee"}},"oauth_client":[{"client_id":"201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.employee","certificate_hash":"e2f8db522b29b0d308793ee9f4a397b3c0643e9e"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:3d02836dee65e8f8fdd5fe","android_client_info":{"package_name":"com.leopardo.manager"}},"oauth_client":[{"client_id":"201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.manager","certificate_hash":"6480d1a63d320670a16c49881e9594d89accf243"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:32f913a4d2937ebcfdd5fe","android_client_info":{"package_name":"com.leopardo.platformadmin"}},"oauth_client":[{"client_id":"201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.platformadmin","certificate_hash":"efe50bb78c09f421c07292778652d4db67ef24c0"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:98120a33d1309f03fdd5fe","android_client_info":{"package_name":"com.leopardo.rh"}},"oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}}],"configuration_version":"1"}
+{
+  "project_info": {
+    "project_number": "201283742683",
+    "project_id": "leopardo-rh",
+    "storage_bucket": "leopardo-rh.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.employee"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.employee",
+            "certificate_hash": "e2f8db522b29b0d308793ee9f4a397b3c0643e9e"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.manager"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.manager",
+            "certificate_hash": "6480d1a63d320670a16c49881e9594d89accf243"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.platformadmin"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.platformadmin",
+            "certificate_hash": "efe50bb78c09f421c07292778652d4db67ef24c0"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.rh"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/front/mobile_apps/leopardo_platform_admin/android/app/google-services.json
+++ b/front/mobile_apps/leopardo_platform_admin/android/app/google-services.json
@@ -1,1 +1,182 @@
-{"project_info":{"project_number":"201283742683","project_id":"leopardo-rh","storage_bucket":"leopardo-rh.firebasestorage.app"},"client":[{"client_info":{"mobilesdk_app_id":"1:201283742683:android:0f417d1a89347a92fdd5fe","android_client_info":{"package_name":"com.leopardo.employee"}},"oauth_client":[{"client_id":"201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.employee","certificate_hash":"e2f8db522b29b0d308793ee9f4a397b3c0643e9e"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:3d02836dee65e8f8fdd5fe","android_client_info":{"package_name":"com.leopardo.manager"}},"oauth_client":[{"client_id":"201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.manager","certificate_hash":"6480d1a63d320670a16c49881e9594d89accf243"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:32f913a4d2937ebcfdd5fe","android_client_info":{"package_name":"com.leopardo.platformadmin"}},"oauth_client":[{"client_id":"201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com","client_type":1,"android_info":{"package_name":"com.leopardo.platformadmin","certificate_hash":"efe50bb78c09f421c07292778652d4db67ef24c0"}},{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}},{"client_info":{"mobilesdk_app_id":"1:201283742683:android:98120a33d1309f03fdd5fe","android_client_info":{"package_name":"com.leopardo.rh"}},"oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3}],"api_key":[{"current_key":"AIzaSyCYauGSBVQw-WUyvNuODkjKreoGyaq8aII"}],"services":{"appinvite_service":{"other_platform_oauth_client":[{"client_id":"201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com","client_type":3},{"client_id":"201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com","client_type":2,"ios_info":{"bundle_id":"com.leopardo.manager","app_store_id":"123456"}}]}}}],"configuration_version":"1"}
+{
+  "project_info": {
+    "project_number": "201283742683",
+    "project_id": "leopardo-rh",
+    "storage_bucket": "leopardo-rh.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.employee"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-6u4o2bg8d7s7fcvmkp369q77nan1eioi.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.employee",
+            "certificate_hash": "e2f8db522b29b0d308793ee9f4a397b3c0643e9e"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.manager"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-gseug05jqjmcvdrar75jm7buoemnmcou.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.manager",
+            "certificate_hash": "6480d1a63d320670a16c49881e9594d89accf243"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.platformadmin"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-4kio2hulvb1go5bcro81r0lqub5g679j.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.leopardo.platformadmin",
+            "certificate_hash": "efe50bb78c09f421c07292778652d4db67ef24c0"
+          }
+        },
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.leopardo.rh"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyREPLACE_WITH_REAL_FIREBASE_KEY_0000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "201283742683-3tad975gn325vvr3qpq85vcotsr0cplt.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "201283742683-0ehoepfvhegchl3r869l8d98jb9uoijh.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.leopardo.manager",
+                "app_store_id": "123456"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
Partie code de #1467 (la rotation de la clé reste une action humaine, l'issue reste ouverte) :
- 4 google-services.json → stub à clés factices versionné
- secret Actions GOOGLE_SERVICES_JSON créé
- CI mobile restaure le fichier réel avant build (3 workflows)
- runbook de rotation mis à jour