### PR TITLE
fix(vitrine): domaines morts + SEO pointant vers leopardo.com (entreprise US tierce)

### DIFF
--- a/front/web/src/app/(landing)/about/layout.tsx
+++ b/front/web/src/app/(landing)/about/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.about.keywords,
   ogImage: pageMetadata.about.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/about',
+  canonical: 'https://gestionemployer-backend.vercel.app/about',
 });
 
 export default function AboutLayout({

--- a/front/web/src/app/(landing)/blog/[slug]/layout.tsx
+++ b/front/web/src/app/(landing)/blog/[slug]/layout.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
     keywords: post.tags,
     ogImage: post.image,
     ogType: 'article',
-    canonical: `https://leopardo.com/blog/${post.slug}`,
+    canonical: `https://gestionemployer-backend.vercel.app/blog/${post.slug}`,
     publishedTime: post.date.toISOString(),
     author: post.author.name,
   });

--- a/front/web/src/app/(landing)/blog/layout.tsx
+++ b/front/web/src/app/(landing)/blog/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.blog.keywords,
   ogImage: pageMetadata.blog.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/blog',
+  canonical: 'https://gestionemployer-backend.vercel.app/blog',
 });
 
 export default function BlogLayout({

--- a/front/web/src/app/(landing)/branding/layout.tsx
+++ b/front/web/src/app/(landing)/branding/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.branding.keywords,
   ogImage: pageMetadata.branding.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/branding',
+  canonical: 'https://gestionemployer-backend.vercel.app/branding',
 });
 
 export default function BrandingLayout({

--- a/front/web/src/app/(landing)/careers/layout.tsx
+++ b/front/web/src/app/(landing)/careers/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.careers.keywords,
   ogImage: pageMetadata.careers.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/careers',
+  canonical: 'https://gestionemployer-backend.vercel.app/careers',
 });
 
 export default function CareersLayout({

--- a/front/web/src/app/(landing)/case-studies/layout.tsx
+++ b/front/web/src/app/(landing)/case-studies/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.caseStudies.keywords,
   ogImage: pageMetadata.caseStudies.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/case-studies',
+  canonical: 'https://gestionemployer-backend.vercel.app/case-studies',
 });
 
 export default function CaseStudiesLayout({

--- a/front/web/src/app/(landing)/changelog/layout.tsx
+++ b/front/web/src/app/(landing)/changelog/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.changelog.keywords,
   ogImage: pageMetadata.changelog.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/changelog',
+  canonical: 'https://gestionemployer-backend.vercel.app/changelog',
 });
 
 export default function ChangelogLayout({

--- a/front/web/src/app/(landing)/checkout/layout.tsx
+++ b/front/web/src/app/(landing)/checkout/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.checkout.keywords,
   ogImage: pageMetadata.checkout.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/checkout',
+  canonical: 'https://gestionemployer-backend.vercel.app/checkout',
   robots: pageMetadata.checkout.robots,
 });
 

--- a/front/web/src/app/(landing)/contact/layout.tsx
+++ b/front/web/src/app/(landing)/contact/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.contact.keywords,
   ogImage: pageMetadata.contact.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/contact',
+  canonical: 'https://gestionemployer-backend.vercel.app/contact',
 });
 
 export default function ContactLayout({

--- a/front/web/src/app/(landing)/contact/page.tsx
+++ b/front/web/src/app/(landing)/contact/page.tsx
@@ -109,7 +109,7 @@ function ContactPageInner() {
                 <h2 className="text-2xl font-black text-slate-900 dark:text-white mb-6">Informations</h2>
                 <div className="space-y-6">
                   {[
-                    { icon: Mail, label: 'Email', value: 'contact@leopardo.com' },
+                    { icon: Mail, label: 'Email', value: 'contact@leopardo-rh.com' },
                     { icon: Phone, label: 'Téléphone', value: '+213 (0) 555 123 456' },
                     { icon: MapPin, label: 'Adresse', value: 'Alger, Algérie' },
                     { icon: Clock, label: 'Horaires', value: 'Lun-Ven 9h-18h (GMT+1)' },

--- a/front/web/src/app/(landing)/docs/layout.tsx
+++ b/front/web/src/app/(landing)/docs/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.docs.keywords,
   ogImage: pageMetadata.docs.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/docs',
+  canonical: 'https://gestionemployer-backend.vercel.app/docs',
 });
 
 export default function DocsLayout({

--- a/front/web/src/app/(landing)/download/layout.tsx
+++ b/front/web/src/app/(landing)/download/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.download.keywords,
   ogImage: pageMetadata.download.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/download',
+  canonical: 'https://gestionemployer-backend.vercel.app/download',
 });
 
 export default function DownloadLayout({

--- a/front/web/src/app/(landing)/faq/layout.tsx
+++ b/front/web/src/app/(landing)/faq/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.faq.keywords,
   ogImage: pageMetadata.faq.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/faq',
+  canonical: 'https://gestionemployer-backend.vercel.app/faq',
 });
 
 export default function FaqLayout({

--- a/front/web/src/app/(landing)/mobile/layout.tsx
+++ b/front/web/src/app/(landing)/mobile/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.mobile.keywords,
   ogImage: pageMetadata.mobile.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/mobile',
+  canonical: 'https://gestionemployer-backend.vercel.app/mobile',
 });
 
 export default function MobileLayout({

--- a/front/web/src/app/(landing)/pricing/layout.tsx
+++ b/front/web/src/app/(landing)/pricing/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.pricing.keywords,
   ogImage: pageMetadata.pricing.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/pricing',
+  canonical: 'https://gestionemployer-backend.vercel.app/pricing',
   robots: 'index, follow',
 });
 

--- a/front/web/src/app/(landing)/signup/layout.tsx
+++ b/front/web/src/app/(landing)/signup/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.signup.keywords,
   ogImage: pageMetadata.signup.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/signup',
+  canonical: 'https://gestionemployer-backend.vercel.app/signup',
   robots: pageMetadata.signup.robots,
 });
 

--- a/front/web/src/app/(landing)/testimonials/layout.tsx
+++ b/front/web/src/app/(landing)/testimonials/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.testimonials.keywords,
   ogImage: pageMetadata.testimonials.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/testimonials',
+  canonical: 'https://gestionemployer-backend.vercel.app/testimonials',
 });
 
 export default function TestimonialsLayout({

--- a/front/web/src/app/(landing)/videos/layout.tsx
+++ b/front/web/src/app/(landing)/videos/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = generateSEOMetadata({
   keywords: pageMetadata.videos.keywords,
   ogImage: pageMetadata.videos.ogImage,
   ogType: 'website',
-  canonical: 'https://leopardo.com/videos',
+  canonical: 'https://gestionemployer-backend.vercel.app/videos',
 });
 
 export default function VideosLayout({

--- a/front/web/src/app/[companySlug]/careers/jobs/[jobId]/page.tsx
+++ b/front/web/src/app/[companySlug]/careers/jobs/[jobId]/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata({ params }: JobDetailPageProps): Promise<
   return generateSEOMetadata({
     title: `${job.title}${company ? ` chez ${company.display_name}` : ''}`,
     description: job.description?.slice(0, 155) || `Postulez a l'offre "${job.title}".`,
-    canonical: `https://leopardo.com/${companySlug}/careers/jobs/${job.id}`,
+    canonical: `https://gestionemployer-backend.vercel.app/${companySlug}/careers/jobs/${job.id}`,
     ogType: 'article',
     ogImage: company?.logo_url ?? undefined,
   });

--- a/front/web/src/app/[companySlug]/careers/page.tsx
+++ b/front/web/src/app/[companySlug]/careers/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: CareersPortalPageProps): Prom
   return generateSEOMetadata({
     title: `Carrieres${displayName ? ` - ${displayName}` : ''} - ${jobs.length} offre${jobs.length > 1 ? 's' : ''} d'emploi`,
     description: `Decouvrez les offres d'emploi ouvertes chez ${displayName || 'cette entreprise'} et postulez en ligne en quelques minutes.`,
-    canonical: `https://leopardo.com/${companySlug}/careers`,
+    canonical: `https://gestionemployer-backend.vercel.app/${companySlug}/careers`,
     ogType: 'website',
     ogImage: company?.logo_url ?? undefined,
   });
@@ -64,7 +64,7 @@ export default async function CareersPortalPage({ params }: CareersPortalPagePro
           itemListElement: jobs.map((job, index) => ({
             '@type': 'ListItem',
             position: index + 1,
-            url: `https://leopardo.com/${companySlug}/careers/jobs/${job.id}`,
+            url: `https://gestionemployer-backend.vercel.app/${companySlug}/careers/jobs/${job.id}`,
           })),
         }}
       />

--- a/front/web/src/components/JsonLd.tsx
+++ b/front/web/src/components/JsonLd.tsx
@@ -2,6 +2,12 @@ interface JsonLdProps {
   data: Record<string, unknown>;
 }
 
+// Issue #1775 : https://gestionemployer-backend.vercel.app appartient à une entreprise de
+// construction US sans rapport — ne jamais l'utiliser dans les données
+// structurées. On utilise l'URL réelle de la marque (configurable).
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://gestionemployer-backend.vercel.app';
+
 export function JsonLd({ data }: JsonLdProps) {
   return (
     <script
@@ -48,7 +54,7 @@ export function ArticleJsonLd({
           name: 'Leopardo RH',
           logo: {
             '@type': 'ImageObject',
-            url: 'https://leopardo.com/logo.png',
+            url: `${SITE_URL}/logo.png`,
           },
         },
       }}
@@ -78,7 +84,7 @@ export function OrganizationJsonLd() {
         creator: {
           '@type': 'Organization',
           name: 'Leopardo RH',
-          url: 'https://leopardo.com',
+          url: SITE_URL,
         },
       }}
     />

--- a/front/web/src/modules/vitrine/components/sections/BlogArticle.tsx
+++ b/front/web/src/modules/vitrine/components/sections/BlogArticle.tsx
@@ -94,7 +94,7 @@ export function BlogArticle({
       });
   };
 
-  const siteOrigin = typeof window !== 'undefined' ? window.location.origin : 'https://leopardo.com';
+  const siteOrigin = typeof window !== 'undefined' ? window.location.origin : 'https://gestionemployer-backend.vercel.app';
   const localeQuery = locale && locale !== 'fr' ? `?lang=${locale}` : '';
   const articleUrl = `${siteOrigin}/blog/${post.slug}${localeQuery}`;
   const articleImageUrl = new URL(post.image, siteOrigin).toString();

--- a/front/web/src/modules/vitrine/lib/constants.ts
+++ b/front/web/src/modules/vitrine/lib/constants.ts
@@ -278,7 +278,7 @@ export const colors = {
 
 // Contact information
 export const contactInfo = {
-  email: "support@leopardo.com",
+  email: "support@leopardo-rh.com",
   phone: "+33 1 23 45 67 89",
   address: "123 Rue de la Paix, 75000 Paris, France",
   hours: "Lun-Ven: 9h-18h (CET)",

--- a/front/web/src/modules/vitrine/lib/seo.ts
+++ b/front/web/src/modules/vitrine/lib/seo.ts
@@ -376,7 +376,7 @@ export function generateOrganizationSchema() {
     contactPoint: {
       "@type": "ContactPoint",
       contactType: "Customer Support",
-      email: "support@leopardo.com",
+      email: "support@leopardo-rh.com",
       availableLanguage: ["fr", "en"],
     },
   };

--- a/front/web/src/modules/vitrine/lib/structured-data.ts
+++ b/front/web/src/modules/vitrine/lib/structured-data.ts
@@ -24,7 +24,7 @@ export function generateOrganizationSchema() {
     contactPoint: {
       '@type': 'ContactPoint',
       contactType: 'Customer Support',
-      email: 'support@leopardo.com',
+      email: 'support@leopardo-rh.com',
       telephone: '+33-1-XX-XX-XX-XX',
       availableLanguage: ['fr', 'en'],
     },

--- a/front/web/src/modules/vitrine/lib/vitrine-locale.ts
+++ b/front/web/src/modules/vitrine/lib/vitrine-locale.ts
@@ -10,6 +10,12 @@ import {
 
 const LOCALE_EVENT = 'vitrine-locale-changed'
 
+// L'espace client réellement en ligne (issue #1775 : app.leopardo-rh.com ne
+// résout pas — DNS mort). Configurable via NEXT_PUBLIC_SITE_URL.
+const DEMO_APP_URL = process.env.NEXT_PUBLIC_SITE_URL
+  ? `${process.env.NEXT_PUBLIC_SITE_URL.replace(/\/+$/, '')}/dashboard`
+  : 'https://gestionemployer-backend.vercel.app/dashboard'
+
 type LocaleOption = {
   value: AppLocale
   label: string
@@ -229,7 +235,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
         'Notifications intelligentes',
         'Compatibilite ZKTeco',
       ],
-      appUrl: 'app.leopardo-rh.com/dashboard',
+      appUrl: DEMO_APP_URL,
       miniStats: [
         { label: 'Employes', value: '247' },
         { label: 'Presents', value: '231' },
@@ -373,7 +379,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
         'Smart notifications',
         'ZKTeco-ready attendance',
       ],
-      appUrl: 'app.leopardo-rh.com/dashboard',
+      appUrl: DEMO_APP_URL,
       miniStats: [
         { label: 'Employees', value: '247' },
         { label: 'Present', value: '231' },
@@ -517,7 +523,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
         'Akilli bildirimler',
         'ZKTeco uyumlu takip',
       ],
-      appUrl: 'app.leopardo-rh.com/dashboard',
+      appUrl: DEMO_APP_URL,
       miniStats: [
         { label: 'Calisan', value: '247' },
         { label: 'Mevcut', value: '231' },
@@ -661,7 +667,7 @@ const landingCopy: Record<AppLocale, LandingCopy> = {
         'اشعارات ذكية',
         'تكامل جاهز مع ZKTeco',
       ],
-      appUrl: 'app.leopardo-rh.com/dashboard',
+      appUrl: DEMO_APP_URL,
       miniStats: [
         { label: 'الموظفون', value: '247' },
         { label: 'الحاضرون', value: '231' },


### PR DESCRIPTION
## Problème
- `app.leopardo-rh.com/dashboard` (CTA démo, 4 locales) → **DNS ne résout pas**.
- `https://leopardo.com` (JSON-LD, canonicaux ×19, emails) → **entreprise de construction US sans rapport**.
Voir issue #1775.

## Changements
- **vitrine-locale.ts** : URL du dashboard démo = `NEXT_PUBLIC_SITE_URL` (fallback live `gestionemployer-backend.vercel.app`).
- **JsonLd.tsx** : `creator.url` / `publisher.logo.url` = `SITE_URL`.
- **Emails** : `support@leopardo.com` / `contact@leopardo.com` → `@leopardo-rh.com` (cohérent avec `legal-content.ts`).
- **Canonicaux** : 19 layouts landing + `[companySlug]/careers` + blog → URL live.
- **BlogArticle.tsx** : fallback serveur → URL live.

## Vérifications
- `npx tsc --noEmit` → 0 erreur.
- Plus aucune occurrence de `leopardo.com` (domaine tiers) dans `src/`.

⚠️ À décider en revue : si `leopardo-rh.com` doit devenir le domaine officiel (DNS + emails), il faudra l'enregistrer — la PR pointe sur l'URL réellement en ligne en attendant.