### PR TITLE
fix(test): PHPStan Strict main rouge — null-safety fresh() CabinetDocumentControllerTest (bloqueur #1921)

### DIFF
--- a/api/tests/Feature/Cabinet/CabinetDocumentControllerTest.php
+++ b/api/tests/Feature/Cabinet/CabinetDocumentControllerTest.php
@@ -160,7 +160,10 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertForbidden();
-        $this->assertSame('Bulletin mars 2026.pdf', $document->fresh()->name);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertSame('Bulletin mars 2026.pdf', $fresh->name);
     }
 
     public function test_read_only_document_cannot_be_moved(): void
@@ -174,7 +177,10 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertForbidden();
-        $this->assertNull($document->fresh()->folder_id);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertNull($fresh->folder_id);
     }
 
     public function test_read_only_document_cannot_have_notes_updated(): void
@@ -188,7 +194,10 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertForbidden();
-        $this->assertNull($document->fresh()->notes);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertNull($fresh->notes);
     }
 
     public function test_normal_document_can_be_renamed_and_moved(): void
@@ -202,6 +211,9 @@ class CabinetDocumentControllerTest extends TestCase
         ]);
 
         $response->assertOk();
-        $this->assertSame('Nouveau nom.pdf', $document->fresh()->name);
+
+        $fresh = $document->fresh();
+        $this->assertNotNull($fresh);
+        $this->assertSame('Nouveau nom.pdf', $fresh->name);
     }
 }


### PR DESCRIPTION
## Bloqueur identifié par la revue resp
`main` est **rouge PHPStan — Strict (level 8)** : le test `CabinetDocumentControllerTest` (mergé via #1975) accède à `$document->fresh()->name/folder_id/notes` sans null-safety — 4 erreurs « Cannot access property on CabinetDocument|null » sur CHAQUE PR et sur main.

**Pourquoi le fix n'a pas atterri** : deux PRs correctives (#1984 et #1986) se sont mutuellement fermées comme doublons, aucune n'a été mergée → le correctif est orphelin. Cette PR le rétablit proprement (cherry-pick du commit original).

## Changement
Pattern `assertNotNull` + variable locale (même convention que la suite) sur les 4 assertions `fresh()` de `CabinetDocumentControllerTest`.

## Impact
- Débloque le PHPStan — Strict sur main et sur les ~20 PRs ouvertes (chacune rejouait l'échec).
- Aucun changement de comportement (assertions identiques).

Coordination lead — 2026-08-14.