### PR TITLE
fix(openapi): couverture 2 routes manquantes + réparation YAML cassé (Closes #1971)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -829,6 +829,53 @@ paths:
                     type: string
                     example: "ok"
 
+  /supported-countries:
+    get:
+      tags: ["Platform"]
+      summary: "Lister les pays supportes et leur niveau de confiance paie"
+      description: "Issue #1867/#1971 — registre unique des pays supportes : code ISO, libelle, langue, devise, fuseau horaire, niveau de confiance des regles de paie et disponibilite (regles resolubles ou non). Source de verite pour les formulaires de provisioning et les ecrans de calcul — aucun fallback silencieux. (Route reelle : /v1/supported-countries — le prefixe de version n'est pas porte par les chemins openapi, cf. convention /health.)"
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: "Registre des pays supportes"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required: ["country", "label", "language", "currency", "timezone", "confidence", "available"]
+                      properties:
+                        country:
+                          type: string
+                          example: "SN"
+                        label:
+                          type: string
+                          example: "Senegal"
+                        language:
+                          type: string
+                          example: "fr"
+                        currency:
+                          type: string
+                          example: "XOF"
+                        timezone:
+                          type: string
+                          example: "Africa/Dakar"
+                        confidence:
+                          type: string
+                          example: "pilot"
+                          description: "Niveau de confiance des regles de paie (pilot|placeholder|unknown)"
+                        available:
+                          type: boolean
+                          example: true
+                          description: "true si des regles de paie resolubles existent pour ce pays"
+        "401":
+          $ref: "#/components/responses/Error401"
+
   /platform/country-defaults:
     get:
       tags: ["Platform"]
@@ -6304,6 +6351,32 @@ paths:
         "404":
           $ref: "#/components/responses/Error404"
 
+  /me/pay-slips/{paySlip}/document:
+    get:
+      tags: ["Me"]
+      summary: "Telecharger le document archive d'un de mes bulletins de paie"
+      description: "Issue #1817/#1971 — renvoie le document Cabinet archive (bulletin signe/immuable) si le run est cloture ; sinon repli sur le PDF standard. Memes droits que /me/pay-slips/{paySlip} (proprietaire ou manager de la meme entreprise)."
+      operationId: downloadMyPaySlipDocument
+      parameters:
+        - name: paySlip
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: "Document archive (PDF) ou repli PDF standard"
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+
   /me/balance:
     get:
       tags: ["Me"]
@@ -7048,12 +7121,6 @@ paths:
       summary: "Déclaration CNPS mensuelle Cameroun — format DAS CSV (CEMAC/CM #1823)"
       description: "Télécharge le CSV DAS du run : une ligne par bulletin validé (matricule CNPS, nom, prénom, brut, assiette plafonnée à 750 000 XAF, vieillesse salariale/patronale 4,2 %, famille patronale 7,0 %, AT patronale 2,0 % non plafonnée, total patronal) + ligne TOTAUX. Taux et plafond résolus depuis CemacPayrollRules (asOf period du run). RBAC : manager principal/comptable ; 404 cross-tenant ; 422 si le run n'est pas un run CM."
       operationId: downloadCnpsCmDeclaration
-  /payroll-runs/{payrollRun}/regularize:
-    post:
-      tags: ["Payroll Engine"]
-      summary: "Créer un run de régularisation (DZ-DEPTH #1818)"
-      description: "Crée un run type=regularization lié à un run verrouillé (original_run_id), même période, statut draft — sans modifier l'original. Motif obligatoire, tracé dans l'audit payroll_run_regularization_created. Seul un run `locked` est régularisable (422 sinon)."
-      operationId: regularizePayrollRun
       parameters:
         - name: payrollRun
           in: path
@@ -7066,6 +7133,26 @@ paths:
             text/csv:
               schema:
                 type: string
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /payroll-runs/{payrollRun}/regularize:
+    post:
+      tags: ["Payroll Engine"]
+      summary: "Créer un run de régularisation (DZ-DEPTH #1818)"
+      description: "Crée un run type=regularization lié à un run verrouillé (original_run_id), même période, statut draft — sans modifier l'original. Motif obligatoire, tracé dans l'audit payroll_run_regularization_created. Seul un run `locked` est régularisable (422 sinon)."
+      operationId: regularizePayrollRun
+      parameters:
+        - name: payrollRun
+          in: path
+          required: true
+          schema: { type: integer }
       requestBody:
         required: true
         content:
@@ -16313,6 +16400,8 @@ components:
           type: string
           nullable: true
         status:
+          type: string
+          enum: [draft, calculating, validated, cancelled]
         type:
           type: string
           enum: [standard, regularization]
@@ -16322,8 +16411,6 @@ components:
         reason:
           type: string
           nullable: true
-          type: string
-          enum: [draft, calculating, validated, cancelled]
         total_gross:
           type: number
           nullable: true

--- a/dev-hub/openapi/v1.yaml
+++ b/dev-hub/openapi/v1.yaml
@@ -840,6 +840,53 @@ paths:
                     type: string
                     example: "ok"
 
+  /supported-countries:
+    get:
+      tags: ["Platform"]
+      summary: "Lister les pays supportes et leur niveau de confiance paie"
+      description: "Issue #1867/#1971 — registre unique des pays supportes : code ISO, libelle, langue, devise, fuseau horaire, niveau de confiance des regles de paie et disponibilite (regles resolubles ou non). Source de verite pour les formulaires de provisioning et les ecrans de calcul — aucun fallback silencieux. (Route reelle : /v1/supported-countries — le prefixe de version n'est pas porte par les chemins openapi, cf. convention /health.)"
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: "Registre des pays supportes"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required: ["country", "label", "language", "currency", "timezone", "confidence", "available"]
+                      properties:
+                        country:
+                          type: string
+                          example: "SN"
+                        label:
+                          type: string
+                          example: "Senegal"
+                        language:
+                          type: string
+                          example: "fr"
+                        currency:
+                          type: string
+                          example: "XOF"
+                        timezone:
+                          type: string
+                          example: "Africa/Dakar"
+                        confidence:
+                          type: string
+                          example: "pilot"
+                          description: "Niveau de confiance des regles de paie (pilot|placeholder|unknown)"
+                        available:
+                          type: boolean
+                          example: true
+                          description: "true si des regles de paie resolubles existent pour ce pays"
+        "401":
+          $ref: "#/components/responses/Error401"
+
   /platform/country-defaults:
     get:
       tags: ["Platform"]
@@ -6315,6 +6362,32 @@ paths:
         "404":
           $ref: "#/components/responses/Error404"
 
+  /me/pay-slips/{paySlip}/document:
+    get:
+      tags: ["Me"]
+      summary: "Telecharger le document archive d'un de mes bulletins de paie"
+      description: "Issue #1817/#1971 — renvoie le document Cabinet archive (bulletin signe/immuable) si le run est cloture ; sinon repli sur le PDF standard. Memes droits que /me/pay-slips/{paySlip} (proprietaire ou manager de la meme entreprise)."
+      operationId: downloadMyPaySlipDocument
+      parameters:
+        - name: paySlip
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: "Document archive (PDF) ou repli PDF standard"
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+
   /me/balance:
     get:
       tags: ["Me"]
@@ -6998,6 +7071,159 @@ paths:
           $ref: "#/components/responses/Error401"
         "422":
           description: "Validated runs cannot be cancelled"
+
+  /payroll-runs/{payrollRun}/declarations/cnss-ci:
+    get:
+      tags: ["Payroll Engine"]
+      summary: "Déclaration CNSS mensuelle Côte d'Ivoire — CSV (CEDEAO #1830)"
+      description: "CSV DAS ivoirien : une ligne par bulletin validé (matricule CNSS, nom, prénom, brut, assiette plafonnée à 1 647 315 XOF, retraite salariale 3,2 %, retraite patronale 4,5 %, famille 5,75 %, AT 2 %, totaux) + TOTAUX. 422 si le run n'est pas CI. RBAC manager ; 404 cross-tenant."
+      operationId: downloadCnssCiDeclaration
+      parameters:
+        - name: payrollRun
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: "Fichier CSV CNSS CI"
+          content:
+            text/csv:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /payroll-runs/{payrollRun}/declarations/ipres-sn:
+    get:
+      tags: ["Payroll Engine"]
+      summary: "Déclaration IPRES/CSS mensuelle Sénégal — CSV (CEDEAO #1830)"
+      description: "CSV sénégalais : une ligne par bulletin validé (matricule IPRES, nom, prénom, catégorie general/cadre, brut, assiette T1 plafonnée 432 000 XOF, cotisations T1 5,6 %/8,4 %, assiette T2 cadres 2 160 000−432 000, cotisations T2 2,4 %/3,6 %, CSS famille 3 %) + TOTAUX. 422 si le run n'est pas SN. RBAC manager ; 404 cross-tenant."
+      operationId: downloadIpresSnDeclaration
+      parameters:
+        - name: payrollRun
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: "Fichier CSV IPRES/CSS SN"
+          content:
+            text/csv:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /payroll-runs/{payrollRun}/declarations/cnps-cm:
+    get:
+      tags: ["Payroll Engine"]
+      summary: "Déclaration CNPS mensuelle Cameroun — format DAS CSV (CEMAC/CM #1823)"
+      description: "Télécharge le CSV DAS du run : une ligne par bulletin validé (matricule CNPS, nom, prénom, brut, assiette plafonnée à 750 000 XAF, vieillesse salariale/patronale 4,2 %, famille patronale 7,0 %, AT patronale 2,0 % non plafonnée, total patronal) + ligne TOTAUX. Taux et plafond résolus depuis CemacPayrollRules (asOf period du run). RBAC : manager principal/comptable ; 404 cross-tenant ; 422 si le run n'est pas un run CM."
+      operationId: downloadCnpsCmDeclaration
+      parameters:
+        - name: payrollRun
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: "Fichier CSV DAS"
+          content:
+            text/csv:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          $ref: "#/components/responses/Validation422"
+
+  /payroll-runs/{payrollRun}/regularize:
+    post:
+      tags: ["Payroll Engine"]
+      summary: "Créer un run de régularisation (DZ-DEPTH #1818)"
+      description: "Crée un run type=regularization lié à un run verrouillé (original_run_id), même période, statut draft — sans modifier l'original. Motif obligatoire, tracé dans l'audit payroll_run_regularization_created. Seul un run `locked` est régularisable (422 sinon)."
+      operationId: regularizePayrollRun
+      parameters:
+        - name: payrollRun
+          in: path
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason:
+                  type: string
+                  minLength: 5
+                  maxLength: 2000
+      responses:
+        "201":
+          description: "Run de régularisation créé"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PayrollRun"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
+        "422":
+          description: "Le run ne concerne pas le Cameroun (CNPS CM)"
+          $ref: "#/components/responses/Validation422"
+
+  /payroll-runs/{payrollRun}/regularizations:
+    get:
+      tags: ["Payroll Engine"]
+      summary: "Lister les régularisations d'un run (DZ-DEPTH #1818)"
+      operationId: listPayrollRunRegularizations
+      parameters:
+        - name: payrollRun
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: "Runs de régularisation liés"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PayrollRun"
+        "401":
+          $ref: "#/components/responses/Error401"
+        "403":
+          $ref: "#/components/responses/Error403"
+        "404":
+          $ref: "#/components/responses/Error404"
 
   /payroll-runs/{payrollRun}/summary:
     get:
@@ -8220,6 +8446,22 @@ paths:
                       net_before_tax: { type: number }
                       net_salary: { type: number }
                       total_cost_employer: { type: number }
+                      contract:
+                        type: object
+                        description: "Contrat de calcul complet et explicable (MULTI-PAYS #1869) — mêmes appels métier que le bulletin."
+                        properties:
+                          country_code: { type: string }
+                          currency: { type: string }
+                          gross: { type: number }
+                          social_employee: { type: number }
+                          tax_base: { type: number }
+                          income_tax: { type: number }
+                          other_deductions: { type: number }
+                          net_salary: { type: number }
+                          social_employer: { type: number }
+                          total_cost: { type: number }
+                          rules_period: { type: string, format: date }
+                          slab_version: { type: string }
         "401":
           $ref: "#/components/responses/Error401"
         "403":
@@ -16171,6 +16413,15 @@ components:
         status:
           type: string
           enum: [draft, calculating, validated, cancelled]
+        type:
+          type: string
+          enum: [standard, regularization]
+        original_run_id:
+          type: integer
+          nullable: true
+        reason:
+          type: string
+          nullable: true
         total_gross:
           type: number
           nullable: true

--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,9 +1,9 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "5d8db2f72fbe98646a1f0cda3db9f4fd18a30d263fec4692b4e2f84475420975",
+  "spec_sha256": "fdc31a6f16c5da20c412f1e24278dd6ed41490a42c977de79e12e5d186029fe1",
   "openapi": "3.0.3",
   "api_version": "4.23.5",
-  "operation_count": 449,
+  "operation_count": 467,
   "targets": [
     "javascript",
     "python"

--- a/dev-hub/sdk/javascript/leopardoClient.js
+++ b/dev-hub/sdk/javascript/leopardoClient.js
@@ -188,6 +188,8 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Confirmer toutes les dates islamiques d'une année (super-admin) */
     confirmIslamicCalendarYear(options = {}) {
       return request("POST", "/admin/islamic-calendar/confirm-year/{year}", options);
+    },
+
     /** Simuler l'impact d'un barème (platform_admin, dry-run) — issue #1814 */
     simulatePayrollAdmin(options = {}) {
       return request("POST", "/admin/payroll/simulate", options);
@@ -221,6 +223,8 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Modifier un jour férié (super-admin) */
     updatePublicHolidayAdmin(options = {}) {
       return request("PUT", "/admin/public-holidays/{publicHoliday}", options);
+    },
+
     /** Approuver une modification de taux (platform_admin) — issue #1813 */
     approveRateValidation(options = {}) {
       return request("PUT", "/admin/rate-validation/{table}/{id}/approve", options);
@@ -1276,6 +1280,11 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("GET", "/me/pay-slips/{paySlip}", options);
     },
 
+    /** Telecharger le document archive d'un de mes bulletins de paie */
+    downloadMyPaySlipDocument(options = {}) {
+      return request("GET", "/me/pay-slips/{paySlip}/document", options);
+    },
+
     /** Telecharger un de mes bulletins de paie en PDF */
     downloadMyPaySlipPdf(options = {}) {
       return request("GET", "/me/pay-slips/{paySlip}/pdf", options);
@@ -1471,6 +1480,21 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("POST", "/payroll-runs/{payrollRun}/cancel", options);
     },
 
+    /** Déclaration CNPS mensuelle Cameroun — format DAS CSV (CEMAC/CM #1823) */
+    downloadCnpsCmDeclaration(options = {}) {
+      return request("GET", "/payroll-runs/{payrollRun}/declarations/cnps-cm", options);
+    },
+
+    /** Déclaration CNSS mensuelle Côte d'Ivoire — CSV (CEDEAO #1830) */
+    downloadCnssCiDeclaration(options = {}) {
+      return request("GET", "/payroll-runs/{payrollRun}/declarations/cnss-ci", options);
+    },
+
+    /** Déclaration IPRES/CSS mensuelle Sénégal — CSV (CEDEAO #1830) */
+    downloadIpresSnDeclaration(options = {}) {
+      return request("GET", "/payroll-runs/{payrollRun}/declarations/ipres-sn", options);
+    },
+
     /** Journal de paie mensuel CSV (F-10) */
     getPayrollRunsByPayrollRunJournal(options = {}) {
       return request("GET", "/payroll-runs/{payrollRun}/journal", options);
@@ -1489,6 +1513,16 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Documents de paiement d'un cycle paie */
     getPayrollRunsByPayrollRunPaymentDocuments(options = {}) {
       return request("GET", "/payroll-runs/{payrollRun}/payment-documents", options);
+    },
+
+    /** Lister les régularisations d'un run (DZ-DEPTH #1818) */
+    listPayrollRunRegularizations(options = {}) {
+      return request("GET", "/payroll-runs/{payrollRun}/regularizations", options);
+    },
+
+    /** Créer un run de régularisation (DZ-DEPTH #1818) */
+    regularizePayrollRun(options = {}) {
+      return request("POST", "/payroll-runs/{payrollRun}/regularize", options);
     },
 
     /** Resume de la session de paie */
@@ -2064,6 +2098,11 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Statut SSO de l'entreprise */
     getSsoStatus(options = {}) {
       return request("GET", "/sso/status", options);
+    },
+
+    /** Lister les pays supportes et leur niveau de confiance paie */
+    getSupportedCountries(options = {}) {
+      return request("GET", "/supported-countries", options);
     },
 
     /** Lister les taches */

--- a/dev-hub/sdk/python/leopardo_client.py
+++ b/dev-hub/sdk/python/leopardo_client.py
@@ -171,6 +171,7 @@ class LeopardoClient:
     def confirmislamiccalendaryear(self, **kwargs):
         """Confirmer toutes les dates islamiques d'une année (super-admin)"""
         return self.request("POST", "/admin/islamic-calendar/confirm-year/{year}", **kwargs)
+
     def simulatepayrolladmin(self, **kwargs):
         """Simuler l'impact d'un barème (platform_admin, dry-run) — issue #1814"""
         return self.request("POST", "/admin/payroll/simulate", **kwargs)
@@ -198,6 +199,7 @@ class LeopardoClient:
     def updatepublicholidayadmin(self, **kwargs):
         """Modifier un jour férié (super-admin)"""
         return self.request("PUT", "/admin/public-holidays/{publicHoliday}", **kwargs)
+
     def approveratevalidation(self, **kwargs):
         """Approuver une modification de taux (platform_admin) — issue #1813"""
         return self.request("PUT", "/admin/rate-validation/{table}/{id}/approve", **kwargs)
@@ -1042,6 +1044,10 @@ class LeopardoClient:
         """Voir un de mes bulletins de paie"""
         return self.request("GET", "/me/pay-slips/{paySlip}", **kwargs)
 
+    def downloadmypayslipdocument(self, **kwargs):
+        """Telecharger le document archive d'un de mes bulletins de paie"""
+        return self.request("GET", "/me/pay-slips/{paySlip}/document", **kwargs)
+
     def downloadmypayslippdf(self, **kwargs):
         """Telecharger un de mes bulletins de paie en PDF"""
         return self.request("GET", "/me/pay-slips/{paySlip}/pdf", **kwargs)
@@ -1198,6 +1204,18 @@ class LeopardoClient:
         """Annuler une session de paie"""
         return self.request("POST", "/payroll-runs/{payrollRun}/cancel", **kwargs)
 
+    def downloadcnpscmdeclaration(self, **kwargs):
+        """Déclaration CNPS mensuelle Cameroun — format DAS CSV (CEMAC/CM #1823)"""
+        return self.request("GET", "/payroll-runs/{payrollRun}/declarations/cnps-cm", **kwargs)
+
+    def downloadcnsscideclaration(self, **kwargs):
+        """Déclaration CNSS mensuelle Côte d'Ivoire — CSV (CEDEAO #1830)"""
+        return self.request("GET", "/payroll-runs/{payrollRun}/declarations/cnss-ci", **kwargs)
+
+    def downloadipressndeclaration(self, **kwargs):
+        """Déclaration IPRES/CSS mensuelle Sénégal — CSV (CEDEAO #1830)"""
+        return self.request("GET", "/payroll-runs/{payrollRun}/declarations/ipres-sn", **kwargs)
+
     def get_payroll_runs_by_payrollrun_journal(self, **kwargs):
         """Journal de paie mensuel CSV (F-10)"""
         return self.request("GET", "/payroll-runs/{payrollRun}/journal", **kwargs)
@@ -1213,6 +1231,14 @@ class LeopardoClient:
     def get_payroll_runs_by_payrollrun_payment_documents(self, **kwargs):
         """Documents de paiement d'un cycle paie"""
         return self.request("GET", "/payroll-runs/{payrollRun}/payment-documents", **kwargs)
+
+    def listpayrollrunregularizations(self, **kwargs):
+        """Lister les régularisations d'un run (DZ-DEPTH #1818)"""
+        return self.request("GET", "/payroll-runs/{payrollRun}/regularizations", **kwargs)
+
+    def regularizepayrollrun(self, **kwargs):
+        """Créer un run de régularisation (DZ-DEPTH #1818)"""
+        return self.request("POST", "/payroll-runs/{payrollRun}/regularize", **kwargs)
 
     def get_payroll_runs_by_payrollrun_summary(self, **kwargs):
         """Resume de la session de paie"""
@@ -1673,6 +1699,10 @@ class LeopardoClient:
     def get_sso_status(self, **kwargs):
         """Statut SSO de l'entreprise"""
         return self.request("GET", "/sso/status", **kwargs)
+
+    def get_supported_countries(self, **kwargs):
+        """Lister les pays supportes et leur niveau de confiance paie"""
+        return self.request("GET", "/supported-countries", **kwargs)
 
     def get_tasks(self, **kwargs):
         """Lister les taches"""

--- a/dev-hub/tools/openapi-coverage-allowlist.txt
+++ b/dev-hub/tools/openapi-coverage-allowlist.txt
@@ -26,6 +26,10 @@ POST ai/voice/transcribe
 POST ai/workflows/prepare-payroll
 
 ## api.php — 91 route(s)
+# MULTI-PAYS (#1867/#1971) : registre des pays supportés — documenté dans openapi.yaml
+# (chemin sans préfixe v1, convention /health) ; la clé v1/... ne peut jamais matcher le
+# parseur openapi (slash initial), d'où cette entrée d'allowlist.
+GET v1/supported-countries
 # Auth/Core : webhooks fournisseurs entrants (stripe/chargily), endpoints onboarding/trial/i18n/health internes — exclusions documentées dans le gap doc
 DELETE v1platform/announcements/{param}
 DELETE v1platform/impersonations/{param}


### PR DESCRIPTION
## Résumé
Issue #1971 : main rouge — garde Route → OpenAPI coverage échoue sur 2 routes non documentées.

## Changements
1. **GET /v1/supported-countries** (#1867) — documenté dans api/openapi.yaml (tag Platform, contrat complet : pays, label, langue, devise, timezone, confidence, available). Suit la convention repo : les routes api.php sont documentées **sans** le préfixe v1 (cf. /health), la clé v1/supported-countries (impossible à matcher par le parseur qui exige un slash initial) est ajoutée à l'allowlist avec justification.
2. **GET /me/pay-slips/{paySlip}/document** (#1817) — documenté (tag Me, repli PDF standard si pas de document archivé, mêmes droits RBAC que /me/pay-slips/{paySlip}).
3. **Réparation YAML cassé sur main** (lint Redocly échouait indépendamment) :
   - /payroll-runs/{payrollRun}/regularize : double bloc responses (copier-coller du CSV CNPS, 200 text/csv aberrant) → remplacé par le bloc 201 correct ;
   - schéma PayrollRun mutilé (status sans type, type: dupliqué sous reason, run_type mal indenté) → réparé selon le modèle (status: draft/calculating/validated/cancelled, type: standard/regularization) ;
   - /payroll-runs/{payrollRun}/declarations/cnps-cm : bloc responses absent → restauré (200 text/csv + 401/403/404/422).

## Validation
- check-openapi-route-coverage.py : 0 nouvelle route non couverte ✅
- redocly lint : 0 erreur ✅
- generate-openapi-sdk.mjs --check : SDKs JS/Python + v1.yaml régénérés ✅

Closes #1971