### PR TITLE
ci(release): durcissement release.yml + badge Release README (#1722)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  checks: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -49,6 +50,62 @@ jobs:
 
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${TAG}"
+
+      - name: Verify tag commit is on main
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.tag }}"
+          TAG_COMMIT=$(git rev-parse "${TAG}^{commit}")
+          echo "tag_commit=${TAG_COMMIT}" >> "$GITHUB_OUTPUT"
+
+          # Le tag doit pointer sur un commit de `main` (jamais un tag orphelin
+          # ou un tag pousse depuis un clone stale). Issue #1722.
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "${TAG_COMMIT}" "origin/main"; then
+            echo "::error::Le tag ${TAG} (commit ${TAG_COMMIT}) n'est pas un ancetre de origin/main — release refusee."
+            exit 1
+          fi
+          echo "Tag ${TAG} -> ${TAG_COMMIT} (sur main) : OK"
+
+      - name: Verify required checks on the release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHA="${{ steps.verify.outputs.tag_commit }}"
+          REQUIRED=( \
+            "Backend Coverage (PHP 8.4 + PostgreSQL 16)" \
+            "PHPStan — Strict (Core/Modules/Shared, level 8)" \
+            "Module Structure Validator" \
+            "Frontend — ESLint + TypeScript" \
+            "actionlint (+ shellcheck)" \
+          )
+          FAILED=()
+          for ctx in "${REQUIRED[@]}"; do
+            RUNS=$(curl -fsSL \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs?per_page=100" \
+              | jq -c --arg ctx "$ctx" '[.check_runs[] | select(.name == $ctx) | .conclusion]')
+            COUNT=$(jq 'length' <<<"$RUNS")
+            if [[ "${COUNT}" -eq 0 ]]; then
+              echo "::notice::${ctx}: aucun run sur ${SHA} (workflow non declenche sur push) — non bloquant"
+              continue
+            fi
+            CONC=$(jq -r 'unique | join(",")' <<<"$RUNS")
+            if [[ "${CONC}" == *"failure"* || "${CONC}" == *"timed_out"* || "${CONC}" == *"cancelled"* ]]; then
+              echo "::error::Check requis en echec sur ${SHA} : ${ctx} (${CONC})"
+              FAILED+=("${ctx}")
+            else
+              echo "::notice::${ctx} -> ${CONC} : OK"
+            fi
+          done
+          if [[ ${#FAILED[@]} -gt 0 ]]; then
+            echo "::error::Release bloquee — checks requis en echec : ${FAILED[*]}"
+            exit 1
+          fi
+          echo "Required checks: all green (or not run on push) : OK"
 
       - name: Extract changelog for this version
         id: changelog

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![CI/CD](https://img.shields.io/github/actions/workflow/status/kitokoh/leopardo-hr/tests.yml?branch=main&style=for-the-badge&logo=github&label=CI%2FCD)](https://github.com/kitokoh/leopardo-hr/actions)
 [![Coverage](https://img.shields.io/badge/coverage-71%25-30a14e?style=for-the-badge&logo=php&label=Backend)](https://github.com/kitokoh/leopardo-hr/actions/workflows/coverage-gate.yml)
+[![Release](https://img.shields.io/github/v/release/kitokoh/leopardo-hr?sort=semver&style=for-the-badge&logo=github&label=Release)](https://github.com/kitokoh/leopardo-hr/releases/latest)
 [![Security](https://img.shields.io/badge/security-Enterprise--Grade-brightgreen?style=for-the-badge&logo=anchor)](docs/security/SECURITY.md)
 [![License: MIT](https://img.shields.io/github/license/kitokoh/leopardo-hr?style=for-the-badge&label=License)](LICENSE)
 
@@ -152,7 +153,7 @@ Developer guide: [DEVELOPMENT.md](DEVELOPMENT.md) · [Conventions](CONVENTIONS.m
 - [x] **Phase 3 (partial)** — OpenAPI spec + JS/Python SDKs + Postman collection
 - [ ] **Phase 4** — Public API ecosystem, billing & app marketplace
 - [ ] **Phase 5** — Global financial integrations (SEPA / SWIFT / mobile money)
-- [ ] **v1.0 release** — semantic tags + release notes ([issue #1722](https://github.com/kitokoh/leopardo-hr/issues/1722))
+- [x] **v1.0 release** — tag sémantique `v4.24.0` + release notes automatiques via `release.yml` ([issue #1722](https://github.com/kitokoh/leopardo-hr/issues/1722))
 
 Operational reality is tracked in [PILOTAGE.md](PILOTAGE.md) (source of truth, FR).
 


### PR DESCRIPTION
Durcissement du workflow de release (issue #1722, critère « vérif des checks requis ») :

1. **release.yml** : permissions `checks: read` ; nouveau step « Verify tag commit is on main » (refuse un tag orphelin ou poussé depuis un clone stale) ; nouveau step « Verify required checks » — si un des 5 checks requis de la protection de branche (Backend Coverage, PHPStan Strict, Module Structure, Frontend ESLint+TS, actionlint) est en échec sur le commit du tag, la release est bloquée. Un check non déclenché sur push (ex. coverage-gate, PR-only) reste non bloquant.
2. **README** : badge « Release » (shields.io `github/v/release`) + item roadmap v1.0 coché.

Validation locale : YAML + bash -n OK (actionlint CI le re-confirmera).

Closes #1722