### PR TITLE
fix(api): notifications — ?unread=true accepté comme alias de unread_only (Closes #2331)

### DIFF
--- a/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/NotificationController.php
+++ b/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/NotificationController.php
@@ -26,6 +26,9 @@ class NotificationController extends Controller
         $validated = $request->validate([
             'per_page'    => ['nullable', 'integer', 'min:1', 'max:100'],
             'type'        => ['nullable', 'string', 'max:80'],
+            // #2331 : contrat v4.16.185 — `unread=true` (mobile) est l'alias
+            // canonique ; `unread_only` reste accepté pour compatibilité.
+            'unread'      => ['nullable', 'in:true,false,1,0,on,off,yes,no'],
             'unread_only' => ['nullable', 'in:true,false,1,0,on,off,yes,no'],
             'sort_dir'    => ['nullable', 'in:asc,desc'],
         ]);
@@ -37,7 +40,10 @@ class NotificationController extends Controller
         if (($validated['type'] ?? '') !== '') {
             $query->where('type', $validated['type']);
         }
-        if ($request->has('unread_only') && $request->boolean('unread_only')) {
+        $unreadFilter = $request->has('unread')
+            ? $request->boolean('unread')
+            : $request->boolean('unread_only');
+        if ($unreadFilter) {
             $query->where('is_read', false);
         }
 

--- a/api/tests/Feature/NotificationControllerTest.php
+++ b/api/tests/Feature/NotificationControllerTest.php
@@ -69,6 +69,16 @@ class NotificationControllerTest extends TestCase
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.title', 'Absence approved');
+
+        // #2331 : `unread=true` (contrat mobile v4.16.185) = alias de unread_only.
+        $this->getJson('/api/v1/notifications?unread=true')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.title', 'Absence approved');
+
+        $this->getJson('/api/v1/notifications?unread=false')
+            ->assertOk()
+            ->assertJsonCount(2, 'data'); // pas de filtre quand unread=false
     }
 
     public function test_unread_endpoint_returns_only_unread_notifications(): void


### PR DESCRIPTION
## Problème\n\nContrat v4.16.185 : le mobile envoie `?unread=true` mais le contrôleur ne filtrait que `unread_only` → notifications lues renvoyées.\n\n## Correctif\n\n`unread` accepté comme alias booléen de `unread_only` (OpenAPI documentait déjà `?unread` — le code est désormais aligné).\n\n## Vérifications\n- Tests étendus : `unread=true` → 1 non lue ; `unread=false` → pas de filtre\n\nCloses #2331