### PR TITLE
fix(demo): magic link envoyé après provisioning réussi (Closes #2620)

### DIFF
--- a/api/app/Jobs/ProvisionDemoTenantJob.php
+++ b/api/app/Jobs/ProvisionDemoTenantJob.php
@@ -52,7 +52,12 @@ class ProvisionDemoTenantJob implements ShouldQueue
                     ]);
             }
 
-            // TODO: Generate magic link and send email to the user
+            // Issue #2620 : magic link envoyé au manager après provisioning
+            // réussi (token 72 h à usage unique, hash stocké sur extra_data).
+            if (isset($result['manager']) && $result['manager'] instanceof \App\Core\Auth\Domain\Models\Employee) {
+                $this->issueDemoAccess($result['manager']);
+            }
+
             Log::info('Sandbox provisioned successfully', ['company_id' => $result['company']->id]);
 
         } catch (\Throwable $e) {


### PR DESCRIPTION
## Contexte

T007 (audit expert backend) : `ProvisionDemoTenantJob::handle()` ne branchait jamais `issueDemoAccess()` (TODO) — le prospect ne recevait pas son lien `/demo-login/`.

## Correctif

- `issueDemoAccess($result['manager'])` appelé après provisioning réussi (token 72 h usage unique, hash stocké sur `extra_data`, email best-effort).
- `ProvisionDemoTenantJobTest` (hash + mail `/demo-login/`) redevient vert.

## Vérifications

- 1/1 OK (PHP 8.4 local).

Closes #2620