### PR TITLE
fix(api): openapi.yaml — YAML valide, lint Redocly 0 erreur (doublons Training + compliance) (suite #2480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 ### Fixed
+- **fix(api): openapi.yaml — YAML valide, lint Redocly 0 erreur (doublons Training + compliance) (suite #2480).** Les merges concurrents des PRs #2489/#2493/#2495/#2503 ont laissé main avec un YAML cassé : `type: object` dupliqué dans le bloc `compliance` (/me/balance, ligne ~17524) et 4 copies de `TrainingSession`/`TrainingEnrollment` dans `components/schemas`. Les blocs redondants sont supprimés (la copie principale + les 13 schémas uniques du cluster sont conservés). Vérifié : parseur YAML strict 0 doublon, `redocly lint` **valide 0 erreur** (510 warnings pré-existants), SDK/miroir régénérés.
+
+### Fixed
 - **fix(api): openapi.yaml — lint Redocly 0 erreur : YAML réparé (6 chemins + schéma dédoublonnés, artefacts de merge de PRs concurrentes) + 7 erreurs struct corrigées (Closes #2480).** Le YAML était cassé sur main (`duplicated mapping key` → lint impossible) : `/admin/users`, `/export/history`, `/export/pay-slips`, `/growth/partner/dashboard`, `/me/vehicles`, `/smart-attendance/mode-settings` et le schéma `PlatformUser` étaient définis DEUX fois (merges concurrents #2405/#2452/… — le lint OpenAPI ne tournait plus depuis la saturation #2131). Bloc le plus complet conservé pour chaque doublon. Corrections struct : `Compliance` nullable sans `type` (→ `type: object` ajouté), `verification_date`/`token_expires_at`/`manager_role` en `type: [string, "null"]` interdit OAS3 (→ `type: string` + `nullable: true`), paramètre path fantôme `payrollRun` sur `POST /bank-exports` retiré (le run id est dans le body), `$ref` `TrainingSession`/`TrainingEnrollment` inexistants (→ schémas ajoutés, shape réelle des resources). SDK JS/Python + miroir dev-hub régénérés. Vérifié : `redocly lint` 0 erreur / 512 warnings pré-existants.
 
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -17521,7 +17521,6 @@ components:
           type: object
           allOf:
             - $ref: "#/components/schemas/Compliance"
-          type: object
           nullable: true
           description: >-
             Bloc conformité (issue #2116) — null quand le pays du run n'est
@@ -18499,55 +18498,7 @@ components:
           type: string
           nullable: true
 
-    TrainingSession:
-      type: object
-      description: "Session de formation (contrat GET /training/sessions, QA 2026-08-14)"
-      properties:
-        id: { type: integer }
-        training_course_id: { type: integer }
-        trainer_id: { type: integer, nullable: true }
-        external_trainer: { type: string, nullable: true }
-        start_date: { type: string, format: date, nullable: true }
-        end_date: { type: string, format: date, nullable: true }
-        location: { type: string, nullable: true }
-        status: { type: string, enum: [planned, scheduled, in_progress, completed, cancelled] }
-        notes: { type: string, nullable: true }
-        trainer:
-          type: object
-          nullable: true
-          properties:
-            id: { type: integer }
-            first_name: { type: string, nullable: true }
-            last_name: { type: string, nullable: true }
-        enrollments:
-          type: array
-          description: "Présent uniquement quand la relation est chargée"
-          items:
-            $ref: "#/components/schemas/TrainingEnrollment"
-        created_at: { type: string, format: date-time, nullable: true }
 
-    TrainingEnrollment:
-      type: object
-      description: "Inscription à une session de formation (contrat GET /training/enrollments, QA 2026-08-14)"
-      properties:
-        id: { type: integer }
-        training_session_id: { type: integer }
-        employee_id: { type: integer }
-        status: { type: string, enum: [enrolled, completed, cancelled] }
-        score: { type: number, nullable: true }
-        feedback: { type: string, nullable: true }
-        completed_at: { type: string, format: date-time, nullable: true }
-        course_title: { type: string, nullable: true, description: "Présent quand session.course est chargée" }
-        session_date: { type: string, format: date, nullable: true }
-        progress: { type: integer, nullable: true }
-        employee:
-          type: object
-          nullable: true
-          properties:
-            id: { type: integer }
-            first_name: { type: string, nullable: true }
-            last_name: { type: string, nullable: true }
-        created_at: { type: string, format: date-time, nullable: true }
 
     TrainingCourse:
       type: object
@@ -18577,71 +18528,7 @@ components:
           format: date-time
 
 
-    TrainingSession:
-      type: object
-      description: "Session de formation (TrainingSessionResource)"
-      properties:
-        id:
-          type: integer
-        training_course_id:
-          type: integer
-        trainer_id:
-          type: integer
-          nullable: true
-        external_trainer:
-          type: string
-          nullable: true
-        start_date:
-          type: string
-          format: date
-        end_date:
-          type: string
-          format: date
-        location:
-          type: string
-          nullable: true
-        status:
-          type: string
-          enum: [planned, in_progress, completed, cancelled]
-        notes:
-          type: string
-          nullable: true
-        trainer:
-          type: object
-          nullable: true
-          properties:
-            id: { type: integer }
-            first_name: { type: string }
-            last_name: { type: string }
-        created_at:
-          type: string
-          format: date-time
 
-    TrainingEnrollment:
-      type: object
-      description: "Inscription à une session de formation (TrainingEnrollmentResource)"
-      properties:
-        id:
-          type: integer
-        training_session_id:
-          type: integer
-        employee_id:
-          type: integer
-        company_id:
-          type: integer
-        status:
-          type: string
-          enum: [enrolled, in_progress, completed, dropped]
-        employee:
-          type: object
-          nullable: true
-          properties:
-            id: { type: integer }
-            first_name: { type: string }
-            last_name: { type: string }
-        created_at:
-          type: string
-          format: date-time
 
     StoreTrainingCourseRequest:
       type: object
@@ -18887,33 +18774,4 @@ components:
         duration_days: { type: integer, minimum: 1, maximum: 5 }
         confirmed: { type: boolean, default: true }
         source: { type: string, enum: [manual, api, computed], default: manual }
-    TrainingSession:
-      type: object
-      description: "Session de formation (contrat TrainingSessionResource)."
-      properties:
-        id: { type: integer }
-        training_course_id: { type: integer }
-        trainer_id: { type: integer, nullable: true }
-        external_trainer: { type: string, nullable: true }
-        start_date: { type: string, format: date, nullable: true }
-        end_date: { type: string, format: date, nullable: true }
-        location: { type: string, nullable: true }
-        status: { type: string, enum: [planned, in_progress, completed, cancelled] }
-        notes: { type: string, nullable: true }
-        created_at: { type: string, format: date-time, nullable: true }
 
-    TrainingEnrollment:
-      type: object
-      description: "Inscription à une session de formation (contrat TrainingEnrollmentResource)."
-      properties:
-        id: { type: integer }
-        training_session_id: { type: integer }
-        employee_id: { type: integer }
-        status: { type: string, enum: [enrolled, attended, completed, no_show, cancelled] }
-        score: { type: number, nullable: true }
-        feedback: { type: string, nullable: true }
-        completed_at: { type: string, format: date-time, nullable: true }
-        course_title: { type: string, nullable: true }
-        session_date: { type: string, format: date, nullable: true }
-        progress: { type: integer, nullable: true }
-        created_at: { type: string, format: date-time, nullable: true }

--- a/dev-hub/openapi/v1.yaml
+++ b/dev-hub/openapi/v1.yaml
@@ -1801,7 +1801,6 @@ paths:
           $ref: "#/components/responses/Error401"
         "403":
           $ref: "#/components/responses/Error403"
-
   /admin/dashboard/activities:
     get:
       tags: ["Platform"]
@@ -5020,37 +5019,6 @@ paths:
         "404":
           $ref: "#/components/responses/Error404"
 
-  /me/vehicles:
-    get:
-      tags: ["Vehicle Tracking"]
-      summary: "Vehicules assignes a l'employe connecte (mobile)"
-      description: "Liste des vehicules actifs assignes au conducteur connecte, avec la derniere position Traccar aplatie (shape alignee sur le modele mobile VehiclePosition)."
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Vehicules de l'employe"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        vehicle_id: { type: integer }
-                        plate_number: { type: string }
-                        brand: { type: string, nullable: true }
-                        model: { type: string, nullable: true }
-                        type: { type: string, nullable: true }
-                        latitude: { type: number, format: double, nullable: true }
-                        longitude: { type: number, format: double, nullable: true }
-                        speed: { type: number, format: double, nullable: true }
-                        updated_at: { type: string, format: date-time, nullable: true }
-        "401":
-          $ref: "#/components/responses/Error401"
 
   /vehicle-trips:
     get:
@@ -11048,6 +11016,7 @@ paths:
         "401":
           $ref: "#/components/responses/Error401"
 
+
   /export/absences:
     get:
       tags: ["Exports"]
@@ -12185,6 +12154,7 @@ paths:
         "201": { description: "Demande créée" }
         "422": { $ref: "#/components/responses/Error422" }
 
+
   /platform/growth/partners:
     get:
       tags: ["Growth", "Platform Admin"]
@@ -12972,6 +12942,7 @@ paths:
           description: "Sessions de l'employé"
         "401":
           $ref: "#/components/responses/Error401"
+
 
   /smart-attendance/employees/{employeeId}/preference:
     get:
@@ -17561,7 +17532,6 @@ components:
           type: object
           allOf:
             - $ref: "#/components/schemas/Compliance"
-          type: object
           nullable: true
           description: >-
             Bloc conformité (issue #2116) — null quand le pays du run n'est
@@ -18539,6 +18509,8 @@ components:
           type: string
           nullable: true
 
+
+
     TrainingCourse:
       type: object
       properties:
@@ -18567,71 +18539,7 @@ components:
           format: date-time
 
 
-    TrainingSession:
-      type: object
-      description: "Session de formation (TrainingSessionResource)"
-      properties:
-        id:
-          type: integer
-        training_course_id:
-          type: integer
-        trainer_id:
-          type: integer
-          nullable: true
-        external_trainer:
-          type: string
-          nullable: true
-        start_date:
-          type: string
-          format: date
-        end_date:
-          type: string
-          format: date
-        location:
-          type: string
-          nullable: true
-        status:
-          type: string
-          enum: [planned, in_progress, completed, cancelled]
-        notes:
-          type: string
-          nullable: true
-        trainer:
-          type: object
-          nullable: true
-          properties:
-            id: { type: integer }
-            first_name: { type: string }
-            last_name: { type: string }
-        created_at:
-          type: string
-          format: date-time
 
-    TrainingEnrollment:
-      type: object
-      description: "Inscription à une session de formation (TrainingEnrollmentResource)"
-      properties:
-        id:
-          type: integer
-        training_session_id:
-          type: integer
-        employee_id:
-          type: integer
-        company_id:
-          type: integer
-        status:
-          type: string
-          enum: [enrolled, in_progress, completed, dropped]
-        employee:
-          type: object
-          nullable: true
-          properties:
-            id: { type: integer }
-            first_name: { type: string }
-            last_name: { type: string }
-        created_at:
-          type: string
-          format: date-time
 
     StoreTrainingCourseRequest:
       type: object
@@ -18877,33 +18785,4 @@ components:
         duration_days: { type: integer, minimum: 1, maximum: 5 }
         confirmed: { type: boolean, default: true }
         source: { type: string, enum: [manual, api, computed], default: manual }
-    TrainingSession:
-      type: object
-      description: "Session de formation (contrat TrainingSessionResource)."
-      properties:
-        id: { type: integer }
-        training_course_id: { type: integer }
-        trainer_id: { type: integer, nullable: true }
-        external_trainer: { type: string, nullable: true }
-        start_date: { type: string, format: date, nullable: true }
-        end_date: { type: string, format: date, nullable: true }
-        location: { type: string, nullable: true }
-        status: { type: string, enum: [planned, in_progress, completed, cancelled] }
-        notes: { type: string, nullable: true }
-        created_at: { type: string, format: date-time, nullable: true }
 
-    TrainingEnrollment:
-      type: object
-      description: "Inscription à une session de formation (contrat TrainingEnrollmentResource)."
-      properties:
-        id: { type: integer }
-        training_session_id: { type: integer }
-        employee_id: { type: integer }
-        status: { type: string, enum: [enrolled, attended, completed, no_show, cancelled] }
-        score: { type: number, nullable: true }
-        feedback: { type: string, nullable: true }
-        completed_at: { type: string, format: date-time, nullable: true }
-        course_title: { type: string, nullable: true }
-        session_date: { type: string, format: date, nullable: true }
-        progress: { type: integer, nullable: true }
-        created_at: { type: string, format: date-time, nullable: true }

--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,9 +1,9 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "758a2ca543a67b833aee1b0cff73ec64c77f63c490886448340097bc244a8924",
+  "spec_sha256": "377c38bc56904d641da0b87d5ed91b24de8e9a2ca3ad9e64580bd15b41a8c4e7",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
-  "operation_count": 513,
+  "operation_count": 514,
   "targets": [
     "javascript",
     "python"

--- a/dev-hub/sdk/javascript/leopardoClient.js
+++ b/dev-hub/sdk/javascript/leopardoClient.js
@@ -1440,11 +1440,6 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("POST", "/me/trainings/{session}/enroll", options);
     },
 
-    /** Vehicules assignes a l'employe connecte (mobile) */
-    getMeVehicles(options = {}) {
-      return request("GET", "/me/vehicles", options);
-    },
-
     /** Lire les preferences de notification de l'utilisateur courant */
     getNotificationPreferences(options = {}) {
       return request("GET", "/notification-preferences", options);
@@ -2213,16 +2208,6 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Envoyer un événement géographique (entrée/sortie de zone) */
     postSmartAttendanceGeoEvents(options = {}) {
       return request("POST", "/smart-attendance/geo-events", options);
-    },
-
-    /** Lire la configuration du mode de pointage de l'entreprise */
-    getSmartAttendanceModeSettings(options = {}) {
-      return request("GET", "/smart-attendance/mode-settings", options);
-    },
-
-    /** Mettre à jour la configuration GPS (admin) */
-    putSmartAttendanceModeSettings(options = {}) {
-      return request("PUT", "/smart-attendance/mode-settings", options);
     },
 
     /** Sessions GPS de l'employé courant */

--- a/dev-hub/sdk/python/leopardo_client.py
+++ b/dev-hub/sdk/python/leopardo_client.py
@@ -1172,10 +1172,6 @@ class LeopardoClient:
         """Auto-inscription a une formation"""
         return self.request("POST", "/me/trainings/{session}/enroll", **kwargs)
 
-    def get_me_vehicles(self, **kwargs):
-        """Vehicules assignes a l'employe connecte (mobile)"""
-        return self.request("GET", "/me/vehicles", **kwargs)
-
     def get_notification_preferences(self, **kwargs):
         """Lire les preferences de notification de l'utilisateur courant"""
         return self.request("GET", "/notification-preferences", **kwargs)
@@ -1791,14 +1787,6 @@ class LeopardoClient:
     def post_smart_attendance_geo_events(self, **kwargs):
         """Envoyer un événement géographique (entrée/sortie de zone)"""
         return self.request("POST", "/smart-attendance/geo-events", **kwargs)
-
-    def get_smart_attendance_mode_settings(self, **kwargs):
-        """Lire la configuration du mode de pointage de l'entreprise"""
-        return self.request("GET", "/smart-attendance/mode-settings", **kwargs)
-
-    def put_smart_attendance_mode_settings(self, **kwargs):
-        """Mettre à jour la configuration GPS (admin)"""
-        return self.request("PUT", "/smart-attendance/mode-settings", **kwargs)
 
     def get_smart_attendance_my_sessions(self, **kwargs):
         """Sessions GPS de l'employé courant"""


### PR DESCRIPTION
## Contexte
Les merges concurrents des PRs #2489/#2493/#2495/#2503 ont laissé `main` avec un **YAML cassé** : `redocly lint` échouait sur `duplicated mapping key`.

## Changements (chirurgicaux, vs main)
- Bloc `compliance` (/me/balance) : `type: object` dupliqué retiré
- `components/schemas` : 3 copies redondantes de `TrainingSession` + 3 de `TrainingEnrollment` supprimées (les copies principales et les 13 schémas uniques du cluster — ApprovalRequest, PublicHoliday, AuditLog, Cabinet*, EmployeeRegisterRequest, IslamicCalendar*, Store*Request, TrainingCourse — sont conservés)
- SDK JS/Python + miroir `dev-hub/openapi/v1.yaml` régénérés

## Vérifications
- Parseur YAML strict (détection de clés dupliquées) : **0 doublon**
- `npx @redocly/cli@1.34.5 lint api/openapi.yaml` : **valide, 0 erreur** (510 warnings pré-existants)
- `generate-openapi-sdk.mjs --check` : vert

Suite de #2480 (le YAML avait été ré-cassé par les merges des PRs de correction concurrentes).