### PR TITLE
fix(dashboard): KPI turnover — archived_at inexistant → status=archived + fixture alignée

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DashboardController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DashboardController.php
@@ -145,8 +145,8 @@ class DashboardController extends Controller
 
         $turnover = DB::table('employees')
             ->where('company_id', $companyId)
-            ->whereNotNull('archived_at')
-            ->whereBetween('archived_at', [$periodStart, $periodEnd])
+            ->where('status', 'archived')
+            ->whereBetween('updated_at', [$periodStart, $periodEnd])
             ->count();
 
         $hires = DB::table('employees')

--- a/api/tests/Feature/DashboardControllerTest.php
+++ b/api/tests/Feature/DashboardControllerTest.php
@@ -120,7 +120,7 @@ class DashboardControllerTest extends TestCase
         $manager->forceFill(['created_at' => now()->subMonths(2)])->save();
         Employee::factory()->count(2)->create(['company_id' => $company->id, 'status' => 'active']);
         $archived = Employee::factory()->create(['company_id' => $company->id, 'status' => 'archived']);
-        DB::table('employees')->where('id', $archived->id)->update(['archived_at' => now()]);
+        DB::table('employees')->where('id', $archived->id)->update(['updated_at' => now()]);
         $this->insertAbsence($company->id, $manager->id, 'approved');
 
         Sanctum::actingAs($manager);

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -232,7 +232,6 @@ trait CreatesMvpSchema
             $table->unsignedInteger('manager_id')->nullable();
             $table->decimal('leave_balance', 6, 2)->default(0);
             $table->string('status', 20)->default('active');
-            $table->timestampTz('archived_at')->nullable();
             $table->char('preferred_language', 2)->nullable();
             $table->string('photo_path', 255)->nullable();
             $table->string('iban', 255)->nullable();

--- a/api/tests/Support/sql/mvp_schema.pgsql.sql
+++ b/api/tests/Support/sql/mvp_schema.pgsql.sql
@@ -233,7 +233,6 @@ CREATE TABLE shared_tenants.employees (
     manager_id integer NULL,
     leave_balance numeric(6, 2) NOT NULL DEFAULT 0,
     status varchar(20) NOT NULL DEFAULT 'active',
-    archived_at timestamptz NULL,
     preferred_language char(2) NULL,
     photo_path varchar(255) NULL,
     iban varchar(255) NULL,


### PR DESCRIPTION
## Problème
`GET /api/v1/dashboard/kpi` → **500** pour tous les comptes : `SQLSTATE[42703] column "archived_at" does not exist`. Aucune migration ne crée cette colonne (l'archivage = `status='archived'`) ; la colonne n'existait que dans la fixture de test → tests verts en CI, prod cassée. Voir issue #1771.

## Correctif
1. `DashboardController::kpi()` : `whereNotNull('archived_at')/whereBetween('archived_at')` → `where('status','archived')` + fenêtre sur `updated_at` (mis à jour automatiquement par Eloquent à l'archivage).
2. Test KPI : utilise `updated_at` (fini la colonne fantôme).
3. Fixtures `mvp_schema.pgsql.sql` / `CreatesMvpSchema.php` : suppression de la colonne `archived_at` fantôme → la fixture reflète désormais les migrations réelles.

## Vérifications
- Endpoint réel (schéma migrations) : `GET /dashboard/kpi` → **200** (`turnover: 2, new_hires: 13, absence_rate: 10`).
- `DashboardControllerTest` : **5/5 passent** avec la fixture corrigée.
- PHPStan : pas de nouvelle erreur (le diff ne touche pas au typage).