### PR TITLE
feat(payroll): bulletins rétroactifs et régularisations (Closes #1818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 # Format : Keep a Changelog (keepachangelog.com) 
 # Versioning : Semantic Versioning (semver.org) 
 
-## [Unreleased]
+### Added
+- **feat(payroll): bulletins rétroactifs et régularisations — correctif d'un run clôturé (Closes #1818).** `PayrollRegularizationService::createRegularization()` : seul un run `locked` est régularisable → crée un run `type=regularization` (même période/pays, `original_run_id` renseigné, motif) + audit `payroll_run_regularization_created` (reason, original_run_id, actor_id), sans modifier l'original. Endpoints `POST /api/v1/payroll-runs/{run}/regularize` (principal/comptable, 422 si non verrouillé) et `GET /api/v1/payroll-runs/{run}/regularizations` (404 cross-tenant). Migration additive `payroll_runs.type/original_run_id/reason` (+ contrainte CHECK idempotente). PDF : bannière « Bulletin de régularisation — corrige le run #N » (blade + i18n fr/en/ar/tr). Le run de régularisation suit le workflow complet (draft → calculated → validated → locked). Tests : `PayrollRegularizationTest` (7 cas — création, 422 non-verrouillé, workflow complet, listing, isolation tenant, RBAC, mention PDF).
 
 ### Chore
 - **chore(version): défaut APP_VERSION aligné sur PILOTAGE.md (4.24.0).** `api/config/app.php` gardait le défaut `4.23.5` (commit « Version Sync » #739) alors que le repo est en 4.24.0 depuis la release préparée (#1722) — la prod affichait 4.23.5 dans `/api/v1/health` malgré le nouveau code déployé (Render n'a pas d'APP_VERSION). Le défaut passe à 4.24.0 ; l'env garde la priorité.

--- a/api/app/Http/Resources/Api/V1/PayrollRunResource.php
+++ b/api/app/Http/Resources/Api/V1/PayrollRunResource.php
@@ -22,6 +22,10 @@ class PayrollRunResource extends JsonResource
             'period_start' => $this->period_start?->toDateString(),
             'period_end' => $this->period_end?->toDateString(),
             'status' => $this->status,
+            // Issue #1818 : type de run + lien de régularisation.
+            'type' => $this->type ?? 'standard',
+            'original_run_id' => $this->original_run_id,
+            'reason' => $this->reason,
             'total_gross' => $this->total_gross,
             'total_deductions' => $this->total_deductions,
             'total_net' => $this->total_net,

--- a/api/app/Modules/Payroll/Domain/Models/PayrollRun.php
+++ b/api/app/Modules/Payroll/Domain/Models/PayrollRun.php
@@ -46,10 +46,16 @@ class PayrollRun extends Model
     public const STATUS_LOCKED = 'locked';
     public const STATUS_CANCELLED = 'cancelled';
     public const STATUS_ERROR = 'error'; // async batch job failed
+
+    /** Issue #1818 — types de run (régularisation = correctif d'un run clôturé). */
+    public const TYPE_STANDARD = 'standard';
+
+    public const TYPE_REGULARIZATION = 'regularization';
     use BelongsToCompany;
 
     protected $fillable = [
         'company_id', 'period_start', 'period_end', 'country_code', 'status',
+        'type', 'original_run_id', 'reason',
         'total_gross', 'total_deductions', 'total_net', 'total_employer_cost',
         'employee_count', 'calculated_at', 'validated_by', 'validated_at',
         'paid_at', 'locked_by', 'locked_at', 'notes',

--- a/api/app/Modules/Payroll/Infrastructure/Services/PaySlipPdfGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PaySlipPdfGenerator.php
@@ -7,6 +7,7 @@ namespace App\Modules\Payroll\Infrastructure\Services;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\Payroll\Domain\Models\PaySlip;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Support\CountryDefaults;
 use App\Support\I18nCatalog;
 use Barryvdh\DomPDF\Facade\Pdf;
@@ -56,6 +57,11 @@ class PaySlipPdfGenerator
             // F-09 (#1539) : cumuls annuels (brut, retenues, net) des
             // bulletins validés de l'employé jusqu'à la période du bulletin.
             'annualCumuls' => $this->annualCumuls($paySlip),
+            // Issue #1818 : mention « BULLETIN DE RÉGULARISATION » portée en
+            // haut du bulletin quand le run est un correctif (type
+            // regularization, original_run_id renseigné).
+            'isRegularization' => $paySlip->payrollRun?->type === PayrollRun::TYPE_REGULARIZATION,
+            'originalRunId' => $paySlip->payrollRun?->original_run_id,
         ]);
 
         $pdf->setPaper('A4', 'portrait');

--- a/api/app/Modules/Payroll/Infrastructure/Services/PayrollRegularizationService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/PayrollRegularizationService.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Payroll\Infrastructure\Services;
+
+use App\Core\Auth\Domain\Models\AuditLog;
+use App\Core\Auth\Domain\Models\Employee;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+
+/**
+ * Issue #1818 — bulletins rétroactifs et régularisations.
+ *
+ * Un run clôturé (locked) peut être corrigé en créant un run de
+ * régularisation : même période, même pays, `type = regularization`,
+ * `original_run_id` renseigné, motif tracé — SANS modifier le run original.
+ *
+ * Le run de régularisation suit le workflow standard (draft → calculated →
+ * validated → locked → archivage Cabinet #1817). Les structures salariales
+ * étant scopées à l'entreprise (company_id + country_code), le correctif se
+ * fait en ajustant structures/composants avant le calcul du run de
+ * régularisation.
+ */
+class PayrollRegularizationService
+{
+    /**
+     * @throws \RuntimeException si le run n'est pas verrouillé (clôture faite)
+     */
+    public function createRegularization(PayrollRun $original, Employee $actor, ?string $reason = null): PayrollRun
+    {
+        if ($original->status !== PayrollRun::STATUS_LOCKED) {
+            throw new \RuntimeException('Seul un run verrouillé (clôture comptable) est régularisable.');
+        }
+
+        $regularization = PayrollRun::query()->create([
+            'company_id' => $original->company_id,
+            'period_start' => $original->period_start,
+            'period_end' => $original->period_end,
+            'country_code' => $original->country_code,
+            'status' => PayrollRun::STATUS_DRAFT,
+            'type' => PayrollRun::TYPE_REGULARIZATION,
+            'original_run_id' => $original->id,
+            'reason' => $reason,
+            'notes' => $reason !== null ? "Régularisation du run #{$original->id} : {$reason}" : null,
+        ]);
+
+        AuditLog::create([
+            'company_id' => $original->company_id,
+            'user_id' => $actor->id,
+            'action' => 'payroll_run_regularization_created',
+            'auditable_type' => $regularization->getMorphClass(),
+            'auditable_id' => $regularization->id,
+            'old_values' => null,
+            'new_values' => [
+                'original_run_id' => $original->id,
+                'period_start' => $original->period_start->toDateString(),
+                'period_end' => $original->period_end->toDateString(),
+            ],
+            'metadata' => [
+                'reason' => $reason,
+                'original_run_id' => $original->id,
+                'actor_id' => $actor->id,
+            ],
+        ]);
+
+        return $regularization;
+    }
+}

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollRunController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollRunController.php
@@ -17,6 +17,7 @@ use App\Modules\Payroll\Infrastructure\Services\PayrollAnomalyService;
 use App\Modules\Payroll\Infrastructure\Services\PayrollCalculator;
 use App\Modules\Payroll\Infrastructure\Services\PayrollClosingService;
 use App\Modules\Payroll\Infrastructure\Services\PayrollJournalGenerator;
+use App\Modules\Payroll\Infrastructure\Services\PayrollRegularizationService;
 use App\Modules\Payroll\Interfaces\Api\V1\Requests\StorePayrollRunRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -28,6 +29,7 @@ class PayrollRunController extends Controller
     public function __construct(
         private readonly PayrollCalculator $calculator,
         private readonly PayrollClosingService $closing,
+        private readonly PayrollRegularizationService $regularization,
         private readonly DataAccessAuditLogger $auditLogger,
     ) {}
 
@@ -174,6 +176,63 @@ class PayrollRunController extends Controller
         $payrollRun->update(['status' => 'cancelled']);
 
         return (new PayrollRunResource($payrollRun->refresh()))->response();
+    }
+
+    /**
+     * Issue #1818 — crée un run de régularisation pour un run clôturé
+     * (locked). Réservé principal/comptable ; 404 cross-tenant ; 422 si le
+     * run n'est pas verrouillé.
+     */
+    public function regularize(Request $request, PayrollRun $payrollRun): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        if ($payrollRun->company_id !== $actor->company_id) {
+            abort(404);
+        }
+        if (! $actor->isManager() || ! ($actor->isPrincipal() || $actor->isComptable())) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'reason' => 'sometimes|nullable|string|max:1000',
+        ]);
+
+        try {
+            $regularization = $this->regularization->createRegularization(
+                $payrollRun,
+                $actor,
+                $validated['reason'] ?? null,
+            );
+        } catch (\RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return (new PayrollRunResource($regularization))->response();
+    }
+
+    /**
+     * Issue #1818 — liste les runs de régularisation liés à un run donné
+     * (original_run_id = {run}). 404 cross-tenant.
+     */
+    public function regularizations(Request $request, PayrollRun $payrollRun): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        if ($payrollRun->company_id !== $actor->company_id) {
+            abort(404);
+        }
+        if ($actor->isManager() === false) {
+            abort(403);
+        }
+
+        $runs = PayrollRun::query()
+            ->where('company_id', $actor->company_id)
+            ->where('original_run_id', $payrollRun->id)
+            ->orderByDesc('id')
+            ->get();
+
+        return PayrollRunResource::collection($runs)->response();
     }
 
     /**

--- a/api/database/migrations/tenant/2026_08_14_000004_add_regularization_to_payroll_runs.php
+++ b/api/database/migrations/tenant/2026_08_14_000004_add_regularization_to_payroll_runs.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #1818 — bulletins rétroactifs et régularisations : un run verrouillé
+ * peut être corrigé via un run de régularisation (sans modifier l'original).
+ *
+ * Additive et idempotente (pattern 00015) :
+ *   - `payroll_runs.type` ENUM('standard','regularization') DEFAULT 'standard'
+ *   - `payroll_runs.original_run_id` BIGINT NULLABLE (référence le run corrigé)
+ *   - `payroll_runs.reason` TEXT NULLABLE (motif de régularisation)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('payroll_runs', 'type')) {
+            Schema::table('payroll_runs', static function (Blueprint $table): void {
+                $table->string('type', 20)->default('standard')->after('status');
+            });
+        }
+
+        if (! Schema::hasColumn('payroll_runs', 'original_run_id')) {
+            Schema::table('payroll_runs', static function (Blueprint $table): void {
+                $table->unsignedBigInteger('original_run_id')->nullable()->after('type');
+                $table->index('original_run_id');
+            });
+        }
+
+        if (! Schema::hasColumn('payroll_runs', 'reason')) {
+            Schema::table('payroll_runs', static function (Blueprint $table): void {
+                $table->text('reason')->nullable()->after('original_run_id');
+            });
+        }
+
+        $this->ensureTypeConstraint();
+    }
+
+    public function down(): void
+    {
+        foreach (['reason', 'original_run_id', 'type'] as $column) {
+            if (Schema::hasColumn('payroll_runs', $column)) {
+                Schema::table('payroll_runs', static function (Blueprint $table) use ($column): void {
+                    $table->dropColumn($column);
+                });
+            }
+        }
+    }
+
+    /**
+     * Contrainte CHECK sur payroll_runs.type (idempotente, même pattern que
+     * payroll_runs_status_check — voir 2026_08_09_000001).
+     */
+    private function ensureTypeConstraint(): void
+    {
+        if (! Schema::hasColumn('payroll_runs', 'type')) {
+            return;
+        }
+
+        $schema = resolveTableSchema('payroll_runs');
+
+        $exists = DB::selectOne(
+            "SELECT 1 FROM pg_constraint WHERE conname = 'payroll_runs_type_check' AND conrelid = ?::regclass",
+            ["{$schema}.payroll_runs"]
+        );
+
+        if ($exists !== null) {
+            return;
+        }
+
+        DB::statement(
+            "ALTER TABLE \"{$schema}\".\"payroll_runs\" ADD CONSTRAINT payroll_runs_type_check "
+            ."CHECK (type IN ('standard', 'regularization'))"
+        );
+    }
+};

--- a/api/lang/ar/pdf.php
+++ b/api/lang/ar/pdf.php
@@ -28,6 +28,8 @@ return [
 
     // كشف الراتب (payslip.blade.php)
     'payslip_title' => 'كشف الراتب',
+    'payslip_regularization_banner' => 'قسيمة تسوية',
+    'payslip_regularization_corrects' => 'تصحح الدفعة',
     'payslip_company_fallback' => 'الشركة',
     'payslip_matricule' => 'رقم الموظف',
     'payslip_worked_days' => 'أيام العمل',

--- a/api/lang/en/pdf.php
+++ b/api/lang/en/pdf.php
@@ -28,6 +28,8 @@ return [
 
     // Payslip (payslip.blade.php)
     'payslip_title' => 'Payslip',
+    'payslip_regularization_banner' => 'Regularization pay slip',
+    'payslip_regularization_corrects' => 'corrects run',
     'payslip_company_fallback' => 'Company',
     'payslip_matricule' => 'Employee ID',
     'payslip_worked_days' => 'Days worked',

--- a/api/lang/fr/pdf.php
+++ b/api/lang/fr/pdf.php
@@ -28,6 +28,8 @@ return [
 
     // Bulletin de paie (payslip.blade.php)
     'payslip_title' => 'Bulletin de Paie',
+    'payslip_regularization_banner' => 'Bulletin de régularisation',
+    'payslip_regularization_corrects' => 'corrige le run',
     'payslip_company_fallback' => 'Entreprise',
     'payslip_matricule' => 'Matricule',
     'payslip_worked_days' => 'Jours travaillés',

--- a/api/lang/tr/pdf.php
+++ b/api/lang/tr/pdf.php
@@ -28,6 +28,8 @@ return [
 
     // Maaş bordrosu (payslip.blade.php)
     'payslip_title' => 'Maaş Bordrosu',
+    'payslip_regularization_banner' => 'Düzeltme bordrosu',
+    'payslip_regularization_corrects' => 'düzeltir çalıştırma',
     'payslip_company_fallback' => 'Şirket',
     'payslip_matricule' => 'Personel numarası',
     'payslip_worked_days' => 'Çalışılan günler',

--- a/api/resources/views/pdf/payslip.blade.php
+++ b/api/resources/views/pdf/payslip.blade.php
@@ -40,6 +40,12 @@
     <div class="title">{{ __('pdf.payslip_title') }}</div>
     <div class="period">{{ __('pdf.period') }} : {{ $slip->period_start->format('d/m/Y') }} — {{ $slip->period_end->format('d/m/Y') }}</div>
 
+    @if (! empty($isRegularization))
+        <div style="background: #fef3c7; border: 2px solid #d97706; color: #92400e; font-weight: bold; text-align: center; padding: 10px; margin: 14px 0; text-transform: uppercase;">
+            {{ __('pdf.payslip_regularization_banner') }} — @if(! empty($originalRunId)){{ __('pdf.payslip_regularization_corrects') }} #{{ $originalRunId }}@endif
+        </div>
+    @endif
+
     <div class="info-grid">
         <div class="info-col">
             <div class="info-label">{{ __('pdf.employee') }}</div>

--- a/api/routes/modules/payroll_engine.php
+++ b/api/routes/modules/payroll_engine.php
@@ -79,6 +79,9 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
         Route::post('/payroll-runs/{payrollRun}/lock', [PayrollRunController::class, 'lock'])->whereNumber('payrollRun');
         Route::post('/payroll-runs/{payrollRun}/unlock', [PayrollRunController::class, 'unlock'])->whereNumber('payrollRun');
         Route::post('/payroll-runs/{payrollRun}/cancel', [PayrollRunController::class, 'cancel'])->whereNumber('payrollRun');
+        // Issue #1818 — régularisations de runs clôturés.
+        Route::post('/payroll-runs/{payrollRun}/regularize', [PayrollRunController::class, 'regularize'])->whereNumber('payrollRun');
+        Route::get('/payroll-runs/{payrollRun}/regularizations', [PayrollRunController::class, 'regularizations'])->whereNumber('payrollRun');
         Route::get('/payroll-runs/{payrollRun}/summary', [PayrollRunController::class, 'summary'])->whereNumber('payrollRun');
         Route::get('/payroll-runs/{payrollRun}/anomalies', [PayrollRunController::class, 'anomalies'])->whereNumber('payrollRun');
         Route::get('/payroll-runs/{payrollRun}/export', [PayrollRunController::class, 'export'])->whereNumber('payrollRun');

--- a/api/tests/Feature/Payroll/PayrollRegularizationTest.php
+++ b/api/tests/Feature/Payroll/PayrollRegularizationTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Payroll;
+
+use App\Core\Auth\Domain\Models\AuditLog;
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\SalaryStructure;
+use App\Modules\Payroll\Infrastructure\Services\PayrollCalculator;
+use App\Modules\Payroll\Infrastructure\Services\PayrollClosingService;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #1818 — bulletins rétroactifs et régularisations : un run clôturé
+ * (locked) peut être corrigé via un run de régularisation traçable, sans
+ * modifier l'original.
+ */
+class PayrollRegularizationTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    public function test_regularize_locked_run_creates_draft(): void
+    {
+        [$company] = $this->actors();
+        $comptable = $this->comptable($company);
+        $run = $this->lockedRun($company, $comptable);
+
+        Sanctum::actingAs($comptable);
+
+        $response = $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', [
+            'reason' => 'Prime oubliée sur la paie de mai',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.type', 'regularization')
+            ->assertJsonPath('data.status', 'draft')
+            ->assertJsonPath('data.original_run_id', $run->id)
+            ->assertJsonPath('data.reason', 'Prime oubliée sur la paie de mai')
+            ->assertJsonPath('data.period_start', $run->period_start->toDateString())
+            ->assertJsonPath('data.country_code', 'DZ');
+
+        $this->assertDatabaseHas('payroll_runs', [
+            'id' => $response->json('data.id'),
+            'type' => 'regularization',
+            'original_run_id' => $run->id,
+            'status' => 'draft',
+        ]);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'company_id' => $company->id,
+            'action' => 'payroll_run_regularization_created',
+        ]);
+
+        $audit = AuditLog::where('company_id', $company->id)
+            ->where('action', 'payroll_run_regularization_created')
+            ->firstOrFail();
+        $this->assertSame($run->id, $audit->metadata['original_run_id']);
+        $this->assertSame('Prime oubliée sur la paie de mai', $audit->metadata['reason']);
+        $this->assertSame($comptable->id, $audit->metadata['actor_id']);
+
+        // Le run original n'est PAS modifié.
+        $this->assertSame('locked', $run->fresh()->status);
+    }
+
+    public function test_cannot_regularize_non_locked_run(): void
+    {
+        [$company] = $this->actors();
+        $comptable = $this->comptable($company);
+
+        $draft = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth()->toDateString(),
+            'period_end' => now()->endOfMonth()->toDateString(),
+            'status' => PayrollRun::STATUS_DRAFT,
+        ]);
+
+        Sanctum::actingAs($comptable);
+
+        $this->postJson('/api/v1/payroll-runs/'.$draft->id.'/regularize', ['reason' => 'test'])
+            ->assertStatus(422);
+    }
+
+    public function test_regularization_follows_full_workflow(): void
+    {
+        [$company] = $this->actors();
+        $comptable = $this->comptable($company);
+        $run = $this->lockedRun($company, $comptable);
+
+        Sanctum::actingAs($comptable);
+
+        $regularizationId = $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', [
+            'reason' => 'Absence mal encodée',
+        ])->json('data.id');
+
+        $regularization = PayrollRun::findOrFail($regularizationId);
+
+        // Workflow complet : draft → calculated → validated → locked.
+        (new PayrollCalculator)->calculateRun($regularization);
+        $regularization->refresh();
+        $this->assertSame('calculated', $regularization->status);
+
+        /** @var Employee $rh */
+        $rh = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        (new PayrollClosingService)->validateRh($regularization, $rh);
+        $regularization->refresh();
+        $this->assertSame('validated', $regularization->status);
+
+        (new PayrollClosingService)->lock($regularization, $comptable);
+        $regularization->refresh();
+        $this->assertSame('locked', $regularization->status);
+        $this->assertSame(PayrollRun::TYPE_REGULARIZATION, $regularization->type);
+        $this->assertSame($run->id, $regularization->original_run_id);
+    }
+
+    public function test_regularization_listing_scoped_to_original_run(): void
+    {
+        [$company] = $this->actors();
+        $comptable = $this->comptable($company);
+        $run = $this->lockedRun($company, $comptable);
+
+        Sanctum::actingAs($comptable);
+
+        $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', ['reason' => 'régularisation 1']);
+        $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', ['reason' => 'régularisation 2']);
+
+        $this->getJson('/api/v1/payroll-runs/'.$run->id.'/regularizations')
+            ->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.original_run_id', $run->id);
+    }
+
+    public function test_cross_tenant_regularization_blocked(): void
+    {
+        [$company] = $this->actors();
+        $comptable = $this->comptable($company);
+        $run = $this->lockedRun($company, $comptable);
+
+        /** @var Company $otherCompany */
+        $otherCompany = Company::factory()->create();
+        /** @var Employee $otherManager */
+        $otherManager = Employee::factory()->manager()->create(['company_id' => $otherCompany->id]);
+
+        Sanctum::actingAs($otherManager);
+
+        $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', ['reason' => 'x'])->assertNotFound();
+        $this->getJson('/api/v1/payroll-runs/'.$run->id.'/regularizations')->assertNotFound();
+    }
+
+    public function test_rbac_employee_cannot_regularize(): void
+    {
+        [$company, $employee] = $this->actors();
+        $comptable = $this->comptable($company);
+        $run = $this->lockedRun($company, $comptable);
+
+        Sanctum::actingAs($employee);
+
+        $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', ['reason' => 'x'])->assertForbidden();
+    }
+
+    public function test_pdf_mentions_regularization_banner(): void
+    {
+        [$company, $employee] = $this->actors();
+        $comptable = $this->comptable($company);
+        $run = $this->lockedRun($company, $comptable);
+
+        Sanctum::actingAs($comptable);
+
+        $regularizationId = $this->postJson('/api/v1/payroll-runs/'.$run->id.'/regularize', [
+            'reason' => 'Prime oubliée',
+        ])->json('data.id');
+
+        $regularization = PayrollRun::findOrFail($regularizationId);
+        (new PayrollCalculator)->calculateRun($regularization);
+
+        $slip = $regularization->paySlips()->firstOrFail();
+
+        $pdf = (new \App\Modules\Payroll\Infrastructure\Services\PaySlipPdfGenerator)->generate($slip);
+
+        // Le PDF est binaire (dompdf) — vérifier que la mention est bien
+        // rendue : on teste la vue rendue plutôt que le binaire compressé.
+        $html = view('pdf.payslip', [
+            'slip' => $slip,
+            'lines' => $slip->lines->sortBy('order'),
+            'employee' => $employee,
+            'company' => $company,
+            'currency' => 'DZD',
+            'legalMentions' => '',
+            'companyLegal' => [],
+            'annualCumuls' => [],
+            'isRegularization' => true,
+            'originalRunId' => $run->id,
+        ])->render();
+
+        $this->assertStringContainsString('Bulletin de régularisation', $html);
+        $this->assertStringContainsString('corrige le run', $html);
+        $this->assertStringContainsString('#'.$run->id, $html);
+        $this->assertNotEmpty($pdf, 'Le PDF doit être généré');
+    }
+
+    /**
+     * @return array{0: Company, 1: Employee}
+     */
+    private function actors(): array
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create();
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'salary_type' => 'fixed',
+            'salary_base' => 60000,
+            'status' => 'active',
+        ]);
+
+        return [$company, $employee];
+    }
+
+    /**
+     * Comptable créé APRÈS le calcul du run (un manager actif créé avant
+     * recevrait un bulletin) — statut actif requis pour agir via l'API.
+     */
+    private function comptable(Company $company): Employee
+    {
+        /** @var Employee $comptable */
+        $comptable = Employee::factory()->manager()->create([
+            'company_id' => $company->id,
+            'manager_role' => 'comptable',
+            'status' => 'active',
+        ]);
+
+        return $comptable;
+    }
+
+    private function lockedRun(Company $company, Employee $comptable): PayrollRun
+    {
+        $run = PayrollRun::query()->create([
+            'company_id' => $company->id,
+            'country_code' => 'DZ',
+            'period_start' => now()->startOfMonth()->toDateString(),
+            'period_end' => now()->endOfMonth()->toDateString(),
+            'status' => PayrollRun::STATUS_DRAFT,
+        ]);
+
+        SalaryStructure::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Grille par défaut (test)',
+            'base_salary' => 60000,
+            'currency' => 'DZD',
+            'country_code' => 'DZ',
+            'frequency' => 'monthly',
+            'active' => true,
+        ]);
+
+        (new PayrollCalculator)->calculateRun($run);
+
+        /** @var Employee $rh */
+        $rh = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        (new PayrollClosingService)->validateRh($run->refresh(), $rh);
+        (new PayrollClosingService)->lock($run->refresh(), $comptable);
+
+        return $run->refresh();
+    }
+}


### PR DESCRIPTION
## Objectif

Permettre la création d'un bulletin de régularisation lié à un run déjà clôturé (`locked`), traçable et auditable — sans modifier le run original (F-11 #1818).

## Changements

- **`PayrollRegularizationService::createRegularization()`** : seul un run `locked` est régularisable (sinon 422) → crée un run `type=regularization`, `status=draft`, même période, même `country_code`, `original_run_id` renseigné, motif enregistré + audit `payroll_run_regularization_created` (reason, original_run_id, actor_id).
- **Endpoints** : `POST /api/v1/payroll-runs/{run}/regularize` (principal/comptable, 404 cross-tenant) et `GET /api/v1/payroll-runs/{run}/regularizations` (liste des correctifs).
- **Migration additive** (idempotente, pattern 00015) : `payroll_runs.type` (standard/regularization + CHECK), `original_run_id` (indexé), `reason`.
- **PDF** : bannière « BULLETIN DE RÉGULARISATION — corrige le run #N » (blade + i18n fr/en/ar/tr).
- **`PayrollRunResource`** expose `type` / `original_run_id` / `reason`.
- Le run de régularisation suit le workflow standard (draft → calculated → validated → locked → archivage Cabinet #1817).

## Vérifications

- [x] `PayrollRegularizationTest` : 7 tests verts localement
- [x] PHPStan module Payroll : 0 erreur

Closes #1818