### PR TITLE
feat(payroll): Sénégal — TRIMF + CFCE + IPRES cadres T2 + plafonds (Closes #1827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 # Format : Keep a Changelog (keepachangelog.com) 
 # Versioning : Semantic Versioning (semver.org) 
 
-## [Unreleased]
+### Added
+- **feat(payroll): Sénégal (SN) — pilot vers prêt pour production : TRIMF + CFCE + IPRES cadres T2 + plafonds (Closes #1827).** `SenegalPayrollRules` : TRIMF 6 tranches forfaitaires via `calculateBracketTax()` (900 → 36 000 XOF, portée dans le bulletin), CFCE 3 % patronal sur masse brute (`CFCE_SN_PAT`), IPRES T1 plafonné à 432 000 XOF/mois (5,6 %/8,4 %) + régime cadres T2 sur tranche 432 001-2 160 000 (2,4 %/3,6 %, hypothèse pilote brut > 432 k), CSS famille 3 % + AT 1 %, abattement frais professionnels 30 % non plafonné, préavis niveau employé (30 j — matrice 8 j/1 m/3 m documentée), `confidenceLevel()` reste `pilot` (validation expert SN requise). Référentiel `docs/payroll/SN_COMPLIANCE.md` créé ; tests unitaires `SenegalRulesUnitTest` (5 cas : TRIMF 6 tranches, CFCE, plafond T1, T2 cadres, abattement) + `PayrollCountryRulesTest` aligné (SN : 56/154).
 
 ### Chore
 - **chore(version): défaut APP_VERSION aligné sur PILOTAGE.md (4.24.0).** `api/config/app.php` gardait le défaut `4.23.5` (commit « Version Sync » #739) alors que le repo est en 4.24.0 depuis la release préparée (#1722) — la prod affichait 4.23.5 dans `/api/v1/health` malgré le nouveau code déployé (Render n'a pas d'APP_VERSION). Le défaut passe à 4.24.0 ; l'env garde la priorité.

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/SenegalPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/SenegalPayrollRules.php
@@ -24,9 +24,19 @@ class SenegalPayrollRules extends AbstractCountryRules
     public function socialContributions(): array
     {
         return [
-            ['name' => 'IPRES Salariale', 'code' => 'IPRES_SN_EMP', 'type' => 'employee', 'rate' => 5.6, 'cap' => null],
-            ['name' => 'IPRES Patronale', 'code' => 'IPRES_SN_PAT', 'type' => 'employer', 'rate' => 8.4, 'cap' => null],
-            ['name' => 'CSS Patronale', 'code' => 'CSS_SN_PAT', 'type' => 'employer', 'rate' => 3.0, 'cap' => null],
+            // IPRES régime général T1 — plafonné à 432 000 XOF/mois.
+            ['name' => 'IPRES Salariale', 'code' => 'IPRES_SN_EMP', 'type' => 'employee', 'rate' => 5.6, 'cap' => 432000.0],
+            ['name' => 'IPRES Patronale', 'code' => 'IPRES_SN_PAT', 'type' => 'employer', 'rate' => 8.4, 'cap' => 432000.0],
+            // IPRES régime cadres T2 — tranche 432 001 – 2 160 000 XOF
+            // (issue #1827, docs/payroll/SN_COMPLIANCE.md §4bis).
+            ['name' => 'IPRES Cadres Salariale (T2)', 'code' => 'IPRES_SN_EMP_T2', 'type' => 'employee', 'rate' => 2.4, 'cap' => null],
+            ['name' => 'IPRES Cadres Patronale (T2)', 'code' => 'IPRES_SN_PAT_T2', 'type' => 'employer', 'rate' => 3.6, 'cap' => null],
+            // CSS — prestations familiales 3 % (non plafonnées) + AT 1 % pilote.
+            ['name' => 'CSS Prestations Familiales Patronale', 'code' => 'CSS_SN_PAT_FAM', 'type' => 'employer', 'rate' => 3.0, 'cap' => null],
+            ['name' => 'CSS Accidents du Travail Patronale', 'code' => 'CSS_SN_PAT_AT', 'type' => 'employer', 'rate' => 1.0, 'cap' => null],
+            // CFCE — Contribution Forfaitaire à la Charge de l'Employeur 3 %
+            // (issue #1827, docs/payroll/SN_COMPLIANCE.md §5).
+            ['name' => 'CFCE Patronale', 'code' => 'CFCE_SN_PAT', 'type' => 'employer', 'rate' => 3.0, 'cap' => null],
         ];
     }
 
@@ -52,19 +62,79 @@ class SenegalPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
-        // ZONE-INFRA (#1820): IPRES/CSS are each capped at the statutory
-        // ceiling (432 000 XOF/month) — the employer-side IPRES and CSS
-        // contributions each get their own cap application instead of a
-        // summed rate applied to the full gross (which overcharged above
-        // the ceiling). The `social_contributions` DB rows may override
-        // rates/caps (effective dating, company overrides).
+        // Issue #1827 (docs/payroll/SN_COMPLIANCE.md §4-§5) :
+        //  - IPRES T1 5,6 % salarié / 8,4 % patronal plafonnés à 432 000 XOF ;
+        //  - IPRES T2 (régime cadres) 2,4 % / 3,6 % sur la tranche
+        //    432 001 – 2 160 000 XOF — appliquée quand le brut dépasse le
+        //    plafond T1 (hypothèse pilote : brut > 432 k ⇒ régime cadres) ;
+        //  - CSS prestations familiales 3 % + AT 1 % (non plafonnées) ;
+        //  - CFCE 3 % sur la masse salariale brute (patronal uniquement).
         $ipresCap = 432000.0;
+        $t2Floor = 432000.0;
+        $t2Ceiling = 2160000.0;
+
+        $employee = $this->computeContribution($grossSalary, 'IPRES_SN_EMP', 5.6, $ipresCap);
+        $employer = $this->computeContribution($grossSalary, 'IPRES_SN_PAT', 8.4, $ipresCap);
+
+        if ($grossSalary > $t2Floor) {
+            $t2Base = min($grossSalary, $t2Ceiling) - $t2Floor;
+            $employee += round($t2Base * $this->resolveContributionRate('IPRES_SN_EMP_T2', 2.4) / 100, 2);
+            $employer += round($t2Base * $this->resolveContributionRate('IPRES_SN_PAT_T2', 3.6) / 100, 2);
+        }
+
+        $employer += $this->computeContribution($grossSalary, 'CSS_SN_PAT_FAM', 3.0, null)
+            + $this->computeContribution($grossSalary, 'CSS_SN_PAT_AT', 1.0, null)
+            + $this->computeContribution($grossSalary, 'CFCE_SN_PAT', 3.0, null);
 
         return [
-            'employee' => $this->computeContribution($grossSalary, 'IPRES_SN_EMP', 5.6, $ipresCap),
-            'employer' => $this->computeContribution($grossSalary, 'IPRES_SN_PAT', 8.4, $ipresCap)
-                + $this->computeContribution($grossSalary, 'CSS_SN_PAT', 3.0, $ipresCap),
+            'employee' => round($employee, 2),
+            'employer' => round($employer, 2),
         ];
+    }
+
+    /**
+     * Issue #1827 : TRIMF — Taxe Représentative des Impôts du Minimum Fiscal
+     * (CGI Sénégal) : taxe forfaitaire mensuelle retenue sur le salarié par
+     * tranche de brut (docs/payroll/SN_COMPLIANCE.md §3). Portée dans le
+     * bulletin par PayrollCalculator (ligne « Taxe de minimum fiscal »).
+     * NB : le mécanisme légal « max(IR, TRIMF) » (le salarié paie le plus
+     * élevé des deux) est un raffinement à valider avec l'expert SN — ici
+     * les deux lignes coexistent conformément au périmètre de l'issue.
+     */
+    public function calculateBracketTax(float $grossSalary): float
+    {
+        return match (true) {
+            $grossSalary <= 25000 => 900.0,
+            $grossSalary <= 75000 => 2700.0,
+            $grossSalary <= 150000 => 5400.0,
+            $grossSalary <= 350000 => 9000.0,
+            $grossSalary <= 700000 => 18000.0,
+            default => 36000.0,
+        };
+    }
+
+    /**
+     * Issue #1827 : abattement frais professionnels sénégalais — 30 % du
+     * brut, NON plafonné (docs/payroll/SN_COMPLIANCE.md §6). Appliqué par
+     * PayrollCalculator::calculateSlip() sur l'assiette imposable.
+     *
+     * @return array{rate: float, cap: float|null}
+     */
+    public function professionalExpensesDeduction(): array
+    {
+        return ['rate' => 30.0, 'cap' => null];
+    }
+
+    /**
+     * Issue #1827 : préavis sénégalais (Code du travail) — 8 jours ouvriers,
+     * 1 mois employés/techniciens, 3 mois cadres. L'interface n'expose que
+     * l'ancienneté : implémentation pilote au niveau employé/technicien
+     * (30 jours) ; ouvriers/cadres documentés dans SN_COMPLIANCE.md §8, la
+     * catégorie du contrat sera prise en compte dans un suivi.
+     */
+    public function noticePeriodDays(float $yearsOfService): float
+    {
+        return 30.0;
     }
 
     public function timezone(): string

--- a/api/tests/Unit/AbstractCountryRulesCapTest.php
+++ b/api/tests/Unit/AbstractCountryRulesCapTest.php
@@ -35,26 +35,33 @@ class AbstractCountryRulesCapTest extends TestCase
     {
         $rules = new SenegalPayrollRules;
 
-        // Brut 1 000 000 XOF > plafond 432 000 → assiette 432 000 :
-        //   salariale : 432 000 × 5,6 % = 24 192,00
-        //   patronale : 432 000 × (8,4 % + 3,0 %) = 432 000 × 11,4 % = 49 248,00
+        // Issue #1827 (docs/payroll/SN_COMPLIANCE.md §4-§5) — brut 1 000 000
+        // > plafond T1 432 000 :
+        //   T1 salariale : 432 000 × 5,6 % = 24 192,00
+        //   T2 salariale (cadres) : 568 000 × 2,4 % = 13 632,00 → 37 824,00
+        //   T1 patronale : 432 000 × 8,4 % = 36 288,00
+        //   T2 patronale : 568 000 × 3,6 % = 20 448,00
+        //   CSS famille 3 % = 30 000 · CSS AT 1 % = 10 000 · CFCE 3 % = 30 000
+        //   → patronale totale 126 736,00
         $charges = $rules->calculateSocialCharges(1000000.0);
 
-        $this->assertSame(24192.0, $charges['employee']);
-        $this->assertSame(49248.0, $charges['employer']);
+        $this->assertSame(37824.0, $charges['employee']);
+        $this->assertSame(126736.0, $charges['employer']);
     }
 
     public function test_senegal_contribution_uncapped_when_gross_below_432k(): void
     {
         $rules = new SenegalPayrollRules;
 
-        // Brut 200 000 XOF < plafond → assiette pleine :
+        // Issue #1827 — brut 200 000 XOF < plafond → assiette pleine (T2 non
+        // déclenché) :
         //   salariale : 200 000 × 5,6 % = 11 200,00
-        //   patronale : 200 000 × 11,4 % = 22 800,00
+        //   patronale : 200 000 × (8,4 % + 3 % + 1 % + 3 %) = 200 000 × 15,4 %
+        //     = 30 800,00
         $charges = $rules->calculateSocialCharges(200000.0);
 
         $this->assertSame(11200.0, $charges['employee']);
-        $this->assertSame(22800.0, $charges['employer']);
+        $this->assertSame(30800.0, $charges['employer']);
     }
 
     public function test_cameroon_cnps_capped_at_750k_xaf(): void

--- a/api/tests/Unit/Payroll/SenegalRulesUnitTest.php
+++ b/api/tests/Unit/Payroll/SenegalRulesUnitTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Payroll;
+
+use App\Modules\Payroll\Infrastructure\Services\CountryRules\SenegalPayrollRules;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1827 — Sénégal (SN) : SenegalPayrollRules « pilot » vers prêt pour
+ * « production » — TRIMF, CFCE, IPRES T1 plafonné + T2 cadres, abattement
+ * 30 %. Volontairement SANS base de données (méthodologie golden F-03/F-13).
+ * Référence légale : docs/payroll/SN_COMPLIANCE.md.
+ */
+class SenegalRulesUnitTest extends TestCase
+{
+    private function sn(): SenegalPayrollRules
+    {
+        return new SenegalPayrollRules;
+    }
+
+    public function test_trimf_all_6_brackets(): void
+    {
+        // Calcul manuel (docs/payroll/SN_COMPLIANCE.md §3) — table TRIMF
+        // forfaitaire mensuelle par tranche de brut :
+        //   0-25k : 900 · 25 001-75k : 2 700 · 75 001-150k : 5 400
+        //   150 001-350k : 9 000 · 350 001-700k : 18 000 · > 700k : 36 000
+        $rules = $this->sn();
+
+        self::assertSame(900.0, $rules->calculateBracketTax(25000.0));
+        self::assertSame(2700.0, $rules->calculateBracketTax(25001.0));
+        self::assertSame(2700.0, $rules->calculateBracketTax(75000.0));
+        self::assertSame(5400.0, $rules->calculateBracketTax(75001.0));
+        self::assertSame(5400.0, $rules->calculateBracketTax(150000.0));
+        self::assertSame(9000.0, $rules->calculateBracketTax(150001.0));
+        self::assertSame(9000.0, $rules->calculateBracketTax(350000.0));
+        self::assertSame(18000.0, $rules->calculateBracketTax(350001.0));
+        self::assertSame(18000.0, $rules->calculateBracketTax(700000.0));
+        self::assertSame(36000.0, $rules->calculateBracketTax(700001.0));
+        self::assertSame(36000.0, $rules->calculateBracketTax(2000000.0));
+    }
+
+    public function test_cfce_in_social_contributions(): void
+    {
+        // CFCE — Contribution Forfaitaire à la Charge de l'Employeur
+        // (docs/payroll/SN_COMPLIANCE.md §5) : 3 % patronal sur masse brute.
+        $codes = array_column($this->sn()->socialContributions(), 'code');
+
+        self::assertContains('CFCE_SN_PAT', $codes);
+
+        $cfce = collect($this->sn()->socialContributions())->firstWhere('code', 'CFCE_SN_PAT');
+        self::assertSame('employer', $cfce['type']);
+        self::assertSame(3.0, $cfce['rate']);
+        self::assertNull($cfce['cap']);
+    }
+
+    public function test_ipres_t1_capped_at_432k(): void
+    {
+        // Calcul manuel (docs/payroll/SN_COMPLIANCE.md §4) :
+        //   brut 432 000 → IPRES salariale 5,6 % × 432 000 = 24 192 (T2 non
+        //   déclenché à la borne exacte) ;
+        //   brut 500 000 → T1 plafonné à 24 192 + T2 2,4 % × 68 000 = 1 632
+        //   → salariale totale 25 824.
+        self::assertSame(24192.0, $this->sn()->calculateSocialCharges(432000.0)['employee']);
+        self::assertSame(25824.0, $this->sn()->calculateSocialCharges(500000.0)['employee']);
+    }
+
+    public function test_ipres_t2_for_cadre(): void
+    {
+        // Calcul manuel (docs/payroll/SN_COMPLIANCE.md §4bis) — brut 1 000 000 :
+        //   T1 salarié 5,6 % × 432 000 = 24 192 · T1 patronal 8,4 % × 432 000 = 36 288
+        //   Tranche T2 = 1 000 000 − 432 000 = 568 000
+        //   T2 salarié 2,4 % × 568 000 = 13 632 · T2 patronal 3,6 % × 568 000 = 20 448
+        //   CSS famille 3 % = 30 000 · CSS AT 1 % = 10 000 · CFCE 3 % = 30 000
+        //   → salarié 37 824 · patronal 126 736
+        $charges = $this->sn()->calculateSocialCharges(1000000.0);
+
+        self::assertSame(37824.0, $charges['employee']);
+        self::assertSame(126736.0, $charges['employer']);
+    }
+
+    public function test_professional_expenses_30_percent(): void
+    {
+        $abatement = $this->sn()->professionalExpensesDeduction();
+
+        // 30 % du brut, NON plafonné (docs/payroll/SN_COMPLIANCE.md §6).
+        self::assertSame(30.0, $abatement['rate']);
+        self::assertNull($abatement['cap']);
+
+        self::assertSame(90000.0, 300000.0 * 0.30);
+    }
+}

--- a/api/tests/Unit/Payroll/SenegalRulesUnitTest.php
+++ b/api/tests/Unit/Payroll/SenegalRulesUnitTest.php
@@ -50,6 +50,7 @@ class SenegalRulesUnitTest extends TestCase
         self::assertContains('CFCE_SN_PAT', $codes);
 
         $cfce = collect($this->sn()->socialContributions())->firstWhere('code', 'CFCE_SN_PAT');
+        self::assertNotNull($cfce);
         self::assertSame('employer', $cfce['type']);
         self::assertSame(3.0, $cfce['rate']);
         self::assertNull($cfce['cap']);

--- a/api/tests/Unit/PayrollCountryRulesTest.php
+++ b/api/tests/Unit/PayrollCountryRulesTest.php
@@ -23,7 +23,7 @@ class PayrollCountryRulesTest extends TestCase
             'TN' => [new TunisiaPayrollRules, 91.8, 165.7],
             'FR' => [new FrancePayrollRules, 170.3, 300.0],
             'TR' => [new TurkeyPayrollRules, 150.0, 225.0],
-            'SN' => [new SenegalPayrollRules, 56.0, 114.0],
+            'SN' => [new SenegalPayrollRules, 56.0, 154.0],
         ];
 
         foreach ($rules as $countryCode => [$countryRules, $expectedEmployeeCharge, $expectedEmployerCharge]) {

--- a/docs/payroll/SN_COMPLIANCE.md
+++ b/docs/payroll/SN_COMPLIANCE.md
@@ -1,0 +1,132 @@
+# 🇸🇳 Référentiel de conformité paie — Sénégal (SN)
+
+> **Issue #1827** — Référentiel légal versionné du moteur de paie sénégalais.
+> `SenegalPayrollRules` passe de « pilot » vers prêt pour « production » :
+> TRIMF, CFCE, régime cadres IPRES T2, plafonds, abattement frais pro.
+> ⚠️ **Toutes les valeurs sont à valider par un expert-comptable sénégalais
+> avant passage à « production »** (confidenceLevel() reste `pilot`).
+> Sources : CGI Sénégal, IPRES, CSS, Code du travail.
+
+## Statut
+
+| Règle | État | Référence | Validité |
+|---|---|---|---|
+| IR (barème annuel 6 tranches) | ✅ implémentée (pilot) | CGI Sénégal | à valider expert |
+| TRIMF (6 tranches forfaitaires) | ✅ implémentée (pilot) | CGI Sénégal | à valider expert |
+| CFCE 3 % patronal | ✅ implémentée (pilot) | CGI Sénégal | à valider expert |
+| IPRES T1 5,6 % / 8,4 % (plaf. 432 000) | ✅ implémentée (pilot) | IPRES | à valider expert |
+| IPRES T2 cadres 2,4 % / 3,6 % (tranche 432k-2 160k) | ✅ implémentée (pilot) | IPRES | à valider expert |
+| CSS famille patronale 3 % | ✅ implémentée (pilot) | CSS | à valider expert |
+| CSS AT patronale 1 % | ✅ implémentée (pilot) | CSS — variable selon secteur | à valider expert |
+| Abattement frais pro 30 % (non plafonné) | ✅ implémentée (pilot) | CGI Sénégal | à valider expert |
+| SMIG 58 900 XOF/mois | ✅ implémentée | — | à valider |
+| Congés (2,1 j/mois = 25,2 j/an, +1 j/5 ans) | 📝 à documenter/test | Code du travail | — |
+| Préavis (8 j ouvriers / 1 m employés / 3 m cadres) | ✅ implémentée (pilot, niveau employé) | Code du travail | à valider expert |
+| Jours fériés fixes SN | 📝 via CRUD jours fériés (#1811) | loi | — |
+| Jours fériés islamiques (Korité, Tabaski, Gamou, Taamhrit) | 📝 via calendrier islamique (#1812) | table `islamic_calendar` | — |
+
+## 1. IR — Impôt sur le revenu (salaires)
+
+**Barème ANNUEL** (`SenegalPayrollRules::defaultTaxSlabs()`) :
+
+| Tranche annuelle (XOF) | Taux |
+|---|---|
+| 0 – 630 000 | 0 % |
+| 630 001 – 1 500 000 | 20 % |
+| 1 500 001 – 4 000 000 | 30 % |
+| 4 000 001 – 8 000 000 | 35 % |
+| 8 000 001 – 13 500 000 | 37 % |
+| > 13 500 000 | 40 % |
+
+## 2. Assiette IR
+
+```
+assiette IR mensuelle = brut − cotisations salariales (IPRES T1+T2)
+                        − abattement frais pro (30 % du brut, non plafonné)
+```
+
+## 3. TRIMF — Taxe Représentative des Impôts du Minimum Fiscal
+
+Taxe forfaitaire mensuelle retenue sur le salarié
+(`calculateBracketTax()`, portée dans le bulletin par PayrollCalculator sur
+la ligne « Taxe de minimum fiscal ») :
+
+| Tranche brut mensuel (XOF) | TRIMF mensuel |
+|---|---|
+| 0 – 25 000 | 900 |
+| 25 001 – 75 000 | 2 700 |
+| 75 001 – 150 000 | 5 400 |
+| 150 001 – 350 000 | 9 000 |
+| 350 001 – 700 000 | 18 000 |
+| > 700 000 | 36 000 |
+
+⚠️ Le mécanisme légal « le salarié paie le plus élevé de IR / TRIMF »
+(max(IR, TRIMF)) est un raffinement à valider avec l'expert SN — dans le
+périmètre de l'issue #1827, les deux lignes coexistent dans le bulletin.
+
+## 4. IPRES — Régime Général T1
+
+| Cotisation | Taux | Type | Plafond |
+|---|---|---|---|
+| IPRES salariale | 5,6 % | salarié | 432 000 XOF/mois |
+| IPRES patronale | 8,4 % | employeur | 432 000 XOF/mois |
+
+## 4bis. IPRES — Régime Cadres T2
+
+Sur la tranche **432 001 – 2 160 000 XOF/mois** (salaires au-delà du plafond
+T1, hypothèse pilote : brut > 432 000 ⇒ régime cadres) :
+
+| Cotisation | Taux | Type |
+|---|---|---|
+| IPRES cadres salariale (T2) | 2,4 % | salarié |
+| IPRES cadres patronale (T2) | 3,6 % | employeur |
+
+## 5. CFCE — Contribution Forfaitaire à la Charge de l'Employeur
+
+**3 % sur la masse salariale brute** (charge patronale uniquement, non
+plafonnée) — `CFCE_SN_PAT`.
+
+## 6. CSS — Caisse de Sécurité Sociale
+
+| Cotisation | Taux | Type | Plafond |
+|---|---|---|---|
+| Prestations familiales patronale | 3,0 % | employeur | aucun |
+| Accidents du travail patronale | 1,0 % | employeur | aucun (pilote, variable) |
+
+## 7. Abattement frais professionnels
+
+**30 % du brut, non plafonné** — `professionalExpensesDeduction() =
+['rate' => 30.0, 'cap' => null]`.
+
+## 8. Préavis
+
+| Catégorie | Préavis |
+|---|---|
+| Ouvriers | 8 jours |
+| Employés / Techniciens | 1 mois |
+| Cadres | 3 mois |
+
+⚠️ L'interface n'expose que l'ancienneté : implémentation pilote au niveau
+**employé/technicien** (30 jours) — ouvriers et cadres documentés ici, la
+catégorie du contrat sera prise en compte dans un suivi.
+
+## 9. Congés payés
+
+2,1 j/mois = 25,2 j/an, majoration +1 j/5 ans d'ancienneté — 📝 à
+documenter/test.
+
+## 10. Jours fériés
+
+Fixes : 1ᵉʳ janvier, 4 avril, 1ᵉʳ mai, 15 août, 1ᵉʳ novembre, 25 décembre +
+fêtes islamiques mobiles (Korité, Tabaski, Gamou, Taamhrit) via table
+`islamic_calendar` (#1812). Gestion dynamique via #1811.
+
+## Procédure de mise à jour des taux
+
+1. Valider les nouveaux taux avec un expert-comptable sénégalais.
+2. Modifier les valeurs par défaut dans `SenegalPayrollRules` ET/OU insérer
+   de nouvelles lignes `tax_slabs` / `social_contributions` datées
+   (`effective_from`) pour un changement de barème sans régression.
+3. Mettre à jour ce fichier + les golden tests (`GoldenSnPayrollTest`).
+4. Faire valider par l'équipe (`php artisan test --filter=Payroll`).
+5. Passer `confidenceLevel()` de `pilot` à `production` une fois validé.


### PR DESCRIPTION
## Objectif

Faire passer `SenegalPayrollRules` de « pilot » vers prêt pour « production » : TRIMF, CFCE, régime cadres IPRES T2, plafonds, abattement frais professionnels. Référentiel `docs/payroll/SN_COMPLIANCE.md` créé.

## Changements

- **`calculateBracketTax()`** : table **TRIMF** 6 tranches forfaitaires mensuelles (900 / 2 700 / 5 400 / 9 000 / 18 000 / 36 000 XOF), portée dans le bulletin par PayrollCalculator (mécanisme ZONE-INFRA #1820, ligne « Taxe de minimum fiscal »). NB : le « max(IR, TRIMF) » légal est documenté comme raffinement à valider avec l'expert SN.
- **`socialContributions()`** : `CFCE_SN_PAT` (3 % patronal), `CSS_SN_PAT_FAM` (3 %), `CSS_SN_PAT_AT` (1 %), `IPRES_SN_EMP_T2` / `IPRES_SN_PAT_T2` (2,4 % / 3,6 % cadres) ; `IPRES_SN_EMP` / `IPRES_SN_PAT` passent à cap 432 000.
- **`calculateSocialCharges()`** : IPRES T1 plafonné **432 000 XOF/mois** ; tranche T2 (432 001 – 2 160 000) appliquée quand le brut dépasse le plafond T1 (hypothèse pilote documentée) ; CSS famille 3 % + AT 1 % + CFCE 3 % (non plafonnés).
- **`professionalExpensesDeduction()`** : 30 % du brut, non plafonné.
- **`noticePeriodDays()`** : 30 j (niveau employé/technicien — matrice 8 j / 1 m / 3 m documentée dans SN_COMPLIANCE.md §8, catégorie = suivi).
- **`confidenceLevel()`** : reste `pilot` (validation expert SN requise avant production).
- **Tests** : `SenegalRulesUnitTest` (5 cas exigés) ; `PayrollCountryRulesTest` + `AbstractCountryRulesCapTest` alignés sur les nouvelles valeurs SN (56/154 à 1 000 XOF).

## Vérifications

- [x] `SenegalRulesUnitTest` + tests alignés : 47 verts localement
- [x] PHPStan module Payroll : 0 erreur

Closes #1827