### PR TITLE
fix(web): checkout — sandbox opt-in explicite, 503 sans Stripe, carte test masquée en prod (Closes #2628)

### DIFF
--- a/front/web/.env.local.example
+++ b/front/web/.env.local.example
@@ -15,7 +15,16 @@ LEOPARDO_INTERNAL_TOKEN=
 NEXT_PUBLIC_API_DIRECT=false
 
 # --- Stripe (checkout self-service) ---
+# Cle live (sk_live_...) OBLIGATOIRE en production : sans elle et sans le flag
+# sandbox ci-dessous, /api/billing/checkout repond 503 CHECKOUT_UNAVAILABLE
+# (jamais de paiement simule en production, voir issue #2628).
 STRIPE_SECRET_KEY=sk_live_or_test_...
+# Opt-in explicite du checkout simule (dev/staging uniquement).
+# En mode sandbox, l'UI affiche la carte de test et aucun paiement n'est debite.
+SANDBOX_CHECKOUT=false
+# Flag expose au navigateur pour l'UI checkout (doit etre `true` en miroir de
+# SANDBOX_CHECKOUT uniquement en dev/staging — jamais en production).
+NEXT_PUBLIC_CHECKOUT_SANDBOX=false
 
 # --- Site / branding ---
 # `leopardo-hr.vercel.app` renvoie 404 (verifie) ; l'URL reellement en ligne

--- a/front/web/src/app/(landing)/checkout/page.tsx
+++ b/front/web/src/app/(landing)/checkout/page.tsx
@@ -175,6 +175,12 @@ const PLAN_CONFIG = {
 type PlanKey = keyof typeof PLAN_CONFIG;
 
 /* ─────────────────────────────────────────────
+   CHECKOUT MODE (sandbox = explicit opt-in via NEXT_PUBLIC_CHECKOUT_SANDBOX=true)
+   In production the test card UI is never shown: payment must be real (#2628).
+───────────────────────────────────────────── */
+const CHECKOUT_SANDBOX = process.env.NEXT_PUBLIC_CHECKOUT_SANDBOX === 'true';
+
+/* ─────────────────────────────────────────────
    SANDBOX TEST CARD
 ───────────────────────────────────────────── */
 const SANDBOX_CARD = {
@@ -897,9 +903,9 @@ function StepPayment({
   const cfg = PLAN_CONFIG[plan];
   const price = billing === 'annual' ? cfg.priceAnnual : cfg.priceMonthly;
 
-  const [cardNumber, setCardNumber] = useState(SANDBOX_CARD.number);
-  const [expiry, setExpiry] = useState(SANDBOX_CARD.expiry);
-  const [cvc, setCvc] = useState(SANDBOX_CARD.cvc);
+  const [cardNumber, setCardNumber] = useState(CHECKOUT_SANDBOX ? SANDBOX_CARD.number : '');
+  const [expiry, setExpiry] = useState(CHECKOUT_SANDBOX ? SANDBOX_CARD.expiry : '');
+  const [cvc, setCvc] = useState(CHECKOUT_SANDBOX ? SANDBOX_CARD.cvc : '');
   const [cardName, setCardName] = useState(
     account.firstName ? `${account.firstName} ${account.lastName}` : SANDBOX_CARD.name,
   );
@@ -997,7 +1003,8 @@ function StepPayment({
         Informations de paiement
       </h2>
 
-      {/* Sandbox notice */}
+      {/* Sandbox notice (dev/staging only — never shown in production, #2628) */}
+      {CHECKOUT_SANDBOX && (
       <div className="mt-3 mb-6 p-4 rounded-2xl bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800/50">
         <div className="flex items-start gap-3">
           <div className="w-8 h-8 rounded-xl bg-amber-400/20 flex items-center justify-center flex-shrink-0">
@@ -1027,6 +1034,7 @@ function StepPayment({
           </div>
         </div>
       </div>
+      )}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Card number */}
@@ -1040,7 +1048,7 @@ function StepPayment({
               type="text"
               value={cardNumber}
               onChange={(e) => setCardNumber(formatCardNumber(e.target.value))}
-              placeholder="4242 4242 4242 4242"
+              placeholder={CHECKOUT_SANDBOX ? '4242 4242 4242 4242' : '1234 5678 9012 3456'}
               maxLength={19}
               className={`${inputBase} pl-10 font-mono ${isSandboxCard ? 'border-amber-400 ring-amber-500/10' : ''}`}
             />

--- a/front/web/src/app/api/billing/checkout/route.ts
+++ b/front/web/src/app/api/billing/checkout/route.ts
@@ -20,6 +20,13 @@ const LEOPARDO_API_URL =
   resolveBackendBaseUrl().replace(/\/api\/v1$/, '');
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || '';
 
+/**
+ * Sandbox checkout is an explicit opt-in (dev/staging only):
+ * SANDBOX_CHECKOUT=true. It is NEVER inferred from a missing Stripe key,
+ * otherwise production would silently simulate payments (see #2628).
+ */
+const SANDBOX_CHECKOUT = process.env.SANDBOX_CHECKOUT === 'true';
+
 /** Sandbox plan prices (EUR cents) — used when Stripe is not configured or in test mode */
 const SANDBOX_PRICES: Record<string, Record<string, number>> = {
   pilot: { monthly: 2900, annual: 2400 },
@@ -52,7 +59,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const body = await request.json();
     const data = checkoutSchema.parse(body);
 
-    const isSandbox = !STRIPE_SECRET_KEY || STRIPE_SECRET_KEY.startsWith('sk_test_') || STRIPE_SECRET_KEY === 'sandbox';
+    // Sandbox ONLY when explicitly enabled (dev/staging). In production, a
+    // missing/live-invalid Stripe key must fail loudly, never fake a payment.
+    const isSandbox = SANDBOX_CHECKOUT;
+
+    /* ── NO PAYMENT PATH CONFIGURED ─────────────────────────── */
+    if (!isSandbox && (!STRIPE_SECRET_KEY || STRIPE_SECRET_KEY.startsWith('sk_test_'))) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'CHECKOUT_UNAVAILABLE',
+          message:
+            'Le paiement en ligne est temporairement indisponible. Contactez le support à support@leopardo-rh.com.',
+        },
+        { status: 503 }
+      );
+    }
 
     /* ── SANDBOX MODE ──────────────────────────────── */
     if (isSandbox) {

--- a/front/web/src/app/api/robots/route.ts
+++ b/front/web/src/app/api/robots/route.ts
@@ -41,7 +41,6 @@ Disallow: /
 
 # Sitemap location
 Sitemap: ${siteUrl}/sitemap.xml
-Sitemap: ${siteUrl}/api/sitemap
 
 # Cache control
 Cache-control: max-age=86400


### PR DESCRIPTION
## Contexte
Issue #2628 : en production, `POST /api/billing/checkout` répondait `sandbox:true` (« Paiement simulé — aucune carte débitée », `provisioned:false`) : le visiteur croyait avoir souscrit (plans payants), il n'avait rien. L'UI affichait en permanence la carte test 4242.

## Changements
- `route.ts` : le sandbox n'est plus déduit de l'absence de clé Stripe — opt-in explicite `SANDBOX_CHECKOUT=true`. Sans clé live et sans flag → **503 CHECKOUT_UNAVAILABLE** (message support clair).
- `checkout/page.tsx` : la notice sandbox + « Remplir avec la carte test » + carte 4242 pré-remplie ne s'affichent que si `NEXT_PUBLIC_CHECKOUT_SANDBOX=true` ; placeholder générique en prod.
- `.env.local.example` : documente `SANDBOX_CHECKOUT` / `NEXT_PUBLIC_CHECKOUT_SANDBOX` (false par défaut).

## Vérification
`curl -X POST /api/billing/checkout` en prod → 503 (jamais sandbox:true). En dev avec `SANDBOX_CHECKOUT=true` → flux simulé inchangé.