### PR TITLE
fix(web): zod déclaré dans package.json (dépendance fantôme des route handlers forms/checkout) (Closes #2822)

### DIFF
--- a/front/web/package.json
+++ b/front/web/package.json
@@ -29,7 +29,8 @@
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",


### PR DESCRIPTION
QA 2026-08-15 [P3][Web] #2822 : `zod` importé par 3 route handlers (`api/billing/checkout`, `api/forms/contact`, `api/forms/demo`) mais absent de package.json → build dépend d'un hoisting transitoire.

Correctif : `zod: ^4.0.0` ajouté aux dépendances (version résolue actuelle : 4.4.3).

Closes #2822