### PR TITLE
fix(test): TaxRateChangeLogTest — accolade hors classe (ParseError → Backend Coverage rouge sur main, régression #2024)

### DIFF
--- a/api/tests/Feature/Payroll/TaxRateChangeLogTest.php
+++ b/api/tests/Feature/Payroll/TaxRateChangeLogTest.php
@@ -203,7 +203,6 @@ class TaxRateChangeLogTest extends TestCase
             TaxRateChangeLog::query()->find($id),
         );
     }
-}
 
     public function test_db_level_truncate_is_blocked_by_trigger(): void
     {


### PR DESCRIPTION
## Réparation main (urgente)
Régression introduite par le merge de #2024 : `api/tests/Feature/Payroll/TaxRateChangeLogTest.php` a une accolade fermante de classe à la ligne 206, laissant `test_db_level_truncate_is_blocked_by_trigger` HORS de la classe → **ParseError** à chaque exécution PHPUnit → le rapport de coverage n'est jamais produit (0 %) → le check requis **Backend Coverage (PHP 8.4 + PostgreSQL 16)** est rouge sur main et sur CHAQUE PR.

## Correctif
Suppression de l'accolade déplacée : la méthode rejoint la classe (la fermeture finale de classe reste la ligne 230).

Note : la PR #2046 (issue #1923) porte le même correctif — celui-ci est isolé pour débloquer la CI de toutes les PRs en attente.

---

Fixes #2024 (régression accolade introduite par la PR #2024 — ParseError suite de test)