### PR TITLE
fix(api): CORS — dev server admin (port 3001) whitelisté et verrouillé par un test (Closes #1769)

### DIFF
--- a/api/tests/Feature/Security/CorsAndTrustedProxyTest.php
+++ b/api/tests/Feature/Security/CorsAndTrustedProxyTest.php
@@ -31,6 +31,19 @@ class CorsAndTrustedProxyTest extends TestCase
         }
     }
 
+    public function test_cors_whitelist_includes_admin_dev_servers(): void
+    {
+        // Issue #1769 : le dev server du dashboard admin (Vite, port 3001)
+        // appelle l'API en URL absolue (hors proxy) → il doit être whitelisté,
+        // sinon le navigateur bloque le login en local (seul localhost:3000
+        // via FRONTEND_URL était autorisé). Ajouté dans #1785, verrouillé ici
+        // par un test de non-régression.
+        $origins = config('cors.allowed_origins');
+
+        $this->assertIsArray($origins);
+        $this->assertContains('http://localhost:3000', $origins);
+        $this->assertContains('http://localhost:3001', $origins);
+    }
     public function test_trusts_x_forwarded_for(): void
     {
         // Render is the single edge proxy in front of this app; the request's


### PR DESCRIPTION
## Problème
Le SPA admin (`front/admin-dashboard`, Vite port **3001**) appelle l'API en URL absolue (`VITE_API_URL || http://localhost:8000/api/v1`, hors proxy) : seuls `http://localhost:3000` (`FRONTEND_URL`) et `APP_URL` étaient whitelistés par défaut dans `config/cors.php` → le navigateur bloquait la requête CORS et le login admin échouait silencieusement en local (issue #1769).

## Changements
- **Déjà en place depuis #1785** : `http://localhost:3001` ajouté à la whitelist `config/cors.php` + `ADMIN_DASHBOARD_URL` documenté dans `.env.example`.
- **Cette PR verrouille le correctif** : test de non-régression dans `CorsAndTrustedProxyTest` (3000 + 3001 whitelistés) + entrée CHANGELOG — une future refonte CORS ne pourra plus re-casser le dev local sans que la CI ne le signale.

Closes #1769