### PR TITLE
fix(billing): webhooks Stripe/Chargily fail-closed — secret absent = payload rejeté (Closes #2614, #2615)

### DIFF
--- a/api/app/Modules/Billing/Infrastructure/Services/ChargilyService.php
+++ b/api/app/Modules/Billing/Infrastructure/Services/ChargilyService.php
@@ -31,8 +31,12 @@ class ChargilyService
     public function verifyWebhookSignature(string $payload, string $signatureHeader): ?array
     {
         if (empty($this->webhookSecret)) {
-            Log::warning('Chargily: Webhook secret not configured, skipping signature verification.');
-            return json_decode($payload, true);
+            // #2615 fail-closed : secret absent = webhook non vérifiable = on
+            // REJETTE (null). Un secret vide ne doit jamais accepter un
+            // payload (fail-open = signature by-passable en prod).
+            Log::error('Chargily: Webhook secret not configured — webhook REJETÉ (fail-closed).');
+
+            return null;
         }
 
         // Strip the "sha256=" prefix if present

--- a/api/app/Modules/Billing/Infrastructure/Services/StripeService.php
+++ b/api/app/Modules/Billing/Infrastructure/Services/StripeService.php
@@ -119,10 +119,13 @@ class StripeService
      */
     public function verifyWebhookSignature(string $payload, string $sigHeader): ?array
     {
-        if (!$this->webhookSecret) {
-            Log::warning('Stripe: Webhook secret not configured, skipping verification.');
+        if (! $this->webhookSecret) {
+            // #2614 fail-closed : secret absent = webhook non vérifiable = on
+            // REJETTE (null). Un secret vide ne doit jamais accepter un
+            // payload (fail-open = signature by-passable en prod).
+            Log::error('Stripe: Webhook secret not configured — webhook REJETÉ (fail-closed).');
 
-            return json_decode($payload, true);
+            return null;
         }
 
         $elements = [];

--- a/api/tests/Unit/PaymentWebhookFailClosedTest.php
+++ b/api/tests/Unit/PaymentWebhookFailClosedTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Modules\Billing\Infrastructure\Services\StripeService;
+use App\Modules\Billing\Infrastructure\Services\ChargilyService;
+use Tests\TestCase;
+use ReflectionProperty;
+
+/**
+ * Issues #2614/#2615 — fail-closed des webhooks de paiement.
+ *
+ * Un secret de webhook NON CONFIGURÉ doit REJETER le payload (null),
+ * jamais l'accepter en « skippant » la vérification (fail-open = toute
+ * signature est acceptée en prod si le secret manque).
+ */
+class PaymentWebhookFailClosedTest extends TestCase
+{
+    private function setSecret(object $service, string $secret): void
+    {
+        $prop = new ReflectionProperty($service, 'webhookSecret');
+        $prop->setAccessible(true);
+        $prop->setValue($service, $secret);
+    }
+
+    private function validStripeSignature(string $payload, string $secret): string
+    {
+        $timestamp = (string) time();
+
+        return 't='.$timestamp.',v1='.hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
+    }
+
+    public function test_stripe_rejects_when_secret_missing(): void
+    {
+        $service = new StripeService;
+        $this->setSecret($service, '');
+
+        $this->assertNull(
+            $service->verifyWebhookSignature('{"type":"checkout.session.completed"}', 't=1,v1=abc'),
+            'Secret Stripe absent → le webhook doit être REJETÉ (fail-closed, #2614).'
+        );
+    }
+
+    public function test_stripe_accepts_valid_signature(): void
+    {
+        $service = new StripeService;
+        $secret = 'whsec_test_123';
+        $this->setSecret($service, $secret);
+
+        $payload = '{"type":"checkout.session.completed","data":{"object":{"id":"cs_1"}}}';
+        $sig = $this->validStripeSignature($payload, $secret);
+
+        $result = $service->verifyWebhookSignature($payload, $sig);
+        $this->assertIsArray($result);
+        $this->assertSame('checkout.session.completed', $result['type']);
+    }
+
+    public function test_stripe_rejects_mismatched_signature(): void
+    {
+        $service = new StripeService;
+        $this->setSecret($service, 'whsec_test_123');
+
+        $payload = '{"type":"checkout.session.completed"}';
+
+        $this->assertNull($service->verifyWebhookSignature($payload, 't='.time().',v1=invalid'));
+    }
+
+    public function test_chargily_rejects_when_secret_missing(): void
+    {
+        $service = new ChargilyService;
+        $this->setSecret($service, '');
+
+        $this->assertNull(
+            $service->verifyWebhookSignature('{"type":"checkout.paid"}', 'sha256=abc'),
+            'Secret Chargily absent → le webhook doit être REJETÉ (fail-closed, #2615).'
+        );
+    }
+
+    public function test_chargily_accepts_valid_signature(): void
+    {
+        $service = new ChargilyService;
+        $secret = 'test_secret';
+        $this->setSecret($service, $secret);
+
+        $payload = '{"type":"checkout.paid","data":{}}';
+        $sig = 'sha256='.hash_hmac('sha256', $payload, $secret);
+
+        $result = $service->verifyWebhookSignature($payload, $sig);
+        $this->assertIsArray($result);
+        $this->assertSame('checkout.paid', $result['type']);
+    }
+
+    public function test_chargily_rejects_mismatched_signature(): void
+    {
+        $service = new ChargilyService;
+        $this->setSecret($service, 'test_secret');
+
+        $this->assertNull($service->verifyWebhookSignature('{"type":"checkout.paid"}', 'sha256=invalid'));
+    }
+}


### PR DESCRIPTION
## Contexte

T001/T002 (audit expert backend 2026-08-15) : `StripeService::verifyWebhookSignature()` et `ChargilyService::verifyWebhookSignature()` **fail-open** — secret non configuré = payload accepté sans vérification.

## Correctif

- Secret vide → `Log::error` + `return null` (rejet) — fail-closed (Stripe + Chargily).
- **`PaymentWebhookFailClosedTest`** : 6 cas (secret vide → null · signature valide → payload · mismatch → null, ×2 services).

## Vérifications

- 6/6 OK (PHP 8.4 local).

Closes #2614, Closes #2615