### PR TITLE
fix(payroll): RICF CI — namespace Company + golden 3M plafond CNSS (Closes #2580)

### DIFF
--- a/api/tests/Feature/Payroll/FamilyPartsRicfTest.php
+++ b/api/tests/Feature/Payroll/FamilyPartsRicfTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Payroll;
 
-use App\Core\Auth\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;

--- a/api/tests/Feature/Payroll/Golden/GoldenCiPayrollTest.php
+++ b/api/tests/Feature/Payroll/Golden/GoldenCiPayrollTest.php
@@ -498,20 +498,21 @@ class GoldenCiPayrollTest extends TestCase
 
     public function test_golden_ci_ricf_parts_max_brut_3m(): void
     {
-        // Calcul manuel (#2117) : brut 3 000 000, 5 parts (plafond légal) :
-        //   CNSS salariale = 3 000 000 × 3,2 % = 96 000 (plafond retraite
-        //     1 647 315 non atteint)
+        // Calcul manuel (#2117/#2580) : brut 3 000 000, 5 parts (plafond légal) :
+        //   CNSS salariale = min(3 000 000, plafond retraite 1 647 315) × 3,2 %
+        //     = 52 714,08 — le plafond EST atteint pour ce brut (le calcul
+        //     initial l'avait oublié : 96 000)
         //   ITS brut 2024 = 165 000×16 % + 560 000×21 % + 1 600 000×24 %
         //     + 600 000×28 % = 696 000
         //   RICF (art. 120) = 44 000 (plafond)
         //   ITS net = 696 000 − 44 000 = 652 000
-        //   Net = 3 000 000 − 96 000 − 652 000 = 2 252 000
+        //   Net = 3 000 000 − 52 714,08 − 652 000 = 2 295 285,92
         $rules = $this->rules();
 
         $breakdown = (new PayrollCalculator)->computeNetBreakdown(3000000.0, $rules, 5.0);
 
         $this->assertSame(652000.0, $breakdown['income_tax']);
-        $this->assertSame(2252000.0, $breakdown['net_salary']);
+        $this->assertSame(2295285.92, $breakdown['net_salary']);
     }
 
     public function test_golden_ci_ricf_default_1_part_no_change(): void


### PR DESCRIPTION
Closes #2580 — RICF CI : namespace Company + golden 3M recalculé.

1. **`FamilyPartsRicfTest`** : import `App\Core\Auth\Domain\Models\Company` (inexistant) → `App\Core\Tenant\Domain\Models\Company` (Class not found ×4).
2. **`GoldenCiPayrollTest::test_golden_ci_ricf_parts_max_brut_3m`** : le calcul manuel oubliait le plafond retraite CNSS (1 647 315 XOF) — pour un brut de 3 000 000 le plafond EST atteint → CNSS salariale = min(3M, 1 647 315) × 3,2 % = **52 714,08** (et non 96 000) → net = **2 295 285,92** (la valeur du moteur — le golden était faux, la garde « calculé à la main » a fonctionné).

Vérifs : commentaire de calcul corrigé, valeurs alignées moteur ; CI à valider.
