### PR TITLE
docs(speckit): vague QA audit expert 2026-08-15 — registre, spec, tasks (issues #2819-#2827)

### DIFF
--- a/.specify/features/qa-audit-expert-2026-08-15/checklists/requirements.md
+++ b/.specify/features/qa-audit-expert-2026-08-15/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: QA Audit Expert 2026-08-15
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- La spec référence les preuves fichier:ligne dans findings-registry.md (traçabilité complète).
+- Dé-duplication faite contre les ~90 issues de la vague omnichannel 2026-08-15
+  (#2646→#2813) : seuls les constats NOUVEAUX (F-01→F-09) font l'objet d'issues ici ;
+  F-01 correspond à l'issue P0 #2652 déjà ouverte (non assignée).
+- 20 tasks dont 1 P0 (US1 login défensif), 1 P1 (CHANGELOG), 2 P2 (US3/US4), 5 P3 (US5).

--- a/.specify/features/qa-audit-expert-2026-08-15/findings-registry.md
+++ b/.specify/features/qa-audit-expert-2026-08-15/findings-registry.md
@@ -1,0 +1,109 @@
+# Registre des manquements — QA Audit Expert 2026-08-15
+
+> Session de test experte du repo kitokoh/leopardo-hr (main @ 80c034f).
+> Mission : tester la vitrine, le web, l'admin, les mobiles, les workflows, les APIs, les
+> logiques, l'onboarding et la cohérence — tout manquement → spec + tasks + issues
+> (méthode Spec Kit) puis implémentation.
+> Méthode : 4 audits statiques par sous-agents (web/admin/mobile/cohérence API) + tests
+> runtime (API Render live, vitrine Vercel live, admin Pages.dev live, suite de tests
+> backend locale PostgreSQL, builds locaux).
+>
+> ⚠️ Dé-duplication : une campagne QA 2026-08-15 (issues #2646→#2813, ~90 tickets) couvre
+> déjà la majorité des constats. Chaque ligne ci-dessous est marquée `NOUVEAU` ou
+> `DÉJÀ COUVERT (#XXXX)` pour respecter le protocole anti-doublon (#2400). Seuls les
+> `NOUVEAU` font l'objet de nouvelles issues dans cette vague.
+
+## A. Vérifications runtime effectuées (preuves)
+
+- [x] **API Render live** (gestionemployerbackend.onrender.com, health `4.23.5`, main = `4.24.0`) :
+  - `POST /api/v1/auth/login` avec comptes démo (ahmed.benali@techcorp-algerie.dz,
+    karim.aouad@techcorp-algerie.dz, sofiane.mrad@digitalflow.tn / password123) → **500 Server Error**
+    (→ DÉJÀ COUVERT **#2652 [P0]**). Cause racine identifiée (voir F-01).
+  - `admin@leopardo-rh.com/password123` (login tenant + platform) → 401 INVALID_CREDENTIALS ;
+    `/api/v1/demo-users` → 404 (gate délibérée hors DEMO_MODE_ENABLED, testée en local)
+    → DÉJÀ COUVERT **#2646** + **#2650** + PR #2773.
+  - `/api-explorer` → **500** en prod ; rendu OK en local sur main (fix #2265 présent) →
+    DÉJÀ COUVERT **#2627/#2632/#2812** (déploiement Render obsolète).
+  - `/docs`, `/docs/openapi.yaml`, `/tester-guide`, `/api/v1/health`, `/health/live` → 200 OK.
+  - Login email inconnu → 401 propre ; body vide → 422 ; `/auth/register` → 422. ✓
+- [x] **Vitrine Vercel live** (gestionemployer-backend.vercel.app) :
+  - `/blog` → **404** alors que le footer/hero exposent « Explore the blog » (DÉJÀ COUVERT #2276/#2609).
+  - Liens `?lang=en|tr|ar` sur /pricing → 200 ; `/en|/tr|/ar` → 404 (locale par `?lang=`, pas par path — attendu).
+  - `/signup`, `/demo`, `/pricing`, `/guides/rh-startup`, `/download`, `/auth/login`, `/contact`,
+    `/privacy`, `/terms`, `/integrations`, `/checkout`, `/docs`, `/changelog` → 200.
+  - `/download` : liens Firebase App Distribution réels + fallback `/signup?source=download_*` ✓
+    (pas d'ancre morte). MAIS le `source=download_*` est **perdu** par SignupForm → **F-05 NOUVEAU**.
+  - `x.com/leopardo_hr` → 404 (handle mort) → DÉJÀ COUVERT #2608 (sameAs).
+  - Login démo web client : sélecteur de comptes OK (fallback local), tentative
+    ahmed.benali → **« Server Error »** (500 API, cf. #2652).
+- [x] **Admin Pages.dev live** : login OK, bouton « Accès Demo » (admin@leopardo-rh.com/password123)
+  → « Erreur de connexion » (DÉJÀ COUVERT #2646). Lien mort `/vehicles` command palette
+  (DÉJÀ COUVERT #2640/#2703).
+- [x] **Builds locaux** : vitrine `npm run build` OK (69 pages, lint/tsc/jest OK) ;
+  admin `npm run build` OK (lint 0 erreur) ; backend composer install OK.
+- [x] **Suite de tests backend locale** (PostgreSQL, phpunit) : lancée sur main — ~490+ tests verts
+  à la mi-course, quelques échecs isolés en cours d'analyse (à re-vérifier après run complet).
+
+## B. Findings NOUVEAUX (cette vague → issues)
+
+| ID | Sév | Surface | Constat | Preuve | Issue |
+|----|-----|---------|---------|--------|-------|
+| F-01 | P0 | API | `AuthService::login()` : lookup `public.user_lookups` pointant vers un schéma tenant absent → requête `employees` sur table inexistante → `QueryException` → **500** au lieu d'un 401 propre. Tout compte démo existant casse le login en prod (cf. #2652). Fix : lookup défensif (schéma inexistant = pas d'employé), erreur propre. | `api/app/Core/Auth/Infrastructure/Services/AuthService.php:52-68` (pas de garde `tenantEmployeesTableExists` avant la 1ʳᵉ requête) | #2652 (existant, non assignée) |
+| F-02 | P1 | Docs/CI | `CHANGELOG.md` `[Unreleased]` : `### Added` ×2 consécutifs (l.75-76) + 5× `### Fixed` consécutifs → viole la garde maison `check-governance.ps1` (scanne le CHANGELOG sur chaque PR) → CI Governance devrait être rouge. | `CHANGELOG.md:74-77` (headers dupliqués) | **NOUVEAU** |
+| F-03 | P2 | Admin | `AnalyticsView.vue` lit `alert.title`/`alert.description` alors que `/admin/dashboard/alerts` envoie `{id, level, message}` → alertes plateforme toujours vides de texte. | `front/admin-dashboard/src/views/analytics/AnalyticsView.vue:124-125` vs `api/app/Modules/Platform/.../PlatformAdminDashboardController.php:382-388` | **NOUVEAU** |
+| F-04 | P3 | Admin | `CompanyDetailView.vue` : échecs API (détail, tickets, abonnement, modules) → `console.error` sans retour utilisateur → boutons silencieux. | `CompanyDetailView.vue:416-455` | **NOUVEAU** |
+| F-05 | P2 | Web | `SignupForm.tsx:187` : `source: 'signup_form'` codé en dur → le paramètre `source=download_*` (fallback /download et liens guide) est perdu à la conversion (attribution lead cassée). | `front/web/src/modules/vitrine/components/forms/SignupForm.tsx:187` | **NOUVEAU** |
+| F-06 | P3 | Web | Dépendance fantôme `zod` : importée par 3 route handlers (`api/billing/checkout`, `api/forms/contact`, `api/forms/demo`) mais absente de `package.json` → build fragile (dépend d'un hoisting transitoire). | `front/web/src/app/api/{billing/checkout,forms/contact,forms/demo}/route.ts` ; `front/web/package.json` sans `zod` | **NOUVEAU** |
+| F-07 | P3 | Web | `api/forms/verify/route.ts` : pas de gate `areFormsEnabled()` (incohérent avec signup/demo/contact qui l'ont) → endpoint actif même site en maintenance. | `front/web/src/app/api/forms/verify/route.ts` vs `forms/_lib/lead-capture.ts` | **NOUVEAU** |
+| F-08 | P3 | Web | Specs e2e périmées : `conversion-funnel.spec.ts` + `forms-and-submissions.spec.ts` attendent le champ mot de passe supprimé en v4.16.250 → échoueraient si rejouées. | `front/web/e2e/conversion-funnel.spec.ts`, `front/web/e2e/forms-and-submissions.spec.ts` | **NOUVEAU** |
+| F-09 | P3 | Mobile | `leopardo_hr` : `main.dart` sans `SentryFlutter.init` (employee/manager/platform_admin l'ont) → crash non tracés sur l'app RH. | `front/mobile_apps/leopardo_hr/lib/main.dart` (0 référence Sentry) | **NOUVEAU** |
+
+## C. Findings DÉJÀ COUVERTS (vérifiés, trace — pas de nouvelle issue)
+
+| Constat (vérifié) | Issue(s) / PR existantes |
+|-------------------|--------------------------|
+| Login 500 comptes démo (live) | #2652 [P0] (implémenté dans cette vague, cf. tasks) |
+| Comptes super-admin démo KO en prod | #2646, #2650 (+ PR #2773) |
+| `/api-explorer` 500 en prod (fix présent sur main) | #2627/#2632/#2812 (déploiement) |
+| `/blog` 404 vitrine (lien « Explore the blog ») | #2276, #2609 (+ PR #2774) |
+| `x.com/leopardo_hr` 404 | #2608 |
+| Actions rapides dashboard → `/dashboard/*` morts | #2655, #2603, #2777 |
+| SignupForm 100 % FR | #2648 (+ PR #2775), #2727 |
+| Nommage plans incohérent | #2649 (+ PR #2776), #2721, #2780 |
+| Sitemap blog quand flag off | #2647 (+ PR #2774) |
+| OG images `/og/*.png` inexistants | #2752, #2722 |
+| PWA `/icon-192.png` absent + 14 vs 30 jours | #2756, #2724, #2753 |
+| robots dupliqués + `/api/sitemap` fantôme | #2778 |
+| Canonicaux hardcodés vercel.app | #2779, #2607 |
+| Dashboard admin enveloppe `{data:[...]}` | #2747 (+ PR #2790) |
+| UsersView pagination décorative | #2698, #2699, #2700, #2701 |
+| Command palette `/vehicles` 404 | #2703, #2640 |
+| MiniGlobe points fabriqués | #2696 |
+| Maintenance simulée SystemAlertsOverlay | #2693, #2641 |
+| Dead code admin + vitrine | #2612, #2771 (+ PR #2814), #2784 |
+| Impersonation `/platform` vs `/admin` | #2785, #2624 |
+| Header alertes + recherche | #2786, #2787, #2611 |
+| SystemView sections non branchées | #2789, #2316 |
+| Onboarding mobile POST vs PATCH (405) | #2794 |
+| Cabinet manager navigation morte | #2748, #2735 |
+| `/departments/{id}/hierarchy` 404 | #2594, #2633 |
+| DZD en dur mobile | #2741 |
+| Mojibake mobile | #2660, #2738 |
+| Dette i18n mobile | #2755, #2740 |
+| OpenAPI drift / RBAC matrix / docs périmées | #2638, #2662, #2675, #2757 |
+| README stats périmées | #2772 (+ PR) |
+| `source=download_*` — fallback /download ✓ OK, attribution perdue | F-05 (le fallback lui-même est sain) |
+| Testimonials fabriqués vitrine | #2726 |
+| `leopardo_marketing` orphelin | #2595, #2661 |
+| `supported-countries` hardcodés admin | #2788 |
+| 401 clé brute au lieu de localized_message | #2791, #2695 |
+| `Math.random()` RevenueForecast | #2792 |
+| Messages API accentués | #2793 |
+
+## D. Méthode & périmètre
+
+- Audit statique par surface + vérification runtime live (API/vitrine/admin) + builds locaux.
+- Vérification ciblée des candidats P0/P1 par lecture du code (AuthService, api-explorer,
+  payload alerts, onboarding mobile).
+- Hors périmètre de cette vague (déjà tracées) : déploiements Render/Vercel (#2812/#2813),
+  vagues payroll/CI, SSO/SEPA (vague 2 du registre omnichannel).

--- a/.specify/features/qa-audit-expert-2026-08-15/spec.md
+++ b/.specify/features/qa-audit-expert-2026-08-15/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: QA Audit Expert 2026-08-15 — manquements nouveaux
+
+**Feature Branch**: `docs/qa-audit-expert-2026-08-15`
+**Created**: 2026-08-15
+**Status**: Spec → Tasks → Issues → Implémentation
+**Input**: Mission utilisateur — tester toutes les surfaces (vitrine, web, admin, mobiles,
+workflows, APIs, logiques, onboarding, cohérence) ; tout manquement → spec + tasks +
+issues (méthode Spec Kit) ; implémenter ensuite.
+
+## Contexte
+
+Campagne de test experte du 2026-08-15 sur le repo kitokoh/leopardo-hr. Les constats
+complets (preuves fichier:ligne, vérifications runtime) sont dans
+[findings-registry.md](./findings-registry.md). La campagne QA omnichannel du même jour
+couvre déjà ~90 issues (#2646→#2813) ; cette spec ne porte que sur les manquements
+**nouveaux** (F-01→F-09) et sur l'implémentation du P0 #2652 (login 500), non assigné.
+
+## User Stories & Testing
+
+### User Story 1 — Le login API ne renvoie plus jamais 500 sur un compte existant (P0)
+
+Un employé (ou un compte démo) dont l'environnement a perdu son schéma tenant ou dont le
+lookup pointe vers un schéma absent obtient une **erreur propre et explicite** (401
+identifiants invalides ou message métier clair), jamais un 500 « Server Error ».
+
+**Independent Test**: `POST /api/v1/auth/login` avec un email dont le
+`public.user_lookups.schema_name` pointe vers un schéma inexistant → 401 JSON propre
+(et non 500) ; le flux nominal (schéma existant) reste inchangé (200 + token).
+
+**Acceptance Scenarios**:
+1. **Given** un lookup `user_lookups` pointant vers un schéma sans table `employees`,
+   **When** login avec ces identifiants, **Then** réponse 401 structurée (pas de 500).
+2. **Given** un compte valide sur un schéma sain, **When** login, **Then** 200 + token
+   (aucune régression).
+3. **Given** un compte verrouillé/suspendu, **When** login, **Then** le comportement
+   existant (423/403 métier) est préservé.
+
+---
+
+### User Story 2 — Le CHANGELOG respecte sa propre garde de gouvernance (P1)
+
+Un contributeur qui ouvre une PR voit la CI Governance verte : plus de headers de section
+dupliqués (`### Added` ×2, `### Fixed` ×5) sous `[Unreleased]`.
+
+**Independent Test**: la commande de garde `check-governance.ps1` (ou le scan équivalent
+des headers) passe sur `CHANGELOG.md` ; `git diff` ne montre que la réorganisation des
+headers, aucun contenu supprimé.
+
+**Acceptance Scenarios**:
+1. **Given** le CHANGELOG courant, **When** on vérifie la structure `[Unreleased]`,
+   **Then** chaque catégorie (`Added`/`Changed`/`Fixed`/`Removed`) apparaît une seule fois,
+   regroupant toutes les entrées.
+2. **Given** la garde maison, **When** on la lance, **Then** elle passe sans erreur.
+
+---
+
+### User Story 3 — Les alertes plateforme admin sont lisibles (P2)
+
+Un super-admin ouvre Analytics → « Alertes plateforme » : chaque alerte affiche son texte
+(`message` du backend), pas un bloc vide. Les actions « Ignorer » restent fonctionnelles.
+
+**Independent Test**: `AnalyticsView.vue` mappe `message` (et non `title`/`description`) ;
+le rendu avec le payload réel `/admin/dashboard/alerts` montre le texte de l'alerte.
+
+**Acceptance Scenarios**:
+1. **Given** une alerte critique renvoyée par l'API, **When** AnalyticsView la rend,
+   **Then** le texte de l'alerte est visible avec son niveau (critical/warning/info).
+2. **Given** aucune alerte, **When** rendu, **Then** l'état vide « Aucune alerte active »
+   est conservé.
+
+---
+
+### User Story 4 — L'attribution des leads vitrine est conservée de bout en bout (P2)
+
+Un prospect cliqué depuis `/download` (ou un guide) avec `source=download_*` arrive sur
+`/signup` et soumet le formulaire : la soumission `/api/forms/signup` transmet la même
+`source` (et non `signup_form` codée en dur).
+
+**Independent Test**: navigation vers `/signup?source=download_employee_android` +
+soumission → payload envoyé avec `source=download_employee_android`.
+
+**Acceptance Scenarios**:
+1. **Given** `/signup?source=download_employee_android`, **When** soumission,
+   **Then** le payload contient `source: 'download_employee_android'`.
+2. **Given** `/signup` sans paramètre, **When** soumission, **Then** `source: 'signup_form'`
+   (défaut conservé).
+
+---
+
+### User Story 5 — Assainissements rapides (P3) — hygiène web/mobile/admin
+
+Un développeur peut builder et tester sans fragilités : `zod` déclaré dans `package.json`,
+`/api/forms/verify` derrière la même gate que les autres routes forms, `CompanyDetailView`
+affiche les erreurs API, `leopardo_hr` initialise Sentry comme les autres apps, et les
+specs e2e web reflètent le formulaire sans mot de passe.
+
+**Independent Test**: `npm run build` vitrine vert (zod résolu) ; gate forms homogène ;
+lint admin vert ; grep Sentry sur `leopardo_hr` non vide ; specs e2e à jour.
+
+**Acceptance Scenarios**:
+1. **Given** package.json, **When** `npm ls zod`, **Then** `zod` est présent et déclaré.
+2. **Given** `/api/forms/verify`, **When** la gate `areFormsEnabled()` est fermée,
+   **Then** l'endpoint répond comme les autres routes forms (état désactivé).
+3. **Given** une erreur API sur la fiche entreprise, **When** chargement, **Then** un
+   message d'erreur visible s'affiche (toast), pas seulement `console.error`.
+4. **Given** `leopardo_hr`, **When** démarrage, **Then** Sentry est initialisé
+   (même pattern que `leopardo_employee`).
+5. **Given** les specs e2e vitrine, **When** rejouées, **Then** elles correspondent au
+   formulaire courant (sans champ mot de passe).
+
+## Functional Requirements
+
+- FR-1 (US1) : `AuthService::login()` ne lève jamais de `QueryException` sur la résolution
+  d'employé : toute erreur de résolution (table absente, schéma absent) → pas d'employé →
+  `InvalidCredentialsException` (401) ou erreur métier documentée.
+- FR-2 (US1) : le chemin nominal (schéma sain) est inchangé ; les abilities tenant,
+  verrouillage et statuts restent appliqués.
+- FR-3 (US1) : un test de régression couvre le cas lookup→schéma absent (401, pas 500).
+- FR-4 (US2) : `CHANGELOG.md` restructuré : une seule occurrence de chaque header de
+  catégorie sous `[Unreleased]`, toutes les entrées conservées.
+- FR-5 (US3) : `AnalyticsView.vue` lit `alert.message` (avec fallback `title` pour
+  compatibilité) ; les clés `id`/`level` inchangées.
+- FR-6 (US4) : `SignupForm` propage `source` depuis la query string (défaut `signup_form`).
+- FR-7 (US5) : `zod` ajouté aux dépendances de `front/web` ; `api/forms/verify` branché sur
+  `areFormsEnabled()` ; toasts d'erreur dans `CompanyDetailView` ; `SentryFlutter.init`
+  dans `leopardo_hr` ; specs e2e `conversion-funnel` + `forms-and-submissions` réalignées.
+
+## Success Criteria
+
+- 0 cas de login 500 sur compte existant (probe : login démo → 401 propre) — US1.
+- `check-governance.ps1` vert sur le CHANGELOG — US2.
+- Alerte plateforme rendue avec texte visible sur le payload réel — US3.
+- `source=download_*` présent dans le payload signup quand présent dans l'URL — US4.
+- Builds vitrine/admin verts, Sentry présent dans les 4 apps, specs e2e réalignées — US5.
+
+## Key Entities
+
+- `AuthService` (login), `public.user_lookups`, `CHANGELOG.md`, `AnalyticsView.vue`,
+  `SignupForm.tsx`, `package.json` (front/web), `lead-capture.ts`, `CompanyDetailView.vue`,
+  `main.dart` (leopardo_hr), specs e2e web.
+
+## Assumptions
+
+- Les déploiements Render/Vercel (#2812/#2813) sont hors périmètre d'implémentation de
+  cette vague (traités en issues ops).
+- Les constats déjà couverts par la vague omnichannel ne sont PAS ré-implémentés ici
+  (voir registre §C).
+- La vérification runtime du login (prod) restera 500 tant que le déploiement #2812 n'est
+  pas fait ; la validation du fix se fait par tests locaux + le futur déploiement.

--- a/.specify/features/qa-audit-expert-2026-08-15/tasks.md
+++ b/.specify/features/qa-audit-expert-2026-08-15/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — QA Audit Expert 2026-08-15 (manquements nouveaux)
+
+> Format strict : `- [ ] [TaskID] [P?] [Story?] Description avec chemin de fichier`.
+> Chaque user story forme un incrément testable indépendamment.
+
+## Phase 1 — Setup (aucun prérequis hors branche)
+
+- [ ] T001 Créer la branche `docs/qa-audit-expert-2026-08-15` depuis `origin/main` avec les artefacts Spec Kit (spec.md, findings-registry.md, tasks.md, checklists/requirements.md) et ouvrir la PR docs (Closes issue registre).
+
+## Phase 2 — Fondations
+
+- [ ] T002 [P] Vérifier l'absence de branche existante pour #2652 et les nouvelles issues (`gh api repos/kitokoh/leopardo-hr/branches | grep <issue>`), puis self-assign + branche `fix/<issue>-<slug>` avec commit vide de claim (protocole anti-doublon #2400).
+
+## Phase 3 — US1 : login API sans 500 (P0)
+
+- [ ] T003 [US1] Ajouter la garde `tenantEmployeesTableExists($schema)` avant la requête `Employee` du premier chemin de lookup dans `api/app/Core/Auth/Infrastructure/Services/AuthService.php` (schéma absent → pas d'employé → `InvalidCredentialsException`).
+- [ ] T004 [US1] Envelopper la résolution d'employé (lookup + fallback) d'un catch `QueryException` ciblé (`42P01`/table inconnue) → traiter comme « aucun employé » et logger en warning structuré, jamais 500.
+- [ ] T005 [US1] Ajouter le test de régression `api/tests/Feature/Auth/DemoLoginDefensiveTest.php` (ou étendre `DemoUserControllerTest`) : lookup → schéma inexistant → 401 JSON (pas 500) ; lookup valide → 200 (inchangé).
+- [ ] T006 [US1] Vérifier `vendor/bin/pint --test`, `phpstan` diff, et `php artisan test --filter=Demo` vert ; PR `fix/2652-...` avec `Closes #2652` + entrée CHANGELOG.
+
+## Phase 4 — US2 : CHANGELOG gouvernance (P1)
+
+- [ ] T007 [US2] Restructurer `CHANGELOG.md` sous `## [Unreleased]` : une seule occurrence de chaque header (`### Added` / `### Changed` / `### Fixed` / `### Removed`), entrées regroupées sans perte de contenu.
+- [ ] T008 [US2] Vérifier la garde maison (scan des headers `### ` dupliqués, cf. `dev-hub/tools/check-governance.ps1` ou équivalent grep) passe ; PR `fix/<issue>-changelog-governance` avec `Closes #<issue>`.
+
+## Phase 5 — US3 : alertes plateforme lisibles (P2)
+
+- [ ] T009 [US3] Dans `front/admin-dashboard/src/views/analytics/AnalyticsView.vue:124-125`, mapper `alert.message` (fallback `alert.title`/`alert.description`) au lieu de `title`/`description` seuls.
+- [ ] T010 [US3] `npm run lint` + build admin verts ; PR `fix/<issue>-analytics-alerts` avec `Closes #<issue>` + CHANGELOG.
+
+## Phase 6 — US4 : attribution source vitrine (P2)
+
+- [ ] T011 [US4] Dans `front/web/src/modules/vitrine/components/forms/SignupForm.tsx:187`, lire `source` depuis `useSearchParams()` (défaut `'signup_form'`) et l'envoyer dans le payload signup.
+- [ ] T012 [US4] Test composant : `/signup?source=download_employee_android` → payload `source=download_employee_android` ; sans paramètre → `signup_form`. Lint + tsc + jest verts ; PR `fix/<issue>-signup-source` avec `Closes #<issue>` + CHANGELOG.
+
+## Phase 7 — US5 : assainissements P3
+
+- [ ] T013 [P] [US5] Ajouter `zod` aux dépendances de `front/web/package.json` (version alignée sur l'usage) ; `npm install` + build vert.
+- [ ] T014 [P] [US5] Brancher `front/web/src/app/api/forms/verify/route.ts` sur `areFormsEnabled()` (même gate que les autres routes forms).
+- [ ] T015 [P] [US5] `front/admin-dashboard/src/views/companies/CompanyDetailView.vue` : ajouter `toast.error(...)` (message localisé si dispo) dans les 4 catch (détail, tickets, abonnement, modules).
+- [ ] T016 [P] [US5] `front/mobile_apps/leopardo_hr/lib/main.dart` : initialiser `SentryFlutter.init` (même pattern que `leopardo_employee`, dsn via `--dart-define`).
+- [ ] T017 [P] [US5] Réaligner `front/web/e2e/conversion-funnel.spec.ts` et `front/web/e2e/forms-and-submissions.spec.ts` sur le formulaire sans mot de passe (champ `email` + bouton, pas de `password`).
+- [ ] T018 [US5] Vérifications finales : builds vitrine/admin verts, `npm ls zod` OK, lint e2e, CHANGELOG entries ; PRs par issue avec `Closes #<issue>`.
+
+## Polish & cross-cutting
+
+- [ ] T019 [P] Mettre à jour `AGENTS.md`/CHANGELOG si une leçon opérationnelle émerge (ex. garde lookup défensif).
+- [ ] T020 [P] Vérifier les checks GitHub Actions des PRs, merger les PR vertes (`gh pr merge --merge --delete-branch`), supprimer les branches.
+
+## Dépendances
+
+- US1 (T003-T006) indépendante → priorité absolue (P0).
+- US2 (T007-T008) indépendante → P1.
+- US3 (T009-T010), US4 (T011-T012), US5 (T013-T018) indépendantes → P2/P3.
+
+## Exécution parallèle
+
+- T003+T007+T009+T011+T013 peuvent partir simultanément (fichiers disjoints).
+- Stratégie MVP : US1 d'abord (bloqueur prod), puis US2, puis P2/P3 par PR unitaire.


### PR DESCRIPTION
Vague de test experte 2026-08-15 : registre des manquements (dédupliqué contre la vague omnichannel #2646→#2813), spec, tasks et checklist Spec Kit.

Issues couvertes (implémentées dans des PRs séparées) : #2652, #2819, #2820, #2821, #2822, #2823, #2824, #2826, #2827.