### PR TITLE
fix(payroll): restaure CNSS/INPS BF+ML perdus au merge #1866 + tests CI alignés (golden/isolation/resolver)

### DIFF
--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CedeaoPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CedeaoPayrollRules.php
@@ -88,6 +88,34 @@ class CedeaoPayrollRules extends AbstractCountryRules
 
     public function socialContributions(): array
     {
+        if ($this->memberCountryCode === 'BF') {
+            // CNSS Burkina Faso (issue #1829) : retraite salarié 5,5 % +
+            // retraite patronal 6,5 % + famille patronal 7,0 % plafonnés à
+            // 900 000 XOF/mois, AT patronal 3,5 % non plafonné (taux pilote).
+            // Restauré depuis 88433982 (valeurs perdues au merge conflictuel
+            // de #1866 — mêmes symptômes que les golden DZ de c68dfe04).
+            return [
+                ['name' => 'CNSS Retraite Salariale', 'code' => 'CNSS_BF_RET_EMP', 'type' => 'employee', 'rate' => 5.5, 'cap' => 900000.0],
+                ['name' => 'CNSS Retraite Patronale', 'code' => 'CNSS_BF_RET_PAT', 'type' => 'employer', 'rate' => 6.5, 'cap' => 900000.0],
+                ['name' => 'CNSS Prestations Familiales Patronale', 'code' => 'CNSS_BF_FAM_PAT', 'type' => 'employer', 'rate' => 7.0, 'cap' => 900000.0],
+                ['name' => 'CNSS Risques Professionnels Patronale', 'code' => 'CNSS_BF_AT_PAT', 'type' => 'employer', 'rate' => 3.5, 'cap' => null],
+            ];
+        }
+
+        if ($this->memberCountryCode === 'ML') {
+            // INPS Mali (issue #1829) : retraite salarié 3,6 % + retraite
+            // patronal 7,4 % plafonnés à 3 000 000 XOF/mois, famille patronal
+            // 4,0 % et AT patronal 2,0 % non plafonnés (taux pilote).
+            // Restauré depuis 88433982 (valeurs perdues au merge conflictuel
+            // de #1866 — mêmes symptômes que les golden DZ de c68dfe04).
+            return [
+                ['name' => 'INPS Retraite Salariale', 'code' => 'INPS_ML_RET_EMP', 'type' => 'employee', 'rate' => 3.6, 'cap' => 3000000.0],
+                ['name' => 'INPS Retraite Patronale', 'code' => 'INPS_ML_RET_PAT', 'type' => 'employer', 'rate' => 7.4, 'cap' => 3000000.0],
+                ['name' => 'INPS Prestations Familiales Patronale', 'code' => 'INPS_ML_FAM_PAT', 'type' => 'employer', 'rate' => 4.0, 'cap' => null],
+                ['name' => 'INPS Risques Professionnels Patronale', 'code' => 'INPS_ML_AT_PAT', 'type' => 'employer', 'rate' => 2.0, 'cap' => null],
+            ];
+        }
+
         // CI (#1825) : taux CNSS légaux (CGI CI / Code de la sécurité
         // sociale ivoirien) — retraite 3,2 % salarié + 4,5 % patronal,
         // famille 5,75 % patronal (plafond 1 647 315 XOF/mois), AT 2,0 %
@@ -109,6 +137,34 @@ class CedeaoPayrollRules extends AbstractCountryRules
 
     protected function defaultTaxSlabs(): array
     {
+        if ($this->memberCountryCode === 'BF') {
+            // IUTS Burkina Faso (CGI 2024) — tranches ANNUELLES, taux « tout
+            // compris » (contribution communale incluse) — issue #1829,
+            // docs/payroll/BF_COMPLIANCE.md §1. Restauré depuis 88433982
+            // (valeurs perdues au merge conflictuel de #1866).
+            return [
+                ['min' => 0, 'max' => 600000, 'rate' => 0, 'fixed_deduction' => 0],
+                ['min' => 600001, 'max' => 1500000, 'rate' => 12.1, 'fixed_deduction' => 0],
+                ['min' => 1500001, 'max' => 3000000, 'rate' => 13.9, 'fixed_deduction' => 0],
+                ['min' => 3000001, 'max' => 4500000, 'rate' => 18.7, 'fixed_deduction' => 0],
+                ['min' => 4500001, 'max' => null, 'rate' => 23.6, 'fixed_deduction' => 0],
+            ];
+        }
+
+        if ($this->memberCountryCode === 'ML') {
+            // ITS Mali (CGI 2024) — tranches ANNUELLES — issue #1829,
+            // docs/payroll/ML_COMPLIANCE.md §1. Restauré depuis 88433982
+            // (valeurs perdues au merge conflictuel de #1866).
+            return [
+                ['min' => 0, 'max' => 540000, 'rate' => 0, 'fixed_deduction' => 0],
+                ['min' => 540001, 'max' => 1320000, 'rate' => 5, 'fixed_deduction' => 0],
+                ['min' => 1320001, 'max' => 2040000, 'rate' => 10, 'fixed_deduction' => 0],
+                ['min' => 2040001, 'max' => 3480000, 'rate' => 15, 'fixed_deduction' => 0],
+                ['min' => 3480001, 'max' => 6360000, 'rate' => 20, 'fixed_deduction' => 0],
+                ['min' => 6360001, 'max' => null, 'rate' => 30, 'fixed_deduction' => 0],
+            ];
+        }
+
         // CI (#1825) : ITSAS Côte d'Ivoire (CGI CI art. 116-120) — tranches
         // ANNUELLES : 0–600 000 XOF : 0 % · 600 001–2 000 000 : 2 % ·
         // 2 000 001–5 000 000 : 21 % · 5 000 001–10 000 000 : 24,5 % ·
@@ -215,6 +271,39 @@ class CedeaoPayrollRules extends AbstractCountryRules
 
     public function calculateSocialCharges(float $grossSalary): array
     {
+        if ($this->memberCountryCode === 'BF') {
+            // CNSS Burkina Faso (issue #1829) : retraite salariale 5,5 % +
+            // patronale 6,5 % + famille 7,0 % plafonnées à 900 000 XOF/mois,
+            // AT 3,5 % non plafonné (docs/payroll/BF_COMPLIANCE.md §3).
+            // Restauré depuis 88433982 (valeurs perdues au merge conflictuel
+            // de #1866 — mêmes symptômes que les golden DZ de c68dfe04).
+            return [
+                'employee' => $this->computeContribution($grossSalary, 'CNSS_BF_RET_EMP', 5.5, 900000.0),
+                'employer' => round(
+                    $this->computeContribution($grossSalary, 'CNSS_BF_RET_PAT', 6.5, 900000.0)
+                    + $this->computeContribution($grossSalary, 'CNSS_BF_FAM_PAT', 7.0, 900000.0)
+                    + $this->computeContribution($grossSalary, 'CNSS_BF_AT_PAT', 3.5, null),
+                    2
+                ),
+            ];
+        }
+
+        if ($this->memberCountryCode === 'ML') {
+            // INPS Mali (issue #1829) : retraite salariale 3,6 % + patronale
+            // 7,4 % plafonnées à 3 000 000 XOF/mois, famille 4,0 % + AT 2,0 %
+            // non plafonnés (docs/payroll/ML_COMPLIANCE.md §3). Restauré
+            // depuis 88433982 (valeurs perdues au merge conflictuel de #1866).
+            return [
+                'employee' => $this->computeContribution($grossSalary, 'INPS_ML_RET_EMP', 3.6, 3000000.0),
+                'employer' => round(
+                    $this->computeContribution($grossSalary, 'INPS_ML_RET_PAT', 7.4, 3000000.0)
+                    + $this->computeContribution($grossSalary, 'INPS_ML_FAM_PAT', 4.0, null)
+                    + $this->computeContribution($grossSalary, 'INPS_ML_AT_PAT', 2.0, null),
+                    2
+                ),
+            ];
+        }
+
         // CI (#1825) : CNSS avec plafond statutaire 1 647 315 XOF/mois sur la
         // retraite et la famille ; l'AT (2 %) n'est pas plafonné. Les autres
         // cinq membres CEDEAO restent sur le placeholder (non plafonné)
@@ -313,10 +402,11 @@ class CedeaoPayrollRules extends AbstractCountryRules
 
     public function confidenceLevel(): string
     {
-        // CI passe en 'pilot' (#1825) : barèmes ITSAS CGI 2024 + CNSS + CN +
-        // préavis Code du travail implémentés, à valider par un
-        // expert-comptable ivoirien avant passage en 'production'.
-        return $this->memberCountryCode === 'CI' ? 'pilot' : 'placeholder';
+        // CI (#1825) : barèmes ITSAS CGI 2024 + CNSS + CN + préavis Code du
+        // travail implémentés. BF/ML (#1829) : IUTS/ITS + CNSS/INPS depuis
+        // les sources légales publiques (CGI 2024) — à valider par un
+        // expert-comptable local avant passage en 'production'.
+        return in_array($this->memberCountryCode, ['CI', 'BF', 'ML'], true) ? 'pilot' : 'placeholder';
     }
 
     /**

--- a/api/tests/Feature/Payroll/CountryIsolationMatrixTest.php
+++ b/api/tests/Feature/Payroll/CountryIsolationMatrixTest.php
@@ -131,6 +131,11 @@ class CountryIsolationMatrixTest extends TestCase
             'max_amount' => 100000,
             'rate' => 5,
             'fixed_deduction' => 0,
+            // Issue #1813 : seules les lignes ACTIVES participent aux
+            // calculs (le défaut en base est désormais 'draft' depuis la
+            // migration du workflow de validation) — sans ce statut le
+            // barème est ignoré et le test échouait (rate 0.0 au lieu de 5.0).
+            'status' => TaxSlab::STATUS_ACTIVE,
             'effective_from' => '2026-01-01',
         ]);
 

--- a/api/tests/Feature/Payroll/CountryRulesResolverTest.php
+++ b/api/tests/Feature/Payroll/CountryRulesResolverTest.php
@@ -122,7 +122,7 @@ class CountryRulesResolverTest extends TestCase
                 return [];
             }
 
-            public function calculateIncomeTax(float $grossTaxable, float $annualBasis = 12): float
+            public function calculateIncomeTax(float $grossTaxable, float $annualBasis = 12, ?float $grossForAbatement = null): float
             {
                 return 0.0;
             }
@@ -287,7 +287,7 @@ class CountryRulesResolverTest extends TestCase
                 return [];
             }
 
-            public function calculateIncomeTax(float $grossTaxable, float $annualBasis = 12): float
+            public function calculateIncomeTax(float $grossTaxable, float $annualBasis = 12, ?float $grossForAbatement = null): float
             {
                 return 0.0;
             }


### PR DESCRIPTION
## Contexte

Payroll CI — Golden & Conformité est **rouge sur main** (run #31799649315, commit 4b22530) : 3 jobs en échec. Investigation des logs (jobs 94764368836 / 94764368775 / 94764368811).

## Correctifs

### 1. CedeaoPayrollRules — branches BF et ML restaurées depuis 88433982

Valeurs **perdues au merge conflictuel de #1866** (mêmes symptômes que les golden DZ resynchronisés dans c68dfe04) :
- **BF** : CNSS salariale 5,5 % / patronale 6,5 % + famille 7,0 % (plafond 900 000 XOF) + AT 3,5 % non plafonné ; IUTS 0/12,1/13,9/18,7/23,6 %.
- **ML** : INPS salariale 3,6 % / patronale 7,4 % (plafond 3 000 000 XOF) + famille 4,0 % + AT 2,0 % non plafonnés ; ITS 0/5/10/15/20/30 %.
- `confidenceLevel()` BF/ML repasse en `pilot` comme à l'origine.

→ `GoldenBfPayrollTest` / `GoldenMlPayrollTest` re-verts (échec observé : `Failed asserting that 1247.9 is identical to 1906.52`).

### 2. CountryIsolationMatrixTest — barème tenant A créé avec `status=active`

Depuis la migration du workflow de validation (#1813), le défaut en base est `draft` et **seules les lignes ACTIVES participent aux calculs** : le test créait un barème `draft` ignoré → `rate 0.0` au lieu de `5.0`.

### 3. CountryRulesResolverTest — signatures `calculateIncomeTax` alignées sur l'interface

Les deux classes anonymes n'avaient pas le paramètre `?float $grossForAbatement = null` ajouté à l'interface → **PHP Fatal error** tuant le run coverage (exit 255, clover jamais généré).

## Vérifications

- `php -l` OK sur les 3 fichiers modifiés.
- Valeurs golden BF/ML recalculées à la main (voir commentaires des tests) — correspondent aux restaurations.
- Ce PR déclenche Payroll CI (chemins `api/app/Modules/Payroll/**` + `api/tests/Feature/Payroll/**`) + Tests + Backend Coverage Gate + actionlint + Architecture Quality.