### PR TITLE
fix(api): GET /trial/status — limiteur dédié 60/min hors throttle:5,15 (Closes #2621)

### DIFF
--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -209,6 +209,13 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute((int) config('security.rate_limits.public_careers_per_minute', 60))
                 ->by('public-careers:'.$request->ip());
         });
+
+        // Issue #2621 : GET /trial/status est POLLÉ par la vitrine (~1 req /
+        // 5 s pendant 60 s) — un limit 5/15 min le 429ait systématiquement.
+        // Limiteur dédié 60/min/IP (statut non sensible, pas de mutation).
+        RateLimiter::for('trial-status', function (Request $request) {
+            return Limit::perMinute(60)->by('trial-status:'.$request->ip());
+        });
     }
 
     private function resolvePlanLimit(string $plan): int

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -98,8 +98,11 @@ Route::prefix('v1')->group(function (): void {
     Route::middleware(['throttle:5,15'])->group(function (): void {
         Route::post('/trial/signup', [SelfServiceTrialController::class, 'signup']);
         Route::post('/trial/verify', [SelfServiceTrialController::class, 'verify']);
-        Route::get('/trial/status', [SelfServiceTrialController::class, 'status']);
     });
+
+    // Issue #2621 : GET /trial/status est POLLÉ par la vitrine (~1 req/5 s)
+    // — limit dédié 60/min (hors throttle:5,15 qui 429erait le polling).
+    Route::middleware(['throttle:trial-status'])->get('/trial/status', [SelfServiceTrialController::class, 'status']);
 
     // PA2-MKT-007 - Public vitrine lead capture (signup/demo/contact/
     // newsletter), called server-to-server from front/web's Next.js API

--- a/api/tests/Feature/TrialStatusThrottleTest.php
+++ b/api/tests/Feature/TrialStatusThrottleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * Issue #2621 — GET /trial/status est pollé par la vitrine (~1 req/5 s) :
+ * il doit sortir du throttle `5,15` (qui 429erait le polling) et disposer
+ * d'un limit dédié 60/min/IP.
+ */
+class TrialStatusThrottleTest extends TestCase
+{
+    public function test_trial_status_allows_20_polls_per_minute(): void
+    {
+        // 20 polls successifs avec un token arbitraire : le endpoint répond
+        // 404 (token invalide) mais JAMAIS 429 (limiteur dédié 60/min).
+        for ($i = 0; $i < 20; $i++) {
+            $response = $this->getJson('/api/v1/trial/status?token='.str_repeat('a', 64));
+            $this->assertNotEquals(429, $response->getStatusCode(), "Poll {$i} : ne doit pas être rate-limité.");
+        }
+    }
+
+    public function test_trial_status_route_carries_dedicated_throttle(): void
+    {
+        $route = collect(app('router')->getRoutes())
+            ->first(fn ($r) => $r->uri() === 'api/v1/trial/status' && in_array('GET', $r->methods(), true));
+
+        $this->assertNotNull($route, 'Route GET /api/v1/trial/status introuvable.');
+        $this->assertStringContainsString(
+            'throttle:trial-status',
+            implode(',', $route->gatherMiddleware()),
+            'GET /trial/status doit porter le limiteur dédié throttle:trial-status.'
+        );
+    }
+}


### PR DESCRIPTION
## Contexte

T008 (audit expert backend) : `GET /trial/status` (pollé par la vitrine ~1 req/5 s pendant 60 s) était sous `throttle:5,15` → 429 systématique du polling.

## Correctif

- Nouveau `RateLimiter::for('trial-status')` (60/min/IP) dans `AppServiceProvider`.
- `GET /trial/status` sorti du groupe `throttle:5,15` (signup/verify restent stricts).
- `TrialStatusThrottleTest` : 20 polls sans 429 + middleware dédié présent.

## Vérifications

- 2/2 OK (PHP 8.4 local).

Closes #2621