### PR TITLE
fix(test): CountryRulesResolverTest — classes anonymes complétées (fatal PHP main rouge, #1871/#2088)

### DIFF
--- a/api/tests/Feature/Payroll/CountryRulesResolverTest.php
+++ b/api/tests/Feature/Payroll/CountryRulesResolverTest.php
@@ -188,6 +188,29 @@ class CountryRulesResolverTest extends TestCase
                 return '';
             }
 
+            public function complianceWarningKey(): string
+            {
+                return 'payroll.compliance_warning_placeholder';
+            }
+
+            /**
+             * @return array<int, string>
+             */
+            public function legalSources(): array
+            {
+                return [];
+            }
+
+            public function complianceVerifiedAt(): ?string
+            {
+                return null;
+            }
+
+            public function rulesVersion(): string
+            {
+                return 'test-rules-v1';
+            }
+
             public function noticePeriodDays(float $yearsOfService): float
             {
                 return 0.0;
@@ -356,6 +379,29 @@ class CountryRulesResolverTest extends TestCase
             public function complianceWarning(): string
             {
                 return '';
+            }
+
+            public function complianceWarningKey(): string
+            {
+                return 'payroll.compliance_warning_placeholder';
+            }
+
+            /**
+             * @return array<int, string>
+             */
+            public function legalSources(): array
+            {
+                return [];
+            }
+
+            public function complianceVerifiedAt(): ?string
+            {
+                return null;
+            }
+
+            public function rulesVersion(): string
+            {
+                return 'test-rules-v1';
             }
 
             public function noticePeriodDays(float $yearsOfService): float


### PR DESCRIPTION
## Main rouge résiduel — fatal PHP dans CountryRulesResolverTest

Depuis #1871, les 2 classes anonymes de `CountryRulesResolverTest` n'implémentent pas `rulesVersion()` → **PHP Fatal** à l'instanciation → toute la suite échoue (Backend Coverage rouge sur main). Le correctif était dans #2088/#2096 (clos, superseded par les merges directs lead) mais n'a pas été reporté sur main.

Ajoute aux 2 classes anonymes : `rulesVersion()` (requis par le contrat) + `complianceWarningKey()`/`legalSources()`/`complianceVerifiedAt()` (préparés pour #2087 — l'interface va les exiger).

Vérifié localement : 6/6 tests verts (`CountryRulesResolverTest`).