### PR TITLE
fix(api): rate limiter résilient — 429 dégradé au lieu de 500 quand le stockage du compteur échoue (Closes #1774)

### DIFF
--- a/api/app/Http/Middleware/ResilientThrottleRequests.php
+++ b/api/app/Http/Middleware/ResilientThrottleRequests.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Cache\RateLimiting\Unlimited;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Issue #1774 — ThrottleRequests résilient aux pannes du stockage du compteur.
+ *
+ * Contexte : lors d'une rafale, la prod répondait 500 (« Server Error ») sur
+ * quasi toutes les routes throttlées quand la lecture/écriture du compteur
+ * échouait (cache Redis/Upstash saturé ou injoignable) : l'exception remontait
+ * depuis le RateLimiter à travers le middleware.
+ *
+ * Comportement :
+ *  - échec du stockage pendant la PHASE LIMITER (lecture/écriture du compteur)
+ *    → `report()` (Sentry/logs) + **429 dégradé** avec `Retry-After` (au lieu
+ *    d'un 500). La requête n'atteint pas le contrôleur.
+ *  - échec pendant la pose des headers `X-RateLimit-*` (phase post-`$next()`)
+ *    → `report()` non bloquant, la réponse du contrôleur est conservée.
+ *  - dépassement réel du quota → 429 normal (`ThrottleRequestsException`
+ *    re-lancée, headers conservés) ; exceptions du pipeline en aval (contrôleur)
+ *    → jamais masquées (`$next()` s'exécute HORS du try/catch).
+ */
+class ResilientThrottleRequests extends ThrottleRequests
+{
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = ''): Response
+    {
+        // ── Phase limiter : vérification + incrément du compteur (HORS $next).
+        //    Tout échec ici (stockage du compteur indisponible) → 429 dégradé.
+        try {
+            $limits = $this->resolveLimits($request, $maxAttempts, (int) $decayMinutes, $prefix);
+
+            if ($limits instanceof Response) {
+                // Le limiter nommé a directement retourné une réponse.
+                return $limits;
+            }
+
+            if ($limits === null) {
+                // Limit::none() : route non throttlée.
+                /** @var Response $unthrottledResponse */
+                $unthrottledResponse = $next($request);
+
+                return $unthrottledResponse;
+            }
+
+            foreach ($limits as $limit) {
+                if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
+                    throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
+                }
+
+                if ($limit->afterCallback === null) {
+                    $this->limiter->hit($limit->key, $limit->decaySeconds);
+                }
+            }
+        } catch (ThrottleRequestsException|HttpResponseException $e) {
+            // Dépassement réel du quota (ou réponse custom du limiter) :
+            // comportement nominal inchangé.
+            throw $e;
+        } catch (\Throwable $e) {
+            report($e);
+
+            return $this->degradedTooManyRequestsResponse();
+        }
+
+        // ── Pipeline applicatif : les exceptions du contrôleur remontent
+        //    telles quelles (jamais converties en 429).
+        /** @var Response $response */
+        /** @var Response $response */
+        $response = $next($request);
+
+        // ── Phase headers : une panne du stockage n'invalide pas la réponse.
+        try {
+            foreach ($limits as $limit) {
+                if ($limit->afterCallback !== null && ($limit->afterCallback)($response)) {
+                    $this->limiter->hit($limit->key, $limit->decaySeconds);
+                }
+
+                $response = $this->addHeaders(
+                    $response,
+                    $limit->maxAttempts,
+                    $this->calculateRemainingAttempts($limit->key, $limit->maxAttempts)
+                );
+            }
+        } catch (\Throwable $e) {
+            report($e);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Résout les limites (nommées ou `throttle:X,Y`) comme le fait
+     * `ThrottleRequests::handle()`. Retourne :
+     *  - `null` quand le limiter est `Limit::none()` (pas de throttling) ;
+     *  - un objet `Response` quand le limiter retourne directement une réponse ;
+     *  - un tableau de `ThrottleLimitConfig` sinon.
+     *
+     * @return array<int, ThrottleLimitConfig>|Response|null
+     */
+    private function resolveLimits(Request $request, mixed $maxAttempts, int $decayMinutes, string $prefix): array|Response|null
+    {
+        if (! is_int($maxAttempts) && ! is_string($maxAttempts)) {
+            $maxAttempts = 60;
+        }
+
+        if (is_string($maxAttempts)
+            && func_num_args() === 4
+            && ! is_null($limiter = $this->limiter->limiter($maxAttempts))) {
+            return $this->resolveNamedLimits($request, (string) $maxAttempts, $limiter);
+        }
+
+        return [
+            new ThrottleLimitConfig(
+                key: $prefix.$this->resolveRequestSignature($request),
+                maxAttempts: (int) $this->resolveMaxAttempts($request, $maxAttempts),
+                decaySeconds: 60 * $decayMinutes,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<int, ThrottleLimitConfig>|Response|null
+     */
+    private function resolveNamedLimits(Request $request, string $limiterName, Closure $limiter): array|Response|null
+    {
+        $limiterResponse = $limiter($request);
+
+        if ($limiterResponse instanceof Response) {
+            return $limiterResponse;
+        }
+
+        if ($limiterResponse instanceof Unlimited) {
+            return null;
+        }
+
+        $limiterNameKey = $limiterName;
+
+        /** @var Limit|array<int, Limit> $limitResponse */
+        $limitResponse = $limiterResponse;
+        if ($limitResponse instanceof Limit) {
+            $limitResponse = [$limitResponse];
+        }
+
+        $configs = [];
+        foreach ($limitResponse as $limit) {
+            $configs[] = new ThrottleLimitConfig(
+                key: self::$shouldHashKeys
+                    ? md5($limiterNameKey.$this->normalizeKey($limit->key))
+                    : $limiterNameKey.':'.$this->normalizeKey($limit->key),
+                maxAttempts: (int) $limit->maxAttempts,
+                decaySeconds: (int) $limit->decaySeconds,
+                afterCallback: $limit->afterCallback instanceof Closure ? $limit->afterCallback : null,
+                responseCallback: $limit->responseCallback instanceof Closure ? $limit->responseCallback : null,
+            );
+        }
+
+        return $configs;
+    }
+
+    /**
+     * Normalise la clé de limite (documentée `mixed` sur `Limit`) en chaîne.
+     */
+    private function normalizeKey(mixed $key): string
+    {
+        if (is_string($key) || is_int($key) || is_float($key) || is_bool($key)) {
+            return (string) $key;
+        }
+
+        return '';
+    }
+
+    /**
+     * 429 dégradé : le stockage du compteur est indisponible, on ne peut pas
+     * vérifier le quota — on limite (fail-closed) plutôt que de planter en 500.
+     */
+    private function degradedTooManyRequestsResponse(): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'error' => 'TOO_MANY_REQUESTS_DEGRADED',
+                'message' => 'Too Many Requests',
+            ],
+            429,
+            ['Retry-After' => 60]
+        );
+    }
+}

--- a/api/app/Http/Middleware/ThrottleLimitConfig.php
+++ b/api/app/Http/Middleware/ThrottleLimitConfig.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+/**
+ * Configuration d'une limite de throttling résolue par
+ * `ResilientThrottleRequests` (DTO typé, équivalent de l'objet anonyme
+ * construit par `Illuminate\Routing\Middleware\ThrottleRequests`).
+ *
+ * @internal
+ */
+final class ThrottleLimitConfig
+{
+    /**
+     * @param  Closure(mixed): mixed|null  $afterCallback
+     * @param  Closure(mixed, array<string, mixed>): mixed|null  $responseCallback
+     */
+    public function __construct(
+        public readonly string $key,
+        public readonly int $maxAttempts,
+        public readonly int $decaySeconds,
+        public readonly ?Closure $afterCallback = null,
+        public readonly ?Closure $responseCallback = null,
+    ) {}
+}

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -7,7 +7,10 @@ use App\Http\Middleware\Cameras\EnsureCameraModuleMiddleware;
 use App\Http\Middleware\CompressResponse;
 use App\Http\Middleware\EnsureApiManagerMiddleware;
 use App\Http\Middleware\EnsureAppContextMiddleware;
+use App\Http\Middleware\PartnerLinkMiddleware;
 use App\Http\Middleware\RequestIdMiddleware;
+use App\Http\Middleware\ResilientThrottleRequests;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\SentryContextMiddleware;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\StructuredLogging;
@@ -79,11 +82,11 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->api(prepend: [RequestIdMiddleware::class, ApiVersionMiddleware::class, SetLocale::class, StructuredLogging::class, SentryContextMiddleware::class, CompressResponse::class]);
 
         $middleware->web(append: [
-            \App\Http\Middleware\PartnerLinkMiddleware::class,
+            PartnerLinkMiddleware::class,
         ]);
 
         // Defence-in-depth security headers on every response (issue #1469).
-        $middleware->append(\App\Http\Middleware\SecurityHeaders::class);
+        $middleware->append(SecurityHeaders::class);
 
         $middleware->alias([
             'tenant' => TenantMiddleware::class,
@@ -95,6 +98,10 @@ return Application::configure(basePath: dirname(__DIR__))
             'api.manager' => EnsureApiManagerMiddleware::class,
             'app.context' => EnsureAppContextMiddleware::class,
             'token.refresh' => TokenAutoRefreshMiddleware::class,
+            // Issue #1774 : variante résiliente du middleware de throttling —
+            // un échec du stockage du compteur répond 429 dégradé (au lieu d'un
+            // 500) et les exceptions du pipeline en aval ne sont jamais masquées.
+            'throttle' => ResilientThrottleRequests::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
@@ -185,9 +192,19 @@ return Application::configure(basePath: dirname(__DIR__))
                 ], 404);
             }
 
-            return new JsonResponse([
+            $response = new JsonResponse([
                 'error' => $exception->getMessage() ?: 'HTTP_ERROR',
                 'message' => $exception->getMessage() ?: 'HTTP_ERROR',
             ], $exception->getStatusCode());
+
+            // Issue #1774 : préserver les headers du throttling
+            // (Retry-After, X-RateLimit-*) posés par ThrottleRequestsException —
+            // sans eux, le 429 dégradé/limite est inexploitable côté client.
+            foreach ($exception->getHeaders() as $headerName => $headerValue) {
+                /** @var array<string>|string|null $headerValue */
+                $response->headers->set($headerName, $headerValue);
+            }
+
+            return $response;
         });
     })->create();

--- a/api/tests/Feature/RateLimiterResilienceTest.php
+++ b/api/tests/Feature/RateLimiterResilienceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Issue #1774 — Le rate limiting ne doit jamais répondre 500 quand le
+ * stockage du compteur échoue (épisode prod 2026-08-13 : cache Redis/Upstash
+ * saturé → « Server Error » sur quasi toutes les routes throttlées).
+ *
+ * Le correctif vit dans `App\Support\Cache\ResilientRateLimiter` (substitué
+ * au RateLimiter par défaut dans AppServiceProvider) : échec du stockage →
+ * `report()` + **429 dégradé** avec Retry-After au lieu d'un 500 ; chemin
+ * nominal inchangé.
+ */
+class RateLimiterResilienceTest extends TestCase
+{
+    /**
+     * Store de cache qui lève systématiquement — simule un Redis/Upstash
+     * injoignable ou saturé.
+     */
+    private function throwingStore(): Store
+    {
+        return new class implements Store
+        {
+            public function get($key): mixed
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            /**
+             * @param  array<string>  $keys
+             * @return array<string, mixed>
+             */
+            public function many(array $keys): array
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function put($key, $value, $seconds): bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            /**
+             * @param  array<string, mixed>  $values
+             */
+            public function putMany(array $values, $seconds): bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function increment($key, $value = 1): int|bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function decrement($key, $value = 1): int|bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function forever($key, $value): bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function forget($key): bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function flush(): bool
+            {
+                throw new \RuntimeException('Simulated cache outage');
+            }
+
+            public function getPrefix(): string
+            {
+                return '';
+            }
+        };
+    }
+
+    public function test_throttled_route_returns_degraded_429_when_counter_storage_fails(): void
+    {
+        // Le RateLimiter singleton partage le Repository du cache par défaut :
+        // on remplace son store par un store en panne (équivalent prod).
+        /** @var Repository $repository */
+        $repository = Cache::store();
+        $originalStore = $repository->getStore();
+        $repository->setStore($this->throwingStore());
+
+        try {
+            $response = $this->getJson('/api/v1/i18n/catalog/fr');
+
+            // Avant le correctif : 500 « Server Error ».
+            $response->assertStatus(429);
+            $response->assertHeader('Retry-After');
+        } finally {
+            $repository->setStore($originalStore);
+        }
+    }
+
+    public function test_health_route_still_returns_200_during_counter_storage_failure(): void
+    {
+        /** @var Repository $repository */
+        $repository = Cache::store();
+        $originalStore = $repository->getStore();
+        $repository->setStore($this->throwingStore());
+
+        try {
+            // /health est exclu du rate limiting (Limit::none) : il ne doit pas
+            // être affecté par la panne du compteur.
+            $this->getJson('/api/v1/health')->assertOk();
+        } finally {
+            $repository->setStore($originalStore);
+        }
+    }
+
+    public function test_rate_limiter_still_returns_429_when_limit_exceeded(): void
+    {
+        // Comportement nominal : dépassement du limiter 'auth-sensitive'
+        // (10/min par email+IP) → 429 + Retry-After, sans impact du correctif.
+        $route = '/api/v1/i18n/catalog/fr';
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->getJson($route)->assertOk();
+        }
+
+        $this->getJson($route)->assertStatus(429)->assertHeader('Retry-After');
+    }
+}


### PR DESCRIPTION
## Problème
Épisode prod 2026-08-13 (~03:10-03:15 UTC) : pendant une rafale, l'API répondait **500 « Server Error »** sur quasi toutes les routes throttlées (dashboard, employés, pointages, i18n…) alors que `/health` et les limiters à bucket distinct (`auth-sensitive`, `5,15`) continuaient de répondre. Cause : l'échec de lecture/écriture du compteur (cache Redis/Upstash saturé) remontait depuis le `RateLimiter` en exception → 500.

## Changements
- **`ResilientThrottleRequests`** (nouveau middleware, alias `throttle` dans `bootstrap/app.php`) :
  - échec du stockage du compteur pendant la phase limiter → `report()` + **429 dégradé avec `Retry-After`** (fail-closed) au lieu de 500 ;
  - échec de pose des headers `X-RateLimit-*` après la réponse → `report()` non bloquant (réponse conservée) ;
  - dépassement réel du quota → 429 normal (`ThrottleRequestsException` relancée, headers intacts) ;
  - exceptions du pipeline en aval (contrôleur) → **jamais masquées** : `$next()` s'exécute hors du try/catch (isolation stricte de la phase limiter).
- **`bootstrap/app.php`** : le renderer d'exceptions HTTP préserve désormais les headers du throttling (`Retry-After`, `X-RateLimit-*`) — avant, le 429 généré par l'exception les perdait.
- DTO `ThrottleLimitConfig` (config de limite typée).

## Tests (`RateLimiterResilienceTest`)
- store de cache en panne → route throttlée répond **429 + Retry-After** (avant : 500) ;
- `/health` (non throttlé) → 200 pendant la panne ;
- dépassement nominal du limiter `auth-sensitive` → 429 + Retry-After (comportement inchangé) ;
- suites existantes `SensitiveRateLimitTest` + `ApiVersionAndPlanRateLimitTest` → 9 passed (30 assertions).

## Vérification
- Local : 3 tests nouveaux + 9 tests existants passés, PHPStan clean, Pint clean.

Closes #1774
