### PR TITLE
docs(compliance): registre VALIDATION_EXPERTE — GA #2118, MA #2260, TN #2261 (suivi #2124)

### DIFF
--- a/docs/payroll/VALIDATION_EXPERTE.md
+++ b/docs/payroll/VALIDATION_EXPERTE.md
@@ -26,7 +26,7 @@ bloquantes ouvertes.
 | CM (Cameroun) | `CemacPayrollRules` | pilot | `CM_COMPLIANCE.md` | ❌ à valider | IRPP art. 68, CNPS plafonds |
 | BF (Burkina) | `CedeaoPayrollRules` | pilot | `BF_COMPLIANCE.md` | ❌ à valider | IUTS 27,5 % CGI 2024, CNSS 2024 |
 | ML (Mali) | `CedeaoPayrollRules` | pilot | `ML_COMPLIANCE.md` | ❌ à valider | ITS 6 tranches, INPS 2024 |
-| GA (Gabon) | `CemacPayrollRules` | pilot | `GA_COMPLIANCE.md` | ❌ à valider | IRPP 8 tranches (art. 174 vs 135), abattement DGI 20 %/833 333 non implémenté |
+| GA (Gabon) | `CemacPayrollRules` | pilot | `GA_COMPLIANCE.md` | ❌ à valider | IRPP 8 tranches (art. 174 vs 135), abattement DGI 20 %/833 333 ✅ implémenté (#2118, voir #2124) |
 | CG (Congo) | `CemacPayrollRules` | pilot | `CG_COMPLIANCE.md` | ❌ à valider | IRPP 6 tranches, CNSS 2024 |
 | SN (Sénégal) | `SenegalPayrollRules` | pilot | `SN_COMPLIANCE.md` | ❌ à valider (issue #1912) | TRIMF, IPRES T2, CSS AT, CFCE, abattement 30 %, plafond CSS 63 000 vs 80 000, **taux CSS famille 7 % officiel vs 3 % implémenté** |
 | CI (Côte d'Ivoire) | `CedeaoPayrollRules` | pilot | `CI_COMPLIANCE.md` | ❌ à valider | **Réforme ITS 2024 (art. 119 bis, ord. 2023-718/719)** — l'ancien barème annuel est abrogé ; CN supprimée ; abattement 20 % obsolète |

--- a/docs/payroll/VALIDATION_EXPERTE.md
+++ b/docs/payroll/VALIDATION_EXPERTE.md
@@ -19,6 +19,8 @@ bloquantes ouvertes.
 |---|---|---|---|---|---|
 | DZ (Algérie) | `AlgeriaPayrollRules` | pilot* | `DZ_COMPLIANCE.md` | ❌ à valider | barèmes IRG/CNAS à confirmer |
 | FR | `FrancePayrollRules` | pilot* | — | ❌ à valider | barème IR/charges à confirmer |
+| MA (Maroc) | `MoroccoPayrollRules` | pilot | `MA_COMPLIANCE.md` | ❌ à valider | abattement frais pro 35 % (art. 58) ✅ implémenté (#2260) ; CNSS/AMO/IR à confirmer |
+| TN (Tunisie) | `TunisiaPayrollRules` | pilot | (fiche à créer) | ❌ à valider | abattement IRPP 10 % (art. 39) ✅ implémenté (#2261) ; reste à confirmer |
 
 > \* DZ/FR sont **pilot dans le code** (`confidenceLevel()`), pas production —
 > aucun pays n'a de validation experte signée à ce jour ; la colonne


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference:** suivi #2124 (docs compliance — validation experte reliquats)
**Category:** Documentation

---

## 🚀 Changes Description

Mise à jour du registre `docs/payroll/VALIDATION_EXPERTE.md` (source de vérité de la validation experte multi-pays) :

- **GA** : abattement DGI 20 % / 833 333 XAF marqué **✅ implémenté** (#2118, `GA_COMPLIANCE.md` §1 déjà à jour).
- **MA (Maroc)** : ligne ajoutée — abattement frais professionnels 35 % (CGI art. 58) ✅ implémenté (#2260), fiche `MA_COMPLIANCE.md` créée, reste CNSS/AMO/IR à confirmer par expert.
- **TN (Tunisie)** : ligne ajoutée — abattement IRPP 10 % (CGI art. 39) ✅ implémenté (#2261), fiche à créer.

---

## 🗺️ Surfaces touchées

- [ ] API
- [ ] Web
- [ ] Admin dashboard
- [ ] Mobile
- [ ] Kiosk
- [ ] CI / GitHub Actions
- [x] Docs uniquement

---

## 🔌 Contrat API

- [x] Aucun changement de contrat API.

---

## ⚠️ Risques résiduels

- Les confirmations expertes formelles restent en attente (#1904) : CNAC DZ (#1819), CSS famille SN (#1912), signatures MA/TN.
