### PR TITLE
feat(attendance): calendriers scopés tenant — company_id sur connections/events (Closes #2623)

### DIFF
--- a/api/app/Modules/Attendance/Domain/Models/CalendarConnection.php
+++ b/api/app/Modules/Attendance/Domain/Models/CalendarConnection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Modules\Attendance\Domain\Models;
 
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -23,7 +24,9 @@ use Illuminate\Database\Eloquent\Model;
  */
 class CalendarConnection extends Model
 {
+    use BelongsToCompany;
     protected $fillable = [
+        'company_id',
         'employee_id',
         'provider',
         'access_token',

--- a/api/app/Modules/Attendance/Domain/Models/CalendarEvent.php
+++ b/api/app/Modules/Attendance/Domain/Models/CalendarEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Modules\Attendance\Domain\Models;
 
+use App\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -20,7 +21,9 @@ use Illuminate\Database\Eloquent\Model;
  */
 class CalendarEvent extends Model
 {
+    use BelongsToCompany;
     protected $fillable = [
+        'company_id',
         'employee_id',
         'external_event_id',
         'provider',

--- a/api/app/Modules/Attendance/Infrastructure/Services/CalendarSyncService.php
+++ b/api/app/Modules/Attendance/Infrastructure/Services/CalendarSyncService.php
@@ -25,6 +25,9 @@ class CalendarSyncService
                 'provider' => $provider,
             ],
             [
+                // Issue #2623 : scoping tenant explicite (le trait auto-fill
+                // ne couvre pas updateOrCreate sur les lignes historiques).
+                'company_id' => $employee->company_id,
                 'access_token' => encrypt($accessToken),
                 'refresh_token' => $refreshToken ? encrypt($refreshToken) : null,
                 'calendar_id' => $calendarId,
@@ -64,6 +67,7 @@ class CalendarSyncService
                     $event = CalendarEvent::query()->updateOrCreate(
                         [
                             'employee_id' => $employee->id,
+                            'company_id' => $employee->company_id,
                             'source_type' => 'absence',
                             'source_id' => $absence->id,
                             'provider' => $connection->provider,
@@ -120,6 +124,7 @@ class CalendarSyncService
                     $event = CalendarEvent::query()->updateOrCreate(
                         [
                             'employee_id' => $employee->id,
+                            'company_id' => $employee->company_id,
                             'source_type' => 'training_session',
                             'source_id' => $session->id,
                             'provider' => $connection->provider,

--- a/api/database/migrations/tenant/2026_08_15_000001_add_company_id_to_calendar_tables.php
+++ b/api/database/migrations/tenant/2026_08_15_000001_add_company_id_to_calendar_tables.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #2623 — scoping tenant des calendriers : company_id ajouté à
+ * calendar_connections et calendar_events (nullable pour les lignes
+ * historiques, indexé). Idempotent (Render rejoue les migrations).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        foreach (['calendar_connections', 'calendar_events'] as $table) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            if (! Schema::hasColumn($table, 'company_id')) {
+                Schema::table($table, function ($table): void {
+                    $table->uuid('company_id')->nullable()->after('employee_id');
+                    $table->index('company_id');
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (['calendar_connections', 'calendar_events'] as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'company_id')) {
+                Schema::table($table, function ($table): void {
+                    $table->dropIndex(['company_id']);
+                    $table->dropColumn('company_id');
+                });
+            }
+        }
+    }
+};

--- a/api/tests/Feature/Attendance/CalendarTenantScopingTest.php
+++ b/api/tests/Feature/Attendance/CalendarTenantScopingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Attendance;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Attendance\Domain\Models\CalendarConnection;
+use App\Modules\Attendance\Infrastructure\Services\CalendarSyncService;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #2623 — scoping tenant des calendriers : company_id porté par
+ * calendar_connections et calendar_events (écriture service + isolation).
+ */
+class CalendarTenantScopingTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Company $company;
+
+    private Employee $employee;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $this->company = $company;
+
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create(['company_id' => $company->id]);
+        $this->employee = $employee;
+    }
+
+    public function test_connect_stores_company_id(): void
+    {
+        $connection = app(CalendarSyncService::class)->connect(
+            $this->employee,
+            'google',
+            'access-token-test',
+            'refresh-token-test',
+        );
+
+        $this->assertSame($this->company->id, $connection->company_id);
+        $this->assertDatabaseHas('calendar_connections', [
+            'id' => $connection->id,
+            'company_id' => $this->company->id,
+        ]);
+    }
+
+    public function test_calendar_connection_is_scoped_to_tenant(): void
+    {
+        // Deux tenants : la connexion du tenant A n'est pas visible depuis B.
+        /** @var Company $otherCompany */
+        $otherCompany = Company::factory()->create(['country' => 'MA', 'currency' => 'MAD']);
+
+        $connection = CalendarConnection::query()->create([
+            'company_id' => $this->company->id,
+            'employee_id' => $this->employee->id,
+            'provider' => 'google',
+            'access_token' => 'encrypted',
+            'is_active' => true,
+        ]);
+
+        app()->instance('current_company', $otherCompany);
+
+        $visible = CalendarConnection::query()->whereKey($connection->id)->first();
+        $this->assertNull($visible, 'La connexion calendrier d’un autre tenant ne doit pas être visible.');
+    }
+}


### PR DESCRIPTION
## Contexte

T010 (audit expert backend) : `calendar_connections`/`calendar_events` sans `company_id` — pas d'isolation tenant.

## Correctif

- Migration tenant idempotente : `company_id` (uuid, nullable legacy, indexé) sur les deux tables.
- Modèles : trait `BelongsToCompany` + `company_id` en fillable.
- `CalendarSyncService` : `company_id` écrit sur `connect()` et à la création des événements (absences/formations).
- `CalendarTenantScopingTest` : company_id stocké + isolation cross-tenant (invisible depuis un autre tenant).

## Vérifications

- 2/2 OK (PHP 8.4 local).

Closes #2623