### PR TITLE
fix(attendance): NON_WORK_TYPES étendu à resume (Closes #2686)

### DIFF
--- a/api/app/Modules/Attendance/Infrastructure/Services/AttendanceService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/AttendanceService.php
@@ -22,7 +22,10 @@ use Illuminate\Support\Facades\Schema;
 class AttendanceService
 {
     /** @var array<int, string> */
-    private const NON_WORK_TYPES = ['break'];
+    // Issue #2686 (QA 2026-08-15) — les types non travaillés ne doivent pas
+    // compter dans hours_worked/overtime : `resume` marque la fin d'une pause
+    // (pas une session de travail), au même titre que `break`.
+    private const NON_WORK_TYPES = ['break', 'resume'];
 
     public function __construct(
         private readonly AttendanceGeofenceService $geofenceService,


### PR DESCRIPTION
Closes #2686 — QA expert 2026-08-15 (P3). `NON_WORK_TYPES` ne contenait que `break` : une session fermée en `resume` (fin de pause) comptait dans hours_worked/overtime. Étendu à `['break', 'resume']` — mission/travel/training restent travaillés (convention existante).
