### PR TITLE
fix(api): soldes congés — snapshot leave_balances synchronisé par AbsenceService (Closes #2329)

### DIFF
--- a/api/app/Modules/Planning/Infrastructure/Services/AbsenceService.php
+++ b/api/app/Modules/Planning/Infrastructure/Services/AbsenceService.php
@@ -13,6 +13,7 @@ use App\Exceptions\AbsenceNotPendingException;
 use App\Exceptions\InsufficientLeaveBalanceException;
 use App\Modules\Planning\Domain\Models\Absence;
 use App\Modules\Planning\Domain\Models\AbsenceType;
+use App\Modules\Planning\Domain\Models\LeaveBalance;
 use App\Modules\Planning\Domain\Models\LeaveBalanceLog;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
@@ -60,6 +61,13 @@ class AbsenceService
             'proof_path' => $proofPath,
         ]);
 
+        // #2329 : snapshot leave_balances synchronisé — la demande pending
+        // réserve les jours (pending += days). La source de vérité reste la
+        // chaîne leave_balance_logs (comptage réel).
+        if ($type->deducts_leave) {
+            $this->syncLeaveBalanceSnapshot($absence, 'pending_add');
+        }
+
         AbsenceRequested::dispatch($absence);
 
         return $absence;
@@ -97,6 +105,11 @@ class AbsenceService
                     $absence->id,
                     $newBalance
                 );
+
+                // #2329 : la demande pending passe en used (pending -= days,
+                // used += days).
+                $this->syncLeaveBalanceSnapshot($absence, 'pending_remove');
+                $this->syncLeaveBalanceSnapshot($absence, 'used_add');
             }
 
             $absence->update([
@@ -136,6 +149,14 @@ class AbsenceService
                     $absence->id,
                     $newBalance
                 );
+
+                // #2329 : snapshot — used -= days (approbation annulée).
+                $this->syncLeaveBalanceSnapshot($absence, 'used_remove');
+            }
+
+            // #2329 : demande pending rejetée → pending -= days.
+            if ($absence->status === 'pending' && $absence->absenceType?->deducts_leave === true) {
+                $this->syncLeaveBalanceSnapshot($absence, 'pending_remove');
             }
 
             $absence->update([
@@ -155,6 +176,11 @@ class AbsenceService
     {
         if ($absence->status !== 'pending') {
             throw new AbsenceNotPendingException;
+        }
+
+        // #2329 : snapshot — la demande annulée libère la réservation.
+        if ($absence->absenceType?->deducts_leave === true) {
+            $this->syncLeaveBalanceSnapshot($absence, 'pending_remove');
         }
 
         $absence->update(['status' => 'cancelled']);
@@ -183,6 +209,43 @@ class AbsenceService
         }
 
         return $query->exists();
+    }
+
+    /**
+     * #2329 — synchronise le snapshot `leave_balances` (balance/used/pending)
+     * servi par LeavePolicyController. La source de vérité reste la chaîne
+     * `leave_balance_logs` (comptage réel) ; ce snapshot est un cache
+     * lisible par l'API. Opérations : pending_add / pending_remove /
+     * used_add / used_remove.
+     */
+    private function syncLeaveBalanceSnapshot(Absence $absence, string $operation): void
+    {
+        $type = $absence->absenceType;
+        if ($type === null || ! $type->deducts_leave) {
+            return;
+        }
+
+        $year = (int) Carbon::parse($absence->start_date)->format('Y');
+
+        $balance = LeaveBalance::firstOrCreate(
+            [
+                'company_id' => $absence->company_id,
+                'employee_id' => $absence->employee_id,
+                'absence_type_id' => $type->id,
+                'year' => $year,
+            ],
+            ['balance' => 0, 'used' => 0, 'pending' => 0]
+        );
+
+        $days = (float) $absence->days_count;
+
+        match ($operation) {
+            'pending_add' => $balance->increment('pending', $days),
+            'pending_remove' => $balance->decrement('pending', $days),
+            'used_add' => $balance->increment('used', $days),
+            'used_remove' => $balance->decrement('used', $days),
+            default => null,
+        };
     }
 
     private function logBalanceChange(int $employeeId, int|string|null $companyId, float $delta, string $reason, int $referenceId, float $balanceAfter): LeaveBalanceLog

--- a/api/tests/Feature/Absences/AbsenceLeaveBalanceSnapshotTest.php
+++ b/api/tests/Feature/Absences/AbsenceLeaveBalanceSnapshotTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Absences;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Planning\Domain\Models\AbsenceType;
+use App\Modules\Planning\Domain\Models\LeaveBalanceLog;
+use App\Modules\Planning\Domain\Models\Schedule;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * #2329 — le snapshot `leave_balances` (balance/used/pending) servi par
+ * LeavePolicyController doit être synchronisé par AbsenceService :
+ * create → pending += days ; approve → pending −= days, used += days ;
+ * reject pending → pending −= days ; cancel → pending −= days.
+ * La source de vérité reste la chaîne leave_balance_logs.
+ */
+class AbsenceLeaveBalanceSnapshotTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Employee $manager;
+
+    private Employee $employee;
+
+    private AbsenceType $type;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Company $company */
+        $company = Company::query()->create([
+            'name' => 'Company Snapshot',
+            'slug' => 'company-snapshot',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Alger',
+            'email' => 'a@snapshot.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+            'plan_id' => 1,
+            'subscription_start' => '2026-01-01',
+            'subscription_end' => '2027-01-01',
+            'language' => 'fr',
+            'timezone' => 'UTC',
+            'currency' => 'DZD',
+        ]);
+        /** @var Schedule $schedule */
+        $schedule = Schedule::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Day',
+            'start_time' => '08:00:00',
+            'end_time' => '17:00:00',
+            'late_tolerance_minutes' => 15,
+            'overtime_threshold_daily' => 8.0,
+            'is_default' => true,
+        ]);
+
+        /** @var AbsenceType $type */
+        $type = AbsenceType::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Congé payé',
+            'code' => 'CP',
+            'is_paid' => true,
+            'deducts_leave' => true,
+            'requires_proof' => false,
+        ]);
+        $this->type = $type;
+
+        /** @var Employee $manager */
+        $manager = Employee::query()->create([
+            'company_id' => $company->id,
+            'schedule_id' => $schedule->id,
+            'first_name' => 'Mgr',
+            'last_name' => 'Snapshot',
+            'email' => 'mgr@snapshot.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        $this->manager = $manager;
+
+        /** @var Employee $employee */
+        $employee = Employee::query()->create([
+            'company_id' => $company->id,
+            'schedule_id' => $schedule->id,
+            'first_name' => 'Emp',
+            'last_name' => 'Snapshot',
+            'email' => 'emp@snapshot.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+        $this->employee = $employee;
+
+        // 20 jours de crédit initiaux (source de vérité = logs).
+        LeaveBalanceLog::query()->create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'delta' => 20.0,
+            'reason' => 'initial_credit',
+            'reference_id' => 0,
+            'balance_after' => 20.0,
+        ]);
+    }
+
+    public function test_create_reserves_pending_then_approve_moves_to_used(): void
+    {
+        Sanctum::actingAs($this->employee);
+
+        $response = $this->postJson('/api/v1/absences', [
+            'absence_type_id' => $this->type->id,
+            'start_date' => '2026-05-04',
+            'end_date' => '2026-05-05',
+            'reason' => 'Snapshot test',
+        ]);
+        $response->assertStatus(201);
+        $absenceId = $response->json('data.id');
+
+        // create → pending += 2
+        $this->assertDatabaseHas('leave_balances', [
+            'employee_id' => $this->employee->id,
+            'absence_type_id' => $this->type->id,
+            'year' => 2026,
+            'pending' => 2.0,
+            'used' => 0.0,
+        ]);
+
+        Sanctum::actingAs($this->manager);
+        $this->putJson("/api/v1/absences/{$absenceId}/approve")->assertStatus(200);
+
+        // approve → pending −= 2, used += 2
+        $this->assertDatabaseHas('leave_balances', [
+            'employee_id' => $this->employee->id,
+            'absence_type_id' => $this->type->id,
+            'year' => 2026,
+            'pending' => 0.0,
+            'used' => 2.0,
+        ]);
+
+        // Le snapshot est servi par l'API des soldes.
+        Sanctum::actingAs($this->employee);
+        $balances = $this->getJson('/api/v1/employees/'.$this->employee->id.'/leave-balances?year=2026')
+            ->assertOk()
+            ->json();
+        $this->assertSame(2.0, (float) $balances[0]['used']);
+        $this->assertSame(0.0, (float) $balances[0]['pending']);
+    }
+
+    public function test_reject_pending_releases_reservation(): void
+    {
+        Sanctum::actingAs($this->employee);
+
+        $response = $this->postJson('/api/v1/absences', [
+            'absence_type_id' => $this->type->id,
+            'start_date' => '2026-05-06',
+            'end_date' => '2026-05-07',
+            'reason' => 'Rejected snapshot',
+        ]);
+        $absenceId = $response->json('data.id');
+
+        $this->assertDatabaseHas('leave_balances', [
+            'employee_id' => $this->employee->id,
+            'year' => 2026,
+            'pending' => 2.0,
+        ]);
+
+        Sanctum::actingAs($this->manager);
+        $this->putJson("/api/v1/absences/{$absenceId}/reject", ['rejected_reason' => 'Non justifié'])
+            ->assertStatus(200);
+
+        // reject (pending) → pending −= 2
+        $this->assertDatabaseHas('leave_balances', [
+            'employee_id' => $this->employee->id,
+            'year' => 2026,
+            'pending' => 0.0,
+            'used' => 0.0,
+        ]);
+    }
+
+    public function test_cancel_pending_releases_reservation(): void
+    {
+        Sanctum::actingAs($this->employee);
+
+        $response = $this->postJson('/api/v1/absences', [
+            'absence_type_id' => $this->type->id,
+            'start_date' => '2026-05-11',
+            'end_date' => '2026-05-12',
+            'reason' => 'Cancelled snapshot',
+        ]);
+        $absenceId = $response->json('data.id');
+
+        $this->deleteJson("/api/v1/absences/{$absenceId}")->assertStatus(200);
+
+        $this->assertDatabaseHas('leave_balances', [
+            'employee_id' => $this->employee->id,
+            'year' => 2026,
+            'pending' => 0.0,
+            'used' => 0.0,
+        ]);
+    }
+
+    public function test_leave_balances_snapshot_is_tenant_isolated(): void
+    {
+        /** @var Company $otherCompany */
+        $otherCompany = Company::query()->create([
+            'name' => 'Other Co',
+            'slug' => 'other-co-snapshot',
+            'sector' => 'restaurant',
+            'country' => 'DZ',
+            'city' => 'Oran',
+            'email' => 'o@snapshot.test',
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+            'plan_id' => 1,
+            'subscription_start' => '2026-01-01',
+            'subscription_end' => '2027-01-01',
+            'language' => 'fr',
+            'timezone' => 'UTC',
+            'currency' => 'DZD',
+        ]);
+        /** @var Employee $otherEmployee */
+        $otherEmployee = Employee::query()->create([
+            'company_id' => $otherCompany->id,
+            'first_name' => 'Other',
+            'last_name' => 'Emp',
+            'email' => 'oe@snapshot.test',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        // Le snapshot de l'employé A ne doit pas apparaître pour l'employé B.
+        Sanctum::actingAs($otherEmployee);
+        $otherBalances = $this->getJson('/api/v1/employees/'.$otherEmployee->id.'/leave-balances?year=2026')
+            ->assertOk()
+            ->json();
+
+        $this->assertCount(0, $otherBalances);
+    }
+}


### PR DESCRIPTION
## Problème

Après approbation d'une absence, `GET /me/leave-balances` affichait toujours `used=0` : le comptage vivait dans `leave_balance_logs` mais le snapshot `leave_balances` (servi par LeavePolicyController) n'était jamais synchronisé.

## Correctif

`AbsenceService` synchronise le snapshot :
- create → `pending += days`
- approve → `pending -= days`, `used += days`
- reject (pending) → `pending -= days` ; (approved) → `used -= days`
- cancel → `pending -= days`

La chaîne `leave_balance_logs` reste la source de vérité.

## Vérifications
- 4 tests : flux API create→approve (used=2, pending=0), reject (pending=0), cancel, isolation tenant
- Suites Absence* existantes : 24 passed (0 régression)
- PHPStan strict : `[OK] No errors`

Closes #2329