### PR TITLE
fix(payroll): fatal PHP — noticePeriodDays(float, ?string $category = null) aligné sur l'interface (régression #2136, main rouge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ### Added
+- **fix(payroll): fatal PHP — `noticePeriodDays(float, ?string $category = null)` aligné sur l'interface (régression #2136, main rouge).** Le merge de #2136 (SN préavis par catégorie) a ajouté `$category` à `CountryRulesInterface::noticePeriodDays()` sans aligner les implémentations → `PHP Fatal error: Declaration of ...::noticePeriodDays(float $yearsOfService): float must be compatible with ...` au chargement de `AbstractCountryRules` → toutes les règles pays + tests (Backend Jobs CI, coverage < 65 % en cascade). Signature ajoutée dans `AbstractCountryRules`, `AlgeriaPayrollRules`, `CemacPayrollRules`, `CedeaoPayrollRules` et les classes anonymes de `CountryRulesResolverTest`. Aucun changement de comportement.
 
 - **fix(ci): deploy-admin-dashboard — action `cloudflare/wrangler-action` ré-épinglée sur un SHA résolvable (main rouge préexistant).** Le SHA `daa9d868…` épinglé dans `deploy-admin-dashboard.yml` (livré par #1834) n'existe pas dans le dépôt upstream (`422` au moment du checkout de l'action) → le job « Build & deploy admin-dashboard to Cloudflare Pages » échouait sur CHAQUE push main depuis le 2026-08-14 17:12Z (y compris les vagues `fix/main-*`), même si le check n'est pas requis par la protection. Ré-épinglage sur le SHA réel du tag `v3.14.1` (`da0e0dfe58b7a431659754fdf3f186c529afbe65`, vérifié par l'API GitHub). Aucun changement de comportement du build/deploy.
 

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AbstractCountryRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AbstractCountryRules.php
@@ -382,7 +382,7 @@ abstract class AbstractCountryRules implements CountryRulesInterface
      * decides). Countries with a documented legal notice period override
      * this. FOCUS 2 (F-31).
      */
-    public function noticePeriodDays(float $yearsOfService): float
+    public function noticePeriodDays(float $yearsOfService, ?string $category = null): float
     {
         return 0.0;
     }

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AlgeriaPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/AlgeriaPayrollRules.php
@@ -174,7 +174,7 @@ class AlgeriaPayrollRules extends AbstractCountryRules
      *   exact. (cf. docs/payroll/DZ_COMPLIANCE.md §7 — confidenceLevel reste
      *   'pilot', validation expert comptable DZ requise avant 'production'.)
      */
-    public function noticePeriodDays(float $yearsOfService): float
+    public function noticePeriodDays(float $yearsOfService, ?string $category = null): float
     {
         return $yearsOfService >= 10.0 ? 44.0 : 22.0;
     }

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CedeaoPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CedeaoPayrollRules.php
@@ -331,7 +331,7 @@ class CedeaoPayrollRules extends AbstractCountryRules
      * (palier employé/technicien), matrice complète documentée
      * CI_COMPLIANCE.md §6 — à valider par expert-comptable OHADA-CI.
      */
-    public function noticePeriodDays(float $yearsOfService): float
+    public function noticePeriodDays(float $yearsOfService, ?string $category = null): float
     {
         if (in_array($this->memberCountryCode, ['BF', 'ML'], true)) {
             // BF/ML (issue #1829) : préavis légal 1 mois quel que soit le

--- a/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CemacPayrollRules.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CountryRules/CemacPayrollRules.php
@@ -322,7 +322,7 @@ class CemacPayrollRules extends AbstractCountryRules
      *   5–10 ans : 2 mois (60 j) · > 10 ans : 3 mois (90 j).
      * Les autres membres CEMAC gardent le défaut (0).
      */
-    public function noticePeriodDays(float $yearsOfService): float
+    public function noticePeriodDays(float $yearsOfService, ?string $category = null): float
     {
         if (in_array($this->memberCountryCode, ['GA', 'CG'], true)) {
             // Préavis OHADA (issue #1824) — niveau employé/technicien (1 mois) :

--- a/api/tests/Feature/Payroll/CountryRulesResolverTest.php
+++ b/api/tests/Feature/Payroll/CountryRulesResolverTest.php
@@ -221,7 +221,7 @@ class CountryRulesResolverTest extends TestCase
                 return 'test-rules-v1';
             }
 
-            public function noticePeriodDays(float $yearsOfService): float
+            public function noticePeriodDays(float $yearsOfService, ?string $category = null): float
             {
                 return 0.0;
             }
@@ -424,7 +424,7 @@ class CountryRulesResolverTest extends TestCase
                 return 'test-rules-v1';
             }
 
-            public function noticePeriodDays(float $yearsOfService): float
+            public function noticePeriodDays(float $yearsOfService, ?string $category = null): float
             {
                 return 0.0;
             }


### PR DESCRIPTION
## Contexte

Le merge de #2136 (SN préavis par catégorie, Closes #2123) a ajouté `?string $category = null` à `CountryRulesInterface::noticePeriodDays()` SANS aligner les implémentations → **fatal PHP sur main** :

`PHP Fatal error: Declaration of AbstractCountryRules::noticePeriodDays(float $yearsOfService): float must be compatible with CountryRulesInterface::noticePeriodDays(float $yearsOfService, ?string $category = null): float`

Conséquences : `Backend Jobs CI` rouge + `Backend Coverage` sous 65 % (suites mortes au chargement) → main pas vert.

## Correctif

Signature `float $yearsOfService, ?string $category = null` ajoutée à :
- `AbstractCountryRules` (ligne 385)
- `AlgeriaPayrollRules`, `CemacPayrollRules`, `CedeaoPayrollRules`
- classes anonymes de `CountryRulesResolverTest` (2 occurrences)

`SenegalPayrollRules` était déjà aligné. Aucun changement de comportement (le paramètre optionnel est ignoré par les implémentations non-SN). CHANGELOG.md entrée.