### PR TITLE
infra(lfs): migration Git LFS des assets binaires — préparation (#1727)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,12 +14,19 @@ CHANGELOG.md merge=union
 *.sh    text eol=lf
 *.neon  text eol=lf
 
-# Fichiers binaires
-*.png   binary
-*.jpg   binary
-*.jpeg  binary
-*.gif   binary
+# Fichiers binaires — trackés en Git LFS (issue #1727)
+# Les fichiers LFS sont stockés hors-git (GitHub LFS) ; le checkout CI doit
+# utiliser actions/checkout avec lfs: true (fait sur tous les workflows).
+*.png   filter=lfs diff=lfs merge=lfs -text
+*.jpg   filter=lfs diff=lfs merge=lfs -text
+*.jpeg  filter=lfs diff=lfs merge=lfs -text
+*.webp  filter=lfs diff=lfs merge=lfs -text
+*.webm  filter=lfs diff=lfs merge=lfs -text
+*.mp4   filter=lfs diff=lfs merge=lfs -text
+*.gif   filter=lfs diff=lfs merge=lfs -text
+*.apk   filter=lfs diff=lfs merge=lfs -text
+*.aab   filter=lfs diff=lfs merge=lfs -text
+
+# Autres binaires (hors LFS pour l'instant)
 *.ico   binary
 *.pdf   binary
-*.apk   binary
-*.aab   binary

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@e0207a28405ecad11953ba625a95d92f7889572a # v1

--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -55,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -76,6 +80,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Check module structure
         run: |
@@ -216,6 +222,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/backend-jobs-ci.yml
+++ b/.github/workflows/backend-jobs-ci.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup backend (PHP + Composer + multi-tenant DB)
         uses: ./.github/actions/setup-backend-db

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       # Audit §2.3 / Plan P1: GitHub CodeQL has no native PHP support in this
       # workflow environment, so this job used to be a no-op status stub.

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup backend (PHP + Composer + multi-tenant DB)
         uses: ./.github/actions/setup-backend-db

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Install backup tools
         shell: bash
@@ -111,6 +113,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Install drill tools
         shell: bash

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -88,6 +88,7 @@ jobs:
         if: steps.context.outputs.should_deploy == 'pending-validation'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           ref: ${{ steps.context.outputs.sha }}
           fetch-depth: 2
           persist-credentials: false

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -90,6 +90,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Resolve staging URL
         id: url
@@ -171,6 +173,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -236,6 +240,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/fix-composer-lock.yml
+++ b/.github/workflows/fix-composer-lock.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref_name }}
 

--- a/.github/workflows/i18n-enterprise.yml
+++ b/.github/workflows/i18n-enterprise.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -93,6 +95,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/k6-load-smoke.yml
+++ b/.github/workflows/k6-load-smoke.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Prepare reports directory
         run: mkdir -p dev-hub/load/reports
@@ -122,6 +124,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Prepare reports directory
         run: mkdir -p dev-hub/load/reports
@@ -165,6 +169,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Prepare reports directory
         run: mkdir -p dev-hub/load/reports

--- a/.github/workflows/kiosk-ci.yml
+++ b/.github/workflows/kiosk-ci.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/launch-api-profile-smoke.yml
+++ b/.github/workflows/launch-api-profile-smoke.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Prepare reports directory
         shell: bash

--- a/.github/workflows/launch-observability-smoke.yml
+++ b/.github/workflows/launch-observability-smoke.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Run launch probes
         env:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -41,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Validate mobile apps boundaries
@@ -119,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Flutter + Java
         uses: ./.github/actions/setup-flutter-android
@@ -171,6 +174,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Flutter + Java
         uses: ./.github/actions/setup-flutter-android

--- a/.github/workflows/mobile-distribute-main.yml
+++ b/.github/workflows/mobile-distribute-main.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           ref: ${{ github.sha }}
           persist-credentials: false
 

--- a/.github/workflows/mobile-distribute.yml
+++ b/.github/workflows/mobile-distribute.yml
@@ -85,6 +85,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Resolve selected app
         shell: bash

--- a/.github/workflows/onboarding-smoke.yml
+++ b/.github/workflows/onboarding-smoke.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Copy env (as documented in DEVELOPMENT.md)
         run: cp api/.env.example api/.env

--- a/.github/workflows/openapi-ci.yml
+++ b/.github/workflows/openapi-ci.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Lint api/openapi.yaml
         run: npx --yes @redocly/cli@1.34.5 lint api/openapi.yaml
@@ -63,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Compare routes vs openapi.yaml
         # Toute route NON documentée ET NON allowlistée fait échouer le job.

--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -80,6 +80,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Resolve target URL
         id: target

--- a/.github/workflows/payroll-ci.yml
+++ b/.github/workflows/payroll-ci.yml
@@ -53,6 +53,8 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
@@ -93,6 +95,8 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
@@ -134,6 +138,8 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
@@ -241,6 +247,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:

--- a/.github/workflows/phpstan-baseline.yml
+++ b/.github/workflows/phpstan-baseline.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2

--- a/.github/workflows/plan-action2-claim-guard.yml
+++ b/.github/workflows/plan-action2-claim-guard.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Run claim collision check
         env:

--- a/.github/workflows/plan-action2-post-merge-audit.yml
+++ b/.github/workflows/plan-action2-post-merge-audit.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           # fetch-depth: 0 (pas juste 2) car `github.event.before` peut etre
           # plusieurs commits en arriere si le push contient plus d'un
           # commit (ex. merge --no-ff avec des commits de la branche de

--- a/.github/workflows/plan-action2-project.yml
+++ b/.github/workflows/plan-action2-project.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
       - name: Validate CSV and dependencies
         shell: pwsh
         run: ./dev-hub/tools/validate-plan-action2.ps1
@@ -71,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
       - name: Sync PLAN_ACTION2 tickets
         shell: pwsh
         env:

--- a/.github/workflows/plan-action2-weekly-report.yml
+++ b/.github/workflows/plan-action2-weekly-report.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Generate report
         id: report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Resolve tag

--- a/.github/workflows/secret-history-scan.yml
+++ b/.github/workflows/secret-history-scan.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Checkout full history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Run TruffleHog on full history

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       # Garde arbre HEAD (#1614) : les rapports d'audit/docs ne doivent JAMAIS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Detect changed directories
@@ -118,6 +119,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Setup backend (PHP + Composer + multi-tenant DB)
@@ -180,6 +182,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -200,6 +204,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -456,6 +462,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup backend (PHP + Composer + multi-tenant DB, PCOV coverage)
         uses: ./.github/actions/setup-backend-db
@@ -597,6 +605,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: Validate governance and changelog
@@ -616,6 +625,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Review dependency changes
         # Audit #1706 : ce job était décoratif (continue-on-error:true) alors

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -88,6 +92,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/web-marketing-ci.yml
+++ b/.github/workflows/web-marketing-ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -80,6 +84,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/web-offline-ci.yml
+++ b/.github/workflows/web-offline-ci.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - _(entrées de la prochaine release — rien encore)_
 ### Chore
+- **infra : migration Git LFS des assets binaires (#1727).** `*.png/jpg/jpeg/webp/webm/mp4/gif/apk/aab` trackés en LFS (`.gitattributes`) ; `lfs: true` ajouté à tous les `actions/checkout` des 34 workflows ; migration de l'historique planifiée (force-push coordonné, clone ≥ 50 % plus léger).
 - **docs(oss) : SUPPORT.md + workflows PLAN_ACTION2 internes (#1730 #1731).** SUPPORT.md créé (canaux + SLA) et référencé depuis CONTRIBUTING.md ; bannière « INTERNAL GOVERNANCE » + `if:` anti-fork sur les 4 workflows PLAN_ACTION2 ; cartographie publique/interne dans .github/workflows/README.md ; procédure de revue croisée documentée (CODEOWNERS).
 - **release : préparation v4.24.0 (#1722).** Section `## [4.24.0] - 2026-08-11` dans le CHANGELOG + `PROGRAM_VERSION = 4.24.0` (PILOTAGE.md). Après merge : tag `v4.24.0` → release.yml crée la GitHub Release (notes auto).
 - **release.yml durci (#1722) :** vérifie que le tag pointe sur `main` et que les checks requis ne sont pas en échec avant de créer la release ; badge « Release » ajouté au README.

--- a/dev-hub/tools/add-lfs-checkout.py
+++ b/dev-hub/tools/add-lfs-checkout.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Add `lfs: true` to every actions/checkout step in .github/workflows/*.yml|yaml.
+
+Handles both styles:
+  - name: Checkout            - uses: actions/checkout@<sha> # v7
+    uses: actions/checkout@x    with:
+    with:                         lfs: true
+      lfs: true
+Idempotent: skips steps that already have lfs: true.
+"""
+import glob
+import re
+
+USE_RE = re.compile(r'^(\s*)(?:-\s*)?(uses):\s*actions/checkout@\S+')
+WITH_RE = re.compile(r'^(\s*)with:\s*$')
+KEY_RE = re.compile(r'^(\s*)([\w.-]+):')
+
+changed_files = []
+for path in sorted(glob.glob('.github/workflows/*.yml') + glob.glob('.github/workflows/*.yaml')):
+    with open(path, 'r', encoding='utf-8') as fh:
+        lines = fh.readlines()
+
+    out = []
+    i = 0
+    modified = False
+    while i < len(lines):
+        m = USE_RE.match(lines[i])
+        if not m:
+            out.append(lines[i])
+            i += 1
+            continue
+
+        indent = len(m.group(1))          # whitespace before '-' or 'uses'
+        dash_style = bool(lines[i].lstrip().startswith('- uses:'))
+        if dash_style:
+            key_col = indent + 2          # 'with:' aligns with 'uses'
+        else:
+            key_col = indent              # 'with:' aligns with 'uses:'
+        sub_col = key_col + 2
+
+        # Look for an existing with: block (sibling key of uses)
+        j = i + 1
+        while j < len(lines) and lines[j].strip() == '':
+            j += 1
+        with_block = None
+        if j < len(lines):
+            wm = WITH_RE.match(lines[j])
+            if wm and len(wm.group(1)) == key_col:
+                with_block = (j, key_col)
+
+        if with_block is not None:
+            j, with_indent = with_block
+            k = j + 1
+            has_lfs = False
+            while k < len(lines):
+                km = KEY_RE.match(lines[k])
+                if not km or len(km.group(1)) <= with_indent:
+                    break
+                if km.group(2) == 'lfs':
+                    has_lfs = True
+                k += 1
+            if not has_lfs:
+                out.extend(lines[i:j + 1])
+                out.append(f'{" " * (with_indent + 2)}lfs: true\n')
+                out.extend(lines[j + 1:k])
+                i = k
+                modified = True
+                continue
+            out.append(lines[i])
+            i += 1
+            continue
+
+        # No with: block — insert one aligned as sibling of uses
+        out.append(lines[i])
+        out.append(f'{" " * key_col}with:\n')
+        out.append(f'{" " * sub_col}lfs: true\n')
+        i += 1
+        modified = True
+
+    if modified:
+        with open(path, 'w', encoding='utf-8') as fh:
+            fh.writelines(out)
+        changed_files.append(path)
+
+print(f'{len(changed_files)} workflow(s) modifié(s) :')
+for p in changed_files:
+    print(f'  - {p}')


### PR DESCRIPTION
## Contexte
Issue #1727 : repo de 47,9 Mo, ~38 Mo de binaires versionnés (338 PNG + webm/mp4/gif…). Objectif : clone ≥ 50 % plus léger, images README intactes, CI verte.

## Cette PR (préparation — la réécriture d'historique force-push est faite juste après, en fenêtre coordonnée)
1. **`.gitattributes`** : `*.png/jpg/jpeg/webp/webm/mp4/gif/apk/aab` → `filter=lfs diff=lfs merge=lfs -text` (issue #1727).
2. **34 workflows / 61 steps `actions/checkout`** : ajout de `lfs: true` (checkout LFS-aware partout).
3. **Outil** : `dev-hub/tools/add-lfs-checkout.py` (idempotent, réutilisable).
4. **CHANGELOG** : entrée #1727.

## Étapes suivantes (hors PR, post-merge)
- `git lfs migrate import --include="*.png,*.jpg,*.jpeg,*.webp,*.webm,*.mp4,*.gif,*.apk,*.aab" --everything` sur main
- force-push coordonné + `git lfs push --all`
- vérifs : clone ≥ 50 % plus léger, images README OK, CI verte.

## Vérifications
- YAML valide sur les 34 workflows (validé).
- Répétition de la migration validée sur copie locale.
- Aucun checkout sans `lfs: true` (validé par script).
