### PR TITLE
docs(sec): attestation rotations Neon/Google + plan purge 5 forks (#1723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## [Unreleased]
 
 ### Security
+- **docs(sec): attestations rotations + plan purge forks (#1723).** Health prod vérifié (2026-08-11 18:01 UTC) : `GET /api/v1/health` → `checks.database.ok=true` sur `gestionemployerbackend.onrender.com` ; `HISTORIQUE_SECRETS.md` enrichi (tableau d'attestation Redis/Neon/Google/forks + checklist propriétaire) ; nouveau `docs/security/PLAN_PURGE_FORKS_2026-08-11.md` (inventaire des 5 forks + messages types + procédure takedown GitHub Support). Rotations console Neon/Google à attester par le propriétaire (issues #1601/#1467).
 - **audit 2026-08-10 (#1694–#1712) — complétions revue :** purge ponctuelle du miroir Hive legacy du JWT au démarrage des 4 apps mobiles (#1700) ; login démo `platform_admin` gaté `kDebugMode` (aligné employee/hr/manager, #1697) ; `client_secret` SSO préservé lors d'une réécriture de config sans secret (#1694) ; URLs backend entièrement centralisées dans `src/lib/backend-url.ts` (checkout, lead-capture, signup, verify, careers, api-client, login, kiosk) (#1701).
 - **audit 2026-08-10 (#1694–#1712) — complétions revue :** `per_page` plafonné à 100 sur Growth/Cameras/Notification/CabinetShare + contrat de réponse `data` restauré (liste simple + `meta`, jamais de paginator brut) (#1703) ; `AccrueLeaveBalances` : une transaction par chunk (savepoints par employé) au lieu d'une par employé (#1703) ; follow-up exclusion iCloud iOS documenté (roadmap Edge) (#1700).
 

--- a/docs/security/HISTORIQUE_SECRETS.md
+++ b/docs/security/HISTORIQUE_SECRETS.md
@@ -14,6 +14,7 @@
 
 | Date de mise à jour | Statut |
 |---|---|
+| 2026-08-11 (soir) | 🟡 Purge OK + health prod vérifié (database.ok) ; rotations Neon/Google **à attester côté console** par le propriétaire ; plan de purge des 5 forks documenté (#1723) |
 | 2026-08-11 | 🟢 Purge historique EFFECTUÉE (git filter-repo --replace-text + force-push) — voir POST_MORTEM_PURGE_2026-08-11.md |
 
 > ✅ **Purge effectuée le 2026-08-11** : toutes les valeurs réelles de l'inventaire
@@ -44,6 +45,20 @@
 4. **Vérification faite** : 0/11 valeurs dans `git log --all -p` ; gitleaks 44→12 (résiduels = exemples doc) ; alerte Secret Scanning à résoudre ; prochain run A-2 à confirmer.
 
 Détails et risques résiduels (forks) : `docs/security/POST_MORTEM_PURGE_2026-08-11.md`.
+
+## Attestations de rotation (issue #1723)
+
+| Secret | Rotation | Attestation console | Preuve / action requise |
+|---|---|---|---|
+| Redis Upstash (#1472) | ✅ Fait (2026-08-10) | ✅ Attesté | Rotation attestée 2026-08-10 (issue #1472) |
+| PostgreSQL Neon (#1601) | 🔄 À attester | ⏳ **Action propriétaire** : reset du mot de passe en console Neon, MAJ `DATABASE_URL` Render (API + workers) | Health prod vérifié le 2026-08-11 18:01 UTC : `GET https://gestionemployerbackend.onrender.com/api/v1/health` → `checks.database.ok=true` (latence 39 ms) — l'URL actuelle fonctionne ; l'attestation de la rotation console reste à tracer ici |
+| Clés API Google / Firebase (#1467) | 🔄 À attester | ⏳ **Action propriétaire** : révoquer/restreindre `AIzaSyCYauGS…` et `AIzaSyAkWnXd…` en console Google Cloud/Firebase, MAJ du secret Actions `GOOGLE_SERVICES_JSON` | Historique purgé (0/11 valeurs) ; 2 alertes Secret Scanning résiduelles à résoudre après révocation |
+| 5 forks publics | 🍴 Plan documenté | ⏳ **Action propriétaire** : contacts + takedown GitHub Support si sans réponse | `docs/security/PLAN_PURGE_FORKS_2026-08-11.md` (inventaire + messages types) |
+
+> Checklist propriétaire (#1723) : ① console Neon → reset password + MAJ `DATABASE_URL` Render ;
+> ② console Google/Firebase → révocation des 2 clés + MAJ `GOOGLE_SERVICES_JSON` ;
+> ③ contact des 5 propriétaires de forks (§3 du plan) ; ④ re-vérif health + scan forks ;
+> ⑤ clôture de l'issue #1723 avec les attestations datées.
 
 ## Évolution attendue
 

--- a/docs/security/PLAN_PURGE_FORKS_2026-08-11.md
+++ b/docs/security/PLAN_PURGE_FORKS_2026-08-11.md
@@ -1,0 +1,63 @@
+# 🍴 Plan de purge des forks publics — historique avec secrets (issue #1723)
+
+Statut : **PLAN DOCUMENTÉ** le 2026-08-11 — action de purge à exécuter par le propriétaire
+Issues liées : #1723, #1601 (Neon), #1467 (Google), #1472/#1693 (purge historique)
+Risque : les forks conservent l'**ancien historique** (pré-purge 2026-08-11) contenant
+les valeurs réelles des secrets (Redis, Neon, clés Google) — la purge du dépôt principal
+ne les a **pas** nettoyés.
+
+---
+
+## 1. Pourquoi
+
+Le 2026-08-11, la purge historique du dépôt principal (`git filter-repo --replace-text`,
+voir `POST_MORTEM_PURGE_2026-08-11.md`) a retiré 11 valeurs réelles de l'historique de
+`kitokoh/leopardo-hr`. **Les forks existants conservent l'ancien historique** (GitHub ne
+propage pas les réécritures d'historique aux forks) : les secrets restent récupérables
+via `git log -p` sur ces dépôts publics.
+
+## 2. Inventaire des 5 forks (vérifié API GitHub le 2026-08-11)
+
+| Fork | Propriétaire | Dernier push | Risque |
+|---|---|---|---|
+| `heartshare/leopardo-hr` | heartshare | 2026-08-09 | 🔴 Historique pré-purge |
+| `emelaslan/leopardo-hr` | emelaslan | 2026-08-08 | 🔴 Historique pré-purge |
+| `mirkosalvato1-ctrl/leopardo-hr` | mirkosalvato1-ctrl | 2026-07-29 | 🔴 Historique pré-purge |
+| `Ahmedmaped/hr` | Ahmedmaped | 2026-07-24 | 🔴 Historique pré-purge (nom différent) |
+| `dipit-s/leopardo-hr` | dipit-s | 2026-05-31 | 🟠 Historique pré-purge, inactif |
+
+## 3. Plan d'action (propriétaire)
+
+1. **Contacter chaque propriétaire de fork** (issue/commentaire sur le fork ou email via
+   le profil GitHub) avec le message type §4, en demandant la **suppression du fork**
+   (l'historique réécrit du dépôt principal reste disponible pour tout re-fork).
+2. **Après 7 jours sans réponse**, ouvrir une demande auprès du
+   [GitHub Support](https://support.github.com/contact/dmca-takedown) (takedown pour
+   secret compromis — les secrets de type API key/password relèvent de la politique
+   DMCA/security takedown de GitHub) en joignant l'issue #1723 et le post-mortem.
+3. **Vérification finale** : confirmer via l'API que les 5 forks sont supprimés ou
+   vidés ; re-scanner `trufflehog git <fork_url>` pour attester l'absence de valeurs réelles.
+4. **Attestation** : reporter le statut de chaque fork dans cette issue (#1723) et
+   mettre à jour `HISTORIQUE_SECRETS.md`.
+
+## 4. Message type aux propriétaires de forks
+
+> Bonjour,
+>
+> Le dépôt `kitokoh/leopardo-hr` a fait l'objet d'une **purge d'historique de sécurité**
+> le 2026-08-11 (secrets compromis retirés de tout l'historique git — voir
+> `docs/security/POST_MORTEM_PURGE_2026-08-11.md`). Votre fork conserve l'**ancien
+> historique** contenant ces secrets.
+>
+> Pour la sécurité de tous, merci de **supprimer votre fork** (ou au minimum de
+> forcer la synchronisation depuis l'historique réécrit). L'historique propre reste
+> disponible sur le dépôt principal.
+>
+> Merci — Kitokoh.com
+
+## 5. Impact de la migration Git LFS (issue #1727)
+
+La migration Git LFS prévue (#1727) réécrira une nouvelle fois l'historique de `main`.
+Les forks conservant l'ancien historique seront alors **définitivement orphelins**
+(incompatibles avec le nouveau `main`), ce qui réduit mécaniquement le risque de
+re-synchronisation de secrets : la purge des forks (§3) reste néanmoins requise.


### PR DESCRIPTION
Closes #1723 (partie automatisable)

- **Vérif prod faite** : GET https://gestionemployerbackend.onrender.com/api/v1/health → checks.database.ok=true (latence 39 ms, 2026-08-11 18:01 UTC)
- docs/security/HISTORIQUE_SECRETS.md : tableau d'attestation Redis ✅ / Neon ⏳ / Google ⏳ / forks ⏳ + checklist propriétaire
- Nouveau docs/security/PLAN_PURGE_FORKS_2026-08-11.md : inventaire des 5 forks (heartshare, emelaslan, mirkosalvato1-ctrl, Ahmedmaped, dipit-s) + messages types + procédure takedown GitHub Support

> ⚠️ Actions console **non automatisables** (propriétaire) : reset password Neon (#1601), révocation clés Google (#1467), contacts forks — checklist détaillée dans l'issue.