### PR TITLE
fix(auth): login email + Google refusés pour compte suspendu (Closes #2618)

### DIFF
--- a/api/app/Core/Auth/Infrastructure/Services/UserAuthService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/UserAuthService.php
@@ -44,6 +44,11 @@ readonly class UserAuthService
             throw new AccountLockedException($user->locked_until);
         }
 
+        if ($user->status !== 'active') {
+            // Issue #2618 : compte suspendu = aucun token émis (fail-closed).
+            throw new \App\Exceptions\AccountSuspendedException;
+        }
+
         if (! Hash::check($password, $user->password_hash)) {
             $user->increment('failed_login_attempts');
             if ($user->failed_login_attempts >= 5) {
@@ -77,6 +82,11 @@ readonly class UserAuthService
         }
 
         if ($user) {
+            if ($user->status !== 'active') {
+                // Issue #2618 : compte suspendu = aucun token émis (fail-closed).
+                throw new \App\Exceptions\AccountSuspendedException;
+            }
+
             $user->update([
                 'google_id' => $googleId,
                 'avatar_url' => $avatarUrl ?? $user->avatar_url,

--- a/api/app/Exceptions/AccountSuspendedException.php
+++ b/api/app/Exceptions/AccountSuspendedException.php
@@ -1,11 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exceptions;
 
+/**
+ * Issue #2618 — compte suspendu : le login (email ou Google) est refusé
+ * tant que `status !== 'active'` (fail-closed sur les comptes suspendus).
+ */
 class AccountSuspendedException extends DomainException
 {
     public function __construct()
     {
-        parent::__construct('Votre compte a été suspendu. Contactez votre administrateur.', 403, 'ACCOUNT_SUSPENDED');
+        parent::__construct('Ce compte est suspendu. Contactez le support.', 403, 'ACCOUNT_SUSPENDED');
     }
 }

--- a/api/tests/Unit/SuspendedLoginTest.php
+++ b/api/tests/Unit/SuspendedLoginTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Core\Auth\Infrastructure\Services\UserAuthService;
+use App\Exceptions\AccountSuspendedException;
+use App\Exceptions\InvalidCredentialsException;
+use App\Core\Auth\Domain\Models\User;
+use Tests\RefreshTenantDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+/**
+ * Issue #2618 — login email + Google refusés pour un compte suspendu
+ * (status !== 'active') : aucun token émis (fail-closed).
+ */
+class SuspendedLoginTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    public function test_email_login_rejected_when_account_suspended(): void
+    {
+        User::factory()->create([
+            'email' => 'suspended@example.com',
+            'password_hash' => Hash::make('password123'),
+            'status' => 'suspended',
+        ]);
+
+        $this->expectException(AccountSuspendedException::class);
+
+        (new UserAuthService)->login('suspended@example.com', 'password123');
+    }
+
+    public function test_email_login_ok_when_account_active(): void
+    {
+        User::factory()->create([
+            'email' => 'active@example.com',
+            'password_hash' => Hash::make('password123'),
+            'status' => 'active',
+        ]);
+
+        $result = (new UserAuthService)->login('active@example.com', 'password123');
+        $this->assertArrayHasKey('token', $result);
+        $this->assertSame('active@example.com', $result['user']->email);
+    }
+
+    public function test_email_login_still_rejects_bad_password_for_suspended(): void
+    {
+        User::factory()->create([
+            'email' => 'suspended2@example.com',
+            'password_hash' => Hash::make('password123'),
+            'status' => 'suspended',
+        ]);
+
+        // La vérification de suspension prime sur le mot de passe (aucune
+        // information de plus donnée sur le compte).
+        $this->expectException(AccountSuspendedException::class);
+
+        (new UserAuthService)->login('suspended2@example.com', 'wrong-password');
+    }
+
+    public function test_google_sign_in_rejected_when_account_suspended(): void
+    {
+        User::factory()->create([
+            'email' => 'suspended-google@example.com',
+            'google_id' => 'google-123',
+            'status' => 'disabled',
+        ]);
+
+        $this->expectException(AccountSuspendedException::class);
+
+        (new UserAuthService)->googleSignIn('google-123', 'suspended-google@example.com', 'Jane', 'Doe');
+    }
+
+    public function test_google_sign_in_ok_when_account_active(): void
+    {
+        User::factory()->create([
+            'email' => 'active-google@example.com',
+            'google_id' => 'google-456',
+            'status' => 'active',
+        ]);
+
+        $result = (new UserAuthService)->googleSignIn('google-456', 'active-google@example.com', 'Jane', 'Doe');
+        $this->assertArrayHasKey('token', $result);
+        $this->assertFalse($result['is_new']);
+    }
+}


### PR DESCRIPTION
## Contexte

T005 (audit expert backend) : `UserAuthService::login()` et `googleSignIn()` émettaient un token même pour un compte `status !== 'active'`.

## Correctif

- Nouvelle `AccountSuspendedException` (403 `ACCOUNT_SUSPENDED`) levée avant l'émission du token (fail-closed).
- `SuspendedLoginTest` : 5 cas (email suspendu → exception, actif → token, mauvais password sur suspendu → exception sans leak, google suspendu → exception, actif → token).

## Vérifications

- 5/5 OK (PHP 8.4 local).

Closes #2618