### PR TITLE
fix(seed): structures salariales créées par la démo — paie démontrable (Closes #1777)

### DIFF
--- a/api/database/seeders/DemoCompanySeeder.php
+++ b/api/database/seeders/DemoCompanySeeder.php
@@ -197,6 +197,12 @@ class DemoCompanySeeder extends Seeder
             $allEmployeeIds = array_merge($allEmployeeIds, $employeeIds);
             $activeEmployeeIds = $this->activeEmployeeIds($companyId, $allEmployeeIds);
 
+            // Issue #1777 : sans salary_structure, la paie démo produit 0
+            // bulletin en silence (le moteur ignore les employés sans
+            // structure). On crée une structure par employé actif (base = son
+            // salaire) + un composant prime, affectée via salary_structure_id.
+            $this->createSalaryStructures($companyId, $config, $activeEmployeeIds);
+
             $this->seedAttendanceLogs($companyId, $activeEmployeeIds);
             $absenceTypeIds = $this->createAbsenceTypes($companyId);
             $this->seedAbsences($companyId, $employeeIds, $absenceTypeIds, $managerIds['rh']);
@@ -495,6 +501,63 @@ SQL);
             ->pluck('id')
             ->map(fn ($id) => (int) $id)
             ->all();
+    }
+
+    /**
+     * Issue #1777 : crée une structure salariale par employé actif
+     * (base = son `salary_base`) + un composant prime, et affecte
+     * `employees.salary_structure_id` — sinon le moteur de paie ignore tous
+     * les employés (0 bulletin en silence, run clôturable à vide).
+     */
+    private function createSalaryStructures(string $companyId, array $config, array $activeEmployeeIds): void
+    {
+        if ($activeEmployeeIds === []) {
+            return;
+        }
+
+        $countryCode = strtoupper((string) ($config['country'] ?? 'DZ'));
+        $currency = (string) ($config['currency'] ?? 'DZD');
+
+        $employees = DB::table($this->sharedTable('employees'))
+            ->where('company_id', $companyId)
+            ->whereIn('id', $activeEmployeeIds)
+            ->get(['id', 'salary_base']);
+
+        foreach ($employees as $employee) {
+            $structureId = DB::table($this->sharedTable('salary_structures'))->insertGetId([
+                'company_id' => $companyId,
+                'name' => 'Structure '.$countryCode.' employe #'.$employee->id,
+                'base_salary' => (float) $employee->salary_base,
+                'currency' => $currency,
+                'country_code' => $countryCode,
+                'frequency' => 'monthly',
+                'active' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table($this->sharedTable('salary_components'))->insert([
+                'company_id' => $companyId,
+                'salary_structure_id' => $structureId,
+                'name' => 'Prime de rendement',
+                'code' => 'PRIME_PERF',
+                'type' => 'earning',
+                'calculation_type' => 'percentage_of_base',
+                'amount' => 0,
+                'percentage' => 5,
+                'formula' => null,
+                'is_taxable' => true,
+                'is_recurring' => true,
+                'order' => 1,
+                'active' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table($this->sharedTable('employees'))
+                ->where('id', $employee->id)
+                ->update(['salary_structure_id' => $structureId]);
+        }
     }
 
     private function createAbsenceTypes(string $companyId): array

--- a/api/tests/Feature/DemoCompanySeederSalaryStructuresTest.php
+++ b/api/tests/Feature/DemoCompanySeederSalaryStructuresTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Tenant\Domain\Models\Company;
+use Database\Seeders\DemoCompanySeeder;
+use Illuminate\Support\Facades\DB;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #1777 — Le seed démo doit créer des structures salariales : sans
+ * `salary_structures`, le moteur de paie ignore tous les employés et la
+ * démo « paie en 1 clic » produit 0 bulletin en silence.
+ */
+class DemoCompanySeederSalaryStructuresTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    /**
+     * @param  array{country: string, currency: string}  $config
+     * @param  list<int>  $employeeIds
+     */
+    private function callCreateSalaryStructures(string $companyId, array $config, array $employeeIds): void
+    {
+        /** @var DemoCompanySeeder $seeder */
+        $seeder = app(DemoCompanySeeder::class);
+        $method = new \ReflectionMethod(DemoCompanySeeder::class, 'createSalaryStructures');
+        $method->invoke($seeder, $companyId, $config, $employeeIds);
+    }
+
+    public function test_demo_seed_creates_salary_structure_per_active_employee(): void
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create([
+            'country' => 'DZ',
+            'currency' => 'DZD',
+            'schema_name' => 'shared_tenants',
+        ]);
+
+        $employeeIds = [];
+        foreach ([
+            ['email' => 'a@demo.dz', 'salary_base' => 60000],
+            ['email' => 'b@demo.dz', 'salary_base' => 45000],
+            ['email' => 'inactive@demo.dz', 'salary_base' => 30000],
+        ] as $idx => $spec) {
+            $employeeId = DB::table('shared_tenants.employees')->insertGetId([
+                'company_id' => $company->id,
+                'first_name' => 'Emp',
+                'last_name' => (string) $idx,
+                'email' => $spec['email'],
+                'password_hash' => 'x',
+                'salary_base' => $spec['salary_base'],
+                'status' => $spec['email'] === 'inactive@demo.dz' ? 'archived' : 'active',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            $employeeIds[] = $employeeId;
+        }
+
+        // Seuls les 2 employés actifs reçoivent une structure.
+        $this->callCreateSalaryStructures(
+            (string) $company->id,
+            ['country' => 'DZ', 'currency' => 'DZD'],
+            [0 => $employeeIds[0], 1 => $employeeIds[1]]
+        );
+
+        $structures = DB::table('shared_tenants.salary_structures')
+            ->where('company_id', $company->id)
+            ->get();
+
+        $this->assertCount(2, $structures);
+        $this->assertNotNull($structures[0]);
+        $this->assertNotNull($structures[1]);
+        $this->assertSame(60000.0, (float) $structures[0]->base_salary);
+        $this->assertSame(45000.0, (float) $structures[1]->base_salary);
+        $this->assertSame('DZ', $structures[0]->country_code);
+
+        // Chaque employé actif est affecté à sa structure.
+        $assigned = DB::table('shared_tenants.employees')
+            ->where('company_id', $company->id)
+            ->pluck('salary_structure_id', 'email');
+
+        $this->assertNotNull($assigned['a@demo.dz']);
+        $this->assertNotNull($assigned['b@demo.dz']);
+        $this->assertNull($assigned['inactive@demo.dz']);
+
+        // Composant prime de rendement présent.
+        $components = DB::table('shared_tenants.salary_components')
+            ->where('company_id', $company->id)
+            ->get();
+        $this->assertCount(2, $components);
+        $this->assertNotNull($components[0]);
+        $this->assertSame('PRIME_PERF', $components[0]->code);
+        $this->assertSame(5.0, (float) $components[0]->percentage);
+    }
+
+    public function test_demo_seed_skips_salary_structures_when_no_active_employee(): void
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create([
+            'country' => 'DZ',
+            'currency' => 'DZD',
+            'schema_name' => 'shared_tenants',
+        ]);
+
+        $this->callCreateSalaryStructures((string) $company->id, ['country' => 'DZ', 'currency' => 'DZD'], []);
+
+        $this->assertSame(0, DB::table('shared_tenants.salary_structures')
+            ->where('company_id', $company->id)
+            ->count());
+    }
+}


### PR DESCRIPTION
## Problème
Le parcours démo (« paie en 1 clic ») produisait **zéro bulletin** : `DemoCompanySeeder` ne créait aucune `salary_structures`, or `PayrollCalculator::calculateRun()` ignore les employés sans structure (`if (! $structure) continue`) → run `calculated` à `employee_count: 0` puis validate/lock à vide possibles (cf. #1767).

## Changements
- **`DemoCompanySeeder::createSalaryStructures()`** (nouvelle méthode, appelée après la création des employés) :
  - une **structure salariale par employé actif** (base = son `salary_base`, `country_code`/`currency` de la société, `frequency: monthly`, `active`);
  - un composant **« Prime de rendement »** (`PRIME_PERF`, earning, 5 % de la base) pour une démo démontrable ;
  - affectation `employees.salary_structure_id` (le moteur résout la structure par employé, fallback première structure active).

## Tests (`DemoCompanySeederSalaryStructuresTest`)
- 2 actifs + 1 archivé → 2 structures (bases 60 000/45 000, pays DZ), affectation des actifs uniquement, 2 composants PRIME_PERF 5 % ;
- aucun employé actif → aucune structure (no-op).

## Vérification
- Local : 2 tests passed (11 assertions), Pint clean.

Closes #1777
