### PR TITLE
fix(ci): E2E Admin Dashboard pointé sur le SPA Vue (leo-admin.pages.dev) au lieu du backend Blade

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -27,6 +27,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEFAULT_STAGING_URL: https://gestionemployerbackend.onrender.com
+  DEFAULT_ADMIN_STAGING_URL: https://leo-admin.pages.dev
   DEFAULT_WEB_STAGING_URL: https://gestionemployer-backend.vercel.app
 
 concurrency:
@@ -192,14 +193,14 @@ jobs:
         run: |
                     npx playwright install --with-deps chromium
 
-      - name: Warm up staging instance (Render cold-start, issue #1725)
+      - name: Warm up staging instance (cold-start, issue #1725)
         working-directory: front/admin-dashboard
         env:
-          BASE_URL: ${{ github.event.inputs.staging_url || env.DEFAULT_STAGING_URL }}
+          BASE_URL: ${{ github.event.inputs.staging_url || env.DEFAULT_ADMIN_STAGING_URL }}
         run: |
           set -euo pipefail
           URL="${BASE_URL}/login"
-          echo "Warming up ${URL} (instance Render free tier s'endort apres ~15 min d'inactivite)..."
+          echo "Warming up ${URL} (instance free tier s'endort apres ~15 min d'inactivite)..."
           for attempt in {1..30}; do
             code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "${URL}" || echo 000)
             if [[ "${code}" != "000" ]]; then
@@ -217,7 +218,7 @@ jobs:
         working-directory: front/admin-dashboard
         env:
           CI: true
-          BASE_URL: ${{ github.event.inputs.staging_url || env.DEFAULT_STAGING_URL }}
+          BASE_URL: ${{ github.event.inputs.staging_url || env.DEFAULT_ADMIN_STAGING_URL }}
         run: npx playwright test
 
       - name: Upload Playwright report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Unreleased]
 
 ### Fixed
-- _(entrées de la prochaine release — rien encore)_
+- **ci(e2e) : job Admin Dashboard E2E pointé sur le SPA Vue admin (leo-admin.pages.dev) au lieu du backend Blade.** Le workflow `e2e-staging.yml` testait `gestionemployerbackend.onrender.com` (page de login Laravel) alors que la suite Playwright `front/admin-dashboard` cible le SPA Vue (label « Adresse email », `#password`, ARIA S-6). Le job n'avait jamais réellement tourné (runs antérieurs skippés par la gate `deploy-api`) ; premier vrai run après merge → échec systématique. `DEFAULT_ADMIN_STAGING_URL` ajouté (même URL que `launch-observability-smoke.yml`), warm-up et tests admin pointent désormais dessus.
 ### Chore
 - **infra : migration Git LFS des assets binaires (#1727).** `*.png/jpg/jpeg/webp/webm/mp4/gif/apk/aab` trackés en LFS (`.gitattributes`) ; `lfs: true` ajouté à tous les `actions/checkout` des 34 workflows ; migration de l'historique planifiée (force-push coordonné, clone ≥ 50 % plus léger).
 - **payroll : FOCUS 2 F-31 — règles pays de fin de contrat (#1756).** `CountryRulesInterface::noticePeriodDays()` / `severanceMonthsPerYear()` (défauts dans `AbstractCountryRules`, valeurs pilot DZ documentées) ; `EndOfContractService` résout préavis et indemnité de licenciement via les règles du pays (fini les valeurs codées en dur 1.0/0.0) ; golden tests `GoldenDzEndOfContractRulesTest` (5 ans × 60 000 × 1,0 = 300 000 DZD) ; `DZ_COMPLIANCE.md` §7 mis à jour (durées légales candidates à valider expert).


### PR DESCRIPTION
## Contexte
Closes #1761

Le job `e2e-admin-dashboard` du workflow `e2e-staging.yml` testait la page de login du **backend Laravel** (`gestionemployerbackend.onrender.com`, template Blade avec label « Email » sans association `for`/`id`) alors que la suite Playwright `front/admin-dashboard` cible le **SPA Vue admin** (label « Adresse email », `#password`, ARIA S-6, cf. `LoginView.vue`).

Ce job **n'avait jamais réellement tourné** : les runs E2E antérieurs étaient des faux succès — le job `should-run` sortait `run_e2e=false` quand `deploy-api` était skipped, donc tous les jobs étaient skippés et le workflow était « vert » sans exécuter un seul test. Le premier vrai run E2E (déclenché après un vrai déploiement) a révélé l'échec : 32 tests Playwright en `element(s) not found` sur la page de login.

## Changement
- `env.DEFAULT_ADMIN_STAGING_URL = https://leo-admin.pages.dev` — même URL que celle déjà utilisée par `launch-observability-smoke.yml` (`admin_url`) ;
- warm-up et `BASE_URL` du job `e2e-admin-dashboard` pointent désormais vers cette URL (le SPA Vue réellement déployé), plus le backend Blade.

## Vérification
- Le SPA sur `leo-admin.pages.dev/login` sert bien le formulaire attendu (titre « Leopardo RH - Administration », h1 « Leopardo RH », label « Adresse email », `#password`, bouton « Se connecter ») ;
- aucun changement de logique applicative ; uniquement la cible de test E2E.