### PR TITLE
gov(branch-protection): canonical aligné — reviews 0, CI = gate (Closes #2414)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,12 @@ La gestion du projet Leopardo RH se fait desormais **exclusivement via GitHub Is
 - Ne jamais merger sa propre PR sans que les checks CI obligatoires (`gh pr checks <numero>`) soient verts.
 - Assurez-vous que la description de la PR indique clairement quelle issue P0/P1 est resolue.
 
+### Politique de merge des agents (decision #2414, 2026-08-15)
+
+- `main` exige **0 review humaine** : la CI verte (5 checks requis, voir `dev-hub/tools/branch-protection-canonical.json`) EST le gate de merge. Ne PAS remettre `required_approving_review_count: 1` — tous les agents utilisent le compte `kitokoh` et GitHub interdit l'auto-approbation (deadlock historique #2414).
+- Toute PR agent doit rester `draft` tant que les checks ne sont pas verts, puis etre merger avec `gh pr merge --merge --delete-branch` (ou l'equivalent API). Ne jamais merger une PR rouge.
+- `enforce_admins: false` : le proprietaire peut debloquer un merge en urgence, mais la CI reste la source de verite.
+
 ### Bibliotheque de prompts operationnels
 
 Le dossier `dev-hub/prompts/` contient des prompts numerotes prets a l'emploi pour piloter les agents. Chaque prompt est un fichier Markdown autonome avec des instructions executables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **gov(branch-protection): canonical aligné sur le workflow agent — reviews 0, CI verte = gate (Closes #2414).** Le canonique `dev-hub/tools/branch-protection-canonical.json` exigeait `required_approving_review_count: 1` + `enforce_admins: true` alors que toutes les PRs sont créées par le compte `kitokoh` (agents) : GitHub interdit l'auto-approbation → aucune PR ne pouvait être mergée (deadlock, ~90 PRs accumulées). Décision (Option A de l'issue) : `required_approving_review_count: 0` et `enforce_admins: false` — la CI verte (5 checks requis : Backend Coverage, PHPStan Strict, Module Structure, ESLint+TS, actionlint) EST le gate de merge ; `required_merge_queue` retiré (jamais actif en réalité). Les 5 checks + `strict: true` + interdiction force-push/deletion sont conservés. La garde `branch-protection-guard.yml` (issue #2011) compare la protection RÉELLE au canonique : le fichier est désormais la seule source à changer (la protection réelle était déjà relâchée).
+
 ### Fixed
 
 - **fix(web): locale AR — mojibake UTF-8 double-encodé corrigé dans 11 fichiers + garde anti-régression (Closes #2275).** Les chaînes AR inline de la vitrine (`Navbar`, `PricingSection`, `TrustedBrands`, `LaunchOperatingSystemSection`, pages pricing/download/demo/branding/mobile, page login et layout dashboard) étaient double-encodées (`Ø§Ù„Ø£Ø³Ø¹Ø§Ø±` au lieu de `الأسعار`) : décodées proprement (latin-1/cp1252 → UTF-8). Au passage, mojibake FR/EN/TR inline corrigé (apostrophes « â€™ », tirets « â€” », guillemets « Â« » », caractères turcs « ÅŸ »/« Ä± »/« Ã– »…) dans ~20 autres fichiers `src`. Nouveau garde anti-régression `front/web/scripts/check-mojibake.mjs` (`npm run check:mojibake`) branché sur le CI vitrine (`web-marketing-ci.yml`) : scanne `front/web/src` et fait échouer le job si un pattern mojibake (arabe ou latin) réapparaît. Les catalogues JSON + `locale-catalog.ts` étaient déjà propres (aucun changement).

--- a/dev-hub/tools/branch-protection-canonical.json
+++ b/dev-hub/tools/branch-protection-canonical.json
@@ -9,16 +9,11 @@
       "actionlint (+ shellcheck)"
     ]
   },
-  "enforce_admins": true,
+  "enforce_admins": false,
   "required_pull_request_reviews": {
-    "required_approving_review_count": 1,
+    "required_approving_review_count": 0,
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false
-  },
-  "required_merge_queue": {
-    "enabled": true,
-    "merge_method": "squash",
-    "check_response_timeout_minutes": 60
   },
   "allow_force_pushes": false,
   "allow_deletions": false


### PR DESCRIPTION
## Contexte
Closes #2414 — la protection de `main` exigeait 1 review approbative alors que toutes les PRs sont créées par le compte `kitokoh` (les agents travaillent avec ce token) : GitHub interdit l'auto-approbation → aucune PR ne pouvait être mergée (~90 PRs accumulées, dont beaucoup vertes).

## Décision (Option A recommandée par l'issue)
La CI verte EST le gate de merge :
- `required_approving_review_count` : 1 → **0**
- `enforce_admins` : true → **false** (déblocage d'urgence propriétaire uniquement)
- `required_merge_queue` : retiré (jamais actif en réalité)
- Conservés : les 5 checks requis (Backend Coverage, PHPStan Strict, Module Structure, ESLint+TS, actionlint), `strict: true`, `allow_force_pushes: false`, `allow_deletions: false`

## Changements
- `dev-hub/tools/branch-protection-canonical.json` — aligné sur la protection RÉELLE de main (déjà relâchée pour merger) → la garde horaire `branch-protection-guard.yml` (issue #2011) redevient verte.
- `AGENTS.md` — section « Politique de merge des agents » documentée (0 review, CI = gate, jamais merger une PR rouge).
- `CHANGELOG.md` — entrée sous `[Unreleased] > Changed`.

## Vérification
La garde compare `{strict, contexts, enforce_admins, reviews, allow_force_pushes, allow_deletions}` entre la protection réelle et le canonique : après ce changement, les deux correspondent exactement.