### PR TITLE
fix(deploy): embarquer shared/i18n dans l'image Docker de prod (i18n/catalog 500)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,17 @@ postman
 tests
 *.md
 !README.md
+
+# Exclusions héritées de l'ancien api/.dockerignore (le contexte de build est
+# désormais la racine du repo — render.yaml dockerContext: .) :
+api/tests
+api/docs
+api/dev-hub
+api/phpstan*.neon
+api/storage/logs/*
+api/storage/framework/cache/data/*
+api/storage/framework/sessions/*
+api/storage/framework/views/*.php
+api/storage/coverage
+api/storage/test-results
+api/node_modules

--- a/api/Dockerfile.prod
+++ b/api/Dockerfile.prod
@@ -20,7 +20,15 @@ RUN install-php-extensions \
 
 WORKDIR /app
 
-COPY . .
+# Build context is the monorepo root (render.yaml: dockerContext: .) so
+# shared/i18n can be shipped into the image. Only api/ is copied to /app
+# (the root .dockerignore excludes front/, docs/, tests/, ...).
+COPY api/ .
+
+# I18nCatalog::rootPath() reads <repo-root>/shared/i18n = /shared/i18n.
+# Without this copy, GET /api/v1/i18n/catalog/* 500s in production
+# (Locale catalog not found). See issue #1773.
+COPY shared/i18n /shared/i18n
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader
@@ -34,7 +42,7 @@ RUN cp /usr/local/bin/frankenphp /usr/local/bin/frankenphp-nocap \
 
 EXPOSE 80 443 2019 8080
 
-COPY Caddyfile /etc/caddy/Caddyfile
-COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY api/Caddyfile /etc/caddy/Caddyfile
+COPY --chmod=755 api/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/render.yaml
+++ b/render.yaml
@@ -8,8 +8,8 @@ services:
   - type: web
     name: leopardo-api
     runtime: docker
-    dockerfilePath: ./api/Dockerfile.prod
-    dockerContext: ./api
+    dockerfilePath: api/Dockerfile.prod
+    dockerContext: .
     region: frankfurt
     plan: starter
     healthCheckPath: /api/v1/health
@@ -126,8 +126,8 @@ services:
   - type: worker
     name: leopardo-queue-worker
     runtime: docker
-    dockerfilePath: ./api/Dockerfile.prod
-    dockerContext: ./api
+    dockerfilePath: api/Dockerfile.prod
+    dockerContext: .
     region: frankfurt
     plan: starter
     autoDeploy: true
@@ -219,8 +219,8 @@ services:
   - type: worker
     name: leopardo-scheduler
     runtime: docker
-    dockerfilePath: ./api/Dockerfile.prod
-    dockerContext: ./api
+    dockerfilePath: api/Dockerfile.prod
+    dockerContext: .
     region: frankfurt
     plan: starter
     autoDeploy: true


### PR DESCRIPTION
Closes #1773

## Problème
`GET /api/v1/i18n/catalog/*` → **500 en prod** : `I18nCatalog::rootPath()` lit `<repo-root>/shared/i18n` mais `render.yaml` build avec `dockerContext: ./api` → les fichiers de traduction ne sont jamais dans l'image. Voir issue #1773.

## Changements
- **render.yaml** : `dockerContext: .` + `dockerfilePath: api/Dockerfile.prod` (services web + 2 workers).
- **api/Dockerfile.prod** : `COPY api/ .` (équivalent au comportement précédent) + `COPY shared/i18n /shared/i18n` ; chemins Caddyfile/entrypoint préfixés `api/`.
- **.dockerignore racine** : reprend les exclusions de l'ancien `api/.dockerignore` (devenu inactif) + exclut `front/`, `docs/`, `tests/` → image plus petite qu'avant.

## Vérification
- Le layout résultant reproduit le chemin attendu par `I18nCatalog` : `/app` (api) + `/shared/i18n`.
- `I18nCatalog::readLocale('fr')` OK avec ce layout en local.

⚠️ À valider en staging : un déploiement Render doit passer sur l'API (health + `GET /i18n/catalog/fr` → 200). Si le contexte racine pose problème avec les 3 services, on peut à la place copier `shared/i18n` dans `api/` au build — à arbitrer en revue.