### PR TITLE
fix(expense): gardes de transition approve/reject (Closes #2677)

### DIFF
--- a/api/app/Modules/Expense/Interfaces/Api/V1/Controllers/ExpenseClaimController.php
+++ b/api/app/Modules/Expense/Interfaces/Api/V1/Controllers/ExpenseClaimController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Modules\Expense\Interfaces\Api\V1\Controllers;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\ExpenseClaimResource;
-use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Planning\Domain\Models\ExpenseClaim;
 use App\Modules\Planning\Domain\Models\ExpenseItem;
 use Illuminate\Http\JsonResponse;
@@ -45,13 +45,13 @@ class ExpenseClaimController extends Controller
         $actor = $request->user();
 
         $validated = $request->validate([
-            'title'               => 'required|string|max:200',
-            'description'         => 'nullable|string',
-            'items'               => 'required|array|min:1',
-            'items.*.category'    => 'required|in:transport,meals,accommodation,office,communication,other',
+            'title' => 'required|string|max:200',
+            'description' => 'nullable|string',
+            'items' => 'required|array|min:1',
+            'items.*.category' => 'required|in:transport,meals,accommodation,office,communication,other',
             'items.*.description' => 'required|string|max:255',
-            'items.*.amount'      => 'required|numeric|min:0.01',
-            'items.*.date'        => 'required|date',
+            'items.*.amount' => 'required|numeric|min:0.01',
+            'items.*.date' => 'required|date',
         ]);
 
         $claim = DB::transaction(function () use ($actor, $validated) {
@@ -63,22 +63,22 @@ class ExpenseClaimController extends Controller
             // 'DZD' remains only as a last-resort technical fallback for the
             // rare case where the company record has no currency set.
             $claim = ExpenseClaim::create([
-                'company_id'   => $actor->company_id,
-                'employee_id'  => $actor->id,
-                'title'        => $validated['title'],
-                'description'  => $validated['description'] ?? null,
-                'status'       => 'draft',
+                'company_id' => $actor->company_id,
+                'employee_id' => $actor->id,
+                'title' => $validated['title'],
+                'description' => $validated['description'] ?? null,
+                'status' => 'draft',
                 'total_amount' => $totalAmount,
-                'currency'     => $actor->company?->currency ?? 'DZD',
+                'currency' => $actor->company?->currency ?? 'DZD',
             ]);
 
             foreach ($validated['items'] as $item) {
                 ExpenseItem::create([
                     'expense_claim_id' => $claim->id,
-                    'category'         => $item['category'],
-                    'description'      => $item['description'],
-                    'amount'           => $item['amount'],
-                    'date'             => $item['date'],
+                    'category' => $item['category'],
+                    'description' => $item['description'],
+                    'amount' => $item['amount'],
+                    'date' => $item['date'],
                 ]);
             }
 
@@ -122,8 +122,13 @@ class ExpenseClaimController extends Controller
         abort_unless($expenseClaim->company_id === $actor->company_id, 404);
         abort_unless($actor->isManager(), 403);
 
+        // Issue #2677 (QA 2026-08-15) — garde de transition : seule une
+        // demande soumise peut être approuvée (un brouillon doit d'abord être
+        // soumis ; une demande déjà approuvée/rejetée est un état terminal).
+        abort_if($expenseClaim->status !== 'submitted', 422, 'EXPENSE_CLAIM_NOT_SUBMITTED');
+
         $expenseClaim->update([
-            'status'      => 'approved',
+            'status' => 'approved',
             'approved_by' => (string) $actor->id,
             'approved_at' => now(),
         ]);
@@ -139,14 +144,17 @@ class ExpenseClaimController extends Controller
         abort_unless($expenseClaim->company_id === $actor->company_id, 404);
         abort_unless($actor->isManager(), 403);
 
+        // Issue #2677 — garde de transition : on peut rejeter une demande
+        // soumise ou déjà approuvée, jamais un brouillon ou un rejet existant.
+        abort_if(! in_array($expenseClaim->status, ['submitted', 'approved'], true), 422, 'EXPENSE_CLAIM_NOT_REJECTABLE');
+
         $request->validate(['reason' => 'required|string|max:500']);
 
         $expenseClaim->update([
-            'status'           => 'rejected',
+            'status' => 'rejected',
             'rejection_reason' => $request->input('reason'),
         ]);
 
         return response()->json(['data' => (new ExpenseClaimResource($expenseClaim->fresh()))->resolve($request)]);
     }
 }
-

--- a/api/tests/Feature/Expense/ExpenseClaimWorkflowTest.php
+++ b/api/tests/Feature/Expense/ExpenseClaimWorkflowTest.php
@@ -34,20 +34,20 @@ class ExpenseClaimWorkflowTest extends TestCase
     private function validPayload(): array
     {
         return [
-            'title'       => 'Déplacement client Alger',
+            'title' => 'Déplacement client Alger',
             'description' => 'Mission commerciale',
-            'items'       => [
+            'items' => [
                 [
-                    'category'    => 'transport',
+                    'category' => 'transport',
                     'description' => 'Billet de train',
-                    'amount'      => 2500.50,
-                    'date'        => '2026-07-20',
+                    'amount' => 2500.50,
+                    'date' => '2026-07-20',
                 ],
                 [
-                    'category'    => 'meals',
+                    'category' => 'meals',
                     'description' => 'Repas',
-                    'amount'      => 1200,
-                    'date'        => '2026-07-20',
+                    'amount' => 1200,
+                    'date' => '2026-07-20',
                 ],
             ],
         ];
@@ -69,7 +69,7 @@ class ExpenseClaimWorkflowTest extends TestCase
         $this->assertDatabaseHas('expense_claims', [
             'company_id' => $company->id,
             'employee_id' => $employee->id,
-            'status'     => 'draft',
+            'status' => 'draft',
         ]);
         $this->assertDatabaseCount('expense_items', 2);
     }
@@ -80,12 +80,12 @@ class ExpenseClaimWorkflowTest extends TestCase
         $employee = Employee::factory()->create(['company_id' => $company->id]);
 
         $claim = ExpenseClaim::create([
-            'company_id'   => $company->id,
-            'employee_id'  => $employee->id,
-            'title'        => 'Note de frais',
-            'status'       => 'draft',
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Note de frais',
+            'status' => 'draft',
             'total_amount' => 100,
-            'currency'     => 'DZD',
+            'currency' => 'DZD',
         ]);
 
         Sanctum::actingAs($employee);
@@ -104,12 +104,12 @@ class ExpenseClaimWorkflowTest extends TestCase
         $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
 
         $claim = ExpenseClaim::create([
-            'company_id'   => $company->id,
-            'employee_id'  => $employee->id,
-            'title'        => 'Note de frais',
-            'status'       => 'submitted',
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Note de frais',
+            'status' => 'submitted',
             'total_amount' => 100,
-            'currency'     => 'DZD',
+            'currency' => 'DZD',
             'submitted_at' => now(),
         ]);
 
@@ -120,9 +120,40 @@ class ExpenseClaimWorkflowTest extends TestCase
             ->assertJsonPath('data.status', 'approved');
 
         $this->assertDatabaseHas('expense_claims', [
-            'id'          => $claim->id,
-            'status'      => 'approved',
+            'id' => $claim->id,
+            'status' => 'approved',
             'approved_by' => (string) $manager->id,
+        ]);
+    }
+
+    public function test_manager_cannot_approve_draft_claim(): void
+    {
+        // Issue #2677 — garde de transition : un brouillon doit d'abord être
+        // soumis ; on ne peut pas l'approuver directement (ni rejeter un
+        // brouillon).
+        $company = Company::factory()->create();
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+
+        $claim = ExpenseClaim::create([
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Note de frais',
+            'status' => 'draft',
+            'total_amount' => 100,
+            'currency' => 'DZD',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->putJson("/api/v1/expense-claims/{$claim->id}/approve")
+            ->assertStatus(422);
+        $this->putJson("/api/v1/expense-claims/{$claim->id}/reject", ['reason' => 'x'])
+            ->assertStatus(422);
+
+        $this->assertDatabaseHas('expense_claims', [
+            'id' => $claim->id,
+            'status' => 'draft',
         ]);
     }
 
@@ -133,12 +164,12 @@ class ExpenseClaimWorkflowTest extends TestCase
         $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
 
         $claim = ExpenseClaim::create([
-            'company_id'   => $company->id,
-            'employee_id'  => $employee->id,
-            'title'        => 'Note de frais',
-            'status'       => 'submitted',
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Note de frais',
+            'status' => 'submitted',
             'total_amount' => 100,
-            'currency'     => 'DZD',
+            'currency' => 'DZD',
             'submitted_at' => now(),
         ]);
 
@@ -162,12 +193,12 @@ class ExpenseClaimWorkflowTest extends TestCase
         $managerB = Employee::factory()->manager()->create(['company_id' => $companyB->id]);
 
         $claim = ExpenseClaim::create([
-            'company_id'   => $companyA->id,
-            'employee_id'  => $employeeA->id,
-            'title'        => 'Frais société A',
-            'status'       => 'submitted',
+            'company_id' => $companyA->id,
+            'employee_id' => $employeeA->id,
+            'title' => 'Frais société A',
+            'status' => 'submitted',
             'total_amount' => 100,
-            'currency'     => 'DZD',
+            'currency' => 'DZD',
             'submitted_at' => now(),
         ]);
 
@@ -185,12 +216,12 @@ class ExpenseClaimWorkflowTest extends TestCase
         $employee = Employee::factory()->create(['company_id' => $company->id]);
 
         $claim = ExpenseClaim::create([
-            'company_id'   => $company->id,
-            'employee_id'  => $employee->id,
-            'title'        => 'Note de frais',
-            'status'       => 'submitted',
+            'company_id' => $company->id,
+            'employee_id' => $employee->id,
+            'title' => 'Note de frais',
+            'status' => 'submitted',
             'total_amount' => 100,
-            'currency'     => 'DZD',
+            'currency' => 'DZD',
             'submitted_at' => now(),
         ]);
 


### PR DESCRIPTION
Closes #2677 — QA expert 2026-08-15 (P2). `ExpenseClaimController::approve()/reject()` n'avaient aucune garde de transition : un brouillon pouvait être approuvé, une demande approuvée re-rejetée, etc.

- `approve` : exige `submitted` (422 `EXPENSE_CLAIM_NOT_SUBMITTED`).
- `reject` : accepte `submitted`/`approved` uniquement (422 `EXPENSE_CLAIM_NOT_REJECTABLE`).
- Test `test_manager_cannot_approve_draft_claim` ; suite Expense 19/19 verte.
