### PR TITLE
docs(speckit): vague QA omnichannel 2026-08-15 — registre, spec, tasks (Closes #2771)

### DIFF
--- a/.specify/features/qa-omnichannel-wave-2026-08-15/checklists/requirements.md
+++ b/.specify/features/qa-omnichannel-wave-2026-08-15/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Vague QA Omnichannel 2026-08-15
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- La spec référence les preuves fichier:ligne dans findings-registry.md (traçabilité complète).
+- Scope exclu explicitement (Assumptions) : vague 2 (SSO/SEPA/export/push), issues payroll/CI
+  ouvertes, déploiements (livrés en issues ops dédiées).
+- 56 tasks, dont 11 P1 (US1: 2, US2: 3, US3: 3, US5: 2) et 1 P2 ops (T054/T055 déploiement).

--- a/.specify/features/qa-omnichannel-wave-2026-08-15/findings-registry.md
+++ b/.specify/features/qa-omnichannel-wave-2026-08-15/findings-registry.md
@@ -1,0 +1,122 @@
+# Registre des manquements — QA Omnichannel 2026-08-15
+
+> Session de test de la plateforme Leopardo RH (repo kitokoh/leopardo-hr, main @ 80c034ff).
+> Mission : tester la vitrine, le web, l'admin, les mobiles, les workflows, les APIs, les
+> logiques, l'onboarding et la cohérence — tout manquement → spec + tasks + issues
+> (méthode Spec Kit) puis implémentation.
+> Méthode : audits statiques 4 surfaces (API/web/admin/mobile) + tests runtime
+> (build vitrine local, suite de tests backend locale, API Render live, admin Pages.dev live).
+
+## A. Vérifications runtime effectuées
+
+- [x] Build vitrine Next.js local sur main : `npm run build` → **OK (exit 0)**.
+- [x] Vitrine locale (next start) : sitemap émet 10 URLs `/blog/*` alors que `/blog` → **404**
+      (blog désactivé) → **BUG CONFIRMÉ** (`src/app/sitemap.ts:35`, `enableBlog` déstructuré jamais utilisé).
+- [x] Vitrine locale : `/og/pricing.png` → **404**, aucun `public/og/` ni `public/og-image.png` → **BUG CONFIRMÉ**.
+- [x] Vitrine locale : `/case-studies/{slug}` → 200 sur main (12 slugs OK) — les 404 live sont dus au **déploiement stale**.
+- [x] Vitrine locale : `/dashboard/reports` et `/reports` → 307 login ; `/dashboard/reports` n'est PAS une route (build) → lien mort pour utilisateur connecté (home dashboard).
+- [x] API Render live (`gestionemployerbackend.onrender.com`, health v4.23.5) :
+      `/api/v1/i18n/catalog/fr` → **500** ; `/api/v1/supported-countries` → **404** ;
+      `/api/v1/admin/dashboard/stats|activities|alerts` → **404** ; `/api/v1/admin/impersonations` → **404** ;
+      `/api/v1/platform/impersonations` → **302** ; login invalide → `INVALID_CREDENTIALS` + `localized_message`.
+      → **déploiement Render obsolète vs main** (routes ajoutées post-4.23.5).
+- [x] Vitrine Vercel live : sitemap avec slugs blog ANCIENS (`paie-multi-pays-defis`, `pointage-biometrique-entreprise`)
+      jamais présents dans `data/blog.ts` actuel ; `/case-studies/{slug}` 404 en live ; `/blog` 404.
+      → **déploiement Vercel obsolète** (build précède #2281).
+- [x] Admin Pages.dev live : page login OK ; bouton « Accès Démo » (admin@leopardo-rh.com/password123) → **échec**
+      (démo désactivée en prod) avec message « Erreur de connexion. Vérifiez votre connexion internet. » trompeur.
+- [x] Suite de tests backend (locale, Feature) : en cours — échec isolé `AbsenceApproveTest::manager can approve pending absence` à re-vérifier (flake/env).
+
+## B. Findings — Vitrine web (front/web, Next.js)
+
+| ID | Sév | Constat | Preuve |
+|----|-----|---------|--------|
+| W1 | P1 | Sitemap : 10 URLs `/blog/*` émises alors que `/blog` rend 404 (blog désactivé) — `enableBlog` déstructuré mais jamais utilisé | `src/app/sitemap.ts:35` vs `src/app/(landing)/blog/layout.tsx:24` (notFound) |
+| W2 | P1 | Toutes les ogImages pointent vers `/og/<page>.png` + `/og-image.png` : dossier et fichiers inexistants → images de partage social 404 | `src/modules/vitrine/lib/seo.ts:25,93-340` ; `public/` sans `og/` |
+| W3 | P2 | Ancres mortes page docs : `#webhooks-intro`, `#webhooks-events`, `#webhooks-testing` (ids inexistants) | `src/app/(landing)/docs/page.tsx:76-79` |
+| W4 | P2 | Lien mort home dashboard : `/dashboard/reports` (route réelle `/reports`) | `src/app/(dashboard)/dashboard/page.tsx:542` |
+| W5 | P2 | Service worker : precache de `/dashboard/attendance`, `/dashboard/absences`, `/dashboard/employees`, `/favicon.ico` inexistants → `cache.addAll` rejette → **install SW échoue** | `public/sw.js:14-17,25` |
+| W6 | P2 | `/api/robots` déclare `Sitemap: .../api/sitemap` (route inexistante) ; robots dupliqués et divergents (`robots.ts` vs `/api/robots`) | `src/app/api/robots/route.ts:44` |
+| W7 | P2 | Page dashboard edge-nodes appelle `/edge` (GET/POST/sync) : backend n'expose que `/platform/edge/nodes` → 404 systématique | `src/app/(dashboard)/edge-nodes/page.tsx:57,77,94` |
+| W8 | P2 | Canonicaux hardcodés sur `https://gestionemployer-backend.vercel.app` (17+ fichiers + fallback og) au lieu de `NEXT_PUBLIC_SITE_URL` | `src/app/(landing)/{about,blog,blog/[slug],branding,careers,case-studies,changelog,checkout,contact,docs,download,faq,mobile,pricing,signup,testimonials,videos}/layout.tsx`, seo.ts |
+| W9 | P2 | Pricing incohérents : FAQ cite plans « Starter »/« Business » fantômes ; Enterprise 299 €/mois au checkout vs « Sur devis » pricing ; checkout sans surcoût « +2 €/+4 €/employé » ; manifest « essai 14 jours » vs « 30 jours » partout | `data/faq.ts:164,167...`, `data/pricing.ts:93,179,265...`, `checkout/page.tsx:138-143,58-99`, `public/manifest.json:30` |
+| W10 | P3 | CTA docs « Rejoindre les testeurs » → `/signup?source=download_*` au lieu des vrais liens Firebase App Distribution | `docs/page.tsx:447-449` vs `lib/mobile-download.ts` |
+| W11 | P3 | Vidéos : client témoin « Atlas Industries » vs « Atlas Digital » (testimonials.ts) | `videos/page.tsx:47` |
+| W12 | P3 | CTA Enterprise → `/contact?type=enterprise` mais la page contact lit `?topic=` (paramètre ignoré) | `pricing/page.tsx:718` vs `contact/page.tsx:28-37` |
+| W13 | P3 | `vercel.json` : redirect mort `/old-page` → `/new-page` (ni l'un ni l'autre n'existe) | `vercel.json:73-74` |
+| W14 | P3 | Logo structuré JSON-LD `…/logo.png` inexistant ; `apple-touch-icon` = SVG (iOS refuse) ; pas d'icônes PNG 192/512 → installabilité PWA compromise | `src/components/JsonLd.tsx:57`, `src/app/layout.tsx:94` |
+| W15 | P3 | Code mort : `lib/mdx.ts` + `content/blog/*.mdx` inutilisés, exports orphelins (GradientOrbs, ScrollAnimations, Divider, useScrollAnimation, useFormSubmit, pageVariants, cn, generateOrganizationSchema, tout `lib/seo-metadata.ts`), 2 NewsletterForm dupliqués | grep imports |
+
+## C. Findings — Admin dashboard (front/admin-dashboard, Vue 3)
+
+| ID | Sév | Constat | Preuve |
+|----|-----|---------|--------|
+| A1 | P1 | Crash header/sidebar : le store stocke l'enveloppe `{data:[...]}` puis `.filter(...)` → TypeError `filter is not a function` | `stores/dashboard.js:46,60-61,85` vs `PlatformAdminDashboardController` (`['data'=>…]`) |
+| A2 | P1 | `POST /admin/impersonations` → 404 (le backend expose `POST /platform/impersonations`) → impersonation #2518 inutilisable | `views/users/UsersView.vue:435` vs `api/routes/api.php:284-286` |
+| A3 | P1 | Bouton « alertes critiques » du header : `showAlerts` togglé mais aucun panneau rendu | `components/layout/Header.vue:141,215` |
+| A4 | P2 | Recherche globale : `console.log('Searching for:')` uniquement (« Implement search functionality ») | `components/layout/Header.vue:240` |
+| A5 | P2 | MiniGlobe : 3 points codés en dur (Paris/Istanbul/Casablanca) affichés comme « Activité en temps réel », bouton « Actualiser » = mélange des points | `components/globe/MiniGlobe.vue:22,51-55,70-75` |
+| A6 | P2 | `supportedCountries` codés en dur et incohérents entre écrans (6/12/7/10 pays) alors que `GET /supported-countries` existe | `views/settings/HolidaysView.vue:244`, `TaxSlabsView.vue:144`, `TaxRatesView.vue:237`, `SocialContributionsView.vue:201` |
+| A7 | P2 | SystemView : 6 sections « Non disponible — aucun endpoint backend » en dur alors que les composants dédiés existent | `views/system/SystemView.vue:87-154` |
+| A8 | P2 | UsersView : `per_page=100` sans page server-side ; pagination « client » plafonnée à 100 (pages 2+ = doublons, >100 invisibles) | `views/users/UsersView.vue:310-321` |
+| A9 | P2 | CommandPalette : `vehicles` → `/vehicles` (route inexistante, la vraie est `/fleet`) ; `settings` → `/system` (la vraie est `/settings`) | `components/common/CommandPalette.vue:111,115` |
+| A10 | P2 | Login : « Accès Démo » avec credentials en clair dans le bundle ; bouton affiché même si `DEMO_MODE_ENABLED=false` → échec + message « vérifiez votre connexion internet » trompeur | `views/auth/LoginView.vue:122-129,191-207` |
+| A11 | P2 | 401 `INVALID_CREDENTIALS` : la clé brute est affichée au lieu de `localized_message` ; reload complet au lieu d'une navigation SPA | `stores/auth.js:72`, `services/api.js:185` |
+| A12 | P2 | 12 routes (payroll, leaves, contracts, recruitment, training, fleet, chat, webhooks, exports, reports, predictions, audit) neutralisées par le guard `requiresTenant` → vues construites mais inaccessibles | `router/index.js:154-291,392-395` |
+| A13 | P3 | `holidays.nav.title` : clé i18n absente → H1 affiche la clé brute | `router/index.js:335` vs `i18n/locales/*.json` |
+| A14 | P3 | Carte dashboard « Préparer intégrations partenaires » → `/webhooks` (route guard-blockée) | `views/DashboardView.vue:336` |
+| A15 | P3 | `SystemAlertsOverlay` « Désactiver (maintenance) » = `// Simulate API call` (setTimeout, aucun endpoint) ; bannière jamais affichée | `components/alerts/SystemAlertsOverlay.vue:207` |
+| A16 | P3 | `RevenueForecastWidget` : historique généré avec `Math.random()` (données synthétiques) | `components/analytics/RevenueForecastWidget.vue:187` |
+| A17 | P3 | 12 composants + 8 widgets analytics + 3 composables jamais importés (dead code) | grep |
+| A18 | P3 | Messages non accentués systématiques (« Session expiree », « Donnees invalides ») | `services/api.js:27-44` |
+| A19 | P3 | `confirm()`/`prompt()` natifs + libellés anglais dans UI française | `views/growth/GrowthDashboardView.vue:161,167` |
+| A20 | P3 | Filtre « En attente » proposé mais désactivé dans le code ; refs mortes `showCreateModal`/`showEditModal`/`loadCompanies` | `views/users/UsersView.vue:240-241,275,308,335` |
+
+## D. Findings — Mobile (front/mobile_apps, Flutter)
+
+| ID | Sév | Constat | Preuve |
+|----|-----|---------|--------|
+| M1 | P1 | Manager : navigation Placard vers `/cabinet/folder/${folder.id}` mais routeur déclare `/cabinet/:folderId` → GoRouter `No route found` (crash au clic) | `leopardo_manager/lib/features/cabinet/screens/cabinet_screen.dart:432` vs `leopardo_manager/lib/app.dart:179` |
+| M2 | P1 | Onboarding Employee/HR : `completeStep(int)`/`skipStep(int)` → `POST /onboarding-setup/{id}/complete|skip` alors que le backend expose **PATCH** `/onboarding-setup/{stepKey}/complete|skip` (stepKey = string) → 405+404 ; le middleware `api.manager` → 403 pour un employé | `leopardo_employee/lib/features/onboarding/data/onboarding_repository.dart:23-35`, `leopardo_hr/…:23-35`, `api/routes/modules/billing.php:22-26` |
+| M3 | P1 | App Manager : employé non-manager/RH authentifié → boucle de redirection `/welcome` ↔ `/` (GoRouter Infinite redirect → crash) ; même pattern app HR | `leopardo_manager/lib/app.dart:83-89`, `leopardo_hr/lib/app.dart:83-88` |
+| M4 | P2 | Route `/onboarding` déclarée dans 3 apps mais aucun code n'y navigue → flux onboarding inaccessible | `app.dart:196/219/209` (0 occurrence de navigation) |
+| M5 | P2 | `MobileExperienceService::stageFor()` lit `extra_data.app_actions_count` jamais écrit nulle part → stage `new` permanent (home réduite à 3 chips) | `api/app/Modules/HR/Infrastructure/Services/MobileExperienceService.php:70` (grep global : seule lecture) |
+| M6 | P2 | `appContextFor()` déclare des apps inexistantes (`comptable`, `dept`, `marketing` non distribuée) avec deep_link_scheme jamais consommé par aucun client | `MobileExperienceService.php:42-58` (0 hit Dart) |
+| M7 | P2 | Contrats mobiles (`dev-hub/tools/mobile-workflow-contracts.json`) : `hr.workflows` vidé par #2247 ; `manager_dashboard_placeholder` référence route/écran inexistants | contrat vs `leopardo_manager/lib/` |
+| M8 | P2 | `/onboarding-setup/*` derrière `api.manager` → l'écran onboarding employee serait 403 | `api/routes/modules/billing.php:22` |
+| M9 | P3 | `EnsureAppContextMiddleware` enregistré mais jamais attaché à une route ; aucune app n'envoie `X-App-Context` | `api/bootstrap/app.php:100` (grep routes = 0) |
+| M10 | P3 | `getDepartmentHierarchy()` → `/departments/{id}/hierarchy` inexistant (seul `/org-chart` existe) — méthode jamais appelée | `leopardo_manager/lib/features/organigramme/data/organigramme_repository.dart:61` |
+| M11 | P3 | `int.parse(pathParameters['folderId']!)` : crash sur deep-link non numérique | `app.dart` manager:181, employee:153, hr:155 |
+| M12 | P3 | Routes mortes déclarées jamais naviguées : `/training`, `/expenses`, `/ai-chat`, `/ai-voice`, `/vehicle-map` (employee), `/modules/rh` (manager/hr) ; `PersonalSpaceScreen` non routé ; `suggested_home_route` jamais consommé | grep |
+
+## E. Findings — API backend (api/, Laravel)
+
+| ID | Sév | Constat | Preuve |
+|----|-----|---------|--------|
+| P1 | P2 | 8 outils IA enregistrés actifs mais non implémentés (`get_attendance_today`, `get_attendance_anomalies`, `get_monthly_report`, `get_absences`, `get_daily_summary`, `get_notifications`, `get_leave_balances`, `get_payroll_summary`) → réponse « registered but not yet implemented » | `database/seeders/AIToolRegistrySeeder.php:73-187` vs `app/AI/IntentEngine.php:168-173` |
+| P2 | P2 | `POST /admin/ai/chat` : validation + réponse codée en dur « assistant non disponible » (200 OK qui ne fait rien) | `PlatformAdminAiConversationController.php:74-100` |
+| P3 | P2 | Catch silencieux `catch (\Throwable) { return ['data' => []]; }` sans log (liste conversations IA + fleet alerts) → super-admin voit « aucune donnée » au lieu d'une erreur | `PlatformAdminAiConversationController.php:41,113`, `PlatformAdminFleetAlertController.php:65` |
+| P4 | P2 | Route dupliquée `POST /webhooks/{webhookEndpoint}/test` (2 déclarations, la 1ʳᵉ morte) | `routes/modules/hr_extended.php:158,166` |
+| P5 | P3 | Routes Growth sans throttle (tous les autres modules en ont) | `routes/modules/growth.php:23-44` |
+| P6 | P3 | Callbacks SSO publics SAML/OIDC sans rate-limit ; `{companyId}` SAML sans `whereUuid` (incohérent avec OIDC) | `routes/modules/sso.php:16-28` |
+| P7 | P3 | `ProvisionDemoTenantJob` : TODO « magic link » jamais généré/ envoyé | `app/Jobs/ProvisionDemoTenantJob.php:55` |
+| P8 | P3 | `GET /ai/agent/workflows` liste codée en dur ; workflow `new_employee_onboarding` sans endpoint correspondant | `app/Http/Controllers/AI/AgentController.php:56-80` |
+| P9 | P3 | Fake employee `alice@demo.local` / `password` créé dans chaque tenant trial (chemin prod) | `app/Modules/Billing/Application/Actions/ProvisionGuidedTrial.php:150-176` |
+| P10 | P3 | `CommunicationService` : tout provider non implémenté bascule silencieusement sur audit (délivrance jamais réelle) | `CommunicationService.php:404`, `config/communication.php:33-44` |
+| P11 | P3 | `PayrollCycleController::complianceFor()` avale toutes les exceptions → conformité multi-pays disparaît silencieusement | `PayrollCycleController.php:254-267` |
+| P12 | P3 | 135 routes implémentées absentes de l'OpenAPI (clusters : user/*, public/careers/*, trial/*, hr/*, departments/*, announcements/*, conversations/*, payrolls/*, reports/*, webhooks Stripe/Chargily/email-bounce, platform/*, ai/*, edge/*, notifications/*, health/live|ready, admin/social-contributions/*) | `api/openapi.yaml` vs `routes/` |
+| P13 | P3 | `/billing/checkout` et `/billing/portal` → 503 tant que `services.stripe.secret` absent | `BillingController.php:195` |
+
+## F. Findings — Déploiement / ops (live)
+
+| ID | Sév | Constat | Preuve |
+|----|-----|---------|--------|
+| D1 | P1 | API Render live v4.23.5 obsolète vs main : `/i18n/catalog/fr` → 500, `/supported-countries` → 404, `/admin/dashboard/*` → 404, `/admin/impersonations` → 404, `/platform/impersonations` → 302 sans auth | curl live 2026-08-15 |
+| D2 | P1 | Vitrine Vercel obsolète : sitemap blog avec slugs disparus, `/case-studies/{slug}` 404, build précède #2281 | curl live 2026-08-15 |
+| D3 | P2 | Bouton « Accès Démo » admin affiché alors que démo désactivée en prod → échec avec message trompeur | Pages.dev live |
+
+## G. Déjà couvert (NE PAS dupliquer)
+
+- SSO SAML 501, SEPA IBAN placeholder, export history, notification push, routes mortes backend → spec `qa-hardening-wave-2-2026-08-14` (21 tasks ouvertes, non implémentées à ce jour).
+- 16 opérations OpenAPI sans route, mismatch verbes, EdgeController mort, LogsView admin orpheline → spec `qa-web-openapi-wave-2026-08-14`.
+- Open issues #2590, #2587, #2586, #2583, #2580 (payroll CI/PHPStan/CHANGELOG/correlation) → à traiter hors scope.

--- a/.specify/features/qa-omnichannel-wave-2026-08-15/spec.md
+++ b/.specify/features/qa-omnichannel-wave-2026-08-15/spec.md
@@ -1,0 +1,193 @@
+# Feature Specification: Vague QA Omnichannel — Vitrine, Admin, Mobile, API, Ops (2026-08-15)
+
+**Feature Branch**: `qa-omnichannel-wave-2026-08-15`
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Input**: Mission de test exhaustif de la plateforme (session 2026-08-15) — audits
+statiques 4 surfaces (web, admin, mobile, API) + tests runtime (build vitrine locale,
+suite backend locale, API Render live, admin Pages.dev live) sur `main` (`80c034ff`).
+Constats dans `findings-registry.md` (36 findings, dont 11 P1). Les manquements déjà
+speccés (vague 2 SSO/SEPA/export/push, openapi-wave) et les issues ouvertes ne sont
+pas dupliqués ici.
+
+## User Scenarios & Testing
+
+### User Story 1 — La vitrine web n'émet plus aucune URL morte ni promesse non tenue (Priority: P1)
+
+Le sitemap public émet 10 URLs `/blog/*` alors que le blog est désactivé (`/blog` → 404) ;
+toutes les images de partage social (`ogImage`) pointent vers `/og/<page>.png` inexistants ;
+la page docs porte 3 ancres mortes ; la home du dashboard web pointe vers `/dashboard/reports`
+(route inexistante) ; le service worker precache des routes inexistantes et son installation
+échoue ; la page edge-nodes appelle `/edge` inexistant ; les canonicaux sont hardcodés sur un
+domaine tiers.
+
+**Pourquoi P1** : un sitemap avec 404 pénalise le SEO, des ogImages 404 cassent chaque
+partage, un service worker qui ne s'installe pas casse l'offline (Constitution §X, mobile-first).
+
+**Test indépendant** : build Next.js vert ; assertions sur `sitemap.ts` (blog exclu quand
+désactivé) ; présence de `public/og-image.png` et zéro référence `/og/<page>.png` ;
+ancres docs → ids existants ; lien dashboard → `/reports` ; `sw.js` ne precache que des
+routes existantes ; edge-nodes → `/platform/edge/nodes` ; canonicaux = `NEXT_PUBLIC_SITE_URL`.
+
+**Acceptance Scenarios**:
+
+1. **Given** `NEXT_PUBLIC_ENABLE_BLOG=false`, **When** on génère `/sitemap.xml`, **Then**
+   aucune URL `/blog/*` n'apparaît (et la variable `enableBlog` est réellement utilisée).
+2. **Given** une page de la vitrine, **When** on la partage sur un réseau social, **Then**
+   l'ogImage résolue retourne 200 (fichier réel dans `public/`).
+3. **Given** la page docs, **When** on clique chaque ancre du sommaire, **Then** un élément
+   `id` correspondant existe dans la page.
+4. **Given** un utilisateur connecté au dashboard web, **When** il clique la carte
+   « Rapports », **Then** il arrive sur `/reports` (200), jamais 404.
+5. **Given** la PWA, **When** le service worker s'installe, **Then** tous les assets du
+   precache existent (`cache.addAll` ne rejette pas).
+6. **Given** la page edge-nodes, **When** elle charge, **Then** elle appelle
+   `/platform/edge/nodes` (contrat backend réel).
+7. **Given** n'importe quelle page vitrine, **When** on inspecte son canonical, **Then**
+   il provient de `NEXT_PUBLIC_SITE_URL` (aucun domaine en dur).
+
+### User Story 2 — La console super-admin ne crashe plus et n'a plus de boutons morts (Priority: P1)
+
+Le header de l'admin plante dès que `/admin/dashboard/alerts` répond (enveloppe `{data:[…]}`
+non déballée → `TypeError: filter is not a function`) ; l'impersonation poste vers
+`/admin/impersonations` (404 ; le backend sert `/platform/impersonations`) ; le bouton
+« alertes critiques » n'affiche aucun panneau ; la recherche globale ne fait que logger ;
+le globe affiche des données codées en dur comme « activité temps réel ».
+
+**Pourquoi P1** : un crash du header rend la console inutilisable ; l'impersonation est une
+feature de sécurité annoncée (#2518) qui ne fonctionne jamais.
+
+**Test indépendant** : tests unitaires du store (réponse enveloppée → `criticalAlerts`
+filtrable) ; vérification statique du contrat d'URL (`/platform/impersonations`) ;
+tests composants Header (clic alertes → panneau rendu) ; zéro `console.log` de recherche.
+
+**Acceptance Scenarios**:
+
+1. **Given** une réponse API `/admin/dashboard/alerts` avec enveloppe `{data:[…]}`,
+   **When** le store charge le dashboard, **Then** `criticalAlerts` contient les alertes
+   critiques (aucun TypeError, aucun crash header/sidebar).
+2. **Given** un super-admin, **When** il lance une impersonation depuis la liste des
+   utilisateurs, **Then** la requête part vers `POST /platform/impersonations` et aboutit.
+3. **Given** le header, **When** on clique « alertes critiques », **Then** un panneau
+   listant les alertes réelles s'affiche.
+4. **Given** la recherche globale, **When** on tape une requête, **Then** elle filtre la
+   navigation (routes accessibles) au lieu d'un `console.log`.
+5. **Given** l'écran système, **When** il charge, **Then** les sections utilisent les
+   endpoints réels existants (`/platform/observability/*`) — plus de « Non disponible » en dur.
+6. **Given** l'écran des congés/fiscalité, **When** il liste les pays, **Then** tous les
+   écrans consomment la même source (`GET /supported-countries`), cohérente.
+
+### User Story 3 — Les apps mobiles ne crashent plus et l'onboarding fonctionne (Priority: P1)
+
+Le manager crashe en ouvrant un dossier du Placard (`/cabinet/folder/{id}` vs
+`/cabinet/:folderId`) ; l'onboarding Employee/HR poste `POST /onboarding-setup/{id}/complete`
+(405+404+403 : le backend attend `PATCH …/{stepKey}/complete` et `api.manager`) ;
+les apps Manager et HR bouclent en redirection infinie pour un employé non-manager/non-RH
+authentifié (GoRouter `Infinite redirect` → crash).
+
+**Pourquoi P1** : ce sont des crashs certains en conditions réelles (constitution : mobile
+employee = app prioritaire, builds toujours verts).
+
+**Test indépendant** : tests Dart des routeurs (redirect resolve pour chaque rôle) ;
+tests de contrat onboarding (méthode + stepKey conformes backend) ; test widget
+navigation Placard.
+
+**Acceptance Scenarios**:
+
+1. **Given** un dossier dans le Placard du manager, **When** on clique, **Then** la
+   navigation utilise `/cabinet/:folderId` (route déclarée) — aucun `No route found`.
+2. **Given** l'écran onboarding Employee, **When** on complète une étape, **Then** la
+   requête est `PATCH /onboarding-setup/{stepKey}/complete` (clé string) avec une
+   autorisation employé (pas 403/405).
+3. **Given** un employé authentifié sans rôle manager dans l'app Manager, **When** il se
+   connecte, **Then** il voit un écran explicite (403/redirection contrôlée) — aucune boucle.
+4. **Given** l'app Employee, **When** l'onboarding est disponible, **Then** la route
+   `/onboarding` est atteignable depuis l'UI (pas seulement déclarée).
+5. **Given** le service `MobileExperienceService`, **When** l'employé utilise l'app,
+   **Then** la source de vérité du stage est écrite par un vrai mécanisme
+   (`app_actions_count` alimenté ou remplacé) — plus de stage `new` permanent par design.
+
+### User Story 4 — Les endpoints API annoncés sont réels et les erreurs visibles (Priority: P2)
+
+8 outils IA sont annoncés (`GET /ai/tools`) mais échouent systématiquement (« registered but
+not yet implemented ») ; `POST /admin/ai/chat` répond 200 avec un message codé en dur ;
+des `catch (\Throwable)` avalent les erreurs DB en listes vides sans log ; la route
+`POST /webhooks/{webhookEndpoint}/test` est déclarée deux fois ; les routes Growth et les
+callbacks SSO publics n'ont pas de throttle.
+
+**Pourquoi P2** : pas de crash mais des promesses non tenues et une observabilité
+dégradée pour le super-admin.
+
+**Test indépendant** : tests Feature pour chaque correctif (outils IA, chat admin,
+routes uniques, throttles présents) ; grep anti-`catch (\Throwable)` silencieux.
+
+**Acceptance Scenarios**:
+
+1. **Given** la liste des outils IA, **When** on invoque chaque outil annoncé, **Then**
+   il répond avec des données réelles ou est retiré de la liste — jamais « not yet
+   implemented ».
+2. **Given** `POST /admin/ai/chat`, **When** un super-admin envoie un message, **Then**
+   la réponse est un traitement réel ou une erreur explicite — jamais un 200 factice.
+3. **Given** une erreur DB sur les listes super-admin, **When** l'endpoint échoue, **Then**
+   l'erreur est loggée et retournée (4xx/5xx) — jamais `{data:[]}` silencieux.
+4. **Given** l'audit des routes, **When** on liste les routes webhook test, **Then** une
+   seule déclaration subsiste.
+5. **Given** les routes publiques SSO/Growth, **When** on les audite, **Then** elles
+   portent un throttle adapté et une validation d'URI cohérente.
+
+### User Story 5 — Les déploiements live reflètent main (Priority: P1)
+
+L'API Render sert v4.23.5 (main est au-delà) : `/i18n/catalog/fr` → 500,
+`/supported-countries` → 404, `/admin/dashboard/*` et `/admin/impersonations` → 404.
+La vitrine Vercel sert un build qui précède #2281 (sitemap avec slugs blog disparus,
+`/case-studies/{slug}` → 404).
+
+**Pourquoi P1** : les surfaces publiques et l'admin affichent des erreurs qui n'existent
+plus dans main ; chaque prospect/admin voit une plateforme cassée.
+
+**Test indépendant** : curl des endpoints live après déploiement (200/404 attendus) ;
+comparaison sitemap live vs build main.
+
+**Acceptance Scenarios**:
+
+1. **Given** le déploiement Render, **When** on appelle `/api/v1/health`, **Then** la
+   version servie est ≥ celle de main et `/supported-countries`/`/i18n/catalog/fr` → 200.
+2. **Given** le déploiement Vercel, **When** on parcourt `/case-studies/{slug}` et le
+   sitemap, **Then** aucune URL 404 (hors blog désactivé volontairement).
+3. **Given** la console admin, **When** on clique « Accès Démo », **Then** le bouton n'est
+   affiché que si la démo est activée (message explicite sinon).
+
+## Success Criteria
+
+- Sitemap vitrine : 0 URL 404 (vérifié par crawl).
+- ogImages : 100 % des pages ont une ogImage résolvable (200).
+- Header admin : 0 crash JavaScript sur les 3 écrans principaux (dashboard, users, system).
+- Impersonation admin : fonctionne de bout en bout.
+- Apps mobiles : 0 crash de navigation sur les parcours Placard, onboarding, login
+  non-manager (tests Dart/widget).
+- Outils IA : 0 outil annoncé non implémenté.
+- Erreurs super-admin : aucune liste vide silencieuse (log + erreur explicite).
+- API live : version déployée ≥ main, endpoints récents 200.
+
+## Key Entities
+
+- Vitrine : `sitemap.ts`, `lib/seo.ts`, `public/`, `sw.js`, `(landing)/docs`, `(dashboard)/*`.
+- Admin : `stores/dashboard.js`, `router/index.js`, `views/`, `components/layout/Header.vue`.
+- Mobile : routeurs GoRouter (3 apps), `onboarding_repository.dart` (3 apps),
+  `MobileExperienceService.php`.
+- API : `AIToolRegistrySeeder.php`, `IntentEngine.php`,
+  `PlatformAdminAiConversationController.php`, `routes/modules/{growth,sso,hr_extended}.php`.
+- Ops : déploiements Render/Vercel/Pages.
+
+## Assumptions
+
+- Les fixes Flutter sont écrits et vérifiés statiquement (pas de SDK Flutter dans la sandbox) ;
+  la validation CI mobile reste la porte finale.
+- Les tasks de la vague 2 (SSO SAML 501, SEPA, export history, push) restent en attente
+  d'implémentation (hors périmètre de cette spec).
+- Les issues ouvertes payroll/CI (#2590, #2587, #2586, #2583, #2580) sont hors périmètre.
+- Les déploiements live nécessitent un accès Render/Vercel hors sandbox : l'implémentation
+  est livrée sur main, le déploiement est à la charge de l'équipe (issue dédiée).

--- a/.specify/features/qa-omnichannel-wave-2026-08-15/tasks.md
+++ b/.specify/features/qa-omnichannel-wave-2026-08-15/tasks.md
@@ -1,0 +1,113 @@
+# Tasks: Vague QA Omnichannel 2026-08-15 — manquements NOUVEAUX (dédupliqués)
+
+**Input**: spec.md + findings-registry.md
+
+**Prerequisites**: spec.md (required)
+
+> **Anti-doublon (Constitution §VII + #2400)** : les findings déjà couverts par les vagues
+> parallèles (`qa-audit-2026-08-15`, `qa-audit-expert-{web,mobile,backend}-2026-08-15`) sont
+> référencés, PAS dupliqués (voir table en fin de fichier). #2276 et #2274 ont été **réouvertes**
+> (fermetures sans fix effectif sur main). Numérotation continue à partir de T099 (max existant : T098).
+
+## Phase 1 — Vitrine web (US1)
+
+- [ ] T099 [P1] [US1] `src/app/(dashboard)/dashboard/page.tsx:542` : `href="/dashboard/reports"` → `/reports` (route réelle du groupe `(dashboard)`).
+- [ ] T100 [P2] [US1] Robots dupliqués : supprimer `src/app/api/robots/route.ts` (déclare `Sitemap: /api/sitemap` inexistant) et garder `src/app/robots.ts` canonique.
+- [ ] T101 [P2] [US1] Canonicaux : remplacer le domaine en dur `https://gestionemployer-backend.vercel.app` par `NEXT_PUBLIC_SITE_URL` dans les layout.tsx vitrine + `seo.ts` (17+ fichiers, cf. registry W8).
+- [ ] T102 [P2] [US1] Pricing/checkout : retirer les plans fantômes « Starter »/« Business » des FAQ (4 locales) ; checkout Enterprise → « Sur devis » (cohérent avec pricing) ; afficher le surcoût par employé actif au checkout (Pilot/Operations).
+- [ ] T103 [P3] [US1] `videos/page.tsx:47` : « Atlas Industries » → « Atlas Digital » (source `data/testimonials.ts`).
+- [ ] T104 [P3] [US1] `pricing/page.tsx:718` : CTA Enterprise → `/contact?topic=enterprise` (la page contact lit `?topic=`, pas `?type=`).
+- [ ] T105 [P3] [US1] `src/components/JsonLd.tsx:57` : logo `${SITE_URL}/logo.png` → fichier réel dans `public/` (ou retirer du schéma).
+- [ ] T106 [P3] [US1] Dead code vitrine : supprimer `lib/mdx.ts` + `content/blog/*.mdx` inutilisés, exports orphelins (GradientOrbs, ScrollAnimations, Divider, useScrollAnimation, useFormSubmit, pageVariants, cn, generateOrganizationSchema, `lib/seo-metadata.ts`), dédupliquer `NewsletterForm` (src/components vs modules/vitrine).
+
+## Phase 2 — Admin dashboard (US2)
+
+- [ ] T107 [P1] [US2] Impersonation : `views/users/UsersView.vue:435` → `POST /platform/impersonations` (contrat réel `routes/api.php:284-286`) — la feature #2518 est inutilisable actuellement.
+- [ ] T108 [P1] [US2] `components/layout/Header.vue:141,215` : rendre le panneau « alertes critiques » branché sur `systemAlerts` quand `showAlerts` est vrai (bouton actuellement sans effet visible).
+- [ ] T109 [P2] [US2] `components/layout/Header.vue:240` : recherche globale → filtrage réel de la navigation ; retirer le `console.log` (« Implement search functionality »).
+- [ ] T110 [P2] [US2] Pays supportés : remplacer les 4 tableaux codés en dur incohérents (6/12/7/10 pays) par `GET /supported-countries` (source unique) dans HolidaysView/TaxSlabsView/TaxRatesView/SocialContributionsView.
+- [ ] T111 [P2] [US2] `views/system/SystemView.vue:87-154` : brancher les 6 sections sur les endpoints réels (`/platform/observability/queues`, `/platform/observability/notifications`, `/metrics`…) — retirer « Non disponible » en dur.
+- [ ] T112 [P2] [US2] 401 : `stores/auth.js:72` + `services/api.js:185` — afficher `localized_message` du backend (plus la clé brute `INVALID_CREDENTIALS`) ; navigation SPA vers `/login` (plus `window.location`).
+- [ ] T113 [P3] [US2] `components/analytics/RevenueForecastWidget.vue:187` : retirer `Math.random()` (données réelles ou widget retiré).
+- [ ] T114 [P3] [US2] `services/api.js:27-44` : messages accentués (« Session expirée », « Données invalides », « Réessayez plus tard »).
+
+## Phase 3 — Mobile (US3)
+
+- [ ] T115 [P1] [US3] Onboarding Employee/HR : `onboarding_repository.dart` (2 apps) — `PATCH /onboarding-setup/{stepKey}/complete|skip` avec la clé string (au lieu de POST + id numérique → 405/404) ; rendre l'accès employé possible (middleware, cf. T118).
+- [ ] T116 [P1] [US3] Apps Manager/HR : corriger la boucle de redirection infinie (non-manager/non-RH authentifié → `/welcome` ↔ `/`) — écran « accès refusé » ou redirection contrôlée, jamais de boucle GoRouter.
+- [ ] T117 [P2] [US3] Route `/onboarding` (3 apps) : la rendre atteignable depuis l'UI (entrée home/profil quand le checklist est incomplet) — aujourd'hui déclarée mais injoignable.
+- [ ] T118 [P2] [US3] Backend onboarding : `api/routes/modules/billing.php:22-26` — middleware adapté pour que l'app Employee puisse compléter son onboarding (403 actuel `api.manager`).
+- [ ] T119 [P2] [US3] `MobileExperienceService::stageFor()` (l.70) : source de vérité du stage — écrire `app_actions_count` (ou critère calculable) ; le stage `regular` doit être atteignable (actuellement `new` permanent).
+- [ ] T120 [P2] [US3] `MobileExperienceService::appContextFor()` (l.42-58) : retirer les apps inexistantes (`comptable`, `dept`, `marketing` non distribuée) ou ne les servir que si réelles ; documenter les deep links consommés.
+- [ ] T121 [P3] [US3] `int.parse(pathParameters['folderId']!)` (3 apps) : garde pour deep-link non numérique (fallback, pas de crash).
+- [ ] T122 [P3] [US3] Routes mortes : `/training`, `/expenses`, `/ai-chat`, `/ai-voice`, `/vehicle-map` (employee), `/modules/rh` (manager/hr) — retirer ou brancher sur des écrans réels ; `PersonalSpaceScreen` routé ou supprimé ; `suggested_home_route` consommé ou retiré du contrat API.
+
+## Phase 4 — API backend (US4)
+
+- [ ] T123 [P2] [US4] Outils IA : implémenter les 8 outils lecture dans `app/AI/IntentEngine.php` (scoping employé) ou retirer les outils non implémentés du seeder — plus de « registered but not yet implemented » via `GET /ai/tools`.
+- [ ] T124 [P2] [US4] `PlatformAdminAiConversationController.php:74-100` : `POST /admin/ai/chat` — traitement réel ou 501 explicite documenté ; jamais de 200 factice.
+- [ ] T125 [P2] [US4] Catch silencieux : `PlatformAdminAiConversationController.php:41,113` + `PlatformAdminFleetAlertController.php:65` — logger et retourner 5xx explicite (plus `{data:[]}` sans log).
+- [ ] T126 [P2] [US4] `routes/modules/hr_extended.php:158,166` : supprimer la déclaration dupliquée `POST /webhooks/{webhookEndpoint}/test`.
+- [ ] T127 [P3] [US4] `routes/modules/growth.php:23-44` : ajouter les throttles (`throttle:api` / `throttle:platform-sensitive`) alignés sur les autres modules.
+- [ ] T128 [P3] [US4] `routes/modules/sso.php:16-28` : throttle sur callbacks publics + `whereUuid` sur `{companyId}` SAML (incohérent avec OIDC).
+- [ ] T129 [P3] [US4] `AgentController.php:56-80` : retirer le workflow fantôme `new_employee_onboarding` ou l'implémenter.
+- [ ] T130 [P3] [US4] `ProvisionGuidedTrial.php:150-176` : fake employee `alice@demo.local`/`password` — créer uniquement si `DEMO_MODE_ENABLED`, jamais sur le chemin trial public par défaut.
+- [ ] T131 [P3] [US4] `CommunicationService.php:404` : warning explicite + statut `undelivered` quand un provider bascule silencieusement sur audit.
+- [ ] T132 [P3] [US4] `PayrollCycleController.php:254-267` : logger l'exception au lieu d'avaler en `[]`.
+
+## Phase 5 — Ops & déploiement (US5)
+
+- [ ] T133 [P1] [US5] Déployer l'API Render sur une version ≥ main (résout `/i18n/catalog/fr` 500, `/supported-countries` 404, `/admin/dashboard/*` 404, `/admin/impersonations` 404) — checklist post-deploy curl incluse.
+- [ ] T134 [P1] [US5] Déployer la vitrine Vercel sur le build main courant (résout sitemap stale, `/case-studies/{slug}` 404 live) — checklist post-deploy.
+
+## Table anti-doublon (findings couverts par les vagues parallèles — NE PAS recréer)
+
+| Finding (registry) | Issue(s) existante(s) |
+|---|---|
+| W2 og images | #2722, #2752 |
+| W5 sw precache | #2723 |
+| W7 edge-nodes | #2602 (résolution : retirer la page) |
+| W9 essai 14j vs 30j / meta desc | #2753, #2721 |
+| W10 liens testeurs mobiles | #2733 |
+| W13 vercel.json | #2732 |
+| W14 icônes PWA | #2756 |
+| A1 dashboard.js envelope | #2747 |
+| A5 MiniGlobe | #2696 |
+| A8 UsersView pagination | #2698 |
+| A9 CommandPalette | #2703 |
+| A10 LoginView démo/credentials | #2695, #2730 |
+| A13 clés i18n titres | #2708 |
+| A14 DashboardView carte | #2704 |
+| A15 SystemAlertsOverlay | #2693 |
+| A19 confirm/alert Growth | #2711 |
+| A20 filtre « En attente » | #2699 |
+| M1 cabinet manager | #2735, #2748 |
+| M7 contrats mobiles | #2754 |
+| M10 hierarchy endpoint | #2594 (résolution : créer la route) |
+| P7 magic link | #2620 |
+| P12 OpenAPI | #2662, #2674 |
+| T001 sitemap blog | #2276 (RÉOUVERTE — régression) |
+| T003 ancres docs | #2274 (RÉOUVERTE — résidu) |
+| T031 dead code admin | #2771 (créée par cette vague) |
+
+## Dependencies
+
+- US1 (T099-T106) : indépendante — bloc vitrine (front/web).
+- US2 (T107-T114) : indépendante — bloc admin (front/admin-dashboard).
+- US3 (T115-T122) : indépendante — bloc mobile (front/mobile_apps + api pour T118/T119/T120).
+- US4 (T123-T132) : indépendante — bloc API (api/).
+- US5 : T133/T134 dépendent des accès de déploiement (hors sandbox).
+
+## Parallel execution examples
+
+- Worker A : T099-T106 (vitrine) — branches `fix/<issue>-<slug>` dans front/web.
+- Worker B : T107-T114 (admin) — front/admin-dashboard.
+- Worker C : T123-T132 (API) — api/.
+- Worker D : T115-T122 (mobile) — front/mobile_apps + api (T118-T120).
+
+## Implementation strategy
+
+- MVP P1 : T099, T107, T108, T115, T116 (5 issues P1) — livrés en premier.
+- Vague 2 : P2/P3 par domaine, en parallèle.
+- Validation : build vitrine + lint admin + PHPStan strict + tests ciblés (backend) ;
+  CI mobile (Flutter) comme porte finale pour US3.


### PR DESCRIPTION
Livrables Spec Kit de la vague QA omnichannel (session 2026-08-15) :

- findings-registry.md : 36 findings verifies (preuves fichier:ligne)
- spec.md : 5 user stories P1/P2 avec scenarios d'acceptation
- tasks.md : 37 tasks (T099-T134 + #2771) dedupliquees vs vagues paralleles (table anti-doublon)
- checklists/requirements.md : qualite spec

Issues creees : #2771, #2777-#2813. Reouvertures : #2276 (sitemap regression), #2274 (ancres residuelles).