### PR TITLE
fix(mobile): leopardo_hr — SentryFlutter.init comme les 3 autres apps (DSN via --dart-define) (Closes #2827)

### DIFF
--- a/front/mobile_apps/leopardo_hr/lib/main.dart
+++ b/front/mobile_apps/leopardo_hr/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:leopardo_core/core/storage/secure_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/widgets/startup_gate.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'app.dart';
 
 Future<void> main() async {
@@ -18,13 +19,22 @@ Future<void> main() async {
   };
   ErrorWidget.builder = (details) => _StartupRuntimeError(details: details);
 
-  runApp(
-    StartupGate(
-      appName: 'Leopardo RH',
-      initializer: _bootstrap,
-      criticalInitializer: _bootstrapCritical,
-      optionalInitializer: _safeGoogleSignInInitialize,
-      child: const ProviderScope(child: LeopardoApp()),
+  // #2827 : Sentry initialisé comme les autres apps (employee/manager/platform admin),
+  // non bloquant — le premier rendu passe par StartupGate dans appRunner.
+  await SentryFlutter.init(
+    (options) {
+      options.dsn =
+          const String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+      options.tracesSampleRate = 1.0;
+    },
+    appRunner: () => runApp(
+      StartupGate(
+        appName: 'Leopardo RH',
+        initializer: _bootstrap,
+        criticalInitializer: _bootstrapCritical,
+        optionalInitializer: _safeGoogleSignInInitialize,
+        child: const ProviderScope(child: LeopardoApp()),
+      ),
     ),
   );
 }

--- a/front/mobile_apps/leopardo_hr/pubspec.yaml
+++ b/front/mobile_apps/leopardo_hr/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
     path: ../leopardo_core
 
   flutter_animate: ^4.5.2
+  sentry_flutter: ^8.9.0
   google_sign_in: ^7.2.0
   cached_network_image: ^3.4.1
 


### PR DESCRIPTION
QA 2026-08-15 [P3][Mobile] #2827 : l'app RH n'initialisait pas Sentry (crash non tracés).

Correctif : `SentryFlutter.init` dans `main.dart` (même pattern que leopardo_employee, DSN via `String.fromEnvironment('SENTRY_DSN')`, appRunner StartupGate non bloquant) + `sentry_flutter: ^8.9.0` dans pubspec.yaml.

Closes #2827