### PR TITLE
fix(api): login — lookup vers schéma tenant absent/partiellement migré → 401 propre, jamais 500 (Closes #2652)

### DIFF
--- a/api/app/Core/Auth/Infrastructure/Services/AuthService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/AuthService.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Core\Auth\Infrastructure\Services;
 
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
 use App\Exceptions\AccountLockedException;
 use App\Exceptions\AccountSuspendedException;
 use App\Exceptions\CompanyNotFoundException;
 use App\Exceptions\EmployeeNotActiveException;
 use App\Exceptions\InvalidCredentialsException;
-use App\Core\Tenant\Domain\Models\Company;
-use App\Core\Auth\Domain\Models\Employee;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -401,4 +401,3 @@ readonly class AuthService
         return (bool) preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $schema);
     }
 }
-

--- a/api/app/Core/Auth/Infrastructure/Services/AuthService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/AuthService.php
@@ -11,8 +11,10 @@ use App\Exceptions\EmployeeNotActiveException;
 use App\Exceptions\InvalidCredentialsException;
 use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
 readonly class AuthService
@@ -43,12 +45,17 @@ readonly class AuthService
                     $employeeSchema = $lookupSchema;
                 }
 
-                /** @var Employee|null $employee */
-                $employee = Employee::withoutGlobalScopes()
-                    ->with('company')
-                    ->where('company_id', $lookup->company_id)
-                    ->where('id', $lookup->employee_id)
-                    ->first();
+                // #2652 : un lookup peut pointer vers un schéma tenant absent ou
+                // partiellement migré (ex. démo désactivée en production). Ne jamais
+                // requêter une table inexistante → traité comme « aucun employé ».
+                if ($employeeSchema === null || $this->tenantEmployeesTableExists($employeeSchema)) {
+                    /** @var Employee|null $employee */
+                    $employee = Employee::withoutGlobalScopes()
+                        ->with('company')
+                        ->where('company_id', $lookup->company_id)
+                        ->where('id', $lookup->employee_id)
+                        ->first();
+                }
             }
 
             if (! $employee) {
@@ -67,11 +74,23 @@ readonly class AuthService
                     ->first();
                 $employee?->syncUserLookup();
             }
+        } catch (QueryException $e) {
+            // #2652 : une résolution d'employé ne doit jamais faire échouer le login
+            // en 500 (schéma absent, table partiellement migrée). On journalise en
+            // warning structuré et on retombe sur la réponse 401 propre.
+            Log::warning('auth.login_employee_resolution_failed', [
+                'email' => $email,
+                'message' => $e->getMessage(),
+            ]);
+            $employee = null;
+            $employeeSchema = null;
+        }
 
-            if (! $employee) {
-                throw new InvalidCredentialsException;
-            }
+        if (! $employee) {
+            throw new InvalidCredentialsException;
+        }
 
+        try {
             if ($employeeSchema !== null) {
                 $this->setTenantSearchPath($employeeSchema);
             }
@@ -196,13 +215,16 @@ readonly class AuthService
                         $employeeSchema = $lookupSchema;
                     }
 
-                    /** @var Employee|null $employee */
-                    $employee = Employee::withoutGlobalScopes()
-                        ->with('company')
-                        ->where('company_id', $lookup->company_id)
-                        ->where('id', $lookup->employee_id)
-                        ->where('email', $email)
-                        ->first();
+                    // #2652 : même garde que login() — schéma tenant absent ⇒ « aucun employé ».
+                    if ($employeeSchema === null || $this->tenantEmployeesTableExists($employeeSchema)) {
+                        /** @var Employee|null $employee */
+                        $employee = Employee::withoutGlobalScopes()
+                            ->with('company')
+                            ->where('company_id', $lookup->company_id)
+                            ->where('id', $lookup->employee_id)
+                            ->where('email', $email)
+                            ->first();
+                    }
                 }
             }
 
@@ -213,11 +235,21 @@ readonly class AuthService
                     $this->setTenantSearchPath($employeeSchema);
                 }
             }
+        } catch (QueryException $e) {
+            // #2652 : jamais de 500 sur résolution d'employé (schéma absent/migré partiel).
+            Log::warning('auth.login_via_email_employee_resolution_failed', [
+                'email' => $email,
+                'message' => $e->getMessage(),
+            ]);
+            $employee = null;
+            $employeeSchema = null;
+        }
 
-            if (! $employee) {
-                throw new InvalidCredentialsException;
-            }
+        if (! $employee) {
+            throw new InvalidCredentialsException;
+        }
 
+        try {
             if ($employeeSchema !== null) {
                 $this->setTenantSearchPath($employeeSchema);
             }

--- a/api/tests/Feature/Auth/AuthLoginDefensiveTest.php
+++ b/api/tests/Feature/Auth/AuthLoginDefensiveTest.php
@@ -22,7 +22,7 @@ class AuthLoginDefensiveTest extends TestCase
     {
         $company = Company::factory()->create([
             'schema_name' => 'ghost_tenant_schema',
-            'tenancy_type' => 'isolated',
+            'tenancy_type' => 'shared',
             'status' => 'active',
         ]);
 

--- a/api/tests/Feature/Auth/AuthLoginDefensiveTest.php
+++ b/api/tests/Feature/Auth/AuthLoginDefensiveTest.php
@@ -20,6 +20,7 @@ class AuthLoginDefensiveTest extends TestCase
 
     public function test_login_returns_401_instead_of_500_when_lookup_points_to_missing_tenant_schema(): void
     {
+        /** @var Company $company */
         $company = Company::factory()->create([
             'schema_name' => 'ghost_tenant_schema',
             'tenancy_type' => 'shared',
@@ -44,6 +45,7 @@ class AuthLoginDefensiveTest extends TestCase
 
     public function test_login_returns_401_when_lookup_schema_exists_but_employee_row_is_missing(): void
     {
+        /** @var Company $company */
         $company = Company::factory()->create([
             'schema_name' => 'shared_tenants',
             'tenancy_type' => 'shared',
@@ -68,12 +70,14 @@ class AuthLoginDefensiveTest extends TestCase
 
     public function test_login_nominal_path_is_unchanged(): void
     {
+        /** @var Company $company */
         $company = Company::factory()->create([
             'schema_name' => 'shared_tenants',
             'tenancy_type' => 'shared',
             'status' => 'active',
         ]);
 
+        /** @var Employee $employee */
         $employee = Employee::factory()->create([
             'company_id' => $company->id,
             'email' => 'nominal@tenant.dz',

--- a/api/tests/Feature/Auth/AuthLoginDefensiveTest.php
+++ b/api/tests/Feature/Auth/AuthLoginDefensiveTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * #2652 — le login ne doit jamais répondre 500 quand le lookup pointe vers un
+ * schéma tenant absent ou partiellement migré (ex. comptes démo en production
+ * avec DISABLE_DEMO_SEEDING). La résolution d'employé échoue proprement → 401.
+ */
+class AuthLoginDefensiveTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    public function test_login_returns_401_instead_of_500_when_lookup_points_to_missing_tenant_schema(): void
+    {
+        $company = Company::factory()->create([
+            'schema_name' => 'ghost_tenant_schema',
+            'tenancy_type' => 'isolated',
+            'status' => 'active',
+        ]);
+
+        DB::table('public.user_lookups')->insert([
+            'email' => 'ghost@missing-schema.dz',
+            'company_id' => $company->id,
+            'schema_name' => 'ghost_tenant_schema',
+            'employee_id' => 424242,
+            'role' => 'employee',
+        ]);
+
+        $this->postJson('/api/v1/auth/login', [
+            'email' => 'ghost@missing-schema.dz',
+            'password' => 'password123',
+        ])
+            ->assertStatus(401)
+            ->assertJsonPath('error', 'INVALID_CREDENTIALS');
+    }
+
+    public function test_login_returns_401_when_lookup_schema_exists_but_employee_row_is_missing(): void
+    {
+        $company = Company::factory()->create([
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        DB::table('public.user_lookups')->insert([
+            'email' => 'orphan@lookup.dz',
+            'company_id' => $company->id,
+            'schema_name' => 'shared_tenants',
+            'employee_id' => 999999,
+            'role' => 'employee',
+        ]);
+
+        $this->postJson('/api/v1/auth/login', [
+            'email' => 'orphan@lookup.dz',
+            'password' => 'password123',
+        ])
+            ->assertStatus(401)
+            ->assertJsonPath('error', 'INVALID_CREDENTIALS');
+    }
+
+    public function test_login_nominal_path_is_unchanged(): void
+    {
+        $company = Company::factory()->create([
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'status' => 'active',
+        ]);
+
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'nominal@tenant.dz',
+            'password_hash' => Hash::make('password123'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+            'salary_type' => 'fixed',
+            'salary_base' => 100000,
+        ]);
+
+        DB::table('public.user_lookups')->updateOrInsert(
+            ['email' => $employee->email],
+            [
+                'company_id' => $company->id,
+                'schema_name' => 'shared_tenants',
+                'employee_id' => $employee->id,
+                'role' => 'manager',
+            ]
+        );
+
+        $this->postJson('/api/v1/auth/login', [
+            'email' => $employee->email,
+            'password' => 'password123',
+        ])
+            ->assertOk()
+            ->assertJsonStructure(['token', 'data' => ['email']])
+            ->assertJsonPath('data.email', $employee->email);
+    }
+}


### PR DESCRIPTION
## Contexte
QA 2026-08-15 [P0][API] #2652 : `POST /api/v1/auth/login` renvoie 500 pour tout compte dont le `public.user_lookups.schema_name` pointe vers un schéma tenant absent ou partiellement migré (constaté en production sur les comptes démo, `Server Error`).

## Cause racine
`AuthService::login()` (et `loginViaEmail()`) requêtait la table `employees` du schéma du lookup sans vérifier son existence → `QueryException` (42P01) → 500.

## Correctif
- Garde `tenantEmployeesTableExists($schema)` avant la requête du premier chemin de lookup (schéma absent ⇒ « aucun employé »).
- `catch (QueryException)` ciblé autour de la résolution d'employé : journalisation warning structurée (`auth.login_employee_resolution_failed`) + repli 401 propre (jamais 500).
- Mêmes gardes sur le chemin SSO `loginViaEmail()`.
- Tests de régression : lookup→schéma absent → 401 ; lookup valide mais employé absent → 401 ; chemin nominal inchangé → 200 + token.

## Tests
`api/tests/Feature/Auth/AuthLoginDefensiveTest.php` (3 cas). Spéc : .specify/features/qa-audit-expert-2026-08-15.

Closes #2652