### PR TITLE
fix(phpstan+tests): main vert — 9 erreurs PHPStan Strict + golden GA/ML (reliquat après merges parallèles)

### DIFF
--- a/api/app/Listeners/NotifyTaxRateValidation.php
+++ b/api/app/Listeners/NotifyTaxRateValidation.php
@@ -122,10 +122,10 @@ class NotifyTaxRateValidation
 
         try {
             try {
-                $company = PlatformCompanyLookup::findOrFail((string) $model->company_id);
+                $company = PlatformCompanyLookup::findOrFail((string) $model->getAttribute('company_id'));
             } catch (\Throwable $e) {
                 Log::warning('tax-rate.submitter-company-lookup-failed', [
-                    'company_id' => $model->company_id,
+                    'company_id' => $model->getAttribute('company_id'),
                     'error' => $e->getMessage(),
                 ]);
 
@@ -157,7 +157,7 @@ class NotifyTaxRateValidation
             });
         } catch (\Throwable $e) {
             Log::warning('tax-rate.notification-tenant-failed', [
-                'company_id' => $model->company_id,
+                'company_id' => $model->getAttribute('company_id'),
                 'error' => $e->getMessage(),
             ]);
         } finally {

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -27,7 +27,7 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 
 class EventServiceProvider extends ServiceProvider
 {
-    /** @var array<class-string, array<int, class-string>> */
+    /** @var array<class-string, array<int, string>> */
     protected $listen = [
         EmployeeCreated::class => [AuditLogger::class, WebhookListener::class],
         EmployeeArchived::class => [AuditLogger::class, WebhookListener::class],

--- a/api/tests/Feature/Database/MigrationSchemaPlacementTest.php
+++ b/api/tests/Feature/Database/MigrationSchemaPlacementTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Database;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\PendingCommand;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
@@ -96,9 +97,14 @@ class MigrationSchemaPlacementTest extends TestCase
 
     public function test_artisan_migrate_is_idempotent(): void
     {
-        // PHPStan Strict : artisan() retourne PendingCommand|int — assertExitCode
-        // est la forme typée compatible (pattern MakeModuleCommandTest).
-        $this->artisan('migrate', ['--path' => 'database/migrations/public'])->assertExitCode(0);
-        $this->artisan('migrate', ['--path' => 'database/migrations/tenant'])->assertExitCode(0);
+        // PHPStan Strict : artisan() retourne PendingCommand|int — annotation
+        // @var + assertExitCode (pattern BiometricPurgeExpiredTest).
+        /** @var PendingCommand $command */
+        $command = $this->artisan('migrate', ['--path' => 'database/migrations/public']);
+        $command->assertExitCode(0);
+
+        /** @var PendingCommand $command */
+        $command = $this->artisan('migrate', ['--path' => 'database/migrations/tenant']);
+        $command->assertExitCode(0);
     }
 }

--- a/api/tests/Feature/MultiCountry/ProvisioningCountryStrictTest.php
+++ b/api/tests/Feature/MultiCountry/ProvisioningCountryStrictTest.php
@@ -6,7 +6,6 @@ namespace Tests\Feature\MultiCountry;
 
 use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Tenant\Domain\Models\CompanyRequest;
-use App\Core\Tenant\Domain\Models\SuperAdmin;
 use App\Jobs\ProvisionDemoTenantJob;
 use App\Modules\Billing\Application\Actions\ProvisionGuidedTrial;
 use App\Modules\Billing\Application\Actions\VerifyTrialSignup;
@@ -114,18 +113,12 @@ class ProvisioningCountryStrictTest extends TestCase
         $this->assertNull(CountryDefaults::find('ZZ'));
         $this->assertNull(CountryDefaults::find(''));
         $this->assertNull(CountryDefaults::find(null));
-        $this->assertSame('CI', CountryDefaults::find('ci')['country']);
+        $found = CountryDefaults::find('ci');
+        $this->assertNotNull($found);
+        $this->assertSame('CI', $found['country']);
 
         // for() reste réservé à l'affichage (fallback DZ documenté).
         $this->assertSame('DZ', CountryDefaults::for('ZZ')['country']);
     }
 
-    private function superAdmin(): SuperAdmin
-    {
-        return new SuperAdmin([
-            'id' => 1,
-            'name' => 'Audit',
-            'email' => 'audit@leopardo.test',
-        ]);
-    }
 }

--- a/api/tests/Feature/MultiCountry/TenantCountryLocksTest.php
+++ b/api/tests/Feature/MultiCountry/TenantCountryLocksTest.php
@@ -133,7 +133,7 @@ class TenantCountryLocksTest extends TestCase
             'country' => 'ZZ',
         ])->assertStatus(422)->assertJsonValidationErrors('country');
 
-        $this->assertSame('', $company->fresh()->country);
+        $this->assertSame('', $company->refresh()->country);
     }
 
     public function test_country_change_refused_after_payroll_run_invariant9(): void
@@ -155,7 +155,7 @@ class TenantCountryLocksTest extends TestCase
             'country' => 'CI',
         ])->assertStatus(422);
 
-        $this->assertSame('DZ', $company->fresh()->country);
+        $this->assertSame('DZ', $company->refresh()->country);
     }
 
     public function test_country_change_refused_after_salary_structure_invariant9(): void
@@ -179,6 +179,6 @@ class TenantCountryLocksTest extends TestCase
             'country' => 'CI',
         ])->assertStatus(422);
 
-        $this->assertSame('DZ', $company->fresh()->country);
+        $this->assertSame('DZ', $company->refresh()->country);
     }
 }

--- a/api/tests/Feature/Payroll/Golden/GoldenGaPayrollTest.php
+++ b/api/tests/Feature/Payroll/Golden/GoldenGaPayrollTest.php
@@ -96,8 +96,8 @@ class GoldenGaPayrollTest extends TestCase
         // la valeur légale du palier reste testée ici).
         $tiers = $this->ga()->overtimeRateTiers();
 
-        $this->assertSame(1.20, $tiers[0]);
-        $this->assertSame(10384.8, round(5.0 * 1730.8 * $tiers[0], 2));
+        $this->assertSame(1.20, $tiers[0]['multiplier']);
+        $this->assertSame(10384.8, round(5.0 * 1730.8 * $tiers[0]['multiplier'], 2));
     }
 
     public function test_golden_ga_end_of_contract_notice_employee(): void

--- a/api/tests/Feature/Payroll/Golden/GoldenMlPayrollTest.php
+++ b/api/tests/Feature/Payroll/Golden/GoldenMlPayrollTest.php
@@ -73,8 +73,8 @@ class GoldenMlPayrollTest extends TestCase
         // la valeur légale du palier reste testée ici).
         $tiers = $this->ml()->overtimeRateTiers();
 
-        $this->assertSame(1.15, $tiers[0]);
-        $this->assertSame(9952.1, round(5.0 * 1730.8 * $tiers[0], 2));
+        $this->assertSame(1.15, $tiers[0]['multiplier']);
+        $this->assertSame(9952.1, round(5.0 * 1730.8 * $tiers[0]['multiplier'], 2));
     }
 
     public function test_golden_ml_end_of_contract_notice_employee(): void


### PR DESCRIPTION
## Contexte
Base = main `82db5776`. L'autre session a déjà poussé sur main : dead catch `PayrollSimulationController` (approche `resolve()` direct), compliance DZ → pilot, golden CG (paliers structurés). **Non dupliqués ici.**

## Contenu (reliquat non couvert)

### PHPStan — Strict (check requis) — 9 erreurs
- `TenantCountryLocksTest` : `fresh()` nullable → `refresh()` (retourne `$this`, 3x).
- `ProvisioningCountryStrictTest` : `find()` nullable → `assertNotNull` + narrowing ; méthode privée inutilisée `superAdmin()` retirée (+ import).
- `MigrationSchemaPlacementTest` : `artisan()` → `PendingCommand|int` → annotation `@var PendingCommand` (pattern `BiometricPurgeExpiredTest`).
- `EventServiceProvider` : `$listen` accepte des `'Class@method'` → docblock `array<int, string>`.
- `NotifyTaxRateValidation` : accès magique `$model->company_id` → `getAttribute('company_id')`.

### Golden tests paie DZ — paliers structurés (interface #1938)
- `GoldenGaPayrollTest` / `GoldenMlPayrollTest` : `$tiers[0]` → `$tiers[0]['multiplier']` (pattern `GoldenBf`).

Aucun changement de comportement. Vérification finale mission leopardo-hr (session 2026-08-14).

Closes #2149