### PR TITLE
fix(payroll): PHPStan Modules Architecture — IslamicCalendarService (main rouge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **fix(payroll): PHPStan Modules Architecture — `IslamicCalendarService` (main rouge).** `resolveForPayroll()` utilisait `$holiday['confirmed'] ?? false` alors que le shape du retour de `getHolidaysForCountry()` garantit `confirmed: bool` (non nullable) → erreur PHPStan « offset always exists and is not nullable » sur main (régression fafcf91b #1930). Retrait du `??` redondant.
+
 - feat(tooling): Spec Kit v0.16.3 — Spec-Driven Development intégré. Constitution `.specify/constitution.md`, 5 presets de conformité paie (leopardo-payroll / leopardo-multitenancy / leopardo-dz / leopardo-cemac / leopardo-cedeao), bundle agent, skills GitHub Copilot. Règle anti-doublon documentée dans AGENTS.md.
 - **fix(i18n): checksums `versions.json` régénérés — garde CI `I18N Enterprise` verte (Closes #2041).** Les PRs i18n parallèles (#1987/#2001) avaient régénéré `shared/i18n/versions/versions.json` avec des checksums divergents ; la résolution de conflit « prendre main » a laissé des checksums obsolètes → `node shared/i18n/validators/validate.js` (exécuté par `.github/workflows/i18n-enterprise.yml`, étape « Validate shared catalogs ») échouait sur les 4 locales : `checksum mismatch in versions.json`. Régénération via `node shared/i18n/sync/sync-mobile.js` (source canonique `shared/i18n/locales/*.json`, SHA-256 stable) → `I18N_VALIDATION_OK (4 locales)`. Aucun autre fichier touché (ARB/web/backend déjà alignés). Note process pour les agents : toute modification de catalogue i18n doit régénérer `versions.json` via le sync tooling, jamais à la main.
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/IslamicCalendarService.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/IslamicCalendarService.php
@@ -95,7 +95,9 @@ class IslamicCalendarService
     {
         $holidays = array_filter(
             $this->getHolidaysForCountry($countryCode, $year),
-            static fn (array $holiday): bool => (bool) ($holiday['confirmed'] ?? false),
+            // Le shape de getHolidaysForCountry garantit `confirmed: bool` —
+            // le `?? false` déclenchait PHPStan (offset toujours présent).
+            static fn (array $holiday): bool => (bool) $holiday['confirmed'],
         );
 
         $resolved = [];


### PR DESCRIPTION
## Main rouge — PHPStan Modules Architecture

`api/app/Modules/Payroll/Infrastructure/Services/IslamicCalendarService.php` : `resolveForPayroll()` utilise `$holiday['confirmed'] ?? false` alors que le shape annoté du retour de `getHolidaysForCountry()` garantit `confirmed: bool` (non nullable) → erreur PHPStan :

```
Offset 'confirmed' on array{...} on left side of ?? always exists and is not nullable.
```

Régression introduite par fafcf91b (#1930, calendrier islamique confirmé). Fix minimal : `(bool) $holiday['confirmed']` (le cast booléen est conservé pour la robustesse).

⚠️ Autres rouges main en cours de traitement : collision préfixes migrations tenant #1962 (PR #2063), accolade TaxRateChangeLogTest #2024 (PR #2062), garde protection branche 403 (token), Workers Builds gestionemploye (infra #1914).

---

Closes #1930 (régression PHPStan de la PR #1930)