### PR TITLE
fix(test): PublicHolidayServiceTest — accolade de classe mal placée (CI Golden rouge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ### Added
+- **fix(test): PublicHolidayServiceTest — accolade de classe mal placée (CI Golden rouge).** Le merge #1910 (fix jours fériés #1895/#1897/#1898) a ajouté la méthode test_forget_all_scopes_invalidates_tenant_keys APRÈS l'accolade fermante de la classe, ce qui produisait une erreur de syntaxe PHP (unexpected token public) cassant la passe `php artisan test --filter=Golden` sur main et sur toutes les PR ouvertes. L'accolade fermante est remise en fin de classe (1 ligne déplacée, aucun changement de logique).
 ### Added
 
 - **test(seed): régression #1895 — fériés + calendrier islamique seedés par DatabaseSeeder.** Couverture des seeders `PublicHolidaySeeder` (fériés fixes DZ/CM/CI/SN 2024-2027) et `IslamicCalendarSeeder` (dates islamiques approximatives) : peuplement, **idempotence** des deux, et reproduction de la commande de production `php artisan db:seed --class=DatabaseSeeder --force` (le câblage dans l'orchestrateur est livré par #1910 — ce test le verrouille contre toute régression).

--- a/api/tests/Feature/Payroll/PublicHolidayServiceTest.php
+++ b/api/tests/Feature/Payroll/PublicHolidayServiceTest.php
@@ -192,7 +192,6 @@ class PublicHolidayServiceTest extends TestCase
         );
         $this->assertSame(3.0, $days); // lun 25, mar 26, jeu 28 chômé… → mer 27 & jeu 28 chômés → 25,26,29
     }
-}
 
     public function test_forget_all_scopes_invalidates_tenant_keys(): void
     {
@@ -219,3 +218,4 @@ class PublicHolidayServiceTest extends TestCase
         // Les tenants d'autres pays gardent leur cache (pas d'invalidation croisée).
         $this->assertNotNull(Cache::store()->get('public-holidays:DZ:2026:some-other-tenant'));
     }
+}


### PR DESCRIPTION
## Contexte
Le merge #1910 (fix jours fériés #1895/#1897/#1898) a ajouté `test_forget_all_scopes_invalidates_tenant_keys` APRÈS l'accolade fermante de la classe `PublicHolidayServiceTest` → `PHP Parse error: syntax error, unexpected token "public"` (ligne 197).

Conséquence : `php artisan test --filter=Golden` échoue sur `main` ET sur TOUTES les PR ouvertes (le check « Golden tests paie DZ » est rouge partout).

## Changement
- Accolade fermante de la classe remise en fin de fichier (1 ligne déplacée). Aucun changement de logique ; vérifié par `php -l`.

## Critères d'acceptation
- [x] `php -l` OK
- [x] `php artisan test --filter=Golden` repart vert (à confirmer en CI)
- [x] Débloque la CI de main et des PR ouvertes (#1945, #1946, #1947, #1948)