### PR TITLE
chore(openapi): MANIFEST.json régénéré — garde SDK fraîcheur verte

### DIFF
--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "c37367f888bd12a3afac6d5f9299c54a5a4bead09f0e11b6894e65fa3fce776a",
+  "spec_sha256": "579a1e31ea4cc4f24209b790a1cf9d240f9e8ba24c4ddfc9c5bda5cbab9507fd",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
   "operation_count": 530,


### PR DESCRIPTION
## Contexte
Le merge de #2561 (documentation OpenAPI, drift → 0) a modifié `api/openapi.yaml` sans régénérer le manifeste SDK → le check « Lint OpenAPI contract » échoue sur TOUTES les PRs avec `dev-hub/sdk/MANIFEST.json is not up to date` (garde #2450).

## Changement
`node dev-hub/tools/generate-openapi-sdk.mjs` → 530 opérations générées, **1 seul fichier modifié** : `dev-hub/sdk/MANIFEST.json` (les SDK JS/Python n'ont pas changé de contenu). Check `--check` vert.

Closes #2450 (volet freshness — le miroir/make targets étaient déjà livrés par #2451)
