### PR TITLE
feat(auth): inscription réservée aux invitations valides (Closes #2617)

### DIFF
--- a/api/app/Core/Auth/Application/Actions/RegisterAction.php
+++ b/api/app/Core/Auth/Application/Actions/RegisterAction.php
@@ -4,33 +4,65 @@ declare(strict_types=1);
 
 namespace App\Core\Auth\Application\Actions;
 
+use App\Core\Auth\Domain\Exceptions\RegistrationNotAvailableException;
 use App\Core\Auth\Domain\Models\Employee;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 
 /**
  * Use Case : Inscription d'un nouvel employé (rôle "ordinary").
  *
- * Creates the employee record and issues an API token.
+ * Issue #2617 — inscription réservée aux invitations valides : sans
+ * `invitation_token` valide (existant, non expiré, non consommé, email
+ * correspondant), l'inscription est refusée (422 REGISTRATION_NOT_AVAILABLE).
+ * L'employé est rattaché au `company_id` de l'invitation (plus d'employé
+ * sans tenant), et l'invitation est marquée consommée.
  *
  * @return array{employee: Employee, token: string, token_type: string}
  */
 final class RegisterAction
 {
     /**
-     * @param  array{first_name: string, last_name: string, email: string, password: string, device_name?: string}  $data
+     * @param  array{first_name: string, last_name: string, email: string, password: string, invitation_token: string, device_name?: string}  $data
      * @return array{employee: Employee, token: string, token_type: string}
      */
     public function execute(array $data): array
     {
+        $invitationToken = $data['invitation_token'] ?? null;
+        if (! is_string($invitationToken) || $invitationToken === '') {
+            throw new RegistrationNotAvailableException();
+        }
+
+        $email = strtolower(trim($data['email']));
+
+        $invitation = DB::table('public.user_invitations')
+            ->where('token_hash', hash('sha256', $invitationToken))
+            ->whereNull('accepted_at')
+            ->where('expires_at', '>', now())
+            ->where('email', $email)
+            ->first();
+
+        if ($invitation === null) {
+            // Token absent, expiré, déjà consommé ou email différent : on ne
+            // dit pas lequel (pas de fuite d'information sur les invitations).
+            throw new RegistrationNotAvailableException();
+        }
+
         /** @var Employee $employee */
         $employee = Employee::create([
             'first_name'    => $data['first_name'],
             'last_name'     => $data['last_name'],
-            'email'         => $data['email'],
+            'email'         => $email,
             'password_hash' => Hash::make($data['password']),
-            'role'          => 'ordinary',
+            'role'          => $invitation->role ?? 'ordinary',
             'status'        => 'active',
+            'company_id'    => $invitation->company_id,
         ]);
+
+        // Invitation consommée (idempotence : seule la première passe).
+        DB::table('public.user_invitations')
+            ->where('id', $invitation->id)
+            ->update(['accepted_at' => now()]);
 
         $tokenName = $data['device_name'] ?? 'api';
         $token = $employee->createToken($tokenName);

--- a/api/app/Core/Auth/Domain/Exceptions/RegistrationNotAvailableException.php
+++ b/api/app/Core/Auth/Domain/Exceptions/RegistrationNotAvailableException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\Auth\Domain\Exceptions;
+
+use App\Exceptions\DomainException;
+
+/**
+ * Issue #2617 — l'inscription est réservée aux invitations valides.
+ * Sans invitation_token valide (existant, non expiré, non consommé, email
+ * correspondant), l'inscription est refusée (422 REGISTRATION_NOT_AVAILABLE) :
+ * plus d'inscription anonyme sur la plateforme.
+ */
+class RegistrationNotAvailableException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Registration is available by invitation only.',
+            422,
+            'REGISTRATION_NOT_AVAILABLE'
+        );
+    }
+
+    public function statusCode(): int
+    {
+        return 422;
+    }
+}

--- a/api/app/Core/Auth/Interfaces/Requests/StoreRegistrationRequest.php
+++ b/api/app/Core/Auth/Interfaces/Requests/StoreRegistrationRequest.php
@@ -21,6 +21,8 @@ class StoreRegistrationRequest extends FormRequest
             'email' => ['required', 'email', 'unique:employees,email', 'max:150'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
             'device_name' => ['nullable', 'string', 'max:100'],
+            // Issue #2617 : inscription réservée aux invitations valides.
+            'invitation_token' => ['required', 'string', 'max:64'],
         ];
     }
 }

--- a/api/tests/Feature/AuthSelfRegistrationTest.php
+++ b/api/tests/Feature/AuthSelfRegistrationTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
@@ -40,14 +42,58 @@ class AuthSelfRegistrationTest extends TestCase
         }
     }
 
-    public function test_a_user_can_register_as_an_ordinary_account()
+    private function createInvitation(string $email, ?string $token = 'valid-token-123'): string
     {
+        // Issue #2617 : l'inscription nécessite une invitation valide.
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+
+        DB::table('public.user_invitations')->insert([
+            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'company_id' => $company->id,
+            'schema_name' => 'shared_tenants',
+            'employee_id' => 0,
+            'email' => $email,
+            'role' => 'ordinary',
+            'manager_role' => null,
+            'invited_by_type' => 'platform',
+            'invited_by_email' => 'admin@leopardo-rh.com',
+            'token_hash' => hash('sha256', $token),
+            'expires_at' => now()->addDays(7),
+            'accepted_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    public function test_registration_requires_a_valid_invitation(): void
+    {
+        // Sans invitation : inscription refusée (fail-closed, #2617).
+        $this->postJson('/api/v1/auth/register', [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => 'john.doe@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'invitation_token' => 'missing-token',
+        ])->assertStatus(422)
+            ->assertJsonPath('error', 'REGISTRATION_NOT_AVAILABLE');
+
+        $this->assertDatabaseMissing('employees', ['email' => 'john.doe@example.com']);
+    }
+
+    public function test_a_user_can_register_with_a_valid_invitation(): void
+    {
+        $token = $this->createInvitation('john.doe@example.com');
+
         $response = $this->postJson('/api/v1/auth/register', [
             'first_name' => 'John',
             'last_name' => 'Doe',
             'email' => 'john.doe@example.com',
             'password' => 'password123',
             'password_confirmation' => 'password123',
+            'invitation_token' => $token,
         ]);
 
         $response->assertStatus(201)
@@ -56,10 +102,17 @@ class AuthSelfRegistrationTest extends TestCase
                 'token',
             ]);
 
-        $this->assertDatabaseHas('employees', [
+        // L'employé est rattaché au company_id de l'invitation (plus
+        // d'employé sans tenant) et l'invitation est consommée.
+        $employee = Employee::query()->where('email', 'john.doe@example.com')->firstOrFail();
+        $this->assertNotNull($employee->company_id);
+
+        $this->assertDatabaseHas('user_invitations', [
             'email' => 'john.doe@example.com',
-            'role' => 'ordinary',
         ]);
+        $this->assertNotNull(
+            DB::table('public.user_invitations')->where('email', 'john.doe@example.com')->value('accepted_at')
+        );
     }
 
     public function test_an_ordinary_user_can_submit_a_company_request()


### PR DESCRIPTION
## Contexte

T004 (audit expert backend) : l'inscription créait un employé sans tenant.

## Correctif

- `RegisterAction` : `invitation_token` valide obligatoire → sinon 422 `REGISTRATION_NOT_AVAILABLE` ; employé rattaché au `company_id` de l'invitation ; invitation consommée.
- `StoreRegistrationRequest` : token requis.
- `AuthSelfRegistrationTest` : 422 sans invitation + 201 avec invitation.

## Vérifications

- 3/3 OK (PHP 8.4 local).

Closes #2617