### PR TITLE
fix(web): SignupForm — propager source=download_* de l'URL au lead (getLeadSource, défaut signup_form) (Closes #2823)

### DIFF
--- a/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
@@ -25,7 +25,7 @@ import { Input } from '@/modules/vitrine/components/common/Input';
 import { Button } from '@/modules/vitrine/components/common/Button';
 import { Card } from '@/modules/vitrine/components/common/Card';
 import { signupFormSchema, SignupFormData } from '@/modules/vitrine/lib/validation';
-import { submitSignupForm, submitVerifyForm, fetchTrialStatus, createFormReducer, initialFormState } from '@/modules/vitrine/lib/forms';
+import { submitSignupForm, submitVerifyForm, fetchTrialStatus, createFormReducer, initialFormState, getLeadSource } from '@/modules/vitrine/lib/forms';
 import { useAnalyticsForm } from '@/modules/vitrine/hooks/useAnalytics';
 import { useVitrineLocale } from '@/modules/vitrine/lib/vitrine-locale';
 import type { AppLocale } from '@/lib/i18n';
@@ -508,7 +508,7 @@ export function SignupForm({
 
       if (response.success) {
         trackSignup(data.email, {
-          source: 'signup_form',
+          source: getLeadSource(),
           page,
           company: data.company,
           role: data.role,

--- a/front/web/src/modules/vitrine/lib/forms.ts
+++ b/front/web/src/modules/vitrine/lib/forms.ts
@@ -37,6 +37,21 @@ function getSearchMetadata(): Record<string, string> {
 }
 
 /**
+ * #2823 — la source d'acquisition de l'URL (ex. `source=download_employee_android`
+ * posée par /download et les guides) doit être propagée au lead, pas écrasée par
+ * un défaut codé en dur.
+ */
+export function getLeadSource(): string {
+  if (typeof window === "undefined") {
+    return "signup_form";
+  }
+
+  const source = new URLSearchParams(window.location.search).get("source");
+
+  return source && source.trim().length > 0 ? source.trim() : "signup_form";
+}
+
+/**
  * Form submission handlers
  */
 
@@ -79,7 +94,7 @@ export async function submitSignupForm(
         ...sanitizedData,
         ...getSearchMetadata(),
         locale: getBrowserLocale(),
-        source: "signup_form",
+        source: getLeadSource(),
         page,
         timestamp: new Date().toISOString(),
         requestedWorkflow: "guided_trial",


### PR DESCRIPTION
QA 2026-08-15 [P2][Web] #2823 : `submitSignupForm` envoyait `source: "signup_form"` codé en dur → le paramètre `source=download_*` posé par /download et les guides était perdu à la conversion (attribution leads cassée).

Correctif :
- `getLeadSource()` dans `modules/vitrine/lib/forms.ts` : lit `source` de la query string, défaut `signup_form`.
- Utilisé dans le payload `/api/forms/signup` et dans `trackSignup`.

Lint + tsc + build verts.

Closes #2823