### PR TITLE
fix(mobile): onboarding-setup complete/skip en PATCH + stepKey (Closes #2631)

### DIFF
--- a/front/mobile_apps/leopardo_employee/lib/features/onboarding/data/onboarding_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/onboarding/data/onboarding_repository.dart
@@ -20,19 +20,21 @@ class OnboardingRepository {
     return items.map((e) => OnboardingStep.fromJson(e)).toList();
   }
 
-  Future<void> completeStep(int stepId) async {
+  /// [stepKey] is the string key (e.g. 'first_employee'), matching route {stepKey}
+  Future<void> completeStep(String stepKey) async {
     await apiClient.requestWithRetry(
-      '/onboarding-setup/$stepId/complete',
-      method: 'POST',
+      '/onboarding-setup/$stepKey/complete',
+      method: 'PATCH',
       maxRetriesOverride: 0,
       timeoutOverride: _actionTimeout,
     );
   }
 
-  Future<void> skipStep(int stepId) async {
+  /// [stepKey] is the string key (e.g. 'invite_manager'), matching route {stepKey}
+  Future<void> skipStep(String stepKey) async {
     await apiClient.requestWithRetry(
-      '/onboarding-setup/$stepId/skip',
-      method: 'POST',
+      '/onboarding-setup/$stepKey/skip',
+      method: 'PATCH',
       maxRetriesOverride: 0,
       timeoutOverride: _actionTimeout,
     );

--- a/front/mobile_apps/leopardo_employee/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/onboarding/screens/onboarding_screen.dart
@@ -17,9 +17,9 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
-  Future<void> _complete(int stepId) async {
+  Future<void> _complete(String stepKey) async {
     try {
-      await ref.read(onboardingRepositoryProvider).completeStep(stepId);
+      await ref.read(onboardingRepositoryProvider).completeStep(stepKey);
       ref.invalidate(onboardingChecklistProvider);
     } catch (e) {
       if (mounted) {
@@ -33,9 +33,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     }
   }
 
-  Future<void> _skip(int stepId) async {
+  Future<void> _skip(String stepKey) async {
     try {
-      await ref.read(onboardingRepositoryProvider).skipStep(stepId);
+      await ref.read(onboardingRepositoryProvider).skipStep(stepKey);
       ref.invalidate(onboardingChecklistProvider);
     } catch (e) {
       if (mounted) {
@@ -209,7 +209,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                                         color: MobileSurface.muted,
                                       ),
                                       tooltip: 'Passer',
-                                      onPressed: () => _skip(step.id),
+                                      onPressed: () => _skip(step.key),
                                     ),
                                     Container(
                                       decoration: BoxDecoration(
@@ -222,7 +222,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                                           color: AppColors.success,
                                         ),
                                         tooltip: 'Terminer',
-                                        onPressed: () => _complete(step.id),
+                                        onPressed: () => _complete(step.key),
                                       ),
                                     ),
                                   ],

--- a/front/mobile_apps/leopardo_hr/lib/features/onboarding/data/onboarding_repository.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/onboarding/data/onboarding_repository.dart
@@ -20,19 +20,21 @@ class OnboardingRepository {
     return items.map((e) => OnboardingStep.fromJson(e)).toList();
   }
 
-  Future<void> completeStep(int stepId) async {
+  /// [stepKey] is the string key (e.g. 'first_employee'), matching route {stepKey}
+  Future<void> completeStep(String stepKey) async {
     await apiClient.requestWithRetry(
-      '/onboarding-setup/$stepId/complete',
-      method: 'POST',
+      '/onboarding-setup/$stepKey/complete',
+      method: 'PATCH',
       maxRetriesOverride: 0,
       timeoutOverride: _actionTimeout,
     );
   }
 
-  Future<void> skipStep(int stepId) async {
+  /// [stepKey] is the string key (e.g. 'invite_manager'), matching route {stepKey}
+  Future<void> skipStep(String stepKey) async {
     await apiClient.requestWithRetry(
-      '/onboarding-setup/$stepId/skip',
-      method: 'POST',
+      '/onboarding-setup/$stepKey/skip',
+      method: 'PATCH',
       maxRetriesOverride: 0,
       timeoutOverride: _actionTimeout,
     );

--- a/front/mobile_apps/leopardo_hr/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/onboarding/screens/onboarding_screen.dart
@@ -28,9 +28,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     }
   }
 
-  Future<void> _skip(int stepId) async {
+  Future<void> _skip(String stepKey) async {
     try {
-      await ref.read(onboardingRepositoryProvider).skipStep(stepId);
+      await ref.read(onboardingRepositoryProvider).skipStep(stepKey);
       ref.invalidate(onboardingChecklistProvider);
     } catch (e) {
       if (mounted) {
@@ -166,7 +166,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                                     size: 20,
                                   ),
                                   tooltip: 'Passer',
-                                  onPressed: () => _skip(step.id),
+                                  onPressed: () => _skip(step.key),
                                 ),
                                 IconButton(
                                   icon: const Icon(
@@ -175,7 +175,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                                     size: 20,
                                   ),
                                   tooltip: 'Terminer',
-                                  onPressed: () => _complete(step.id),
+                                  onPressed: () => _complete(step.key),
                                 ),
                               ],
                             ),


### PR DESCRIPTION
## Contexte
Issue #2631 : les apps **employee** et **HR** appelaient `POST /onboarding-setup/{id}/complete|skip` alors que le backend ne déclare que `PATCH /onboarding-setup/{stepKey}/complete|skip` (api/routes/modules/billing.php:25-26) → **405 Method Not Allowed** : les étapes d'onboarding ne pouvaient jamais être complétées/skippées depuis ces apps (l'app manager utilisait déjà PATCH + stepKey).

## Changements
- `leopardo_employee` : `onboarding_repository.dart` — `POST` → `PATCH`, paramètre `stepId` (int) → `stepKey` (string) ; `onboarding_screen.dart` — les boutons passent `step.key`.
- `leopardo_hr` : idem.

## Vérification
Analyse statique : plus aucun `POST` sur `/onboarding-setup` dans les apps ; alignement sur le pattern manager (PATCH + stepKey). CI mobile (analyze/tests) requis.