### PR TITLE
fix(admin): login — suppression des liens morts href='#' (Closes #2290)

### DIFF
--- a/front/admin-dashboard/src/views/auth/LoginView.vue
+++ b/front/admin-dashboard/src/views/auth/LoginView.vue
@@ -131,9 +131,10 @@
               </div>
 
               <div class="text-xs font-bold">
-                <a href="#" class="text-brand-500 hover:text-brand-400 transition-colors">
-                  Mot de passe oublie ?
-                </a>
+                <!-- Pas de flux self-service de réinitialisation pour les comptes
+                     super-admin : la réinitialisation passe par l'ops
+                     (`php artisan super-admin:reset-password`). Lien volontairement
+                     absent plutôt que mort (#QA-2026-08-14). -->
               </div>
             </div>
 
@@ -190,8 +191,7 @@
       <div class="flex items-center justify-between px-2 text-[10px] font-black uppercase tracking-widest text-slate-600">
         <span>© 2026 Leopardo Systems</span>
         <div class="flex items-center gap-4">
-          <a href="#" class="hover:text-slate-400 transition-colors">Sécurité</a>
-          <a href="#" class="hover:text-slate-400 transition-colors">Support</a>
+          <a href="mailto:support@leopardo-rh.com" class="hover:text-slate-400 transition-colors">Support</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Contexte

Campagne QA fonctionnelle 2026-08-14. `LoginView.vue` contenait 3 liens morts (`href="#"`) : « Mot de passe oublié ? », « Sécurité », « Support ».

## Changements
- **« Mot de passe oublié ? » retiré** — aucun flux self-service de réinitialisation n'existe pour les comptes super-admin (réinitialisation ops via `php artisan super-admin:reset-password`) ; commentaire explicatif conservé dans le template.
- **« Sécurité » retiré** — aucune page dédiée.
- **« Support » → `mailto:support@leopardo-rh.com`** — email canonique déjà utilisé par la vitrine (`front/web/src/modules/vitrine/lib/constants.ts`).

## Vérifications
- `grep -c 'href="#"' LoginView.vue` → 0
- `npm run lint` → 0 erreur
- `npm run build` → OK

Closes #2290