### PR TITLE
fix(health): ping Redis normalisé pour Predis — faux négatif corrigé (Closes #1768)

### DIFF
--- a/api/app/Modules/Platform/Infrastructure/Services/QueueObservabilityService.php
+++ b/api/app/Modules/Platform/Infrastructure/Services/QueueObservabilityService.php
@@ -94,7 +94,9 @@ class QueueObservabilityService
 
         try {
             $response = Redis::connection()->ping();
-            $ok = $response === true || $response === 'PONG' || $response === '+PONG';
+            // Issue #1768 : Predis retourne un objet Status (__toString 'PONG').
+            $ok = $response === true
+                || in_array(strtoupper((string) $response), ['PONG', '+PONG'], true);
 
             return [
                 'ok' => $ok,

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/HealthController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/HealthController.php
@@ -83,6 +83,16 @@ class HealthController extends Controller
     }
 
     /**
+     * Issue #1768 : normalise la réponse de `ping()` quel que soit le client
+     * (PhpRedis : true / 'PONG' / '+PONG' ; Predis : objet Status __toString 'PONG').
+     */
+    private static function isPongResponse(mixed $response): bool
+    {
+        return $response === true
+            || in_array(strtoupper((string) $response), ['PONG', '+PONG'], true);
+    }
+
+    /**
      * @return array{ok: bool, status?: string, latency_ms?: int, error?: string}
      */
     private function checkRedis(): array
@@ -110,7 +120,10 @@ class HealthController extends Controller
         $start = microtime(true);
         try {
             $response = Redis::connection()->ping();
-            $ok = $response === true || $response === 'PONG' || $response === '+PONG';
+            // Issue #1768 : Predis retourne un objet Predis\Response\Status
+            // (__toString() = 'PONG') — les comparaisons strictes échouaient
+            // toujours → « unexpected » alors que Redis est sain.
+            $ok = self::isPongResponse($response);
 
             return [
                 'ok' => $ok,

--- a/api/tests/Feature/Platform/HealthRedisPredisTest.php
+++ b/api/tests/Feature/Platform/HealthRedisPredisTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Platform;
+
+use App\Modules\Platform\Interfaces\Api\V1\Controllers\HealthController;
+use Tests\TestCase;
+
+/**
+ * Issue #1768 — `/api/v1/health` rapportait Redis « unexpected » avec le
+ * client Predis : `ping()` retourne un objet `Predis\Response\Status` dont
+ * `__toString()` vaut « PONG », mais les comparaisons strictes du
+ * HealthController échouaient toujours (faux négatif → sonde rouge).
+ */
+class HealthRedisPredisTest extends TestCase
+{
+    public function test_pong_response_variants_are_all_healthy(): void
+    {
+        $method = new \ReflectionMethod(HealthController::class, 'isPongResponse');
+
+        // PhpRedis : true / 'PONG' / '+PONG'
+        self::assertTrue($method->invoke(null, true));
+        self::assertTrue($method->invoke(null, 'PONG'));
+        self::assertTrue($method->invoke(null, '+PONG'));
+
+        // Predis : objet Status dont __toString() = 'PONG' (le bug #1768)
+        $predisStatus = new class
+        {
+            public function __toString(): string
+            {
+                return 'PONG';
+            }
+        };
+        self::assertTrue($method->invoke(null, $predisStatus));
+
+        // Faux négatifs
+        self::assertFalse($method->invoke(null, 'NOPE'));
+        self::assertFalse($method->invoke(null, ''));
+        self::assertFalse($method->invoke(null, null));
+    }
+}


### PR DESCRIPTION
## Problème
Avec `CACHE_STORE=redis`/`QUEUE_CONNECTION=redis` et Redis sain (`ping` → PONG en CLI), `GET /api/v1/health` répondait `{"redis":{"ok":false,"status":"unexpected"}}`. Cause : `HealthController::checkRedis()` comparait `Redis::connection()->ping()` à `true`/`'PONG'`/`'+PONG'` en stricte — or le client **Predis** retourne un objet `Predis\Response\Status` (dont `__toString()` vaut « PONG ») → comparaisons toujours fausses.

## Changements
- `HealthController::checkRedis()` : normalisation `(string) $response` + `in_array(strtoupper(...), ['PONG','+PONG'])`, avec `$response === true` vérifié séparément (PhpRedis) — extrait en `isPongResponse()` statique.
- Même correctif dans `QueueObservabilityService::checkRedis()` (même bug latent).

## Tests (`HealthRedisPredisTest`)
- Variants sains : `true`, `'PONG'`, `'+PONG'`, objet `Status` Predis (`__toString` 'PONG') → ok ;
- faux négatifs : `'NOPE'`, `''`, `null` → ko.

## Vérification
- Local : 1 test (7 assertions), PHPStan strict clean, Pint clean.

Closes #1768
