### PR TITLE
fix(test): CountryRulesResolverTest — rulesVersion() manquant → fatal PHP sur main (résiduel #1871)

### DIFF
--- a/api/tests/Feature/Payroll/CountryRulesResolverTest.php
+++ b/api/tests/Feature/Payroll/CountryRulesResolverTest.php
@@ -188,6 +188,29 @@ class CountryRulesResolverTest extends TestCase
                 return '';
             }
 
+            public function complianceWarningKey(): string
+            {
+                return 'payroll.compliance_warning_placeholder';
+            }
+
+            /**
+             * @return array<int, string>
+             */
+            public function legalSources(): array
+            {
+                return [];
+            }
+
+            public function complianceVerifiedAt(): ?string
+            {
+                return null;
+            }
+
+            public function rulesVersion(): string
+            {
+                return 'test-rules-v1';
+            }
+
             public function noticePeriodDays(float $yearsOfService): float
             {
                 return 0.0;
@@ -356,6 +379,29 @@ class CountryRulesResolverTest extends TestCase
             public function complianceWarning(): string
             {
                 return '';
+            }
+
+            public function complianceWarningKey(): string
+            {
+                return 'payroll.compliance_warning_placeholder';
+            }
+
+            /**
+             * @return array<int, string>
+             */
+            public function legalSources(): array
+            {
+                return [];
+            }
+
+            public function complianceVerifiedAt(): ?string
+            {
+                return null;
+            }
+
+            public function rulesVersion(): string
+            {
+                return 'test-rules-v1';
             }
 
             public function noticePeriodDays(float $yearsOfService): float


### PR DESCRIPTION
Closes #1871

## Contexte
`CountryRulesInterface` expose `rulesVersion()` (contrat de versionnement #1871) mais `CountryRulesResolverTest` ne l'implémente pas dans ses 2 classes anonymes → **Fatal PHP** à la définition de classe → toute la suite `Coverage Payroll` / `Backend Coverage` casse (main rouge résiduel).

## Correctif (test-only)
- `api/tests/Feature/Payroll/CountryRulesResolverTest.php` : `rulesVersion()` ajouté aux 2 classes anonymes (+ méthodes de préparation `complianceWarningKey`/`legalSources`/`complianceVerifiedAt` pour le contrat #2087). Vérifié 6/6.

Aucun changement de comportement.
