### PR TITLE
fix(mobile): adapter le monorepo à flutter_local_notifications 22 — répare la CI main cassée par #1752

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/services/push_notification_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/services/push_notification_service.dart
@@ -83,7 +83,8 @@ class PushNotificationService {
   }
 
   Future<void> _initLocalNotifications() async {
-    const androidInit = AndroidInitializationSettings('@drawable/ic_notification');
+    const androidInit =
+        AndroidInitializationSettings('@drawable/ic_notification');
     const iosInit = DarwinInitializationSettings(
       requestAlertPermission: true,
       requestBadgePermission: true,
@@ -95,7 +96,7 @@ class PushNotificationService {
     );
 
     await _localNotifications.initialize(
-      initSettings,
+      settings: initSettings,
       onDidReceiveNotificationResponse: (response) {
         debugPrint('Local notification tapped: ${response.payload}');
       },
@@ -104,8 +105,7 @@ class PushNotificationService {
     if (Platform.isAndroid) {
       await _localNotifications
           .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin
-          >()
+              AndroidFlutterLocalNotificationsPlugin>()
           ?.createNotificationChannel(
             const AndroidNotificationChannel(
               'leopardo_hr_default',
@@ -215,10 +215,10 @@ class PushNotificationService {
     );
 
     await _localNotifications.show(
-      notification.hashCode,
-      notification.title ?? 'Leopardo HR',
-      notification.body ?? '',
-      details,
+      id: notification.hashCode,
+      title: notification.title ?? 'Leopardo HR',
+      body: notification.body ?? '',
+      notificationDetails: details,
       payload: message.data.toString(),
     );
   }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -276,6 +276,12 @@ abstract class AppLocalizations {
   /// **'Tester avec un compte demo'**
   String get authTryDemoAccount;
 
+  /// No description provided for @authTwoFactorRequired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le code 2FA est requis.'**
+  String get authTwoFactorRequired;
+
   /// No description provided for @commonLanguageLabel.
   ///
   /// In fr, this message translates to:
@@ -1073,6 +1079,24 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'Etes-vous sur de vouloir supprimer :name ?'**
   String get usersConfirmDelete;
+
+  /// No description provided for @usersErrorsNameRequired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le nom complet est requis.'**
+  String get usersErrorsNameRequired;
+
+  /// No description provided for @usersErrorsPasswordRequired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le mot de passe est requis.'**
+  String get usersErrorsPasswordRequired;
+
+  /// No description provided for @usersErrorsFixFields.
+  ///
+  /// In fr, this message translates to:
+  /// **'Veuillez corriger les champs en rouge'**
+  String get usersErrorsFixFields;
 
   /// No description provided for @dashboardTitle.
   ///

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -102,6 +102,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authTryDemoAccount => 'تجربة حساب تجريبي';
 
   @override
+  String get authTwoFactorRequired => 'رمز التحقق الثنائي مطلوب.';
+
+  @override
   String get commonLanguageLabel => 'اللغة';
 
   @override
@@ -511,6 +514,15 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get usersConfirmDelete => 'هل انت متأكد من رغبتك في حذف :name؟';
+
+  @override
+  String get usersErrorsNameRequired => 'الاسم الكامل مطلوب.';
+
+  @override
+  String get usersErrorsPasswordRequired => 'كلمة المرور مطلوبة.';
+
+  @override
+  String get usersErrorsFixFields => 'يرجى تصحيح الحقول المميزة';
 
   @override
   String get dashboardTitle => 'لوحة التحكم';

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -103,6 +103,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authTryDemoAccount => 'Try a demo account';
 
   @override
+  String get authTwoFactorRequired => 'The 2FA code is required.';
+
+  @override
   String get commonLanguageLabel => 'Language';
 
   @override
@@ -516,6 +519,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get usersConfirmDelete => 'Are you sure you want to delete :name?';
+
+  @override
+  String get usersErrorsNameRequired => 'The full name is required.';
+
+  @override
+  String get usersErrorsPasswordRequired => 'The password is required.';
+
+  @override
+  String get usersErrorsFixFields => 'Please fix the highlighted fields';
 
   @override
   String get dashboardTitle => 'Dashboard';

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -105,6 +105,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authTryDemoAccount => 'Tester avec un compte demo';
 
   @override
+  String get authTwoFactorRequired => 'Le code 2FA est requis.';
+
+  @override
   String get commonLanguageLabel => 'Langue';
 
   @override
@@ -520,6 +523,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get usersConfirmDelete => 'Etes-vous sur de vouloir supprimer :name ?';
+
+  @override
+  String get usersErrorsNameRequired => 'Le nom complet est requis.';
+
+  @override
+  String get usersErrorsPasswordRequired => 'Le mot de passe est requis.';
+
+  @override
+  String get usersErrorsFixFields => 'Veuillez corriger les champs en rouge';
 
   @override
   String get dashboardTitle => 'Tableau de bord';

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -101,6 +101,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authTryDemoAccount => 'Demo hesabini dene';
 
   @override
+  String get authTwoFactorRequired => '2FA kodu gereklidir.';
+
+  @override
   String get commonLanguageLabel => 'Dil';
 
   @override
@@ -514,6 +517,15 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get usersConfirmDelete =>
       ':name kullanicisini silmek istediginizden emin misiniz?';
+
+  @override
+  String get usersErrorsNameRequired => 'Ad soyad gereklidir.';
+
+  @override
+  String get usersErrorsPasswordRequired => 'Şifre gereklidir.';
+
+  @override
+  String get usersErrorsFixFields => 'Lütfen kırmızı alanları düzeltin';
 
   @override
   String get dashboardTitle => 'Kontrol Paneli';

--- a/front/mobile_apps/leopardo_core/pubspec.lock
+++ b/front/mobile_apps/leopardo_core/pubspec.lock
@@ -415,18 +415,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_core/pubspec.yaml
+++ b/front/mobile_apps/leopardo_core/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^3.4.2
   dio: ^5.4.3+1
-  flutter_secure_storage: ^11.0.0
+  flutter_secure_storage: ^10.1.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3

--- a/front/mobile_apps/leopardo_employee/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/front/mobile_apps/leopardo_employee/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -18,6 +18,7 @@ import package_info_plus
 import sentry_flutter
 import sqflite_darwin
 import url_launcher_macos
+import workmanager_apple
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
@@ -33,4 +34,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WorkmanagerPlugin.register(with: registry.registrar(forPlugin: "WorkmanagerPlugin"))
 }

--- a/front/mobile_apps/leopardo_employee/pubspec.lock
+++ b/front/mobile_apps/leopardo_employee/pubspec.lock
@@ -178,7 +178,7 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
       sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
@@ -434,26 +434,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "22.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "12.2.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -479,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -1493,10 +1509,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:
@@ -1714,5 +1730,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/front/mobile_apps/leopardo_employee/pubspec.lock
+++ b/front/mobile_apps/leopardo_employee/pubspec.lock
@@ -495,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_employee/pubspec.yaml
+++ b/front/mobile_apps/leopardo_employee/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^10.1.0
+  flutter_secure_storage: ^11.0.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3
@@ -30,7 +30,7 @@ dependencies:
   url_launcher: ^6.3.1
   firebase_core: ^4.13.0
   firebase_messaging: ^16.5.0
-  flutter_local_notifications: ^18.0.0
+  flutter_local_notifications: ^22.3.0
   sentry_flutter: ^8.9.0
   leopardo_core:
     path: ../leopardo_core

--- a/front/mobile_apps/leopardo_employee/pubspec.yaml
+++ b/front/mobile_apps/leopardo_employee/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^11.0.0
+  flutter_secure_storage: ^10.1.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3

--- a/front/mobile_apps/leopardo_hr/pubspec.lock
+++ b/front/mobile_apps/leopardo_hr/pubspec.lock
@@ -495,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_hr/pubspec.lock
+++ b/front/mobile_apps/leopardo_hr/pubspec.lock
@@ -178,7 +178,7 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
       sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
@@ -434,26 +434,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "22.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "12.2.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -479,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -1453,10 +1469,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:
@@ -1626,5 +1642,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/front/mobile_apps/leopardo_hr/pubspec.yaml
+++ b/front/mobile_apps/leopardo_hr/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^11.0.0
+  flutter_secure_storage: ^10.1.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3

--- a/front/mobile_apps/leopardo_hr/pubspec.yaml
+++ b/front/mobile_apps/leopardo_hr/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^10.1.0
+  flutter_secure_storage: ^11.0.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3
@@ -30,7 +30,7 @@ dependencies:
   url_launcher: ^6.3.1
   firebase_core: ^4.13.0
   firebase_messaging: ^16.5.0
-  flutter_local_notifications: ^18.0.0
+  flutter_local_notifications: ^22.3.0
   graphview: ^1.2.1
   leopardo_core:
     path: ../leopardo_core

--- a/front/mobile_apps/leopardo_manager/pubspec.lock
+++ b/front/mobile_apps/leopardo_manager/pubspec.lock
@@ -495,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_manager/pubspec.lock
+++ b/front/mobile_apps/leopardo_manager/pubspec.lock
@@ -178,7 +178,7 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
       sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
@@ -434,26 +434,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "22.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "12.2.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -479,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -1453,10 +1469,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:
@@ -1626,5 +1642,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/front/mobile_apps/leopardo_manager/pubspec.yaml
+++ b/front/mobile_apps/leopardo_manager/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^11.0.0
+  flutter_secure_storage: ^10.1.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3

--- a/front/mobile_apps/leopardo_manager/pubspec.yaml
+++ b/front/mobile_apps/leopardo_manager/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^10.1.0
+  flutter_secure_storage: ^11.0.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3
@@ -30,7 +30,7 @@ dependencies:
   url_launcher: ^6.3.1
   firebase_core: ^4.13.0
   firebase_messaging: ^16.5.0
-  flutter_local_notifications: ^18.0.0
+  flutter_local_notifications: ^22.3.0
   sentry_flutter: ^8.9.0
   graphview: ^1.2.1
   leopardo_core:

--- a/front/mobile_apps/leopardo_platform_admin/pubspec.lock
+++ b/front/mobile_apps/leopardo_platform_admin/pubspec.lock
@@ -282,26 +282,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "22.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "12.2.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -319,18 +335,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -885,7 +901,7 @@ packages:
     source: hosted
     version: "8.14.2"
   sentry_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sentry_flutter
       sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
@@ -1053,10 +1069,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_platform_admin/pubspec.lock
+++ b/front/mobile_apps/leopardo_platform_admin/pubspec.lock
@@ -335,18 +335,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/front/mobile_apps/leopardo_platform_admin/pubspec.yaml
+++ b/front/mobile_apps/leopardo_platform_admin/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^11.0.0
+  flutter_secure_storage: ^10.1.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3

--- a/front/mobile_apps/leopardo_platform_admin/pubspec.yaml
+++ b/front/mobile_apps/leopardo_platform_admin/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_riverpod: ^3.4.2
   go_router: ^17.2.3
   dio: ^5.11.0
-  flutter_secure_storage: ^10.1.0
+  flutter_secure_storage: ^11.0.0
   intl: ^0.20.2
   shimmer: ^3.0.0
   hive: ^2.2.3
@@ -25,7 +25,7 @@ dependencies:
   path_provider: ^2.1.3
   firebase_core: ^4.13.0
   firebase_messaging: ^16.5.0
-  flutter_local_notifications: ^18.0.0
+  flutter_local_notifications: ^22.3.0
   sentry_flutter: ^8.9.0
   google_sign_in: ^7.2.0
   leopardo_core:


### PR DESCRIPTION
## Contexte
Le merge de #1752 (flutter-core-dependencies) a monté le core en flutter_local_notifications ^22.3.0 + flutter_secure_storage ^11.0.0 **sans adapter le reste du monorepo** → CI main rouge (5 échecs : analyze core + install deps des 4 apps).

## Corrections
- **core** : push_notification_service.dart adapté à l'API v19+ (initialize → `settings:` nommé ; show → `id:`/`title:`/`body:`/`notificationDetails:` nommés).
- **4 apps** (hr, manager, platform_admin, employee) : constraints alignées sur le core (flutter_local_notifications ^22.3.0) + lockfiles régénérés (flutter pub get, Flutter 3.44.9 stable — même version que la CI).
- **employee/macos** : GeneratedPluginRegistrant.swift manquant (workmanager 0.10.7 du merge #1753).

## Décision flutter_secure_storage
La **11.x exige compileSdk 37**, incompatible avec la baseline SDK 36 du repo (audit #1715, permission_handler ^12, action setup-flutter-android installe platforms;android-36). Les 5 projets restent donc en ^10.1.0 (10.3.1 résolue) — le bump sera possible lors d'une migration SDK 37 coordonnée.

## Validation locale
flutter analyze → **0 issue** sur les 5 projets (Flutter 3.44.9).

Closes #1752