### PR TITLE
fix(api): WebhookController — accolade de classe manquante (Closes #2572)

### DIFF
--- a/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
@@ -210,3 +210,5 @@ class WebhookController extends Controller
 
         return response()->json(['message' => 'Webhook delivery re-queued.'], 202);
     }
+
+}


### PR DESCRIPTION
## Contexte

Issue #2572 — le fix du doublon `WebhookController::test()` (#2548) a été appliqué sur main mais l'accolade fermante de la classe a été perdue : `php -l` → `Parse error: Unclosed '{' on line 25` (fin de fichier à la ligne 212, depth +1). Toute inclusion de la classe → fatal → suite backend + gate coverage rouges.

## Correctif

- Ajout de l'accolade fermante manquante en fin de fichier.
- `php -l` : No syntax errors.

Closes #2572