### PR TITLE
fix(test): PayrollCalculatorUnitTest — use dupliqué supprimé (Closes #2527)

### DIFF
--- a/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
@@ -40,7 +40,6 @@ class WebhookController extends Controller
         'loan.disbursed',
         'expense.submitted',
         'expense.approved',
-        'webhook.test',
     ];
 
     public function index(Request $request): AnonymousResourceCollection
@@ -120,29 +119,6 @@ class WebhookController extends Controller
         return response()->json(null, 204);
     }
 
-    /**
-     * Issue #2225 — envoie un événement de test au webhook (le client vérifie
-     * que son endpoint reçoit bien les payloads Leopardo).
-     */
-    public function test(Request $request, WebhookEndpoint $webhookEndpoint): JsonResponse
-    {
-        /** @var Employee $actor */
-        $actor = $request->user();
-        if ((string) $webhookEndpoint->company_id !== (string) $actor->company_id) {
-            abort(404);
-        }
-        if (! $actor->isManager()) {
-            abort(403);
-        }
-
-        DispatchWebhook::dispatch($webhookEndpoint, 'test', [
-            'message' => 'Webhook de test Leopardo RH',
-            'timestamp' => now()->toIso8601String(),
-        ]);
-
-        return response()->json(['message' => 'Webhook test event dispatched.']);
-    }
-
     public function events(): JsonResponse
     {
         return response()->json(['data' => self::AVAILABLE_EVENTS]);
@@ -212,8 +188,15 @@ class WebhookController extends Controller
     }
 
     /**
-     * Envoie un événement de test `webhook.test` vers un endpoint (bouton
-     * « Tester » du cockpit admin). La delivery est tracée comme les autres.
+     * POST /webhooks/{webhookEndpoint}/test
+     *
+     * Sends a synchronous test payload to the endpoint URL (same signature
+     * headers and anti-SSRF guard as `DispatchWebhook`) and records a traced
+     * `webhook_deliveries` row with event `test`. QA wave 2026-08-14 — T002
+     * (#2227): the admin SPA "Tester" button used to fail with a 404.
+     *
+     * @return JsonResponse 200 with {status, http_status, duration_ms, delivery}
+     *                       or 422 when the URL is invalid/blocked.
      */
     public function test(Request $request, WebhookEndpoint $webhookEndpoint): JsonResponse
     {
@@ -226,13 +209,82 @@ class WebhookController extends Controller
             abort(404);
         }
 
-        $webhookEndpoint->update(['failure_count' => 0, 'active' => true]);
+        // Anti-SSRF defence-in-depth: same guard as DispatchWebhook::handle().
+        $host = parse_url($webhookEndpoint->url, PHP_URL_HOST);
+        if (! str_starts_with($webhookEndpoint->url, 'https://') || ! is_string($host) || ! NotPrivateUrl::isPublicHost($host)) {
+            return response()->json([
+                'message' => 'Webhook URL rejected: must be a public https URL.',
+                'status' => 'blocked',
+                'http_status' => 0,
+                'duration_ms' => 0,
+            ], 422);
+        }
 
-        DispatchWebhook::dispatch($webhookEndpoint, 'webhook.test', [
-            'test' => true,
-            'message' => 'Test de webhook depuis le cockpit Leopardo RH',
-        ]);
+        $body = [
+            'event' => 'test',
+            'timestamp' => now()->toIso8601String(),
+            'data' => [
+                'test' => true,
+                'message' => 'Leopardo HR webhook test',
+            ],
+        ];
 
-        return response()->json(['message' => 'Webhook test event dispatched.'], 202);
+        $jsonBody = json_encode($body, JSON_THROW_ON_ERROR);
+        $timestamp = time();
+        $signedPayload = "{$timestamp}.{$jsonBody}";
+        $signature = hash_hmac('sha256', $signedPayload, (string) $webhookEndpoint->secret);
+
+        $start = microtime(true);
+
+        try {
+            $response = Http::timeout(10)
+                ->withHeaders([
+                    'Webhook-Id' => Str::uuid()->toString(),
+                    'Webhook-Timestamp' => (string) $timestamp,
+                    'Webhook-Signature' => "v1={$signature},t={$timestamp}",
+                    'X-Leopardo-Event' => 'test',
+                    'Content-Type' => 'application/json',
+                ])
+                ->post($webhookEndpoint->url, $body);
+
+            $durationMs = (int) ((microtime(true) - $start) * 1000);
+
+            $delivery = WebhookDelivery::create([
+                'webhook_endpoint_id' => $webhookEndpoint->id,
+                'event' => 'test',
+                'payload' => $body,
+                'response_code' => $response->status(),
+                'response_body' => mb_substr($response->body(), 0, 2000),
+                'duration_ms' => $durationMs,
+            ]);
+
+            return response()->json([
+                'message' => $response->successful()
+                    ? 'Webhook delivered successfully.'
+                    : 'Webhook delivered but the endpoint returned an error status.',
+                'status' => $response->successful() ? 'success' : 'error',
+                'http_status' => $response->status(),
+                'duration_ms' => $durationMs,
+                'delivery' => (new WebhookDeliveryResource($delivery))->resolve(),
+            ]);
+        } catch (Throwable $e) {
+            $durationMs = (int) ((microtime(true) - $start) * 1000);
+
+            WebhookDelivery::create([
+                'webhook_endpoint_id' => $webhookEndpoint->id,
+                'event' => 'test',
+                'payload' => $body,
+                'response_code' => 0,
+                'response_body' => mb_substr($e->getMessage(), 0, 2000),
+                'duration_ms' => $durationMs,
+            ]);
+
+            return response()->json([
+                'message' => 'Webhook delivery failed: '.$e->getMessage(),
+                'status' => 'error',
+                'http_status' => 0,
+                'duration_ms' => $durationMs,
+            ], 422);
+        }
     }
 }

--- a/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleController.php
+++ b/api/app/Modules/Fleet/Interfaces/Api/V1/VehicleController.php
@@ -136,44 +136,6 @@ class VehicleController extends Controller
         return response()->json(['data' => $position]);
     }
 
-    /**
-     * Sécurité #2217 — véhicules assignés à l'employé connecté (app mobile
-     * employé). Consomme le même format que `position()`.
-     */
-    public function myVehicles(Request $request, TraccarService $traccar): JsonResponse
-    {
-        /** @var Employee $user */
-        $user = $request->user();
-
-        $vehicles = Vehicle::where('company_id', $user->company_id)
-            ->where('assigned_driver_id', $user->id)
-            ->where('status', 'active')
-            ->select(['id', 'plate_number', 'brand', 'model', 'type', 'traccar_device_id', 'assigned_driver_id'])
-            ->get();
-
-        $result = [];
-        foreach ($vehicles as $vehicle) {
-            $position = $vehicle->traccar_device_id !== null
-                ? $traccar->getLastPosition((int) $vehicle->traccar_device_id)
-                : null;
-
-            // Shape aplati aligné sur le modèle mobile `VehiclePosition`
-            // (leopardo_employee / leopardo_hr).
-            $result[] = [
-                'vehicle_id' => $vehicle->id,
-                'plate_number' => $vehicle->plate_number,
-                'brand' => $vehicle->brand,
-                'model' => $vehicle->model,
-                'type' => $vehicle->type,
-                'latitude' => isset($position['latitude']) ? (float) $position['latitude'] : null,
-                'longitude' => isset($position['longitude']) ? (float) $position['longitude'] : null,
-                'speed' => isset($position['speed']) ? (float) $position['speed'] : null,
-                'updated_at' => $position['fixTime'] ?? null,
-            ];
-        }
-
-        return response()->json(['data' => $result]);
-    }
 
     public function trips(Request $request, int $id): JsonResponse
     {

--- a/api/lang/fr/auth.php
+++ b/api/lang/fr/auth.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'demo_link_invalid' => 'Lien d'accès démo invalide ou déjà utilisé.',
-    'demo_link_expired' => 'Ce lien d'accès démo a expiré. Demandez un nouvel accès.',
+    'demo_link_invalid' => "Lien d'accès démo invalide ou déjà utilisé.",
+    'demo_link_expired' => "Ce lien d'accès démo a expiré. Demandez un nouvel accès.",
     'login_success' => 'Connexion réussie.',
     'logout_success' => 'Déconnexion réussie.',
     'session_expired' => 'Votre session a expiré. Veuillez vous reconnecter.',

--- a/api/tests/Feature/OpenApiDocsTest.php
+++ b/api/tests/Feature/OpenApiDocsTest.php
@@ -73,8 +73,9 @@ class OpenApiDocsTest extends TestCase
                 // échappé via la séquence php d'ouverture courte dans la vue ; le
                 // HTML rendu doit contenir la séquence brute (assertSee(..., false)
                 // car le défaut chercherait la forme échappée `&lt;?php`).
-                // NB: ne JAMAIS écrire de tags php littéraux (<?=, ?>) dans un
-                // commentaire PHP — le `?>` ferme le bloc et casse le lexer.
+                // NB: ne JAMAIS écrire de tags php littéraux (short-open ou
+                // closing tag) dans un commentaire PHP — le closing tag ferme
+                // le bloc et casse le lexer.
                 ->assertSee('<?php', false)
                 ->assertSee('GuzzleHttp', false)
                 ->assertSee('Copier');

--- a/api/tests/Feature/OpenApiDocsTest.php
+++ b/api/tests/Feature/OpenApiDocsTest.php
@@ -70,9 +70,11 @@ class OpenApiDocsTest extends TestCase
                 ->assertSee('buildJavaScriptSnippet', false)
                 ->assertSee('buildPhpSnippet', false)
                 // Non-régression #2265 : le littéral `<?php` du snippet builder est
-                // échappé via `<?= '<?php' ?>` dans la vue ; le HTML rendu doit
-                // contenir la séquence brute (assertSee(..., false) car le défaut
-                // chercherait la forme échappée `&lt;?php`).
+                // échappé via la séquence php d'ouverture courte dans la vue ; le
+                // HTML rendu doit contenir la séquence brute (assertSee(..., false)
+                // car le défaut chercherait la forme échappée `&lt;?php`).
+                // NB: ne JAMAIS écrire de tags php littéraux (<?=, ?>) dans un
+                // commentaire PHP — le `?>` ferme le bloc et casse le lexer.
                 ->assertSee('<?php', false)
                 ->assertSee('GuzzleHttp', false)
                 ->assertSee('Copier');


### PR DESCRIPTION
## Contexte

La vague de merges du swarm (06:00-07:00) a laissé des régressions backend qui cassent le chargement des classes/tests → le check requis « Backend Coverage (PHP 8.4 + PostgreSQL 16) » échoue sur les PRs. Le use dupliqué `PayrollCalculatorUnitTest` (#2527) a déjà été corrigé sur main par un autre agent.

## Correctifs (tous lintés `php -l` OK)

1. **`OpenApiDocsTest.php`** (Closes #2546) : commentaire contenant la séquence littérale `<?=` … `?>` — le `?>` **ferme le bloc PHP** même dans un commentaire `//` → « Unclosed `{` on line 61 ». Commentaire réécrit sans tags littéraux.
2. **`WebhookController::test` ×2** (Closes #2548) : doublure #2341 supprimée, version canonique #2353 restaurée (guard `hasManagerRole('principal')`, event `test`, anti-SSRF, shape structurée attendue par `WebhookTestEndpointTest`).
3. **`VehicleController::myVehicles` ×2** (Closes #2548) : doublure supprimée, version fail-open (#2247, try/catch Traccar, shape mobile) conservée.
4. **`api/lang/fr/auth.php`** (Closes #2548) : apostrophes non échappés (`'Lien d'accès…'`) → guillemets doubles.

## Reste connu

- `TrainingController::indexEnrollments` ×2 → #2502 (PR #2505).

## Vérification

- [x] `php -l` : 0 erreur sur les fichiers touchés + sweep complet (hors faux positifs PHP 8.1 : readonly/typed const)

Closes #2546
Closes #2548
