### PR TITLE
fix(api): middleware tenant sur le groupe growth/partner (Closes #2622)

### DIFF
--- a/api/routes/modules/growth.php
+++ b/api/routes/modules/growth.php
@@ -7,7 +7,8 @@ use Illuminate\Support\Facades\Route;
 // Espace Partenaire (Web Client)
 // Access via the main dashboard requires the sanctum guard (Employee token).
 Route::prefix('growth')->group(function () {
-    Route::middleware(['auth:sanctum'])->prefix('partner')->group(function () {
+    // Issue #2622 : isolation tenant obligatoire (cross-tenant = 404).
+    Route::middleware(['auth:sanctum', 'tenant'])->prefix('partner')->group(function () {
         Route::post('/apply', [PartnerDashboardController::class, 'apply']);
         Route::post('/payout', [PartnerDashboardController::class, 'requestPayout']);
         Route::get('/dashboard', [PartnerDashboardController::class, 'dashboard']);

--- a/api/tests/Feature/GrowthPartnerTenantIsolationTest.php
+++ b/api/tests/Feature/GrowthPartnerTenantIsolationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #2622 — le groupe growth/partner doit porter le middleware `tenant`
+ * (isolation : le search_path tenant est posé avant toute requête métier).
+ */
+class GrowthPartnerTenantIsolationTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Company $company;
+
+    private Employee $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $this->company = $company;
+
+        /** @var Employee $manager */
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $this->manager = $manager;
+    }
+
+    public function test_growth_partner_routes_carry_tenant_middleware(): void
+    {
+        $route = collect(app('router')->getRoutes())
+            ->first(fn ($r) => $r->uri() === 'api/v1/growth/partner/dashboard' && in_array('GET', $r->methods(), true));
+
+        $this->assertNotNull($route, 'Route GET /api/v1/growth/partner/dashboard introuvable.');
+        $this->assertContains('tenant', $route->gatherMiddleware(), 'Le middleware tenant doit être présent sur le groupe growth/partner.');
+    }
+
+    public function test_growth_partner_dashboard_accessible_with_tenant_context(): void
+    {
+        Sanctum::actingAs($this->manager);
+
+        // Avec le middleware tenant, la requête pose le search_path du tenant
+        // et répond (200 ou 404 métier selon les données) — jamais 500.
+        $response = $this->getJson('/api/v1/growth/partner/dashboard');
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Contexte

T009 (audit expert backend) : le groupe `growth/partner` portait `auth:sanctum` sans middleware `tenant` → le search_path tenant n'était pas posé.

## Correctif

- `tenant` ajouté au groupe (avec `auth:sanctum`).
- `GrowthPartnerTenantIsolationTest` : middleware présent sur les routes + accès au dashboard sans 500.

## Vérifications

- 2/2 OK (PHP 8.4 local).

Closes #2622