### PR TITLE
test(e2e): stabiliser les 2 tests Playwright flaky (#1575)

### DIFF
--- a/front/admin-dashboard/e2e/notification-fallback-polling.spec.js
+++ b/front/admin-dashboard/e2e/notification-fallback-polling.spec.js
@@ -4,7 +4,24 @@ import { expect, test } from '@playwright/test'
 // n'est pas disponible (proxy/firewall, serveur down, ...), l'admin-dashboard
 // doit continuer a recevoir les notifications via un polling REST regulier
 // de /notifications plutot que de rester silencieusement bloque.
+//
+// Flaky tracking (issue #1575) : ce test dépend du timing de détection
+// d'échec Socket.IO (grace period 8s + retry socket.io). Stabilisation :
+//   - les connexions socket.io sont avortées immédiatement (mock déterministe),
+//   - timeout global du test relevé à 60 s (l'assertion de polling peut
+//     légitimement prendre ~8-30 s),
+//   - retries séparés (3) via describe.configure.
+test.describe.configure({ retries: 3 })
+
 test('falls back to REST polling when the push (Socket.IO) channel is unavailable', async ({ page }) => {
+  // Le serveur de dev n'a pas d'upstream socket.io : pour rendre la détection
+  // d'échec déterministe (pas de dépendance à la grace period), on avorte les
+  // connexions socket.io dès leur tentative.
+  await page.route('**/socket.io/**', (route) => route.abort())
+  await page.route(/\/socket\.io\/?$/, (route) => route.abort())
+
+  test.setTimeout(60_000)
+
   await page.route('**/api/v1/platform/auth/login', async (route) => {
     await route.fulfill({
       status: 200,

--- a/front/admin-dashboard/e2e/recruitment-flow.spec.js
+++ b/front/admin-dashboard/e2e/recruitment-flow.spec.js
@@ -1,9 +1,16 @@
 import { expect, test } from '@playwright/test'
 
 test.describe('Recruitment flow', () => {
+  // Flaky tracking (issue #1575) : timeout relevé à 60 s et retries séparés
+  // (3) — l'interaction avec l'API mockée peut être lente en CI.
+  test.setTimeout(60_000)
+  test.describe.configure({ retries: 3 })
+
   test('creates a job, opens the pipeline, and advances an applicant with mocked API', async ({ page }) => {
     const corsHeaders = {
-      'Access-Control-Allow-Origin': 'http://127.0.0.1:4173',
+      // `*` plutôt qu'une origine figée : le port d'origine du webServer
+      // (4173) peut être 127.0.0.1 ou localhost selon l'environnement CI.
+      'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Headers': 'authorization, content-type, accept',
       'Access-Control-Allow-Methods': 'GET, POST, PATCH, OPTIONS',
     }


### PR DESCRIPTION
## Issue #1575 — Tests Playwright flaky : notification-fallback-polling + recruitment-flow

### Correctifs
1. **notification-fallback-polling** : les connexions `socket.io/**` sont désormais avortées au niveau du route mock — la détection d'échec ne dépend plus des timings réels (grace period 8 s + retries socket.io). Timeout du test relevé à 60 s (l'assertion de polling peut légitimement prendre 8-30 s).
2. **recruitment-flow** : `Access-Control-Allow-Origin: *` (l'origine `http://127.0.0.1:4173` figée cassait les requêtes cross-origin quand le webServer tourne sur `localhost`), timeout 60 s.
3. **Tag flaky + retry séparé** : `test.describe.configure({ retries: 3 })` sur les deux specs.

Closes #1575