### PR TITLE
fix(web): /api/forms/verify — gate areFormsEnabled() alignée sur les autres routes forms (Closes #2824)

### DIFF
--- a/front/web/src/app/api/forms/verify/route.ts
+++ b/front/web/src/app/api/forms/verify/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { resolveBackendBaseUrl } from '@/lib/backend-url';
 import { z } from 'zod';
 import { RateLimiter, sanitizeEmail } from '@/modules/vitrine/lib/validation';
-import { getClientIp } from '../_lib/lead-capture';
+import { areFormsEnabled, formsDisabledResponse, getClientIp } from '../_lib/lead-capture';
 
 const rateLimiter = new RateLimiter(10, 15 * 60 * 1000);
 
@@ -15,6 +15,10 @@ const LEOPARDO_API_URL = process.env.LEOPARDO_API_URL ||
   resolveBackendBaseUrl().replace(/\/api\/v1$/, '');
 
 export async function POST(request: NextRequest) {
+  if (!areFormsEnabled()) {
+    return formsDisabledResponse();
+  }
+
   try {
     const ip = getClientIp(request);
 


### PR DESCRIPTION
QA 2026-08-15 [P3][Web] #2824 : `/api/forms/verify` n'appliquait pas `areFormsEnabled()` (contrairement à signup/demo/contact).

Correctif : gate + `formsDisabledResponse()` sur POST.

Closes #2824