### PR TITLE
fix(payroll): calcul à 0 bulletin refusé — 422 explicite + garde validate/lock (Closes #1767)

### DIFF
--- a/api/app/Modules/Payroll/Infrastructure/Services/PayrollClosingService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PayrollClosingService.php
@@ -34,20 +34,24 @@ class PayrollClosingService
      * Étape 1 — validation RH (contrôle des montants avant clôture comptable).
      *
      * @throws PayrollAlreadyValidatedException si le run est déjà validé
-     * @throws PayrollRunLockedException        si le run est verrouillé
-     * @throws \RuntimeException                si le run n'est pas en état calculé
+     * @throws PayrollRunLockedException si le run est verrouillé
+     * @throws \RuntimeException si le run n'est pas en état calculé
      */
     public function validateRh(PayrollRun $run, Employee $validator): PayrollRun
     {
         if ($run->status === PayrollRun::STATUS_LOCKED) {
-            throw new PayrollRunLockedException();
+            throw new PayrollRunLockedException;
         }
         if ($run->status === PayrollRun::STATUS_VALIDATED) {
-            throw new PayrollAlreadyValidatedException();
+            throw new PayrollAlreadyValidatedException;
         }
         if ($run->status !== PayrollRun::STATUS_CALCULATED) {
             throw new \RuntimeException('Un run doit être calculé avant validation RH (statut actuel : '.$run->status.').');
         }
+
+        // Issue #1767 : interdire la validation d'un run à 0 bulletin (une
+        // clôture comptable à zéro sans avertissement est une erreur RH).
+        $this->assertHasPaySlips($run);
 
         return DB::transaction(function () use ($run, $validator): PayrollRun {
             $updated = PayrollRun::query()
@@ -62,7 +66,7 @@ class PayrollClosingService
             if ($updated === 0) {
                 $fresh = $run->fresh();
                 throw $fresh?->status === PayrollRun::STATUS_LOCKED
-                    ? new PayrollRunLockedException()
+                    ? new PayrollRunLockedException
                     : new PayrollAlreadyValidatedException('L\'état du run a changé entre la lecture et la validation.');
             }
 
@@ -92,11 +96,14 @@ class PayrollClosingService
     public function lock(PayrollRun $run, Employee $validator): PayrollRun
     {
         if ($run->status === PayrollRun::STATUS_LOCKED) {
-            throw new PayrollRunLockedException();
+            throw new PayrollRunLockedException;
         }
         if ($run->status !== PayrollRun::STATUS_VALIDATED) {
             throw new PayrollAlreadyValidatedException('Un run doit être validé (étape RH) avant verrouillage comptable.');
         }
+
+        // Issue #1767 : interdire la clôture comptable d'un run à 0 bulletin.
+        $this->assertHasPaySlips($run);
 
         return DB::transaction(function () use ($run, $validator): PayrollRun {
             $updated = PayrollRun::query()
@@ -111,7 +118,7 @@ class PayrollClosingService
             if ($updated === 0) {
                 $fresh = $run->fresh();
                 throw $fresh?->status === PayrollRun::STATUS_LOCKED
-                    ? new PayrollRunLockedException()
+                    ? new PayrollRunLockedException
                     : new \RuntimeException('L\'état du run a changé entre la lecture et le verrouillage.');
             }
 
@@ -182,6 +189,17 @@ class PayrollClosingService
 
             return $run;
         });
+    }
+
+    /**
+     * Issue #1767 : un run sans aucun bulletin ne doit jamais être validé ni
+     * verrouillé (clôture comptable à zéro sans avertissement).
+     */
+    private function assertHasPaySlips(PayrollRun $run): void
+    {
+        if ($run->paySlips()->count() === 0) {
+            throw new \RuntimeException('Ce run ne contient aucun bulletin — impossible de valider/clôturer une paie vide. Vérifiez les structures salariales actives et recalculez.');
+        }
     }
 
     /**

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollRunController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollRunController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Auth\Infrastructure\Services\DataAccessAuditLogger;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\PayrollRunResource;
 use App\Jobs\WarmPaySlipPdfPathsForPayrollRunJob;
@@ -17,7 +18,6 @@ use App\Modules\Payroll\Infrastructure\Services\PayrollCalculator;
 use App\Modules\Payroll\Infrastructure\Services\PayrollClosingService;
 use App\Modules\Payroll\Infrastructure\Services\PayrollJournalGenerator;
 use App\Modules\Payroll\Interfaces\Api\V1\Requests\StorePayrollRunRequest;
-use App\Core\Auth\Infrastructure\Services\DataAccessAuditLogger;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -110,6 +110,17 @@ class PayrollRunController extends Controller
         $payrollRun->update(['status' => 'calculating']);
         $run = $this->calculator->calculateRun($payrollRun);
 
+        // Issue #1767 : un calcul à 0 bulletin (ex. aucune structure salariale
+        // active pour ce pays) ne doit pas réussir en silence — sinon le run
+        // peut être validé/verrouillé à vide (clôture comptable à zéro).
+        if ((int) $run->employee_count === 0) {
+            $run->update(['status' => PayrollRun::STATUS_DRAFT]);
+
+            return response()->json([
+                'message' => __('payroll.zero_slips_generated'),
+            ], 422);
+        }
+
         return (new PayrollRunResource($run->loadCount('paySlips')))->response();
     }
 
@@ -128,7 +139,7 @@ class PayrollRunController extends Controller
             // Étape 1 du workflow F-11 : validation RH via le service de clôture
             // (mise à jour conditionnelle atomique + audit trail `payroll_run_validated`).
             $this->closing->validateRh($payrollRun, $actor);
-        } catch (PayrollAlreadyValidatedException|\App\Modules\Payroll\Domain\Exceptions\PayrollRunLockedException|\RuntimeException $e) {
+        } catch (PayrollAlreadyValidatedException|PayrollRunLockedException|\RuntimeException $e) {
             return response()->json(['message' => $e->getMessage()], 422);
         }
 
@@ -183,7 +194,7 @@ class PayrollRunController extends Controller
 
         try {
             $this->closing->lock($payrollRun, $actor);
-        } catch (PayrollAlreadyValidatedException|\App\Modules\Payroll\Domain\Exceptions\PayrollRunLockedException|\RuntimeException $e) {
+        } catch (PayrollAlreadyValidatedException|PayrollRunLockedException|\RuntimeException $e) {
             return response()->json(['message' => $e->getMessage()], 422);
         }
 

--- a/api/lang/en/payroll.php
+++ b/api/lang/en/payroll.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'zero_slips_generated' => 'No pay slips generated: make sure at least one active salary structure exists for this country before calculating payroll.',
+];

--- a/api/lang/fr/payroll.php
+++ b/api/lang/fr/payroll.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'zero_slips_generated' => 'Aucun bulletin généré : vérifiez qu\'au moins une structure salariale active existe pour ce pays avant de calculer la paie.',
+];

--- a/api/tests/Feature/Payroll/PayrollRunClosingApiTest.php
+++ b/api/tests/Feature/Payroll/PayrollRunClosingApiTest.php
@@ -8,6 +8,7 @@ use App\Core\Auth\Domain\Models\AuditLog;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
 use Laravel\Sanctum\Sanctum;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
@@ -71,11 +72,36 @@ class PayrollRunClosingApiTest extends TestCase
         return $run;
     }
 
+    /**
+     * Issue #1767 : un run sans bulletin ne peut plus être validé/verrouillé —
+     * le workflow de clôture doit donc disposer d'au moins un bulletin.
+     */
+    private function addPaySlip(PayrollRun $run, Employee $employee): void
+    {
+        PaySlip::create([
+            'payroll_run_id' => $run->id,
+            'company_id' => $this->company->id,
+            'employee_id' => $employee->id,
+            'period_start' => $run->period_start,
+            'period_end' => $run->period_end,
+            'gross_salary' => 60000,
+            'total_deductions' => 12442,
+            'net_salary' => 47558,
+            'employer_contributions' => 15600,
+            'total_cost' => 75600,
+            'working_days' => 22,
+            'actual_days_worked' => 22,
+            'overtime_hours' => 0,
+            'status' => 'calculated',
+        ]);
+    }
+
     public function test_full_closing_workflow_via_api(): void
     {
         Sanctum::actingAs($this->manager);
 
         $run = $this->makeRun(PayrollRun::STATUS_CALCULATED);
+        $this->addPaySlip($run, $this->employee);
 
         // Étape 1 : validation RH → audit trail.
         $this->postJson("/api/v1/payroll-runs/{$run->id}/validate")

--- a/api/tests/Feature/Payroll/PayrollZeroSlipsGuardTest.php
+++ b/api/tests/Feature/Payroll/PayrollZeroSlipsGuardTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Payroll;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #1767 — Un run de paie sans structure salariale ne doit plus
+ * « réussir » en silence à 0 bulletin (puis être validé/verrouillé à vide,
+ * clôture comptable à zéro sans avertissement).
+ */
+class PayrollZeroSlipsGuardTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Company $company;
+
+    private Employee $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $this->company = $company;
+
+        /** @var Employee $manager */
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $this->manager = $manager;
+
+        Employee::factory()->create(['company_id' => $company->id]);
+    }
+
+    private function makeRun(string $status): PayrollRun
+    {
+        /** @var PayrollRun $run */
+        $run = PayrollRun::create([
+            'company_id' => $this->company->id,
+            'period_start' => '2026-07-01',
+            'period_end' => '2026-07-31',
+            'country_code' => 'DZ',
+            'status' => $status,
+        ]);
+
+        return $run;
+    }
+
+    public function test_calculate_returns_422_when_no_salary_structure(): void
+    {
+        Sanctum::actingAs($this->manager);
+
+        $run = $this->makeRun(PayrollRun::STATUS_DRAFT);
+
+        // Avant le correctif : 200, status calculated, employee_count 0.
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/calculate")
+            ->assertStatus(422)
+            ->assertJsonPath('message', fn (string $message) => str_contains($message, 'structure'));
+
+        // Le run repart en draft : l'utilisateur peut corriger la config
+        // (structures salariales) et retenter.
+        $this->assertSame(PayrollRun::STATUS_DRAFT, $run->fresh()?->status);
+    }
+
+    public function test_validate_returns_422_when_run_has_zero_slips(): void
+    {
+        Sanctum::actingAs($this->manager);
+
+        // Run « calculé » à vide (état atteignable avant le correctif).
+        $run = $this->makeRun(PayrollRun::STATUS_CALCULATED);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/validate")
+            ->assertStatus(422)
+            ->assertJsonPath('message', fn (string $message) => str_contains($message, 'aucun bulletin'));
+
+        $this->assertSame(PayrollRun::STATUS_CALCULATED, $run->fresh()?->status);
+    }
+
+    public function test_lock_returns_422_when_run_has_zero_slips(): void
+    {
+        Sanctum::actingAs($this->manager);
+
+        // Run « validé » à vide (état atteignable avant le correctif).
+        $run = $this->makeRun(PayrollRun::STATUS_VALIDATED);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/lock")
+            ->assertStatus(422)
+            ->assertJsonPath('message', fn (string $message) => str_contains($message, 'aucun bulletin'));
+    }
+}


### PR DESCRIPTION
## Problème
Avec les données de démo (aucune `salary_structures`), `POST /api/v1/payroll-runs` puis `calculate` retournaient **200 `calculated` avec `employee_count: 0`**, et `validate`/`lock` acceptaient ensuite une **clôture comptable à vide** (totaux à zéro) sans aucun message — risque d'erreur comptable en production.

## Changements
- **`PayrollRunController::calculate()`** : si le calcul produit 0 bulletin → **422** avec message explicite (« Aucun bulletin généré : vérifiez qu'au moins une structure salariale active existe pour ce pays ») et retour du run en `draft` (l'utilisateur corrige la config et retente — plus d'état `calculated` vide).
- **`PayrollClosingService::validateRh()` / `lock()`** : refusent tout run à 0 bulletin (`RuntimeException` explicite → 422 via le contrôleur). `lock` est couvert en direct (un run validé à vide créé avant le correctif reste bloquable à la clôture).

## Tests
- `PayrollZeroSlipsGuardTest` (nouveau) : calculate → 422 + run re-draft ; validate → 422 ; lock → 422.
- `PayrollRunClosingApiTest::test_full_closing_workflow_via_api` ajusté : le workflow crée désormais un bulletin (il reproduisait l'état fautif « run validé à vide »).

## Vérification
- Local : 8 tests payroll passés (40 assertions), PHPStan strict clean, Pint clean.

Closes #1767
