### PR TITLE
fix(payroll): fillable Employee — matricules CNSS CI / IPRES SN (suivi review #1830)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ### Added
+### Added
+
+- **fix(payroll): déclarations CNSS CI / IPRES SN — `employees.cnss_ci_matricule`, `ipres_matricule`, `ipres_category` ajoutés au `$fillable` et au PHPDoc de `Employee` (suivi review #1830).** Les colonnes existaient en base (migration `000007`) mais le modèle ne les remplissait pas : la protection de mass-assignment ignorait silencieusement ces attributs, les matricules des CSV CNSS CI et IPRES/CSS SN étaient donc toujours vides en production. `CiSnDeclarationTest` redevient vert (les valeurs de matricules sont enfin persistées).
 
 - **fix(payroll): abattement frais pro CI appliqué sur le BRUT réel — 20 % (CGI CI art. 116-120, alignement #1893).** `CedeaoPayrollRules::calculateIncomeTax()` appliquait l'abattement sur la base après CNSS (≈ 19,4 % du brut au lieu de 20 %) ; il utilise désormais `$grossForAbatement` (brut réel transmis par le moteur). Golden CI (#1826) recalculés à la main depuis les sources légales : SMIG 75 000 → ITSAS 152,00 (au lieu de 161,60) ; 100 000 → 536,00 ; 200 000 → 2 072,00 ; 400 000 → 31 845,33 ; 700 000 → 84 462,00 ; provider tranches 0/2/21/24,5/29 % aligné. `CI_COMPLIANCE.md` §2 inchangé (décrivait déjà la formule légale).
 

--- a/api/app/Core/Auth/Domain/Models/Employee.php
+++ b/api/app/Core/Auth/Domain/Models/Employee.php
@@ -43,6 +43,9 @@ use Laravel\Sanctum\HasApiTokens;
  * @property int|null $salary_structure_id
  * @property string|null $matricule
  * @property string|null $cnps_matricule
+ * @property string|null $cnss_ci_matricule
+ * @property string|null $ipres_matricule
+ * @property string|null $ipres_category
  * @property string|null $zkteco_id
  * @property string $first_name
  * @property string|null $middle_name
@@ -141,6 +144,9 @@ class Employee extends Authenticatable implements HasApiTokensContract
         'salary_structure_id',
         'matricule',
         'cnps_matricule',
+        'cnss_ci_matricule',
+        'ipres_matricule',
+        'ipres_category',
         'zkteco_id',
         'first_name',
         'middle_name',


### PR DESCRIPTION
**Pourquoi :** la migration `000007_add_ci_sn_matricules_to_employees` a créé les colonnes `employees.cnss_ci_matricule`, `ipres_matricule`, `ipres_category`, mais `Employee::$fillable` (et le PHPDoc) ne les déclarent pas → la protection de mass-assignment **ignore silencieusement** ces attributs à la création.

**Impact (review lead #1830) :** `CiSnDeclarationTest` (rouge) — `Employee::factory()->create([...cnss_ci_matricule...])` ne persiste pas la valeur → les CSV CNSS CI et IPRES/CSS SN sortent avec des matricules **vides en production** : la feature #1830 est inerte malgré son merge.

**Fix :** +3 champs dans `$fillable` et +3 `@property` PHPDoc (pattern `cnps_matricule` existant). Aucun changement de schéma (migration déjà appliquée). `CiSnDeclarationTest` redevient vert.