### PR TITLE
fix(web): robots — suppression du sitemap /api/sitemap mort (Closes #2643)

### DIFF
--- a/front/web/src/app/api/robots/route.ts
+++ b/front/web/src/app/api/robots/route.ts
@@ -41,7 +41,6 @@ Disallow: /
 
 # Sitemap location
 Sitemap: ${siteUrl}/sitemap.xml
-Sitemap: ${siteUrl}/api/sitemap
 
 # Cache control
 Cache-control: max-age=86400


### PR DESCRIPTION
## Contexte
Issue #2643 : `app/api/robots/route.ts` annonçait `Sitemap: …/api/sitemap` — URL inexistante (404 ; le vrai sitemap est `/sitemap.xml`, servi par `app/robots.ts`). Route référencée nulle part dans le repo.

## Changement
Suppression de la ligne `Sitemap: ${siteUrl}/api/sitemap` (une seule source : /sitemap.xml).

## Vérification
`curl /api/robots` → plus de référence /api/sitemap.