### PR TITLE
fix(payroll): indemnité congés payés — jours acquis réels (balance+used+pending) + référence 12 mois normalisée (F-07, #1537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **fix(payroll): indemnité de congés payés — jours ACQUIS et non le solde restant (F-07, #1537, PR #1659).** `PayrollCalculator::accruedLeaveDays()` sommait `LeaveBalance.balance` (= restant, décrémenté à l'approbation d'un congé) : un employé ayant pris 5 j sur 30 acquis était indemnisé sur 25 (1/10ᵉ sous-évalué de 20 %). Corrigé : `SUM(balance + used + pending)` restreint aux types de congés payés. `referenceGross12Months()` normalise aussi la période partielle (embauche en cours d'année : gross × 12/mois couverts). Golden `GoldenDzLeaveIndemnityRealDataTest` mis à jour (48 000 → 40 000 DZD, calcul à la main sur 30 j acquis).
+
 ### Added
 - **feat(payroll): journal de paie mensuel exposé via l'API (F-10, #1540).** Nouveau `GET /payroll-runs/{run}/journal` → CSV (une ligne par bulletin validé : matricule, nom, brut, cotisations, IRG, autres déductions, net, coût employeur + ligne de totaux), réservé principal/comptable, isolation tenant. Le générateur `PayrollJournalGenerator` (existant, testé en unitaire) était jusqu'ici sans route API. Tests : `PayrollJournalApiTest`. Matrice RBAC_ROUTE_MATRIX mise à jour.
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php
@@ -454,15 +454,32 @@ class PayrollCalculator
     {
         $twelveMonthsAgo = (clone $run->period_start)->subMonths(12);
 
-        $gross = PaySlip::query()
+        $slips = PaySlip::query()
             ->where('company_id', $employee->company_id)
             ->where('employee_id', $employee->id)
             ->where('status', 'validated')
             ->where('period_start', '>=', $twelveMonthsAgo)
             ->where('period_start', '<', $run->period_start)
-            ->sum('gross_salary');
+            ->get(['gross_salary', 'period_start']);
 
-        return $gross > 0.0 ? (float) $gross : $baseSalary * 12.0;
+        if ($slips->isEmpty()) {
+            return $baseSalary * 12.0;
+        }
+
+        $gross = (float) $slips->sum('gross_salary');
+
+        // Période partielle (embauche en cours d'année) : on normalise sur 12
+        // mois pour ne pas sous-évaluer le 1/10ᵉ (ex. 3 bulletins → gross × 12/3).
+        $months = $slips
+            ->map(fn ($slip) => $slip->period_start->format('Y-m'))
+            ->unique()
+            ->count();
+
+        if ($months > 0 && $months < 12) {
+            $gross = $gross * (12.0 / $months);
+        }
+
+        return $gross;
     }
 
     /**
@@ -474,13 +491,20 @@ class PayrollCalculator
     {
         $year = (int) $run->period_start->format('Y');
 
-        $days = LeaveBalance::query()
+        // Jours ACQUIS = solde restant + jours déjà pris (+ en attente) :
+        // LeaveBalance.balance n'est que le RESTANT (décrémenté à l'approbation
+        // d'un congé) — l'utiliser seul sous-évalue l'acquisition (F-07 #1537).
+        $row = LeaveBalance::query()
             ->where('company_id', $employee->company_id)
             ->where('employee_id', $employee->id)
             ->where('year', $year)
-            ->sum('balance');
+            ->whereHas('absenceType', fn ($q) => $q->where('is_paid', true))
+            ->selectRaw('SUM(balance + used + pending) as acquired')
+            ->first();
 
-        return $days > 0.0 ? (float) $days : 30.0;
+        $days = $row !== null ? (float) $row->acquired : 0.0;
+
+        return $days > 0.0 ? $days : 30.0;
     }
 
     public function computeLeaveIndemnity(

--- a/api/tests/Feature/Payroll/Golden/GoldenDzLeaveIndemnityRealDataTest.php
+++ b/api/tests/Feature/Payroll/Golden/GoldenDzLeaveIndemnityRealDataTest.php
@@ -24,10 +24,11 @@ use Tests\TestCase;
  * Scénario calculé à la main :
  *   base mensuelle 60 000 DZD · 10 jours de congé payé · 22 jours ouvrés
  *   référence 12 mois réelle : 12 bulletins validés à 100 000 → 1 200 000
- *   acquis réels : LeaveBalance = 25 j (au lieu du défaut 30)
+ *   acquis réels : LeaveBalance balance 25 + used 5 = 30 j (et non le seul
+ *   solde restant 25 — corr. audit 2026-08-09, #1634)
  *
  *   maintien = 60 000 × 10 / 22          = 27 272,73
- *   1/10ᵉ    = (1 200 000 / 10) × 10/25  = 48 000,00  → retenu (plus favorable)
+ *   1/10ᵉ    = (1 200 000 / 10) × 10/30  = 40 000,00  → retenu (plus favorable)
  *
  * Avec l'ancienne approximation (base×12 = 720 000 / acquis 30) :
  *   1/10ᵉ = 24 000 < maintien → 27 272,73 aurait été retenu à tort.
@@ -100,10 +101,13 @@ class GoldenDzLeaveIndemnityRealDataTest extends TestCase
             ]);
         }
 
-        // Jours acquis réels : 25 (LeaveBalance, année de la période du run).
+        // Jours acquis réels : 30 (balance restante 25 + 5 déjà pris —
+        // LeaveBalance.balance n'est que le restant, l'acquisition = balance
+        // + used + pending, année de la période du run).
         LeaveBalance::create([
             'company_id' => $company->id,
             'employee_id' => $employee->id,
+            'absence_type_id' => $type->id,
             'balance' => 25,
             'used' => 5,
             'pending' => 0,
@@ -126,7 +130,7 @@ class GoldenDzLeaveIndemnityRealDataTest extends TestCase
 
         $indemnityLine = $slip->lines->where('name', 'Indemnité de congés payés')->first();
         $this->assertNotNull($indemnityLine, 'La ligne indemnité de congés payés doit être présente.');
-        $this->assertSame(48000.0, (float) $indemnityLine->amount);
+        $this->assertSame(40000.0, (float) $indemnityLine->amount);
     }
 
     public function test_leave_indemnity_falls_back_without_history(): void


### PR DESCRIPTION
## Suite de PR #1634 (F-07, #1537) — corrections audit 2026-08-09

La PR #1634 a branché le calcul sur les données réelles, mais l'audit a relevé deux défauts corrigés ici :

1. **Jours ACQUIS, pas le solde restant** : `accruedLeaveDays()` sommait `LeaveBalance.balance` (= restant, décrémenté à l'approbation) — un employé ayant pris 5 j sur 30 acquis était payé sur 25 (sous-évaluation du 1/10e de 20 %). Corrigé : `SUM(balance + used + pending)` restreint aux types de congés payés.
2. **Référence 12 mois normalisée** : `referenceGross12Months()` sommait les bulletins validés bruts sans normaliser une période partielle (embauche en cours d'année → 1/10e sous-évalué). Corrigé : proratisation `gross × 12/mois_couverts` quand < 12 mois.

Golden test mis à jour (48 000 → 40 000 DZD, calcul à la main) : acquisition réelle 30 j (25 restants + 5 pris).

Closes #1537 (calcul conforme DZ — 1/10e vs maintien sur données réelles).