### PR TITLE
docs(release): rapport readiness post-vague multi-pays (2026-08-14, #1902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ### Added
+- **fix(payroll): déclarations CSV CI/SN — protection injection formule + totaux mono-passe (Closes #1922).** `CnssDeclarationGenerator` et `IpresDeclarationGenerator` : (1) toute cellule CSV commençant par `=`, `+`, `-`, `@`, tab ou saut de ligne est neutralisée (préfixe `'`) contre la CSV injection (Excel/DDE) ; (2) refactor en source unique de vérité `contributionFor()` — les lignes ET la ligne TOTAUX sont calculées dans la même passe, ce qui corrige une dérive réelle : `totals()` plafonnait l'AT patronal CI (2,0 % non plafonné, cf. #1898) alors que les lignes utilisaient le brut réel (TOTAUX ≠ somme des lignes au-delà de 1 647 315 XOF). Tests : +2 (totaux alignés au-dessus du plafond, injection neutralisée CI + SN).
 ### Added
 
 - **fix(payroll): déclarations CNSS CI / IPRES SN — `employees.cnss_ci_matricule`, `ipres_matricule`, `ipres_category` ajoutés au `$fillable` et au PHPDoc de `Employee` (suivi review #1830).** Les colonnes existaient en base (migration `000007`) mais le modèle ne les remplissait pas : la protection de mass-assignment ignorait silencieusement ces attributs, les matricules des CSV CNSS CI et IPRES/CSS SN étaient donc toujours vides en production. `CiSnDeclarationTest` redevient vert (les valeurs de matricules sont enfin persistées).

--- a/api/app/Modules/Payroll/Infrastructure/Services/CnssDeclarationGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CnssDeclarationGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Payroll\Infrastructure\Services;
 
 use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
 
 /**
  * CEDEAO (#1830) — déclaration CNSS mensuelle Côte d'Ivoire (CSV).
@@ -42,19 +43,24 @@ class CnssDeclarationGenerator
         ];
         $rows = [$header];
 
-        foreach ($slips as $slip) {
-            $gross = (float) $slip->gross_salary;
-            $cappedBase = min($gross, self::CNSS_CI_CAP);
+        $totals = [
+            'gross' => 0.0,
+            'capped_base' => 0.0,
+            'retraite_emp' => 0.0,
+            'retraite_pat' => 0.0,
+            'famille_pat' => 0.0,
+            'at_pat' => 0.0,
+        ];
 
-            $retraiteEmp = round($cappedBase * self::RATE_RETRAITE_EMP / 100, 2);
-            $retraitePat = round($cappedBase * self::RATE_RETRAITE_PAT / 100, 2);
-            $famillePat = round($cappedBase * self::RATE_FAMILLE_PAT / 100, 2);
-            // BUG #1898 : l'AT patronal (2,0 %) est NON plafonné (comme le moteur
-            // calculateSocialCharges — cap => null) — la déclaration le plafonnait
-            // à tort, faussant le total patronal au-delà de 1 647 315 XOF.
-            $atPat = round($gross * self::RATE_AT_PAT / 100, 2);
-            $totalEmp = round($retraiteEmp, 2);
-            $totalPat = round($retraitePat + $famillePat + $atPat, 2);
+        foreach ($slips as $slip) {
+            $contrib = $this->contributionFor($slip);
+
+            $totals['gross'] += $contrib['gross'];
+            $totals['capped_base'] += $contrib['capped_base'];
+            $totals['retraite_emp'] += $contrib['retraite_emp'];
+            $totals['retraite_pat'] += $contrib['retraite_pat'];
+            $totals['famille_pat'] += $contrib['famille_pat'];
+            $totals['at_pat'] += $contrib['at_pat'];
 
             $employee = $slip->employee;
 
@@ -69,18 +75,16 @@ class CnssDeclarationGenerator
                 (string) ($matricule ?? ''),
                 (string) ($lastName ?? ''),
                 (string) ($firstName ?? ''),
-                number_format($gross, 2, '.', ''),
-                number_format($cappedBase, 2, '.', ''),
-                number_format($retraiteEmp, 2, '.', ''),
-                number_format($retraitePat, 2, '.', ''),
-                number_format($famillePat, 2, '.', ''),
-                number_format($atPat, 2, '.', ''),
-                number_format($totalEmp, 2, '.', ''),
-                number_format($totalPat, 2, '.', ''),
+                number_format($contrib['gross'], 2, '.', ''),
+                number_format($contrib['capped_base'], 2, '.', ''),
+                number_format($contrib['retraite_emp'], 2, '.', ''),
+                number_format($contrib['retraite_pat'], 2, '.', ''),
+                number_format($contrib['famille_pat'], 2, '.', ''),
+                number_format($contrib['at_pat'], 2, '.', ''),
+                number_format($contrib['total_emp'], 2, '.', ''),
+                number_format($contrib['total_pat'], 2, '.', ''),
             ];
         }
-
-        $totals = $this->totals($run);
 
         $rows[] = [
             'TOTAL',
@@ -92,8 +96,8 @@ class CnssDeclarationGenerator
             number_format($totals['retraite_pat'], 2, '.', ''),
             number_format($totals['famille_pat'], 2, '.', ''),
             number_format($totals['at_pat'], 2, '.', ''),
-            number_format($totals['total_emp'], 2, '.', ''),
-            number_format($totals['total_pat'], 2, '.', ''),
+            number_format($totals['retraite_emp'], 2, '.', ''),
+            number_format($totals['retraite_pat'] + $totals['famille_pat'] + $totals['at_pat'], 2, '.', ''),
         ];
 
         return $this->toCsv($rows);
@@ -114,15 +118,14 @@ class CnssDeclarationGenerator
         $atPat = 0.0;
 
         foreach ($slips as $slip) {
-            $slipGross = (float) $slip->gross_salary;
-            $slipCapped = min($slipGross, self::CNSS_CI_CAP);
+            $contrib = $this->contributionFor($slip);
 
-            $gross += $slipGross;
-            $cappedBase += $slipCapped;
-            $retraiteEmp += round($slipCapped * self::RATE_RETRAITE_EMP / 100, 2);
-            $retraitePat += round($slipCapped * self::RATE_RETRAITE_PAT / 100, 2);
-            $famillePat += round($slipCapped * self::RATE_FAMILLE_PAT / 100, 2);
-            $atPat += round($slipCapped * self::RATE_AT_PAT / 100, 2);
+            $gross += $contrib['gross'];
+            $cappedBase += $contrib['capped_base'];
+            $retraiteEmp += $contrib['retraite_emp'];
+            $retraitePat += $contrib['retraite_pat'];
+            $famillePat += $contrib['famille_pat'];
+            $atPat += $contrib['at_pat'];
         }
 
         return [
@@ -139,6 +142,39 @@ class CnssDeclarationGenerator
     }
 
     /**
+     * Calcul des cotisations CNSS CI pour un bulletin — source unique de
+     * vérité des lignes ET des totaux (aucune dérive possible).
+     *
+     * @return array{gross: float, capped_base: float, retraite_emp: float, retraite_pat: float, famille_pat: float, at_pat: float, total_emp: float, total_pat: float}
+     */
+    private function contributionFor(PaySlip $slip): array
+    {
+        $gross = (float) $slip->gross_salary;
+        $cappedBase = min($gross, self::CNSS_CI_CAP);
+
+        $retraiteEmp = round($cappedBase * self::RATE_RETRAITE_EMP / 100, 2);
+        $retraitePat = round($cappedBase * self::RATE_RETRAITE_PAT / 100, 2);
+        $famillePat = round($cappedBase * self::RATE_FAMILLE_PAT / 100, 2);
+        // BUG #1898 : l'AT patronal (2,0 %) est NON plafonné (comme le moteur
+        // calculateSocialCharges — cap => null) — la déclaration le plafonnait
+        // à tort, faussant le total patronal au-delà de 1 647 315 XOF.
+        $atPat = round($gross * self::RATE_AT_PAT / 100, 2);
+        $totalEmp = round($retraiteEmp, 2);
+        $totalPat = round($retraitePat + $famillePat + $atPat, 2);
+
+        return [
+            'gross' => $gross,
+            'capped_base' => $cappedBase,
+            'retraite_emp' => $retraiteEmp,
+            'retraite_pat' => $retraitePat,
+            'famille_pat' => $famillePat,
+            'at_pat' => $atPat,
+            'total_emp' => $totalEmp,
+            'total_pat' => $totalPat,
+        ];
+    }
+
+    /**
      * @param  array<int, array<int, string>>  $rows
      */
     private function toCsv(array $rows): string
@@ -146,6 +182,13 @@ class CnssDeclarationGenerator
         $lines = array_map(static function (array $row): string {
             return implode(',', array_map(static function ($cell): string {
                 $cell = (string) $cell;
+
+                // CSV injection (#1922) : un champ commençant par =, +, -, @,
+                // tab ou saut de ligne est neutralisé (préfixe ') pour qu'Excel
+                // / LibreOffice ne l'interprète pas comme une formule/DDE.
+                if ($cell !== '' && str_contains("=+-@\t\r\n", $cell[0])) {
+                    $cell = "'".$cell;
+                }
 
                 return '"'.str_replace('"', '""', $cell).'"';
             }, $row));

--- a/api/app/Modules/Payroll/Infrastructure/Services/IpresDeclarationGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/IpresDeclarationGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Payroll\Infrastructure\Services;
 
 use App\Modules\Payroll\Domain\Models\PayrollRun;
+use App\Modules\Payroll\Domain\Models\PaySlip;
 
 /**
  * CEDEAO (#1830) — déclaration IPRES/CSS mensuelle Sénégal (CSV).
@@ -49,8 +50,29 @@ class IpresDeclarationGenerator
         ];
         $rows = [$header];
 
+        $totals = [
+            'gross' => 0.0,
+            't1_base' => 0.0,
+            't1_emp' => 0.0,
+            't1_pat' => 0.0,
+            't2_base' => 0.0,
+            't2_emp' => 0.0,
+            't2_pat' => 0.0,
+            'css_famille_pat' => 0.0,
+        ];
+
         foreach ($slips as $slip) {
-            $gross = (float) $slip->gross_salary;
+            $contrib = $this->contributionFor($slip);
+
+            $totals['gross'] += $contrib['gross'];
+            $totals['t1_base'] += $contrib['t1_base'];
+            $totals['t1_emp'] += $contrib['t1_emp'];
+            $totals['t1_pat'] += $contrib['t1_pat'];
+            $totals['t2_base'] += $contrib['t2_base'];
+            $totals['t2_emp'] += $contrib['t2_emp'];
+            $totals['t2_pat'] += $contrib['t2_pat'];
+            $totals['css_famille_pat'] += $contrib['css_famille_pat'];
+
             $employee = $slip->employee;
 
             /** @var string|null $matricule */
@@ -61,34 +83,22 @@ class IpresDeclarationGenerator
             $firstName = $employee->first_name ?? null;
             $isCadre = ($employee->ipres_category ?? 'general') === 'cadre';
 
-            $t1Base = min($gross, self::IPRES_T1_CAP);
-            $t2Base = $isCadre ? max(0.0, min($gross, self::IPRES_T2_CAP) - self::IPRES_T1_CAP) : 0.0;
-
-            $t1Emp = round($t1Base * self::RATE_T1_EMP / 100, 2);
-            $t1Pat = round($t1Base * self::RATE_T1_PAT / 100, 2);
-            $t2Emp = round($t2Base * self::RATE_T2_EMP / 100, 2);
-            $t2Pat = round($t2Base * self::RATE_T2_PAT / 100, 2);
-            $cssFamillePat = round(min($gross, self::IPRES_T1_CAP) * self::RATE_CSS_FAMILLE_PAT / 100, 2);
-            $totalPat = round($t1Pat + $t2Pat + $cssFamillePat, 2);
-
             $rows[] = [
                 (string) ($matricule ?? ''),
                 (string) ($lastName ?? ''),
                 (string) ($firstName ?? ''),
                 $isCadre ? 'cadre' : 'general',
-                number_format($gross, 2, '.', ''),
-                number_format($t1Base, 2, '.', ''),
-                number_format($t1Emp, 2, '.', ''),
-                number_format($t1Pat, 2, '.', ''),
-                number_format($t2Base, 2, '.', ''),
-                number_format($t2Emp, 2, '.', ''),
-                number_format($t2Pat, 2, '.', ''),
-                number_format($cssFamillePat, 2, '.', ''),
-                number_format($totalPat, 2, '.', ''),
+                number_format($contrib['gross'], 2, '.', ''),
+                number_format($contrib['t1_base'], 2, '.', ''),
+                number_format($contrib['t1_emp'], 2, '.', ''),
+                number_format($contrib['t1_pat'], 2, '.', ''),
+                number_format($contrib['t2_base'], 2, '.', ''),
+                number_format($contrib['t2_emp'], 2, '.', ''),
+                number_format($contrib['t2_pat'], 2, '.', ''),
+                number_format($contrib['css_famille_pat'], 2, '.', ''),
+                number_format($contrib['total_patronal'], 2, '.', ''),
             ];
         }
-
-        $totals = $this->totals($run);
 
         $rows[] = [
             'TOTAL',
@@ -103,7 +113,7 @@ class IpresDeclarationGenerator
             number_format($totals['t2_emp'], 2, '.', ''),
             number_format($totals['t2_pat'], 2, '.', ''),
             number_format($totals['css_famille_pat'], 2, '.', ''),
-            number_format($totals['total_patronal'], 2, '.', ''),
+            number_format($totals['t1_pat'] + $totals['t2_pat'] + $totals['css_famille_pat'], 2, '.', ''),
         ];
 
         return $this->toCsv($rows);
@@ -126,20 +136,16 @@ class IpresDeclarationGenerator
         $cssFamillePat = 0.0;
 
         foreach ($slips as $slip) {
-            $slipGross = (float) $slip->gross_salary;
-            $isCadre = ($slip->employee->ipres_category ?? 'general') === 'cadre';
+            $contrib = $this->contributionFor($slip);
 
-            $slipT1 = min($slipGross, self::IPRES_T1_CAP);
-            $slipT2 = $isCadre ? max(0.0, min($slipGross, self::IPRES_T2_CAP) - self::IPRES_T1_CAP) : 0.0;
-
-            $gross += $slipGross;
-            $t1Base += $slipT1;
-            $t1Emp += round($slipT1 * self::RATE_T1_EMP / 100, 2);
-            $t1Pat += round($slipT1 * self::RATE_T1_PAT / 100, 2);
-            $t2Base += $slipT2;
-            $t2Emp += round($slipT2 * self::RATE_T2_EMP / 100, 2);
-            $t2Pat += round($slipT2 * self::RATE_T2_PAT / 100, 2);
-            $cssFamillePat += round($slipT1 * self::RATE_CSS_FAMILLE_PAT / 100, 2);
+            $gross += $contrib['gross'];
+            $t1Base += $contrib['t1_base'];
+            $t1Emp += $contrib['t1_emp'];
+            $t1Pat += $contrib['t1_pat'];
+            $t2Base += $contrib['t2_base'];
+            $t2Emp += $contrib['t2_emp'];
+            $t2Pat += $contrib['t2_pat'];
+            $cssFamillePat += $contrib['css_famille_pat'];
         }
 
         return [
@@ -157,6 +163,41 @@ class IpresDeclarationGenerator
     }
 
     /**
+     * Calcul des cotisations IPRES/CSS pour un bulletin — source unique de
+     * vérité des lignes ET des totaux (aucune dérive possible).
+     *
+     * @return array{gross: float, t1_base: float, t1_emp: float, t1_pat: float, t2_base: float, t2_emp: float, t2_pat: float, css_famille_pat: float, total_patronal: float}
+     */
+    private function contributionFor(PaySlip $slip): array
+    {
+        $gross = (float) $slip->gross_salary;
+        $employee = $slip->employee;
+        $isCadre = ($employee->ipres_category ?? 'general') === 'cadre';
+
+        $t1Base = min($gross, self::IPRES_T1_CAP);
+        $t2Base = $isCadre ? max(0.0, min($gross, self::IPRES_T2_CAP) - self::IPRES_T1_CAP) : 0.0;
+
+        $t1Emp = round($t1Base * self::RATE_T1_EMP / 100, 2);
+        $t1Pat = round($t1Base * self::RATE_T1_PAT / 100, 2);
+        $t2Emp = round($t2Base * self::RATE_T2_EMP / 100, 2);
+        $t2Pat = round($t2Base * self::RATE_T2_PAT / 100, 2);
+        $cssFamillePat = round($t1Base * self::RATE_CSS_FAMILLE_PAT / 100, 2);
+        $totalPatronal = round($t1Pat + $t2Pat + $cssFamillePat, 2);
+
+        return [
+            'gross' => $gross,
+            't1_base' => $t1Base,
+            't1_emp' => $t1Emp,
+            't1_pat' => $t1Pat,
+            't2_base' => $t2Base,
+            't2_emp' => $t2Emp,
+            't2_pat' => $t2Pat,
+            'css_famille_pat' => $cssFamillePat,
+            'total_patronal' => $totalPatronal,
+        ];
+    }
+
+    /**
      * @param  array<int, array<int, string>>  $rows
      */
     private function toCsv(array $rows): string
@@ -164,6 +205,13 @@ class IpresDeclarationGenerator
         $lines = array_map(static function (array $row): string {
             return implode(',', array_map(static function ($cell): string {
                 $cell = (string) $cell;
+
+                // CSV injection (#1922) : un champ commençant par =, +, -, @,
+                // tab ou saut de ligne est neutralisé (préfixe ') pour qu'Excel
+                // / LibreOffice ne l'interprète pas comme une formule/DDE.
+                if ($cell !== '' && str_contains("=+-@\t\r\n", $cell[0])) {
+                    $cell = "'".$cell;
+                }
 
                 return '"'.str_replace('"', '""', $cell).'"';
             }, $row));

--- a/api/tests/Feature/Payroll/CiSnDeclarationTest.php
+++ b/api/tests/Feature/Payroll/CiSnDeclarationTest.php
@@ -161,6 +161,89 @@ class CiSnDeclarationTest extends TestCase
         $this->assertSame('208849.79', $row[10]);
     }
 
+    public function test_ci_totals_row_matches_line_sums_above_cap(): void
+    {
+        // Régression #1922 : le total AT était calculé sur l'assiette PLAFONNÉE
+        // dans totals() alors que les lignes utilisaient le brut réel (2,0 %
+        // non plafonné, cf. #1898) → la ligne TOTAUX ne valait pas la somme
+        // des lignes dès que le brut dépassait 1 647 315 XOF.
+        $run = $this->makeRun('CI');
+
+        /** @var Employee $above */
+        $above = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'first_name' => 'Aya',
+            'last_name' => 'Kouassi',
+            'cnss_ci_matricule' => 'CNSS-CI-001',
+        ]);
+        $this->addValidatedSlip($run, $above, 2000000.0);
+
+        /** @var Employee $below */
+        $below = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'first_name' => 'Ibrahima',
+            'last_name' => 'Sanogo',
+            'cnss_ci_matricule' => 'CNSS-CI-002',
+        ]);
+        $this->addValidatedSlip($run, $below, 400000.0);
+
+        $csv = (new CnssDeclarationGenerator)->generate($run);
+        $lines = array_values(array_filter(explode("\n", $csv), fn ($l) => trim($l) !== ''));
+
+        // Lignes : AT = 2 000 000 × 2 % = 40 000,00 · 400 000 × 2 % = 8 000,00
+        $this->assertSame('40000.00', str_getcsv($lines[1])[8]);
+        $this->assertSame('8000.00', str_getcsv($lines[2])[8]);
+
+        // TOTAUX : AT = 48 000,00 (somme des lignes, PAS min(brut, cap) × 2 %).
+        $totalsRow = str_getcsv($lines[3]);
+        $this->assertSame('TOTAL', $totalsRow[0]);
+        $this->assertSame('48000.00', $totalsRow[8]);
+        $this->assertSame('257849.79', $totalsRow[10]); // 208 849,79 + 49 000,00
+
+        // totals() doit être aligné sur les lignes.
+        $totals = (new CnssDeclarationGenerator)->totals($run);
+        $this->assertSame(48000.0, $totals['at_pat']);
+        $this->assertSame(257849.79, $totals['total_pat']);
+        $this->assertSame(2, $totals['slip_count']);
+    }
+
+    public function test_csv_prevents_formula_injection_ci_and_sn(): void
+    {
+        // Régression #1922 : un nom/matricule commençant par =, +, -, @, tab
+        // ou saut de ligne ne doit JAMAIS être interprété comme formule par
+        // Excel/LibreOffice — préfixe ' neutralisant appliqué.
+        $runCi = $this->makeRun('CI');
+        /** @var Employee $emp */
+        $emp = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'first_name' => '=1+1',
+            'last_name' => '@SUM(A1:A9)',
+            'cnss_ci_matricule' => '+CMD',
+        ]);
+        $this->addValidatedSlip($runCi, $emp, 400000.0);
+
+        $csvCi = (new CnssDeclarationGenerator)->generate($runCi);
+        $linesCi = array_values(array_filter(explode("\n", $csvCi), fn ($l) => trim($l) !== ''));
+        $rowCi = str_getcsv($linesCi[1]);
+        $this->assertSame("'=1+1", $rowCi[2]);
+        $this->assertSame("'@SUM(A1:A9)", $rowCi[1]);
+        $this->assertSame("'+CMD", $rowCi[0]);
+
+        $runSn = $this->makeRun('SN');
+        $emp->update([
+            'ipres_matricule' => '-2+3',
+            'ipres_category' => 'cadre',
+            'last_name' => 'Dia',
+            'first_name' => 'Moussa',
+        ]);
+        $this->addValidatedSlip($runSn, $emp, 500000.0);
+
+        $csvSn = (new IpresDeclarationGenerator)->generate($runSn);
+        $linesSn = array_values(array_filter(explode("\n", $csvSn), fn ($l) => trim($l) !== ''));
+        $rowSn = str_getcsv($linesSn[1]);
+        $this->assertSame("'-2+3", $rowSn[0]);
+    }
+
     // ── IPRES/CSS Sénégal ───────────────────────────────────────────────
 
     public function test_sn_csv_general_employee(): void

--- a/docs/validation/RELEASE_READINESS_REPORT_2026_08_14.md
+++ b/docs/validation/RELEASE_READINESS_REPORT_2026_08_14.md
@@ -1,0 +1,64 @@
+# Release readiness report — 2026-08-14
+
+> Rapport post-vague multi-pays (release manager, revue de la cascade #1811→#1901).
+> Complète le rapport du 2026-06-01 (93/100, Go technique contrôlé) et alimente l'issue #1902.
+
+## Décision
+
+**Go conditionnel pour une release technique (tag) — No-Go pour une déclaration commerciale
+« production multi-pays » tant que les P1 de validation expert-comptable et les bugs P1
+listés ci-dessous ne sont pas fermés.**
+
+La vague multi-pays (30+ PRs mergées sur `main` le 2026-08-14 : fériés #1811, calendrier
+islamique #1812, taux #1813, barèmes #1814, cotisations #1815, F-20 #1816, archive bulletin
+#1817, régularisations #1818, chômage DZ #1819, golden CM/CI/SN #1822/#1826/#1828,
+déclarations CNPS/CNSS/IPRES #1823/#1830, pilots GA/CG/BF/ML/CI/SN #1824/#1829/#1825/#1827,
+résolveur #1868, contrat de calcul #1869, isolation #1870, pays obligatoire #1867 et fixes
+CI #1839/#1840/#1906/#1909/#1893/#1900/#1901/#1944) est **architecturalement cohérente** :
+pattern `CountryRulesResolver` unique, règles pays par `AbstractCountryRules`, isolation
+tenant testée, goldens recalculés à la main. Mais la conformité légale multi-pays reste
+**à valider par un expert-comptable** (statut `pilot` assumé dans le code).
+
+## Validation exécutée (2026-08-14)
+
+| Élément | Résultat |
+|---|---|
+| Cascade de merge : 17 PRs initiales → 0 restante (14:00) | ✅ Toutes mergées, branches supprimées, issues `Closes #…` fermées |
+| Revue de code indépendante des PR #1891/#1888/#1890/#1892 (2 reviewers) | ✅ Math goldens re-vérifiés à la main ; faiblesses corrigées (#1906, #1909, #1922/PR #1945) |
+| Cohérence des taux CNSS CI / IPRES SN (moteur vs déclarations) | ✅ Vérifié sur `main` : 3,2/4,5/5,75/2,0 % cap 1 647 315 (CI), T2 cadres 2,4/3,6 % (SN) alignés |
+| Test d'isolation #1870 (`CountryIsolationMatrixTest`) | ✅ Corrigé (#1906 : assertSame instance partagée + contrat ancré) |
+| `Employee` `$fillable` (matricules CNSS/IPRES) | ✅ Corrigé (#1909) |
+| CSV injection + dérive des totaux déclarations CI/SN | 🔧 Fix #1922 en revue (PR #1945) |
+| `release-readiness.ps1 -Strict` (23/23) | ⏳ Non exécutable dans cet environnement (pas de PowerShell) — à rejouer en CI/ops |
+| CI `main` (Tests, Payroll CI, coverage, PHPStan, actionlint) | ⏳ File GitHub Actions saturée (#1903) — runs en cours au 14:00 ; à confirmer vert |
+
+## Verrous P1 ouverts (bloquent la release « sans réserve »)
+
+| Issue | Sujet | Statut |
+|---|---|---|
+| #1911 | SN abattement 30 % appliqué sur le mauvais brut | Fix en cours (branche `fix/sn-abatement-legal`) |
+| #1912 | SN validation expert-comptable avant passage `production` | Ouverte |
+| #1913 | CI/SN — bases CNSS-AT (CI) et CSS famille (SN) plafonnées ou non | Ouverte |
+| #1915 | BF — barème IUTS incomplet (tranche 27,5 % > 6 M FCFA) | Ouverte |
+| #1919 | Paie — jours de congés double-déduits (présence réelle F-20) | Ouverte |
+| #1929 | Admin « Taux légaux » — endpoints tenant appelés hors contexte | Ouverte |
+| #1930/#1931 | Calendrier islamique — dates non confirmées / données en dur 2024-2027 | Ouvertes |
+| #1933 | Migrations public/tenant hors pattern F-17 | Ouverte |
+| #1942 | Régularisations #1818 — run recalcule les bulletins d'une autre période | Ouverte |
+| #1943 | DZ — préavis : jours calendaires vs jours ouvrés (surpaie ~36 %) | Ouverte |
+| #1902 | Préparer la release post-vague (rapport, tag, CHANGELOG versionné) | Ouverte — ce rapport la nourrit |
+
+## Recommandations
+
+1. **Immédiat** : confirmer CI `main` verte après épuisement de la file (#1903) ; merger #1945 (CSV) quand vert.
+2. **Avant tag** : fermer les P1 ci-dessus (les issues existent toutes avec critères d'acceptation, statut `Agent-Ready`).
+3. **Avant promesse commerciale multi-pays** : validation expert-comptable CI/SN/CM/BF/ML/GA/CG (issues #1912/#1913/#1904/#1875), recette mobile device, kiosk matériel.
+4. **Tag de release** : `v0.1.0`-équivalent selon PILOTAGE (CODE_VERSION), section CHANGELOG dédiée, via `release.yml` (#1902).
+
+## Conclusion
+
+La vague multi-pays est **techniquement solide et mergeable** — c'est un excellent état pour
+une release interne/technique. La publication commerciale « production multi-pays » reste
+conditionnelle à la fermeture des P1 conformité/validation listés ci-dessus, tous déjà
+tracés en issues. Ce rapport devra être mis à jour quand `release-readiness.ps1 -Strict`
+sera rejoué et que la CI de `main` aura confirmé le vert.


### PR DESCRIPTION
Rapport `docs/validation/RELEASE_READINESS_REPORT_2026_08_14.md` après la vague multi-pays (30+ PRs mergées le 2026-08-14).

Contenu :
- Décision : **Go conditionnel** (release technique) / No-Go commercial tant que les P1 conformité/validation sont ouverts
- Validation exécutée (cascade de merge, revues indépendantes #1891/#1888/#1890/#1892, cohérence des taux CI/SN vérifiée sur main, fixes #1906/#1909, fix CSV #1922 en revue)
- 11 verrous P1 listés avec statut (tous tracés en issues Agent-Ready)
- Recommandations avant tag et avant promesse commerciale

Nourrit l'issue #1902 (release post-vague).