### PR TITLE
feat(payroll): F-20 — actual_days_worked depuis les logs de présence (Closes #1816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 # Format : Keep a Changelog (keepachangelog.com) 
 # Versioning : Semantic Versioning (semver.org) 
 
-## [Unreleased]
+### Added
+- **feat(payroll): F-20 — actual_days_worked depuis les logs de présence réels (Closes #1816).** `PayrollCalculator::computeWorkedDays()` compte désormais les **jours distincts** avec au moins un log `AttendanceLog` valide (statuts `cancelled`/`rejected`/`incomplete` exclus) sur la période du run ; sans log valide, fallback prorata contrat (comportement historique). Nouveau champ `pay_slips.has_attendance_data` (migration additive + fillable + cast booléen) traçant la source du décompte dans le bulletin. `DZ_COMPLIANCE.md` §5 mis à jour. Tests : `AttendanceDrivenWorkedDaysTest` (5 cas — jours distincts, exclusions, fallback prorata, prorata entrée mi-mois, scope période).
 
 ### Chore
 - **chore(version): défaut APP_VERSION aligné sur PILOTAGE.md (4.24.0).** `api/config/app.php` gardait le défaut `4.23.5` (commit « Version Sync » #739) alors que le repo est en 4.24.0 depuis la release préparée (#1722) — la prod affichait 4.23.5 dans `/api/v1/health` malgré le nouveau code déployé (Render n'a pas d'APP_VERSION). Le défaut passe à 4.24.0 ; l'env garde la priorité.

--- a/api/app/Modules/Payroll/Domain/Models/PaySlip.php
+++ b/api/app/Modules/Payroll/Domain/Models/PaySlip.php
@@ -43,7 +43,7 @@ class PaySlip extends Model
         'payroll_run_id', 'company_id', 'employee_id', 'contract_id',
         'period_start', 'period_end', 'gross_salary', 'total_deductions',
         'net_salary', 'employer_contributions', 'total_cost',
-        'working_days', 'actual_days_worked', 'overtime_hours',
+        'working_days', 'actual_days_worked', 'overtime_hours', 'has_attendance_data',
         'status', 'pdf_path', 'sent_at',
     ];
 
@@ -58,6 +58,7 @@ class PaySlip extends Model
         'working_days' => 'float',
         'actual_days_worked' => 'float',
         'overtime_hours' => 'float',
+        'has_attendance_data' => 'boolean',
         'sent_at' => 'datetime',
     ];
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php
@@ -27,6 +27,7 @@ use App\Modules\Planning\Domain\Models\LeaveBalance;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class PayrollCalculator
 {
@@ -394,6 +395,7 @@ class PayrollCalculator
             'working_days' => $worked['working_days'],
             'actual_days_worked' => $worked['actual_days_worked'],
             'overtime_hours' => $worked['overtime_hours'],
+            'has_attendance_data' => $worked['has_attendance_data'],
             'status' => 'calculated',
         ]);
 
@@ -451,10 +453,16 @@ class PayrollCalculator
      * Recoupe le contrat de l'employé (contract_start / contract_end) avec la
      * période du run : prorata d'entrée/sortie en cours de mois.
      *
-     * overtime_hours : source future = pointage/attendance (F-20) ; 0 tant que
-     * le lien présence → paie n'est pas branché.
+     * F-20 (#1816) — IMPLÉMENTÉ : actual_days_worked = nombre de JOURS
+     * DISTINCTS avec au moins un log de présence valide (AttendanceLog) sur
+     * la période. Fallback : prorata contrat (comportement historique)
+     * quand aucun log valide n'existe. `has_attendance_data` permet au
+     * bulletin de tracer la source du décompte.
      *
-     * @return array{working_days: float, actual_days_worked: float, overtime_hours: float}
+     * overtime_hours : source future = pointage/attendance (F-20) ; 0 tant
+     * que le lien présence → paie n'est pas branché.
+     *
+     * @return array{working_days: float, actual_days_worked: float, overtime_hours: float, has_attendance_data: bool}
      */
     public function computeWorkedDays(PayrollRun $run, Employee $employee): array
     {
@@ -476,12 +484,29 @@ class PayrollCalculator
         $overlapDays = max(0, $overlapStart->diffInDays($overlapEnd) + 1);
 
         $ratio = $periodDays > 0 ? min(1.0, $overlapDays / $periodDays) : 0.0;
-        $actualDays = round($workingDays * $ratio, 2);
+        $contractProrata = round($workingDays * $ratio, 2);
+
+        // F-20 (#1816) : jours distincts avec au moins un log de présence
+        // valide. Guard schema (tests DB-less / environnements sans la table)
+        // → fallback prorata.
+        $distinctDays = 0;
+        $hasAttendanceData = false;
+        if (Schema::hasTable('attendance_logs')) {
+            $distinctDays = (int) AttendanceLog::query()
+                ->where('company_id', $run->company_id)
+                ->where('employee_id', $employee->id)
+                ->whereBetween('date', [$periodStart, $periodEnd])
+                ->whereNotIn('status', ['cancelled', 'rejected', 'incomplete'])
+                ->distinct('date')
+                ->count('date');
+            $hasAttendanceData = $distinctDays > 0;
+        }
 
         return [
             'working_days' => $workingDays,
-            'actual_days_worked' => $actualDays,
+            'actual_days_worked' => $hasAttendanceData ? (float) $distinctDays : $contractProrata,
             'overtime_hours' => 0.0,
+            'has_attendance_data' => $hasAttendanceData,
         ];
     }
 

--- a/api/database/migrations/tenant/2026_08_14_000002_add_has_attendance_data_to_pay_slips.php
+++ b/api/database/migrations/tenant/2026_08_14_000002_add_has_attendance_data_to_pay_slips.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #1816 (F-20) — trace la source du décompte des jours travaillés :
+ * `pay_slips.has_attendance_data` (true = actual_days_worked issu des logs
+ * de présence réels AttendanceLog ; false = fallback prorata contrat).
+ *
+ * Additive et idempotente (pattern 00015) : n'altère pas les colonnes
+ * existantes et peut être rejouée sans effet.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('pay_slips', 'has_attendance_data')) {
+            Schema::table('pay_slips', static function (Blueprint $table): void {
+                $table->boolean('has_attendance_data')->default(false)->after('overtime_hours');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('pay_slips', 'has_attendance_data')) {
+            Schema::table('pay_slips', static function (Blueprint $table): void {
+                $table->dropColumn('has_attendance_data');
+            });
+        }
+    }
+};

--- a/api/tests/Feature/Payroll/AttendanceDrivenWorkedDaysTest.php
+++ b/api/tests/Feature/Payroll/AttendanceDrivenWorkedDaysTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Payroll;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\AttendanceLog;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Infrastructure\Services\PayrollCalculator;
+use Illuminate\Support\Carbon;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #1816 (F-20) — actual_days_worked depuis les logs de présence réels
+ * (AttendanceLog → PayrollCalculator::computeWorkedDays).
+ *
+ * Vérifie : jours distincts avec log valide, exclusion des logs annulés/
+ * rejetés/incomplets, fallback prorata contrat sans présence, trace
+ * has_attendance_data sur le bulletin.
+ */
+class AttendanceDrivenWorkedDaysTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    public function test_actual_days_worked_counts_distinct_valid_attendance_days(): void
+    {
+        [$company, $employee] = $this->actors();
+        $run = $this->makeRun($company, '2026-05-01');
+
+        // 3 jours distincts avec logs valides (le doublon même jour n'est pas
+        // insérable : contrainte unique employee_id/date/session_number).
+        $this->log($company, $employee, '2026-05-04', 'ontime');
+        $this->log($company, $employee, '2026-05-05', 'late');
+        $this->log($company, $employee, '2026-05-06', 'ontime');
+
+        $worked = (new PayrollCalculator)->computeWorkedDays($run, $employee);
+
+        $this->assertSame(3.0, $worked['actual_days_worked']);
+        $this->assertTrue($worked['has_attendance_data']);
+        $this->assertSame(22.0, $worked['working_days']);
+    }
+
+    public function test_incomplete_logs_are_excluded(): void
+    {
+        [$company, $employee] = $this->actors();
+        $run = $this->makeRun($company, '2026-05-01');
+
+        // Filtre F-20 (#1816) : whereNotIn('status', ['cancelled', 'rejected',
+        // 'incomplete']) — seuls ces statuts sont exclus du décompte.
+        $this->log($company, $employee, '2026-05-04', 'incomplete'); // exclu
+        $this->log($company, $employee, '2026-05-05', 'leave');      // décompté
+        $this->log($company, $employee, '2026-05-06', 'holiday');    // décompté
+        $this->log($company, $employee, '2026-05-07', 'ontime');     // décompté
+
+        $worked = (new PayrollCalculator)->computeWorkedDays($run, $employee);
+
+        $this->assertSame(3.0, $worked['actual_days_worked']);
+        $this->assertTrue($worked['has_attendance_data']);
+    }
+
+    public function test_falls_back_to_contract_prorata_without_attendance_data(): void
+    {
+        [$company, $employee] = $this->actors();
+        $run = $this->makeRun($company, '2026-05-01');
+
+        // Aucun log → prorata contrat plein mois = 22 jours, pas de données
+        // de présence.
+        $worked = (new PayrollCalculator)->computeWorkedDays($run, $employee);
+
+        $this->assertSame(22.0, $worked['actual_days_worked']);
+        $this->assertFalse($worked['has_attendance_data']);
+    }
+
+    public function test_fallback_prorata_respects_mid_month_hire(): void
+    {
+        [$company, $employee] = $this->actors(['contract_start' => '2026-05-15']);
+        $run = $this->makeRun($company, '2026-05-01');
+
+        // Entrée le 15/05 : 17 jours calendaires sur 31 → prorata 22 × 17/31
+        // = 12,06 jours (aucun log de présence).
+        $worked = (new PayrollCalculator)->computeWorkedDays($run, $employee);
+
+        $this->assertSame(12.06, $worked['actual_days_worked']);
+        $this->assertFalse($worked['has_attendance_data']);
+    }
+
+    public function test_attendance_days_are_scoped_to_the_run_period(): void
+    {
+        [$company, $employee] = $this->actors();
+        $run = $this->makeRun($company, '2026-05-01');
+
+        $this->log($company, $employee, '2026-04-30', 'ontime'); // hors période
+        $this->log($company, $employee, '2026-05-02', 'ontime'); // dans la période
+
+        $worked = (new PayrollCalculator)->computeWorkedDays($run, $employee);
+
+        $this->assertSame(1.0, $worked['actual_days_worked']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $employeeOverrides
+     * @return array{0: Company, 1: Employee}
+     */
+    private function actors(array $employeeOverrides = []): array
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create();
+
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create(array_merge([
+            'company_id' => $company->id,
+            'status' => 'active',
+            'contract_start' => '2025-01-10',
+            'contract_type' => 'CDI',
+        ], $employeeOverrides));
+
+        return [$company, $employee];
+    }
+
+    private function makeRun(Company $company, string $periodStart): PayrollRun
+    {
+        return PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => $periodStart,
+            'period_end' => Carbon::parse($periodStart)->endOfMonth()->toDateString(),
+            'status' => 'draft',
+        ]);
+    }
+
+    private function log(Company $company, Employee $employee, string $date, string $status = 'ontime'): AttendanceLog
+    {
+        return AttendanceLog::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'date' => $date,
+            'check_in' => $date.' 08:00:00',
+            'check_out' => $date.' 17:00:00',
+            'status' => $status,
+        ]);
+    }
+}

--- a/docs/payroll/DZ_COMPLIANCE.md
+++ b/docs/payroll/DZ_COMPLIANCE.md
@@ -70,6 +70,12 @@
 **Méthode de prorata** : jours travaillés (actual_days_worked / 22 jours ouvrés standards),
 recoupe `contract_start`/`contract_end` avec la période du run (PayrollCalculator::computeWorkedDays).
 
+**F-20 (#1816 — implémenté 2026-08-14)** : `actual_days_worked` provient désormais des logs de
+présence réels (`AttendanceLog`) — nombre de **jours distincts** avec au moins un log valide
+(statuts `cancelled`/`rejected`/`incomplete` exclus) sur la période du run. Sans log valide,
+fallback prorata contrat (comportement historique). Le bulletin trace la source via
+`pay_slips.has_attendance_data` (true = pointage réel, false = prorata).
+
 | Cas | Calcul | Résultat |
 |---|---|---|
 | Entrée 15/07 (17 j calendaires sur 31) | 22 × 17/31 = 12,06 j → 60 000 × 12,06/22 | **32 890,91** |


### PR DESCRIPTION
## Objectif

Brancher les logs de présence réels (`AttendanceLog`) dans `PayrollCalculator::computeWorkedDays()` : `actual_days_worked` reflète le nombre de jours réellement pointés, avec fallback prorata contrat quand aucun log valide n'existe (F-20).

## Changements

- **`computeWorkedDays()`** : compte les **jours distincts** avec au moins un log `AttendanceLog` valide (statuts `cancelled`/`rejected`/`incomplete` exclus) sur la période du run ; `has_attendance_data` ajouté au retour. Garde `Schema::hasTable` (tests DB-less / schémas sans table).
- **Migration additive** : `pay_slips.has_attendance_data BOOLEAN DEFAULT false` (idempotente, pattern 00015).
- **`calculateSlip()`** : persiste `has_attendance_data` sur le bulletin.
- **Docs** : `DZ_COMPLIANCE.md` §5 (source du décompte).
- **Tests** : `AttendanceDrivenWorkedDaysTest` (5 cas — jours distincts, exclusions de statut, fallback prorata, prorata entrée mi-mois, scope période) ; golden prorata existants inchangés (fallback).

## Vérifications

- [x] 18 tests verts localement (attendance + golden prorata DZ)
- [x] PHPStan module Payroll : 0 erreur

Closes #1816