### PR TITLE
fix(test): PHPStan Strict — fresh() nullable sur assertions Cabinet (suivi #1921/#1975)

### DIFF
--- a/api/tests/Feature/Cabinet/CabinetDocumentControllerTest.php
+++ b/api/tests/Feature/Cabinet/CabinetDocumentControllerTest.php
@@ -160,7 +160,10 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertForbidden();
-        $this->assertSame('Bulletin mars 2026.pdf', $document->fresh()->name);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertSame('Bulletin mars 2026.pdf', $fresh->name);
     }
 
     public function test_read_only_document_cannot_be_moved(): void
@@ -174,7 +177,10 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertForbidden();
-        $this->assertNull($document->fresh()->folder_id);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertNull($fresh->folder_id);
     }
 
     public function test_read_only_document_cannot_have_notes_updated(): void
@@ -188,7 +194,10 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertForbidden();
-        $this->assertNull($document->fresh()->notes);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertNull($fresh->notes);
     }
 
     public function test_normal_document_can_be_renamed_and_moved(): void
@@ -202,6 +211,9 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertOk();
-        $this->assertSame('Nouveau nom.pdf', $document->fresh()->name);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertSame('Nouveau nom.pdf', $fresh->name);
     }
 }


### PR DESCRIPTION
## Contexte
PR #1975 (immuabilité read_only, Closes #1921) a été mergée avant que le correctif PHPStan ne soit poussé sur la branche (merge 14:19, fix 14:26) : le test `CabinetDocumentControllerTest` présent sur **main** contient encore les accès `$document->fresh()->name` → PHPStan — Strict (level 8) rouge sur main (4 erreurs « Cannot access property on CabinetDocument|null »).

## Changement
Pattern `assertNotNull` + variable locale (même convention que le reste de la suite) sur les 4 assertions `fresh()` :
- `test_read_only_document_cannot_be_renamed`
- `test_read_only_document_cannot_be_moved`
- `test_read_only_document_cannot_have_notes_updated`
- `test_normal_document_can_be_renamed_and_moved`

## Validation
- PHPStan — Strict (level 8) : les 4 accès nullable sont éliminés.
- Aucun changement de comportement (assertions identiques).