### PR TITLE
fix(api): GET /employees/{id} — company attachée via currentCompany() (Closes #2327)

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
@@ -344,9 +344,13 @@ class EmployeeController extends Controller
     #[RequiresPermission('employees.view')]
     public function show(string $employeeId, Request $request): JsonResponse
     {
+        // v4.16.250 + #2327 : ne PAS eager-loader `company` sous le search_path
+        // tenant (la table `companies` résolue n'a pas la colonne `features` →
+        // SQLSTATE 42703). On charge uniquement `schedule`, puis on attache
+        // `currentCompany()` (public.companies, colonnes complètes) comme
+        // l'index() — pattern attachCompanyContext (#2327).
         $employee = Employee::query()
             ->with([
-                'company:id,name,language,timezone,currency,features',
                 'schedule:id,name,start_time,end_time,break_minutes,late_tolerance_minutes',
             ])
             ->findOrFail($employeeId);
@@ -359,6 +363,11 @@ class EmployeeController extends Controller
             'resource' => 'employee_profile',
             'target_employee_id' => $employee->id,
         ]);
+
+        $company = currentCompany();
+        if ($company instanceof Company) {
+            $employee->setRelation('company', $company);
+        }
 
         return (new EmployeeResource($employee))->response();
     }

--- a/api/tests/Feature/HR/HrControllerTest.php
+++ b/api/tests/Feature/HR/HrControllerTest.php
@@ -84,6 +84,10 @@ class HrControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('data.id', $this->employee->id);
+        // #2327 : la fiche expose le contexte entreprise (company + currency)
+        // sans eager-load `company` sous le search_path tenant (42703).
+        $response->assertJsonPath('data.company.id', $this->company->id);
+        $response->assertJsonPath('data.currency', $this->company->currency);
     }
 
     public function test_manager_gets_404_for_cross_tenant_employee(): void


### PR DESCRIPTION
## Problème\n\n`GET /api/v1/employees/{id}` → 500 SQLSTATE 42703 pour TOUS les employés : l'eager-load `company:id,...,features` résolvait la table `companies` du schéma tenant (sans colonne `features`) sous le search_path.\n\n## Correctif\n\nAligné sur `index()` (pattern v4.16.250) : plus d'eager-load `company` ; `currentCompany()` (public.companies, colonnes complètes) attaché via `setRelation('company', ...)` — `EmployeeResource` reçoit name/language/timezone/currency/features.\n\n## Vérifications\n- Reproduction locale : 500 → 200 (company + currency présents)\n- Test étendu `HrControllerTest::test_manager_can_show_own_company_employee` (asserts company.id + currency)\n\nCloses #2327