### PR TITLE
fix(api): routes /training/* — doublons allSessions/allEnrollments retirés (Closes #2502)

### DIFF
--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -61,8 +61,6 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'
     Route::get('/training/courses', [TrainingController::class, 'indexCourses']);
     Route::get('/training/courses/{trainingCourse}', [TrainingController::class, 'showCourse']);
     Route::get('/training/courses/{trainingCourse}/sessions', [TrainingController::class, 'indexSessions']);
-    Route::get('/training/sessions', [TrainingController::class, 'allSessions']);
-    Route::get('/training/enrollments', [TrainingController::class, 'allEnrollments']);
     Route::post('/training/sessions/{trainingSession}/enroll', [TrainingController::class, 'enroll']);
 
     // ── Loan read (employees can see their loans) ────────────────────────


### PR DESCRIPTION
## Contexte
#2502 — volet **routes** : le fix porté par #2542 a été fermé sans merge, donc `main` appelle encore `allSessions`/`allEnrollments` (méthodes inexistantes) sur `GET /training/sessions` + `/training/enrollments` — enregistrées dans le groupe all-employees AVANT le groupe manager → premier match → **500**. Les méthodes réelles (`indexSessionsAll`/`indexEnrollments`) et le fix de la méthode dupliquée sont en place (#2561 mergé).

## Changement
`api/routes/modules/hr_extended.php` : suppression des 2 routes fantômes du groupe all-employees (elles étaient shadowées par le groupe manager enregistré après). Les routes de gestion vivent uniquement dans le groupe `api.manager` → `indexSessionsAll`/`indexEnrollments`.

Closes #2502 (volet routes)
