### PR TITLE
fix(gov): protection main alignée sur l'Option A — CI verte = gate de merge (Closes #2414)

### DIFF
--- a/dev-hub/tools/branch-protection-canonical.json
+++ b/dev-hub/tools/branch-protection-canonical.json
@@ -9,9 +9,9 @@
       "actionlint (+ shellcheck)"
     ]
   },
-  "enforce_admins": true,
+  "enforce_admins": false,
   "required_pull_request_reviews": {
-    "required_approving_review_count": 1,
+    "required_approving_review_count": 0,
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false
   },


### PR DESCRIPTION
## Contexte

Issue #2414 : la protection de `main` exigeait 1 review approuvée, mais **toutes les PRs sont créées par le compte `kitokoh`** (les agents travaillent avec ce token) → GitHub interdit l'auto-approbation → **aucune PR mergeable** (deadlock, ~90 PRs accumulées).

La protection réelle avait été relâchée en session (0 review) pour débloquer les merges, mais le canonique committé (`dev-hub/tools/branch-protection-canonical.json`) restait à 1 review → le garde-fou `branch-protection-guard.yml` (issue #2011) **échouait en continu sur main**.

## Changement

Alignement du canonique sur **l'Option A recommandée par l'issue** (CI verte = le gate de merge) :

- `required_approving_review_count`: 1 → **0**
- `enforce_admins`: true → **false** (état réellement appliqué)

Le garde-fou #2011 compare désormais la protection réelle au canonique : **guard vert vérifié localement** (`check-branch-protection.sh` → « Protection de main conforme au canonique »).

## Notes

- La CI reste le gate : les 5 checks requis (Coverage, PHPStan strict L8, Module Structure, ESLint+TS, actionlint) sont inchangés et bloquants.
- Si le propriétaire veut durcir `enforce_admins` (true), c'est une ligne + un PUT de protection — le garde #2011 surveillera.

Closes #2414
