### PR TITLE
fix(api): routes backend dédoublonnées — /bank-exports + /me/vehicles (Closes #2494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ## [Unreleased]
 
 ### Fixed
+
+- **fix(api): routes backend dédoublonnées — /bank-exports et /me/vehicles enregistrés une seule fois (Closes #2494).** Artefacts de merges parallèles : `GET/POST /bank-exports` déclarés 2× dans `payroll_engine.php` (PR #2411 + #2426) et `GET /me/vehicles` déclaré 2× (`hr_extended.php` + `tracking.php`, même groupe middleware). Correctif : la 2e déclaration bank-exports est supprimée (bloc consolidé : GET liste, POST génération, GET {bankExport}, GET {bankExport}/download — la route legacy `POST /payroll-runs/{run}/bank-export` conservée) ; `/me/vehicles` ne vit plus que dans `tracking.php` (documenté canonique, commentaire sécurité #2217). Aucun changement de comportement (mêmes contrôleurs/méthodes).
+
 ### Fixed
 - **fix(api): openapi.yaml — lint Redocly 0 erreur : YAML réparé (6 chemins + schéma dédoublonnés, artefacts de merge de PRs concurrentes) + 7 erreurs struct corrigées (Closes #2480).** Le YAML était cassé sur main (`duplicated mapping key` → lint impossible) : `/admin/users`, `/export/history`, `/export/pay-slips`, `/growth/partner/dashboard`, `/me/vehicles`, `/smart-attendance/mode-settings` et le schéma `PlatformUser` étaient définis DEUX fois (merges concurrents #2405/#2452/… — le lint OpenAPI ne tournait plus depuis la saturation #2131). Bloc le plus complet conservé pour chaque doublon. Corrections struct : `Compliance` nullable sans `type` (→ `type: object` ajouté), `verification_date`/`token_expires_at`/`manager_role` en `type: [string, "null"]` interdit OAS3 (→ `type: string` + `nullable: true`), paramètre path fantôme `payrollRun` sur `POST /bank-exports` retiré (le run id est dans le body), `$ref` `TrainingSession`/`TrainingEnrollment` inexistants (→ schémas ajoutés, shape réelle des resources). SDK JS/Python + miroir dev-hub régénérés. Vérifié : `redocly lint` 0 erreur / 512 warnings pré-existants.
 

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -45,7 +45,6 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
     Route::post('/me/trainings/{sessionId}/enroll', [SelfServiceController::class, 'selfEnroll'])->whereNumber('sessionId');
     Route::get('/me/loans', [SelfServiceController::class, 'myLoans']);
     Route::get('/me/loans/{loanId}/repayments', [SelfServiceController::class, 'myLoanRepayments'])->whereNumber('loanId');
-    Route::get('/me/vehicles', [VehicleController::class, 'myVehicles']);
 
     // ── Org Chart (all employees, read-only) ─────────────────────────────
     Route::get('/org-chart', [OrgChartController::class, 'index']);

--- a/api/routes/modules/payroll_engine.php
+++ b/api/routes/modules/payroll_engine.php
@@ -121,9 +121,8 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
         Route::get('/bank-exports', [BankExportController::class, 'index']);
         Route::post('/bank-exports', [BankExportController::class, 'store']);
         Route::post('/payroll-runs/{payrollRun}/bank-export', [BankExportController::class, 'generate'])->whereNumber('payrollRun');
-        // Issue #2267 : contrat OpenAPI GET/POST /bank-exports (liste + génération).
-        Route::get('/bank-exports', [BankExportController::class, 'index']);
-        Route::post('/bank-exports', [BankExportController::class, 'store']);
+        // Contrat OpenAPI #2267 : GET liste, POST génération asynchrone, GET
+        // {bankExport} détail, GET {bankExport}/download.
         Route::get('/bank-exports/{bankExport}', [BankExportController::class, 'show'])->whereNumber('bankExport');
         Route::get('/bank-exports/{bankExport}/download', [BankExportController::class, 'download'])->whereNumber('bankExport');
 


### PR DESCRIPTION
## Contexte
#2494 — routes backend dupliquées (artefacts de merges parallèles, découvert lors de l'arbitrage OpenAPI #2480).

## Changements
1. **`api/routes/modules/payroll_engine.php`** : la 2e déclaration `GET/POST /bank-exports` (issue #2267, PR #2426) est supprimée. Le bloc canonique conserve : `GET /bank-exports` (liste), `POST /bank-exports` (génération asynchrone), `GET /bank-exports/{bankExport}`, `GET /bank-exports/{bankExport}/download`, + la route legacy `POST /payroll-runs/{payrollRun}/bank-export`.
2. **`api/routes/modules/hr_extended.php`** : `GET /me/vehicles` retiré — la route canonique vit dans `tracking.php` (documentée, avec le commentaire sécurité #2217 sur l'exception employee self-service).

Aucun changement de comportement : mêmes contrôleurs/méthodes, une seule déclaration par route (vérifié par grep ; `php artisan route:list` ne montrera chaque route qu'une fois).

Closes #2494
