### PR TITLE
feat(auth): réinitialisation de mot de passe — forgot/reset (Closes #2626)

### DIFF
--- a/api/app/Core/Auth/Infrastructure/Mail/PasswordResetMail.php
+++ b/api/app/Core/Auth/Infrastructure/Mail/PasswordResetMail.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\Auth\Infrastructure\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Issue #2626 — email de réinitialisation de mot de passe.
+ * Le token est envoyé en clair (usage unique, 60 min) ; seul son hash est
+ * stocké en base.
+ */
+class PasswordResetMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $token,
+        public readonly string $email,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Réinitialisation de votre mot de passe Leopardo',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.password-reset',
+            with: [
+                'token' => $this->token,
+                'email' => $this->email,
+            ],
+        );
+    }
+}

--- a/api/app/Core/Auth/Interfaces/Api/V1/PasswordResetController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/PasswordResetController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\Auth\Interfaces\Api\V1;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Auth\Infrastructure\Mail\PasswordResetMail;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+/**
+ * Issue #2626 — réinitialisation de mot de passe.
+ *
+ * POST /auth/forgot-password : émission d'un jeton à usage unique (60 min),
+ * réponse générique anti-énumération.
+ * POST /auth/reset-password : validation du jeton + nouveau mot de passe,
+ * révocation des tokens Sanctum existants.
+ */
+class PasswordResetController
+{
+    private const TOKEN_TTL_MINUTES = 60;
+
+    public function forgot(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'email', 'max:255'],
+        ]);
+
+        $email = strtolower(trim($validated['email']));
+
+        /** @var Employee|null $employee */
+        $employee = Employee::withoutGlobalScopes()->where('email', $email)->first();
+
+        // Anti-énumération : même réponse que l'email existe ou non.
+        if ($employee !== null) {
+            $token = Str::random(64);
+
+            DB::table('public.password_reset_tokens')->insert([
+                'email' => $email,
+                'token_hash' => hash('sha256', $token),
+                'expires_at' => now()->addMinutes(self::TOKEN_TTL_MINUTES),
+                'used_at' => null,
+                'created_at' => now(),
+            ]);
+
+            Mail::to($email)->send(new PasswordResetMail($token, $email));
+        }
+
+        return new JsonResponse([
+            'message' => 'Si un compte existe pour cet email, un lien de réinitialisation a été envoyé.',
+        ]);
+    }
+
+    public function reset(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'email', 'max:255'],
+            'token' => ['required', 'string', 'max:64'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        $email = strtolower(trim($validated['email']));
+        $tokenHash = hash('sha256', $validated['token']);
+
+        $row = DB::table('public.password_reset_tokens')
+            ->where('email', $email)
+            ->where('token_hash', $tokenHash)
+            ->first();
+
+        // Token absent, expiré ou déjà consommé → refus générique (422).
+        if ($row === null || $row->used_at !== null || now()->greaterThan($row->expires_at)) {
+            return new JsonResponse([
+                'message' => 'Jeton de réinitialisation invalide, expiré ou déjà utilisé.',
+                'error' => 'INVALID_RESET_TOKEN',
+            ], 422);
+        }
+
+        /** @var Employee|null $employee */
+        $employee = Employee::withoutGlobalScopes()->where('email', $email)->first();
+
+        if ($employee === null) {
+            return new JsonResponse([
+                'message' => 'Jeton de réinitialisation invalide, expiré ou déjà utilisé.',
+                'error' => 'INVALID_RESET_TOKEN',
+            ], 422);
+        }
+
+        // Consommation du jeton (idempotence) puis mise à jour du mot de passe.
+        DB::table('public.password_reset_tokens')
+            ->where('email', $email)
+            ->where('token_hash', $tokenHash)
+            ->update(['used_at' => now()]);
+
+        $employee->update(['password_hash' => Hash::make($validated['password'])]);
+
+        // Issue #2626 : révocation des sessions existantes (tokens Sanctum).
+        $employee->tokens()->delete();
+
+        return new JsonResponse([
+            'message' => 'Mot de passe réinitialisé. Connectez-vous avec votre nouveau mot de passe.',
+        ]);
+    }
+}

--- a/api/database/migrations/public/2026_08_15_000001_create_password_reset_tokens_table.php
+++ b/api/database/migrations/public/2026_08_15_000001_create_password_reset_tokens_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Issue #2626 — jetons de réinitialisation de mot de passe (usage unique,
+ * 60 min). Table publique (le lookup est par email, hors tenant).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('SET search_path TO public');
+        DB::unprepared(<<<'SQL'
+CREATE TABLE IF NOT EXISTS public.password_reset_tokens (
+    email varchar(150) NOT NULL,
+    token_hash varchar(64) NOT NULL,
+    expires_at timestamp(0) with time zone NOT NULL,
+    used_at timestamp(0) with time zone NULL,
+    created_at timestamp(0) with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (email, token_hash)
+);
+CREATE INDEX IF NOT EXISTS password_reset_tokens_email_index
+    ON public.password_reset_tokens (email);
+SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('SET search_path TO public');
+        DB::unprepared('DROP TABLE IF EXISTS public.password_reset_tokens');
+    }
+};

--- a/api/resources/views/mail/password-reset.blade.php
+++ b/api/resources/views/mail/password-reset.blade.php
@@ -1,0 +1,20 @@
+<x-mail::message>
+# Réinitialisation de votre mot de passe
+
+Vous recevez cet email suite à une demande de réinitialisation du mot de passe
+de votre compte Leopardo.
+
+Votre code de réinitialisation (valable **60 minutes**, usage unique) :
+
+# {{ $token }}
+
+Si vous n'êtes pas à l'origine de cette demande, ignorez cet email — votre
+mot de passe actuel reste inchangé.
+
+<x-mail::button :url="config('app.url')">
+Accéder à Leopardo
+</x-mail::button>
+
+Cordialement,<br>
+L'équipe Leopardo RH
+</x-mail::message>

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Core\Auth\Interfaces\Api\V1\AuthController;
+use App\Core\Auth\Interfaces\Api\V1\PasswordResetController;
 use App\Core\Auth\Interfaces\Api\V1\PlatformAuthController;
 use App\Core\Feature\Interfaces\Api\V1\FeatureManifestController;
 use App\Http\Controllers\Web\PlatformCompanyController;
@@ -75,6 +76,9 @@ Route::prefix('v1')->group(function (): void {
     Route::middleware(['throttle:auth-sensitive'])->group(function (): void {
         Route::post('/auth/login', [AuthController::class, 'login']);
         Route::post('/auth/register', [AuthController::class, 'register']);
+        // Issue #2626 : réinitialisation de mot de passe (usage unique, 60 min).
+        Route::post('/auth/forgot-password', [PasswordResetController::class, 'forgot']);
+        Route::post('/auth/reset-password', [PasswordResetController::class, 'reset']);
         Route::get('/auth/google', [AuthController::class, 'redirectToGoogle']);
         Route::get('/auth/google/callback', [AuthController::class, 'handleGoogleCallback']);
         Route::post('/auth/google/token', [AuthController::class, 'handleGoogleToken']);

--- a/api/tests/Feature/PasswordResetTest.php
+++ b/api/tests/Feature/PasswordResetTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Auth\Infrastructure\Mail\PasswordResetMail;
+use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #2626 — réinitialisation de mot de passe :
+ * demande (réponse générique anti-énumération), reset valide (mdp changé +
+ * tokens Sanctum révoqués + jeton consommé), jeton expiré/réutilisé → 422.
+ */
+class PasswordResetTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Company $company;
+
+    private Employee $employee;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $this->company = $company;
+
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'reset-me@example.com',
+            'password_hash' => Hash::make('old-password'),
+        ]);
+        $this->employee = $employee;
+    }
+
+    private function issueToken(string $email, ?string $expiresAt = null): string
+    {
+        $token = 'reset-token-'.str()->random(20);
+        DB::table('public.password_reset_tokens')->insert([
+            'email' => $email,
+            'token_hash' => hash('sha256', $token),
+            'expires_at' => $expiresAt ?? now()->addMinutes(60),
+            'used_at' => null,
+            'created_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    public function test_forgot_password_returns_generic_response_and_sends_mail(): void
+    {
+        Mail::fake();
+
+        $this->postJson('/api/v1/auth/forgot-password', ['email' => 'reset-me@example.com'])
+            ->assertOk();
+
+        Mail::assertSent(PasswordResetMail::class, fn ($mail) => $mail->hasTo('reset-me@example.com'));
+        $this->assertDatabaseHas('password_reset_tokens', ['email' => 'reset-me@example.com']);
+    }
+
+    public function test_forgot_password_does_not_enumerate_unknown_email(): void
+    {
+        Mail::fake();
+
+        // Même réponse (200 générique) pour un email inconnu — aucune fuite.
+        $this->postJson('/api/v1/auth/forgot-password', ['email' => 'unknown@example.com'])
+            ->assertOk();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_reset_password_updates_password_and_revokes_tokens(): void
+    {
+        $token = $this->issueToken('reset-me@example.com');
+
+        // Un token Sanctum existant à révoquer.
+        $oldToken = $this->employee->createToken('old-session');
+        $this->assertCount(1, $this->employee->tokens()->get());
+
+        $this->postJson('/api/v1/auth/reset-password', [
+            'email' => 'reset-me@example.com',
+            'token' => $token,
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ])->assertOk();
+
+        $this->employee->refresh();
+        $this->assertTrue(Hash::check('new-password-123', $this->employee->password_hash));
+        $this->assertCount(0, $this->employee->tokens()->get(), 'Les tokens Sanctum existants doivent être révoqués.');
+
+        $this->assertNotNull(
+            DB::table('public.password_reset_tokens')
+                ->where('email', 'reset-me@example.com')
+                ->where('token_hash', hash('sha256', $token))
+                ->value('used_at'),
+            'Le jeton doit être marqué consommé.'
+        );
+    }
+
+    public function test_reset_password_rejects_reused_token(): void
+    {
+        $token = $this->issueToken('reset-me@example.com');
+
+        // Première utilisation → OK.
+        $this->postJson('/api/v1/auth/reset-password', [
+            'email' => 'reset-me@example.com',
+            'token' => $token,
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ])->assertOk();
+
+        // Réutilisation du même jeton → 422.
+        $this->postJson('/api/v1/auth/reset-password', [
+            'email' => 'reset-me@example.com',
+            'token' => $token,
+            'password' => 'another-password-456',
+            'password_confirmation' => 'another-password-456',
+        ])->assertStatus(422)
+            ->assertJsonPath('error', 'INVALID_RESET_TOKEN');
+    }
+
+    public function test_reset_password_rejects_expired_token(): void
+    {
+        $token = $this->issueToken('reset-me@example.com', now()->subMinute()->toDateTimeString());
+
+        $this->postJson('/api/v1/auth/reset-password', [
+            'email' => 'reset-me@example.com',
+            'token' => $token,
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ])->assertStatus(422)
+            ->assertJsonPath('error', 'INVALID_RESET_TOKEN');
+    }
+}


### PR DESCRIPTION
## Contexte

T013 (audit expert backend) : aucun flux de réinitialisation de mot de passe.

## Correctif

- **POST /auth/forgot-password** : jeton à usage unique (60 min, hash stocké en base), `PasswordResetMail`, réponse générique anti-énumération.
- **POST /auth/reset-password** : jeton expiré/réutilisé/inconnu → 422 `INVALID_RESET_TOKEN` ; mot de passe mis à jour ; **tokens Sanctum existants révoqués**.
- Migration `public.password_reset_tokens` (idempotente) + routes sous `throttle:auth-sensitive`.
- `PasswordResetTest` : 5 cas (demande + mail, anti-énumération, reset valide + révocation + jeton consommé, réutilisation → 422, expiration → 422).

## Vérifications

- 5/5 OK (PHP 8.4 local).

Closes #2626