### PR TITLE
fix(attendance): ZKTeco — statut calculé ontime/late au lieu de 'present' (Closes #2330)

### DIFF
--- a/api/app/Modules/Attendance/Infrastructure/Services/ZktecoIntegrationService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/ZktecoIntegrationService.php
@@ -6,6 +6,7 @@ namespace App\Modules\Attendance\Infrastructure\Services;
 
 use App\Modules\Attendance\Domain\Models\ZktecoDevice;
 use App\Modules\Attendance\Domain\Models\ZktecoSyncLog;
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -79,6 +80,28 @@ class ZktecoIntegrationService
                 $time = substr($timestamp, 11, 8);
                 $action = $this->resolveAction($record['punch_type'] ?? 0);
 
+                // #2330 : `attendance_logs.status` est un enum PostgreSQL
+                // (ontime/late/absent/leave/holiday/incomplete) — 'present'
+                // levait 22P02 et faisait échouer CHAQUE punch (jamais
+                // persisté). Statut calculé comme AttendanceService::checkIn :
+                // retard vs horaire planifié (start_time − tolérance).
+                $status = 'ontime';
+                $lateMinutes = 0;
+                if ($action === 'check_in' && isset($employee->schedule_id)) {
+                    $schedule = DB::table('schedules')
+                        ->where('id', $employee->schedule_id)
+                        ->where('company_id', $device->company_id)
+                        ->first();
+                    if ($schedule !== null && ! empty($schedule->start_time)) {
+                        $checkIn = Carbon::parse($timestamp);
+                        $start = Carbon::parse($date.' '.$schedule->start_time);
+                        $diffMinutes = $start->diffInMinutes($checkIn, false);
+                        $tolerance = (int) ($schedule->late_tolerance_minutes ?? 0);
+                        $lateMinutes = max(0, (int) floor($diffMinutes - $tolerance));
+                        $status = $lateMinutes > 0 ? 'late' : 'ontime';
+                    }
+                }
+
                 $existing = DB::table('attendance_logs')
                     ->where('employee_id', $employee->id)
                     ->where('date', $date)
@@ -102,7 +125,8 @@ class ZktecoIntegrationService
                         'check_in' => $action === 'check_in' ? $timestamp : null,
                         'check_out' => $action === 'check_out' ? $timestamp : null,
                         'method' => 'zkteco',
-                        'status' => 'present',
+                        'status' => $status,
+                        'late_minutes' => $lateMinutes,
                         'created_at' => now(),
                         'updated_at' => now(),
                     ]);

--- a/api/tests/Feature/ZktecoControllerTest.php
+++ b/api/tests/Feature/ZktecoControllerTest.php
@@ -6,6 +6,10 @@ namespace Tests\Feature;
 
 use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Modules\Attendance\Domain\Models\ZktecoDevice;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Tests\Support\CreatesMvpSchema;
 use Tests\TestCase;
 
@@ -77,6 +81,60 @@ class ZktecoControllerTest extends TestCase
                 ['user_id' => '1', 'timestamp' => '2026-01-01 08:00:00'],
             ],
         ])->assertStatus(404);
+    }
+
+    public function test_sync_attendance_persists_punch_with_valid_enum_status(): void
+    {
+        // #2330 : 'status' => 'present' est invalide pour l'enum
+        // attendance_logs.status (ontime/late/absent/leave/holiday/incomplete)
+        // → 22P02, punch jamais persisté. Le statut doit être calculé
+        // (ontime/late) comme AttendanceService::checkIn.
+        // Le fixture MVP ne crée pas zkteco_sync_logs — table ajoutée ici
+        // (miroir de la migration 2026_05_18_000003).
+        Schema::create('zkteco_sync_logs', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('zkteco_device_id')->constrained('zkteco_devices')->cascadeOnDelete();
+            $table->enum('direction', ['pull', 'push'])->default('pull');
+            $table->enum('sync_type', ['attendance', 'users', 'fingerprints', 'faces'])->default('attendance');
+            $table->unsignedInteger('records_count')->default(0);
+            $table->unsignedInteger('errors_count')->default(0);
+            $table->enum('status', ['started', 'completed', 'failed'])->default('started');
+            $table->text('error_message')->nullable();
+            $table->timestamp('started_at');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+            $table->index(['zkteco_device_id', 'created_at']);
+        });
+
+        $this->employee->update(['zkteco_id' => '42']);
+        ZktecoDevice::query()->create([
+            'company_id' => $this->company->id,
+            'serial_number' => 'ZK-TEST-001',
+            'name' => 'Portique QA',
+        ]);
+
+        $response = $this->postJson('/api/v1/zkteco/sync-attendance/ZK-TEST-001', [
+            'records' => [
+                [
+                    'user_id' => '42',
+                    'timestamp' => '2026-07-15 08:02:00',
+                    'punch_type' => 0, // check_in
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.errors', 0);
+        $response->assertJsonPath('data.records_processed', 1);
+
+        $log = DB::table('attendance_logs')
+            ->where('employee_id', $this->employee->id)
+            ->where('date', '2026-07-15')
+            ->first();
+
+        $this->assertNotNull($log, 'le punch ZKTeco doit être persisté');
+        $this->assertContains($log->status, ['ontime', 'late'], 'statut doit être un enum valide');
+        $this->assertSame('zkteco', $log->method);
     }
 }
 


### PR DESCRIPTION
## Problème\n\nChaque punch ZKTeco échouait silencieusement : `'status' => 'present'` inséré dans `attendance_logs.status` (enum PostgreSQL `ontime/late/absent/leave/holiday/incomplete`) → 22P02 attrapé → errors++, aucune présence enregistrée.\n\n## Correctif\n\nStatut calculé comme `AttendanceService::checkIn` : retard vs horaire planifié (`schedules.start_time` − `late_tolerance_minutes`) → `late`/`ontime` + `late_minutes`.\n\n## Vérifications\n- Test de régression `ZktecoControllerTest::test_sync_attendance_persists_punch_with_valid_enum_status` : punch persisté (status enum valide, errors=0)\n\nCloses #2330