### PR TITLE
fix(payroll): cotisation-simulation déléguée au moteur de paie + impôt calculé (Closes #1782)

### DIFF
--- a/api/app/Modules/Payroll/Domain/Contracts/CountryRulesInterface.php
+++ b/api/app/Modules/Payroll/Domain/Contracts/CountryRulesInterface.php
@@ -22,7 +22,7 @@ interface CountryRulesInterface
      */
     public function taxSlabs(): array;
 
-    public function calculateIncomeTax(float $grossTaxable, float $annualBasis): float;
+    public function calculateIncomeTax(float $grossTaxable, float $annualBasis = 12): float;
 
     /**
      * @return array{employee: float, employer: float}

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/CotisationSimulationController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/CotisationSimulationController.php
@@ -4,100 +4,30 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
-use App\Http\Controllers\Controller;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Http\Controllers\Controller;
+use App\Modules\Payroll\Infrastructure\Services\PayrollCalculator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
+/**
+ * Simulation de cotisations sociales et d'impôt sur le revenu.
+ *
+ * Issue #1782 : ce contrôleur ne duplique PLUS aucune table de taux.
+ * La source de vérité unique est le moteur de paie
+ * (`PayrollCalculator::getRules()` → `CountryRulesInterface`), qui résout
+ * DZ, MA, TN, FR, TR, SN, CEMAC×6, CEDEAO×6 et CA avec les mêmes règles que
+ * les vrais bulletins — taux, caps, barèmes et abattements compris.
+ *
+ * La logique reproduit fidèlement `PayrollCalculator::calculateSlip()` :
+ *   1. cotisations sociales (`calculateSocialCharges`, valeurs définitives) ;
+ *   2. assiette fiscale = brut − cotisations salariales ;
+ *   3. impôt progressif (`calculateIncomeTax`, mêmes barèmes que le bulletin) ;
+ *   4. net réel = brut − cotisations salariales − impôt.
+ */
 class CotisationSimulationController extends Controller
 {
-    private const COUNTRY_RATES = [
-        'DZ' => [
-            'employee' => ['cnas' => 0.09],
-            'employer' => ['cnas' => 0.26],
-            'irg_brackets' => [
-                ['min' => 0, 'max' => 20000, 'rate' => 0],
-                ['min' => 20001, 'max' => 40000, 'rate' => 0.20],
-                ['min' => 40001, 'max' => 80000, 'rate' => 0.30],
-                ['min' => 80001, 'max' => 160000, 'rate' => 0.35],
-                ['min' => 160001, 'max' => PHP_INT_MAX, 'rate' => 0.40],
-            ],
-        ],
-        'MA' => [
-            'employee' => ['cnss' => 0.0448, 'amo' => 0.0226],
-            'employer' => ['cnss' => 0.0898, 'amo' => 0.0340],
-            'ir_brackets' => [
-                ['min' => 0, 'max' => 30000, 'rate' => 0],
-                ['min' => 30001, 'max' => 50000, 'rate' => 0.10],
-                ['min' => 50001, 'max' => 60000, 'rate' => 0.20],
-                ['min' => 60001, 'max' => 80000, 'rate' => 0.30],
-                ['min' => 80001, 'max' => 180000, 'rate' => 0.34],
-                ['min' => 180001, 'max' => PHP_INT_MAX, 'rate' => 0.38],
-            ],
-        ],
-        'FR' => [
-            'employee' => ['securite_sociale' => 0.0705, 'csg_crds' => 0.097],
-            'employer' => ['securite_sociale' => 0.1530, 'assurance_chomage' => 0.0405],
-            'pas_brackets' => [
-                ['min' => 0, 'max' => 10777, 'rate' => 0],
-                ['min' => 10778, 'max' => 27478, 'rate' => 0.11],
-                ['min' => 27479, 'max' => 78570, 'rate' => 0.30],
-                ['min' => 78571, 'max' => 168994, 'rate' => 0.41],
-                ['min' => 168995, 'max' => PHP_INT_MAX, 'rate' => 0.45],
-            ],
-        ],
-        'TN' => [
-            'employee' => ['cnss' => 0.0918],
-            'employer' => ['cnss' => 0.1657],
-            'irpp_brackets' => [
-                ['min' => 0, 'max' => 5000, 'rate' => 0],
-                ['min' => 5001, 'max' => 20000, 'rate' => 0.26],
-                ['min' => 20001, 'max' => 30000, 'rate' => 0.28],
-                ['min' => 30001, 'max' => 50000, 'rate' => 0.32],
-                ['min' => 50001, 'max' => PHP_INT_MAX, 'rate' => 0.35],
-            ],
-        ],
-        'TR' => [
-            'employee' => ['sgk' => 0.14],
-            'employer' => ['sgk' => 0.2050],
-            'gelir_brackets' => [
-                ['min' => 0, 'max' => 110000, 'rate' => 0.15],
-                ['min' => 110001, 'max' => 230000, 'rate' => 0.20],
-                ['min' => 230001, 'max' => 870000, 'rate' => 0.27],
-                ['min' => 870001, 'max' => 3000000, 'rate' => 0.35],
-                ['min' => 3000001, 'max' => PHP_INT_MAX, 'rate' => 0.40],
-            ],
-        ],
-        'SN' => [
-            'employee' => ['ipres' => 0.056],
-            'employer' => ['ipres' => 0.084, 'css' => 0.07],
-            'ir_brackets' => [
-                ['min' => 0, 'max' => 630000, 'rate' => 0],
-                ['min' => 630001, 'max' => 1500000, 'rate' => 0.20],
-                ['min' => 1500001, 'max' => 4000000, 'rate' => 0.30],
-                ['min' => 4000001, 'max' => 8000000, 'rate' => 0.35],
-                ['min' => 8000001, 'max' => PHP_INT_MAX, 'rate' => 0.37],
-            ],
-        ],
-    ];
-
-    /**
-     * CEMAC (PA2-COUNTRY-007) shares the same CNPS/CNSS-style rates and
-     * placeholder progressive schedule across all six member states
-     * (see CemacPayrollRules), so every member code maps to one shared
-     * rate table instead of duplicating it six times.
-     */
-    private const CEMAC_RATES = [
-        'employee' => ['cnps_cnss' => 0.042],
-        'employer' => ['cnps_cnss' => 0.162],
-        'irpp_brackets' => [
-            ['min' => 0, 'max' => 500000, 'rate' => 0],
-            ['min' => 500001, 'max' => 1000000, 'rate' => 0.10],
-            ['min' => 1000001, 'max' => 2500000, 'rate' => 0.20],
-            ['min' => 2500001, 'max' => 5000000, 'rate' => 0.30],
-            ['min' => 5000001, 'max' => PHP_INT_MAX, 'rate' => 0.35],
-        ],
-    ];
+    public function __construct(private readonly PayrollCalculator $payrollCalculator) {}
 
     public function simulate(Request $request): JsonResponse
     {
@@ -113,38 +43,42 @@ class CotisationSimulationController extends Controller
             'country_code' => 'required|string|in:DZ,MA,FR,TN,TR,SN,CM,CF,TD,CG,GA,GQ,CI,ML,BF,BJ,TG,NE,CA',
         ]);
 
+        /** @var array{gross_salary: float|string, country_code: string} $validated */
         $gross = (float) $validated['gross_salary'];
         $countryCode = $validated['country_code'];
-        $rates = self::COUNTRY_RATES[$countryCode]
-            ?? (in_array($countryCode, \App\Modules\Payroll\Infrastructure\Services\CountryRules\CemacPayrollRules::MEMBER_COUNTRY_CODES, true) ? self::CEMAC_RATES : self::COUNTRY_RATES['DZ']);
+
+        $rules = $this->payrollCalculator->getRules($countryCode);
+
+        /** @var array{employee: float, employer: float} $social */
+        $social = $rules->calculateSocialCharges($gross);
+
+        $taxableGross = round($gross - $social['employee'], 2);
+        // Même appel que PayrollCalculator::calculateSlip() : le 2e paramètre
+        // (annualBasis) a un défaut de 12 dans le contrat et toutes les règles.
+        $incomeTax = $rules->calculateIncomeTax($taxableGross);
+        $netSalary = round($gross - $social['employee'] - $incomeTax, 2);
 
         $employeeContributions = [];
-        $totalEmployeeRate = 0.0;
-        foreach ($rates['employee'] as $name => $rate) {
-            $amount = round($gross * $rate, 2);
-            $employeeContributions[] = [
-                'name' => $name,
-                'rate' => $rate,
-                'amount' => $amount,
-            ];
-            $totalEmployeeRate += $rate;
-        }
-
         $employerContributions = [];
-        $totalEmployerRate = 0.0;
-        foreach ($rates['employer'] as $name => $rate) {
-            $amount = round($gross * $rate, 2);
-            $employerContributions[] = [
-                'name' => $name,
-                'rate' => $rate,
-                'amount' => $amount,
-            ];
-            $totalEmployerRate += $rate;
-        }
+        foreach ($rules->socialContributions() as $contribution) {
+            // Base plafonnée quand la règle déclare un cap (sinon brut entier).
+            $base = $contribution['cap'] === null
+                ? $gross
+                : min($gross, (float) $contribution['cap']);
 
-        $totalEmployeeDeduction = round($gross * $totalEmployeeRate, 2);
-        $totalEmployerCost = round($gross * $totalEmployerRate, 2);
-        $netBeforeTax = round($gross - $totalEmployeeDeduction, 2);
+            $item = [
+                'name' => $contribution['name'],
+                'code' => $contribution['code'],
+                'rate' => $contribution['rate'],
+                'amount' => round($base * (float) $contribution['rate'] / 100, 2),
+            ];
+
+            if ($contribution['type'] === 'employee') {
+                $employeeContributions[] = $item;
+            } else {
+                $employerContributions[] = $item;
+            }
+        }
 
         return response()->json([
             'data' => [
@@ -152,10 +86,15 @@ class CotisationSimulationController extends Controller
                 'gross_salary' => $gross,
                 'employee_contributions' => $employeeContributions,
                 'employer_contributions' => $employerContributions,
-                'total_employee_deduction' => $totalEmployeeDeduction,
-                'total_employer_cost' => $totalEmployerCost,
-                'net_before_tax' => $netBeforeTax,
-                'total_cost_employer' => round($gross + $totalEmployerCost, 2),
+                'total_employee_deduction' => $social['employee'],
+                'total_employer_cost' => $social['employer'],
+                'taxable_gross' => $taxableGross,
+                'income_tax' => $incomeTax,
+                // Rétro-compatible : brut − cotisations salariales (sans impôt).
+                'net_before_tax' => round($gross - $social['employee'], 2),
+                // Net réel = brut − cotisations salariales − impôt (issue #1782).
+                'net_salary' => $netSalary,
+                'total_cost_employer' => round($gross + $social['employer'], 2),
             ],
         ]);
     }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7521,8 +7521,8 @@ paths:
   /cotisation-simulation:
     post:
       tags: ["Payroll Engine"]
-      summary: "Simuler les cotisations sociales employe/employeur pour un salaire brut donne, sans persister (manager)"
-      description: "Taux de cotisation en dur par pays (CNAS/CNSS/Securite Sociale/CNSS-TN/SGK/IPRES/CNPS selon le pays), pas de bareme fiscal IRG/IR/PAS applique (net_before_tax = brut - cotisations salariales uniquement)."
+      summary: "Simuler les cotisations sociales employe/employeur et l'impot sur le revenu pour un salaire brut donne, sans persister (manager)"
+      description: "Delegue au moteur de paie (CountryRulesInterface via PayrollCalculator, issue #1782) : memes taux, caps, baremes et abattements que les vrais bulletins. Reponse complete : cotisations + impôt + net reel (income_tax, net_salary)."
       operationId: simulateCotisations
       requestBody:
         required: true
@@ -7555,6 +7555,7 @@ paths:
                           type: object
                           properties:
                             name: { type: string }
+                            code: { type: string }
                             rate: { type: number }
                             amount: { type: number }
                       employer_contributions:
@@ -7563,11 +7564,15 @@ paths:
                           type: object
                           properties:
                             name: { type: string }
+                            code: { type: string }
                             rate: { type: number }
                             amount: { type: number }
                       total_employee_deduction: { type: number }
                       total_employer_cost: { type: number }
+                      taxable_gross: { type: number }
+                      income_tax: { type: number }
                       net_before_tax: { type: number }
+                      net_salary: { type: number }
                       total_cost_employer: { type: number }
         "401":
           $ref: "#/components/responses/Error401"

--- a/api/tests/Feature/CotisationSimulationTest.php
+++ b/api/tests/Feature/CotisationSimulationTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
 use Laravel\Sanctum\Sanctum;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
@@ -16,8 +16,10 @@ class CotisationSimulationTest extends TestCase
 
     public function test_simulate_dz_cotisations(): void
     {
+        /** @var Company $company */
         $company = Company::factory()->create();
 
+        /** @var Employee $manager */
         $manager = Employee::factory()->create([
             'company_id' => $company->id,
             'role' => 'manager',
@@ -41,7 +43,10 @@ class CotisationSimulationTest extends TestCase
                 'employer_contributions',
                 'total_employee_deduction',
                 'total_employer_cost',
+                'taxable_gross',
+                'income_tax',
                 'net_before_tax',
+                'net_salary',
                 'total_cost_employer',
             ],
         ]);
@@ -50,12 +55,115 @@ class CotisationSimulationTest extends TestCase
         $this->assertEquals('DZ', $data['country_code']);
         $this->assertEquals(50000, $data['gross_salary']);
         $this->assertEquals(4500, $data['total_employee_deduction']);
+        $this->assertEquals(13000, $data['total_employer_cost']);
+        $this->assertEquals(45500.0, $data['net_before_tax']);
+        $this->assertGreaterThan(0, $data['income_tax']);
+        $this->assertLessThan($data['net_before_tax'], $data['net_salary']);
+    }
+
+    /**
+     * Issue #1782 — non-régression : la simulation DZ 60 000 doit reproduire
+     * le golden test du moteur de paie (GoldenDzPayrollTest
+     * test_golden_dz_full_slip_flow_at_60000) : CNAS 5 400 / 15 600,
+     * assiette 54 600, IRG 7 042, net 47 558. Avant le correctif, l'impôt
+     * n'était JAMAIS calculé et les tranches IRG du contrôleur étaient fausses
+     * (20/30/35/40 % au lieu de 23/27/30/33/35 %).
+     */
+    public function test_simulate_dz_60000_matches_payroll_golden(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson('/api/v1/cotisation-simulation', [
+            'gross_salary' => 60000,
+            'country_code' => 'DZ',
+        ])->assertOk();
+
+        $data = $response->json('data');
+
+        $this->assertEquals(5400.0, $data['total_employee_deduction']);
+        $this->assertEquals(15600.0, $data['total_employer_cost']);
+        $this->assertEquals(54600.0, $data['taxable_gross']);
+        $this->assertEquals(7042.0, $data['income_tax']);
+        $this->assertEquals(47558.0, $data['net_salary']);
+        $this->assertEquals(75600.0, $data['total_cost_employer']);
+
+        // Le détail déclaré par les règles pays du moteur (CNAS salariale 9 %).
+        $this->assertSame('CNAS_EMP', $data['employee_contributions'][0]['code']);
+        $this->assertEquals(5400.0, $data['employee_contributions'][0]['amount']);
+    }
+
+    /**
+     * Issue #1782 — Côte d'Ivoire (membre CEDEAO) : avant le correctif, CI
+     * tombait sur les taux DZ (9 % / 26 %). Le moteur applique les taux
+     * CEDEAO/UEMOA : 3,6 % salarié / 16,4 % employeur.
+     */
+    public function test_simulate_ci_uses_cedeao_rates_not_dz(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson('/api/v1/cotisation-simulation', [
+            'gross_salary' => 100000,
+            'country_code' => 'CI',
+        ])->assertOk();
+
+        $data = $response->json('data');
+
+        $this->assertSame('CI', $data['country_code']);
+        $this->assertEquals(3600.0, $data['total_employee_deduction']);
+        $this->assertEquals(16400.0, $data['total_employer_cost']);
+        $this->assertEquals(96400.0, $data['net_before_tax']);
+    }
+
+    /**
+     * Issue #1782 — l'impôt est calculé pour tous les pays supportés :
+     * FR (PAS progressif) doit renvoyer un income_tax > 0 et un net_salary
+     * strictement inférieur au net_before_tax.
+     */
+    public function test_simulate_fr_computes_income_tax(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($manager);
+
+        $response = $this->postJson('/api/v1/cotisation-simulation', [
+            'gross_salary' => 5000,
+            'country_code' => 'FR',
+        ])->assertOk();
+
+        $data = $response->json('data');
+
+        $this->assertGreaterThan(0, $data['income_tax']);
+        $this->assertSame(
+            round($data['net_before_tax'] - $data['income_tax'], 2),
+            $data['net_salary']
+        );
     }
 
     public function test_simulate_ma_cotisations(): void
     {
+        /** @var Company $company */
         $company = Company::factory()->create();
 
+        /** @var Employee $manager */
         $manager = Employee::factory()->create([
             'company_id' => $company->id,
             'role' => 'manager',
@@ -98,8 +206,10 @@ class CotisationSimulationTest extends TestCase
 
     public function test_invalid_country_code_rejected(): void
     {
+        /** @var Company $company */
         $company = Company::factory()->create();
 
+        /** @var Employee $manager */
         $manager = Employee::factory()->create([
             'company_id' => $company->id,
             'role' => 'manager',
@@ -117,4 +227,3 @@ class CotisationSimulationTest extends TestCase
         $response->assertUnprocessable();
     }
 }
-

--- a/dev-hub/openapi/v1.yaml
+++ b/dev-hub/openapi/v1.yaml
@@ -7532,8 +7532,8 @@ paths:
   /cotisation-simulation:
     post:
       tags: ["Payroll Engine"]
-      summary: "Simuler les cotisations sociales employe/employeur pour un salaire brut donne, sans persister (manager)"
-      description: "Taux de cotisation en dur par pays (CNAS/CNSS/Securite Sociale/CNSS-TN/SGK/IPRES/CNPS selon le pays), pas de bareme fiscal IRG/IR/PAS applique (net_before_tax = brut - cotisations salariales uniquement)."
+      summary: "Simuler les cotisations sociales employe/employeur et l'impot sur le revenu pour un salaire brut donne, sans persister (manager)"
+      description: "Delegue au moteur de paie (CountryRulesInterface via PayrollCalculator, issue #1782) : memes taux, caps, baremes et abattements que les vrais bulletins. Reponse complete : cotisations + impôt + net reel (income_tax, net_salary)."
       operationId: simulateCotisations
       requestBody:
         required: true
@@ -7566,6 +7566,7 @@ paths:
                           type: object
                           properties:
                             name: { type: string }
+                            code: { type: string }
                             rate: { type: number }
                             amount: { type: number }
                       employer_contributions:
@@ -7574,11 +7575,15 @@ paths:
                           type: object
                           properties:
                             name: { type: string }
+                            code: { type: string }
                             rate: { type: number }
                             amount: { type: number }
                       total_employee_deduction: { type: number }
                       total_employer_cost: { type: number }
+                      taxable_gross: { type: number }
+                      income_tax: { type: number }
                       net_before_tax: { type: number }
+                      net_salary: { type: number }
                       total_cost_employer: { type: number }
         "401":
           $ref: "#/components/responses/Error401"

--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "128f99643f2342e0a9ac1ec2e023453fa10ef266a08a822e44057e3f7c3b156e",
+  "spec_sha256": "566dc0c569b2d1a7fa9dc98be524d3132603c968453fda79b615edb4dce76be1",
   "openapi": "3.0.3",
   "api_version": "4.23.5",
   "operation_count": 435,

--- a/dev-hub/sdk/javascript/leopardoClient.js
+++ b/dev-hub/sdk/javascript/leopardoClient.js
@@ -700,7 +700,7 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("GET", "/contracts/expiring", options);
     },
 
-    /** Simuler les cotisations sociales employe/employeur pour un salaire brut donne, sans persister (manager) */
+    /** Simuler les cotisations sociales employe/employeur et l'impot sur le revenu pour un salaire brut donne, sans persister (manager) */
     simulateCotisations(options = {}) {
       return request("POST", "/cotisation-simulation", options);
     },

--- a/dev-hub/sdk/python/leopardo_client.py
+++ b/dev-hub/sdk/python/leopardo_client.py
@@ -581,7 +581,7 @@ class LeopardoClient:
         return self.request("GET", "/contracts/expiring", **kwargs)
 
     def simulatecotisations(self, **kwargs):
-        """Simuler les cotisations sociales employe/employeur pour un salaire brut donne, sans persister (manager)"""
+        """Simuler les cotisations sociales employe/employeur et l'impot sur le revenu pour un salaire brut donne, sans persister (manager)"""
         return self.request("POST", "/cotisation-simulation", **kwargs)
 
     def get_dashboard_kpi(self, **kwargs):


### PR DESCRIPTION
## Problème
`POST /api/v1/cotisation-simulation` donnait des résultats faux ou incomplets (issue #1782) :
1. **CI → taux algériens** : `country_code=CI` renvoyait 9 %/26 % (CNAS DZ) au lieu des taux CEDEAO/UEMOA 3,6 %/16,4 % — CI absent de la table → fallback silencieux sur DZ.
2. **Impôt jamais calculé** : `net_before_tax` = brut − cotisations uniquement ; `irg_brackets`/`ir_brackets`/`pas_brackets`/`irpp_brackets` = code mort. Un utilisateur croyait voir son net réel.
3. **Dérive des taux** : table dupliquée divergente du moteur (DZ 20/30/35/40 % vs 23/27/30/33/35 % ; FR 16,75 % vs 17,2 %).

## Changements
- **Suppression des tables `COUNTRY_RATES`/`CEMAC_RATES`** du contrôleur → délégation à `PayrollCalculator::getRules()` (`CountryRulesInterface`), la source de vérité des bulletins (DZ, MA, TN, FR, TR, SN, CEMAC×6, CEDEAO×6, CA).
- **Impôt calculé** : assiette = brut − cotisations salariales, `calculateIncomeTax()` (même logique que `PayrollCalculator::calculateSlip()`).
- **Réponse enrichie** : `taxable_gross`, `income_tax`, `net_salary` (net réel) ; `net_before_tax` conservé en rétro-compat.
- **Contrat corrigé** : `CountryRulesInterface::calculateIncomeTax()` → `annualBasis = 12` par défaut (aligné sur toutes les implémentations ; corrige aussi l'appel 1-arg du moteur).
- **OpenAPI** mise à jour (description + schéma de réponse).
- **Tests de non-régression** : golden DZ 60 000 (CNAS 5 400/15 600, assiette 54 600, **IRG 7 042, net 47 558** — identique à `GoldenDzPayrollTest`), CI 100 000 → taux CEDEAO (3 600/16 400), FR → impôt > 0.

## Vérification
- Local : 11 tests passed (46 assertions), PHPStan 0 erreur, Pint clean.
- CI : tests, PHPStan, OpenAPI lint, actionlint.

Closes #1782
