### PR TITLE
fix(notification): webhook email-bounce fail-closed — secret absent = 503 (Closes #2616)

### DIFF
--- a/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/EmailBounceWebhookController.php
+++ b/api/app/Modules/Notification/Interfaces/Api/V1/Controllers/EmailBounceWebhookController.php
@@ -31,14 +31,21 @@ class EmailBounceWebhookController extends Controller
     {
         $configuredSecret = (string) config('services.mail_bounce_webhook.secret', '');
 
-        if ($configuredSecret !== '') {
-            $providedSecret = (string) $request->header('X-Bounce-Webhook-Secret', '');
+        if ($configuredSecret === '') {
+            // #2616 fail-closed : secret non configuré = webhook non
+            // authentifiable = on REFUSE (503). Un webhook sans secret ne
+            // doit jamais traiter un payload (fail-open = spooling/poisoning).
+            Log::error('Email bounce webhook: secret non configuré — webhook REJETÉ (fail-closed).');
 
-            if (! hash_equals($configuredSecret, $providedSecret)) {
-                Log::warning('Email bounce webhook: invalid or missing shared secret');
+            abort(503, 'Email bounce webhook not configured.');
+        }
 
-                return new JsonResponse(['error' => 'Invalid signature'], 400);
-            }
+        $providedSecret = (string) $request->header('X-Bounce-Webhook-Secret', '');
+
+        if (! hash_equals($configuredSecret, $providedSecret)) {
+            Log::warning('Email bounce webhook: invalid or missing shared secret');
+
+            return new JsonResponse(['error' => 'Invalid signature'], 400);
         }
 
         $email = (string) $request->input('email', '');

--- a/api/tests/Feature/EmailBounceWebhookFailClosedTest.php
+++ b/api/tests/Feature/EmailBounceWebhookFailClosedTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #2616 — fail-closed du webhook email-bounce.
+ *
+ * Secret non configuré → 503 (aucun payload traité sans authentification).
+ * Secret configuré + signature valide → 200 · signature invalide → 400.
+ */
+class EmailBounceWebhookFailClosedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_webhook_rejected_when_secret_not_configured(): void
+    {
+        config()->set('services.mail_bounce_webhook.secret', '');
+
+        $this->postJson('/api/v1/webhooks/email-bounce', ['email' => 'test@example.com'])
+            ->assertStatus(503);
+    }
+
+    public function test_webhook_accepted_with_valid_secret(): void
+    {
+        config()->set('services.mail_bounce_webhook.secret', 'test-secret');
+
+        $this->postJson('/api/v1/webhooks/email-bounce', ['email' => 'test@example.com'], [
+            'X-Bounce-Webhook-Secret' => 'test-secret',
+        ])->assertOk();
+    }
+
+    public function test_webhook_rejected_with_invalid_secret(): void
+    {
+        config()->set('services.mail_bounce_webhook.secret', 'test-secret');
+
+        $this->postJson('/api/v1/webhooks/email-bounce', ['email' => 'test@example.com'], [
+            'X-Bounce-Webhook-Secret' => 'wrong-secret',
+        ])->assertStatus(400);
+    }
+}


### PR DESCRIPTION
## Contexte

T003 (audit expert backend) : `EmailBounceWebhookController` traitait le payload sans authentification quand le secret n'était pas configuré.

## Correctif

- Secret non configuré → `abort(503)` (fail-closed) ; signature invalide → 400 ; valide → traitement.
- **`EmailBounceWebhookFailClosedTest`** : 3 cas.

## Vérifications

- 3/3 OK (PHP 8.4 local).

Closes #2616