### PR TITLE
docs(qa): session expert 2026-08-15 — spec kit + rapport

### DIFF
--- a/.specify/features/qa-expert-2026-08-15/plan.md
+++ b/.specify/features/qa-expert-2026-08-15/plan.md
@@ -1,0 +1,37 @@
+# Plan: QA Expert 2026-08-15
+
+**Input**: spec.md
+
+## Phase 1 — F1: médias LFS vitrine (P1) — issue à créer
+1. `git lfs untrack` des 5 fichiers `front/web/public/` (screenshots ×2, videos ×3) + override `.gitattributes` (`front/web/public/screenshots/*.png -filter`, `front/web/public/videos/* -filter`).
+2. `git add --renormalize` + commit des binaires réels (déjà matérialisés par `git lfs pull`).
+3. Vérifier que `git lfs ls-files` ne liste plus ces fichiers ; `file` confirme PNG/MP4/WebM.
+4. Note : déclencher un re-deploy Vercel pour propager (le swarm gère les deploys #2627/#2632 — le merge suffit si le pipeline re-déploie).
+
+## Phase 2 — F2+F3: tests backend rouges (P1/P2)
+1. `SnPayrollFixtures::socialCharges()` — 9 valeurs employer alignées sur le moteur (11426.60 / 16440 / 27840 / 33540 / 54288 / 65376 / 91776 / 168336 / 193536) + commentaires mis à jour (CSS famille 7 % × min(brut, 63 000)).
+2. `GoldenSnPayrollTest` — lignes 51/111/139 réalignées (11426.60 / 54288 / 91776).
+3. `PayrollCountryRulesTest` — ligne SN : employer 154.0 → 194.0.
+4. `PayrollCalculatorUnitTest` — restaurer `use App\Modules\Payroll\Domain\Exceptions\UnsupportedCountryRulesException;`.
+5. `CedeaoRulesUnitTest::test_other_uemoa_members_unaffected` — TG : `'placeholder'` → `'pilot'` (aligné sur #2578).
+6. `CemacRulesUnitTest::test_ga_is_pilot_with_legal_rules` — `noticePeriodDays(3.0)` : 30.0 → 22.0 (jours ouvrés).
+7. `NotificationTest` — instancier `NotificationDispatcher` avec son argument (vérifier le constructeur : quel contrat ?).
+8. `PayrollTenantIsolationTest::test_cross_tenant_tax_slab_is_inaccessible` — `assertForbidden()` → `assertNotFound()` (×2) + commentaire Constitution §II.
+9. Vérifier : les 8 suites → 0 échec. PHPStan strict + Pint sur les fichiers touchés.
+
+## Phase 3 — F4: ancres /docs (P3)
+1. Ajouter `id="api"`, `id="webhooks-events"`, `id="webhooks-intro"`, `id="webhooks-testing"` sur les sections réelles du TOC/liens rapides (ou corriger les hrefs).
+2. Lier les ids orphelins (`mobile-install`, `security`, `webhooks-security`) depuis le TOC/liens rapides (ou les retirer s'ils n'ont pas de contenu).
+3. Script de garde : hrefs `#*` ⊆ ids (réutiliser le check Python de la session).
+
+## Phase 4 — F5: mobile dio.options (P3)
+1. Vérifier la signature de `requestWithRetry` (headers par requête ?).
+2. Remplacer `apiClient.dio.options.headers['Accept-Language'] = lang` par un header par requête dans les 3 `user_auth_repository.dart`.
+3. Garde : `rg "apiClient\.dio\."` → uniquement `dio.download`.
+
+## Vérifications finales
+- `php artisan test` (suites ciblées) vert
+- `npm run lint` + `npm run build` (web + admin) verts (pas touchés mais sanity)
+- `git lfs ls-files` : 0 fichier dans front/web/public
+- CHANGELOG.md : entrées `### Fixed` par PR
+- PRs avec `Closes #N` dans le body

--- a/.specify/features/qa-expert-2026-08-15/spec.md
+++ b/.specify/features/qa-expert-2026-08-15/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: QA Expert — Vague de test complète 2026-08-15
+
+**Feature Branch**: `qa-expert-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + tests locaux réels (backend PHP 8.4 + PostgreSQL 16 + Redis, frontends Next.js/Vue builds + lints, black-box vitrine/admin/API live).
+
+## Contexte
+
+Mission du propriétaire : tester la plateforme « dans tous les sens » — vitrine, web app, admin, mobiles, workflows, API, logiques, onboarding, cohérence — puis consigner chaque manquement selon la méthode Spec Kit (issue + spec/plan/tasks), et implémenter à la fin du test.
+
+Constat : le swarm d'agents a déjà créé ~180 issues ouvertes (vagues QA 2026-08-14/15). La règle anti-doublon (#2400) impose de vérifier issues + branches avant création. Ce spec couvre **uniquement les manquements vérifiés localement et NON couverts** par les issues existantes.
+
+## Findings NON couverts (vérifiés sur main @ 35aef5f4, 2026-08-15)
+
+### F1 [P1][Web] Vitrine déployée : médias Git LFS servis comme pointeurs → images/vidéo cassées en prod
+
+La vitrine `gestionemployer-backend.vercel.app` (déployée via Vercel) sert le **contenu des pointeurs Git LFS** (131 octets de texte) au lieu des fichiers binaires pour 5 assets de `front/web/public/` :
+- `public/screenshots/web-dashboard.png` (1280×840 réel, 245 Ko)
+- `public/screenshots/mobile-attendance.png`
+- `public/videos/product-demo.mp4` (610 Ko réel)
+- `public/videos/product-demo.webm` (445 Ko)
+- `public/videos/product-demo-poster.jpg` (39 Ko)
+
+Vérifié : `curl` sur la prod renvoie `version https://git-lfs.github.com/spec/v1\noid sha256:...` avec `content-type: image/png|video/mp4` ; l'optimiseur Next.js `/_next/image` répond 400 ; le navigateur montre des images cassées sur la home (section ProductScreenshots) et la section vidéo. `vercel.json` buildCommand = `npm run build` (aucun `git lfs pull`). La migration LFS (#1727/#1758) n'a pas prévu le build Vercel. Le fix déploiement du swarm (#2627/#2632) ne résoudra PAS ce problème (Vercel ne résout pas LFS).
+
+**Cause racine** : 5 fichiers LFS-tracked dans `front/web/public/` + build Vercel sans résolution LFS.
+
+**Fix** : désactiver LFS pour ces fichiers (`git lfs untrack` + `.gitattributes` override `-filter`) et committer les binaires réels (récupérés via `git lfs pull`, ~1 Mo au total).
+
+### F2 [P1][Backend] 8 tests unitaires/feature rouges sur main — drift tests ↔ moteur
+
+Suite complète lancée localement (PHP 8.4, PostgreSQL 16, Redis) : **8 tests échouent de façon déterministe** sur main :
+
+| Suite | Test | Cause racine |
+|---|---|---|
+| `PayrollCalculatorUnitTest` | `test_get_rules_throws_for_unknown_country` | `use App\Modules\Payroll\Domain\Exceptions\UnsupportedCountryRulesException;` **manquant** (perdu par merge, cf. commentaire « re-cassé par le merge direct #2164 ») → classe résolue en `Tests\Unit\...` inexistante |
+| `PayrollCountryRulesTest` | `test_country_rules_expose_expected_social_contributions` | Ligne SN attend `employer=154.0` (CSS famille 3 %), moteur produit `194.0` (7 %) |
+| `Payroll\SenegalRulesUnitTest` | `test_ipres_t2_for_cadre` (+ `test_ipres_t1_capped_at_432k` via fixtures) | `SnPayrollFixtures` (#2541) : **9 lignes** avec CSS famille 3 % (ex. 1 M → 89 256) alors que le moteur applique 7 % CIPRES/CLEISS (#2473 : 1 M → 91 776) |
+| `AbstractCountryRulesCapTest` | `senegal contribution capped/uncapped` | idem fixtures SnPayrollFixtures |
+| `CedeaoRulesUnitTest` | `other uemoa members unaffected` | attend `confidenceLevel() === 'placeholder'` pour TG, moteur renvoie `pilot` (changement #2578) |
+| `CemacRulesUnitTest` | `ga is pilot with legal rules` | attend `noticePeriodDays(3.0) === 30.0`, moteur renvoie `22.0` (conversion jours ouvrés #2219/#2280) |
+| `Modules\NotificationTest` | `send notification action instantiates` (+ 2 autres) | `NotificationDispatcher::__construct()` exige 1 argument, le test en passe 0 |
+| `PayrollTenantIsolationTest` | `cross tenant tax slab is inaccessible` (→ F3) | cf. F3 |
+
+GoldenSnPayrollTest a aussi 3 valeurs périmées (9070.60/51768/89256, lignes 51/111/139) — les autres lignes ont été mises à jour par le swarm, preuve du drift partiel.
+
+**Fix** : réaligner les fixtures/tests sur le moteur (vérifié à la main, valeurs conformes `docs/payroll/SN_COMPLIANCE.md` §4bis et goldens #2473) + restaurer le `use` manquant + aligner TG/GA sur l'état réel + corriger l'instanciation NotificationDispatcher.
+
+### F3 [P2][Backend] PayrollTenantIsolationTest — attend 403, reçoit 404 (test périmé vs Constitution §II)
+
+`test_cross_tenant_tax_slab_is_inaccessible` (l.145-157) : un manager tenant B écrit sur un barème du tenant A → attend `403`, reçoit `404`. Depuis que les endpoints barèmes sont réservés SuperAdmin, la résolution du modèle est scopée par tenant → le slab étranger n'est pas résolu (404 anti-énumération). La **Constitution §II impose `assert 404 cross-tenant`** ; le commentaire du test référence un comportement `assertPlatformAdmin → 403` obsolète.
+
+**Fix** : aligner le test sur 404 (anti-énumération) + commentaire explicite ; conserver un test séparé 403 pour un SuperAdmin sans permission si pertinent.
+
+### F4 [P3][Web] /docs — 4 ancres mortes résiduelles + 3 ids orphelins
+
+`front/web/src/app/(landing)/docs/page.tsx` : après les fixes #2274/#2293/#2208 (clos), il reste :
+- 4 ancres référencées sans cible : `#api`, `#webhooks-events`, `#webhooks-intro`, `#webhooks-testing`
+- 3 ids définis sans lien entrant : `#mobile-install`, `#security`, `#webhooks-security`
+
+**Fix** : ajouter les ids manquants sur les sections réelles (ou corriger les liens) + garde anti-ancre-morte optionnelle (User Story 2 de la spec #2274 jamais implémentée).
+
+### F5 [P3][Mobile] `apiClient.dio.options` — pattern interdit dans 3 apps
+
+3 fichiers `user_auth_repository.dart` (employee, manager, hr) mutent le client HTTP global :
+```dart
+apiClient.dio.options.headers['Accept-Language'] = lang;
+```
+La carte rapide interdit `apiClient.dio.*` sauf `dio.download` (pattern `requestWithRetry` obligatoire). La mutation globale de `dio.options` affecte toutes les requêtes suivantes (fuite de header, non thread-safe).
+
+**Fix** : passer le header par requête via `requestWithRetry(headers: ...)` (vérifier le support) ou une interception locale propre.
+
+## User Stories & Testing
+
+### US1 — Vitrine : les médias s'affichent (P1)
+**Independent Test**: `curl -s https://gestionemployer-backend.vercel.app/screenshots/web-dashboard.png | head -c 8` → signature PNG (`\x89PNG`), pas `version https://git-lfs` ; navigateur : `naturalWidth > 0` sur la home.
+**Acceptance**: 1. La home affiche les 2 screenshots. 2. La page /videos joue la vidéo avec poster.
+
+### US2 — Suite backend verte (P1)
+**Independent Test**: `php artisan test --filter="PayrollCalculatorUnitTest|PayrollCountryRulesTest|SenegalRulesUnitTest|CedeaoRulesUnitTest|CemacRulesUnitTest|AbstractCountryRulesCapTest|Modules\\NotificationTest|PayrollTenantIsolationTest"` → 0 échec.
+**Acceptance**: 1. Les valeurs fixtures SN = moteur (7 % CSS famille). 2. TG `pilot`, GA préavis 22 j ouvrés. 3. Le `use` manquant restauré. 4. NotificationDispatcher instancié avec son argument.
+
+### US3 — /docs : zéro ancre morte (P3)
+**Independent Test**: script Python hrefs `#*` ⊆ ids sur la page.
+**Acceptance**: chaque lien du TOC et des liens rapides résout une section ; ids orphelins liés ou retirés.
+
+### US4 — Mobile : zéro `dio.options` (P3)
+**Independent Test**: `rg "apiClient\.dio\." --glob '*.dart'` ne renvoie que des `dio.download`.
+**Acceptance**: les 3 repos auth envoient Accept-Language par requête.
+
+## Dependencies & Execution Order
+
+- **Phase 1 (F1)** : indépendant (média + .gitattributes).
+- **Phase 2 (F2+F3)** : backend — F2 d'abord (fixtures → tests), F3 indépendant.
+- **Phase 3 (F4)** : front/web — indépendant.
+- **Phase 4 (F5)** : mobile — indépendant (fichiers distincts).
+- PRs : une par issue, `Closes #N` dans le body, CHANGELOG sous `## [Unreleased]`, garde anti-doublon vérifiée avant push (branches + PRs existantes).

--- a/.specify/features/qa-expert-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert-2026-08-15/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: QA Expert 2026-08-15
+
+**Input**: spec.md + plan.md
+**Prerequisites**: plan.md (required), spec.md (required)
+
+## Phase 1 — F1 Médias LFS vitrine (P1) — issue à créer
+
+- [ ] T001 [P1] [F1] `git lfs untrack` 5 fichiers front/web/public + override `.gitattributes` (`-filter`) + `git add --renormalize` → binaires réels commités
+- [ ] T002 [P1] [F1] Vérification : `git lfs ls-files` sans ces fichiers, `file` = PNG/MP4/WebM, `curl` prod → signature binaire après re-deploy
+
+## Phase 2 — F2 Tests backend rouges (P1) — issue à créer
+
+- [ ] T003 [P1] [F2] `SnPayrollFixtures::socialCharges()` — 9 valeurs employer alignées moteur (CSS famille 7 %, plafond 63 000) + commentaires
+- [ ] T004 [P1] [F2] `GoldenSnPayrollTest` — lignes 51/111/139 (11426.60 / 54288 / 91776)
+- [ ] T005 [P1] [F2] `PayrollCountryRulesTest` — SN employer 154.0 → 194.0
+- [ ] T006 [P1] [F2] `PayrollCalculatorUnitTest` — restaurer `use UnsupportedCountryRulesException`
+- [ ] T007 [P1] [F2] `CedeaoRulesUnitTest` — TG confidenceLevel placeholder → pilot
+- [ ] T008 [P1] [F2] `CemacRulesUnitTest` — GA noticePeriodDays 30.0 → 22.0
+- [ ] T009 [P1] [F2] `NotificationTest` — NotificationDispatcher instancié avec son argument
+- [ ] T010 [P1] [F2] Vérification : 7 suites ciblées → 0 échec ; Pint + PHPStan strict sur fichiers touchés
+
+## Phase 3 — F3 PayrollTenantIsolation 403→404 (P2) — issue à créer
+
+- [ ] T011 [P2] [F3] `test_cross_tenant_tax_slab_is_inaccessible` — assertForbidden → assertNotFound (PUT + DELETE) + commentaire Constitution §II
+- [ ] T012 [P2] [F3] Vérification : `PayrollTenantIsolationTest` → 8/8 verts
+
+## Phase 4 — F4 Ancres /docs (P3) — issue à créer
+
+- [ ] T013 [P3] [F4] Ajouter/corriger ids (api, webhooks-events, webhooks-intro, webhooks-testing) + lier ids orphelins (mobile-install, security, webhooks-security)
+- [ ] T014 [P3] [F4] Vérification script hrefs ⊆ ids ; lint web vert
+
+## Phase 5 — F5 Mobile dio.options (P3) — issue à créer
+
+- [ ] T015 [P3] [F5] Header Accept-Language par requête (requestWithRetry) dans 3 user_auth_repository.dart
+- [ ] T016 [P3] [F5] Vérification : `rg "apiClient\.dio\."` → uniquement dio.download
+
+## Finalisation
+
+- [ ] T017 CHANGELOG.md — entrées `### Fixed` (une par PR)
+- [ ] T018 PRs avec `Closes #N` dans le body + anti-doublon vérifié (branches/PRs avant push)

--- a/docs/qa/QA_SESSION_2026-08-15-expert.md
+++ b/docs/qa/QA_SESSION_2026-08-15-expert.md
@@ -1,0 +1,77 @@
+# QA Leopardo RH — Session expert du 2026-08-15
+
+Mission (propriétaire) : tester la plateforme dans tous les sens — vitrine, web app, admin,
+mobiles, workflows, API, logiques, onboarding, cohérence — consigner chaque manquement selon la
+méthode Spec Kit (issue + spec/plan/tasks), puis implémenter les correctifs.
+
+**Contexte** : le swarm d'agents avait déjà créé ~180 issues ouvertes (vagues QA 2026-08-14/15).
+Règle anti-doublon (#2400) appliquée : chaque finding vérifié contre les issues ET branches
+existantes avant création. Ce rapport couvre les manquements **nouveaux** (non couverts) + le
+bilan des surfaces testées.
+
+## Méthode
+1. Revue statique : contrats API↔routes (checker Python), ancres/liens/mojibake vitrine,
+   vues/boutons/mock admin, patterns interdits mobile, cohérence docs.
+2. Exécution locale : PHP 8.4 + PostgreSQL 16 + Redis (composer install, 142 migrations),
+   suite de tests complète, PHPStan strict, Pint, builds Next.js + Vite + lints.
+3. Black-box prod : API Render (gestionemployerbackend.onrender.com), admin
+   (leo-admin.pages.dev), vitrine (gestionemployer-backend.vercel.app) — crawl, formulaires,
+   onboarding guidé, erreurs, médias, sitemap.
+
+## Findings NOUVEAUX (issues créées dans cette session)
+
+| Issue | Sév. | Surface | Sujet | Fix implémenté | PR |
+|---|---|---|---|---|---|
+| #2829 | P1 | Web | Médias Git LFS servis comme pointeurs en prod (5 assets : screenshots home + vidéo démo + poster) | Binaires réels commités, sortis du filtre LFS | #2868 |
+| #2830 | P1 | Backend | 8 tests rouges — drift tests ↔ moteur (SnPayrollFixtures CSS 3 % vs 7 %, use manquant ×2, TG/GA, NotificationDispatcher) | 10 fichiers réalignés sur le moteur (vérifié à la main) | #2869 |
+| #2831 | P2 | Backend | PayrollTenantIsolationTest cross-tenant tax-slab attend 403, reçoit 404 (Constitution §II = 404 anti-énumération) | assertNotFound ×2 + commentaire | #2869 |
+| #2832 | P3 | Web | /docs : 3 ancres mortes résiduelles + 3 ids orphelins | TOC/sections réalignés (0 mort, 0 orphelin) | #2870 |
+| #2833 | P3 | Mobile | apiClient.dio.options (pattern interdit) dans 3 user_auth_repository | Suppression (redondant : intercepteur gère Accept-Language) | #2872 |
+
+Spec Kit : `.specify/features/qa-expert-2026-08-15/{spec,plan,tasks}.md`.
+
+## Bilan des surfaces testées (findings déjà couverts par le swarm — non dupliqués)
+
+### Vitrine (front/web) — live `gestionemployer-backend.vercel.app`
+- ✅ Fonctionnelle : /, /pricing, /docs, /signup (parcours guidé OTP complet testé bout en bout),
+  /demo, /contact, /download, /checkout, /faq, /guides, /employes, /documents, /comptabilite…
+- ✅ Formulaires : signup/demo/contact → 200/201 avec lead id ; validation FR champs requis OK
+- ⚠️ Déjà couverts : sitemap /blog 404 (#2647), plans incohérents (#2649), SignupForm FR-only (#2648/#2727),
+  og:images absentes (#2722/#2752), icon-192 manquant (#2724/#2756), témoignages fabriqués (#2726),
+  essai 14 vs 30 j (#2753), i18n FR-only (#2642/#2605/#2657), SEO/canonicals (#2656/#2607)
+- ⚠️ Déploiements prod périmés : API v4.23.5 (main 4.24+) → /i18n/catalog/* 500, /health non routé
+  (#2627/#2632/#2654)
+
+### Admin (front/admin-dashboard) — live `leo-admin.pages.dev`
+- ✅ Login + modale démo fonctionnels (erreur propre si démo désactivée)
+- ⚠️ Déjà couverts : bouton Acces Demo inutilisable en prod (#2646/#2730), EditUserModal factice
+  (#2610/#2641), composants orphelins (#2612/#2658), command palette (#2640/#2703), pagination
+  users (#2698), UserTable bouton Éditer mort (#2697), enveloppe {data:[]} dashboard (#2747)
+
+### Mobiles (Flutter ×5 + core)
+- ✅ Patterns : requestWithRetry + extractDataList OK, withOpacity 0, casts directs 0, runApp OK,
+  manifest routes OK (check-mobile-manifest-routes vert)
+- ⚠️ Déjà couverts : mojibake (#2660/#2738), i18n hardcodée (#2740/#2755), double auth (#2739),
+  cabinet navigation (#2735/#2748), devise DZD (#2741), leopardo_marketing orphelin (#2661)
+
+### API backend (Laravel) — tests locaux + black-box
+- ✅ 1917 tests : 1909 passent (hors 8 drift corrigés par #2830/#2831) ; openapi coverage 0 drift
+  nouveau ; ZKTeco sécurisé (#2216 OK) ; login 401 propre ; onboarding invitation 404 propre ;
+  rate limiting présent
+- ⚠️ Déjà couverts : suspended login (#2618/#2630), register orphelin (#2617/#2636), OAuth state
+  (#2619), webhooks fail-open (#2614/#2615/#2616), OpenAPI drift (#2662/#2675), middleware tenant
+  /ai + /growth (#2622/#2635), Préavis jours (#2671), races solde/pointage (#2669/#2676)…
+
+### CI / Ops
+- ⚠️ File GitHub Actions saturée (runs pending, guard branch-protection rouge) — #2488/#2131
+  (déjà couvert)
+- ⚠️ PHPStan Strict : ~90 erreurs résiduelles majoritairement dans les tests (le swarm fixe en
+  continu — #2587/#2594/#2770) ; 3 erreurs app mineures constatées (PlatformCompanyController
+  unreachable, nullsafe Carbon ×2)
+
+## Notes d'implémentation
+- Les 5 correctifs sont de petits changements ciblés (tests, TOC, .gitattributes, suppression de
+  lignes redondantes) — zéro changement de comportement applicatif, alignement sur l'existant
+  documenté (Constitution, SN_COMPLIANCE.md, #2473/#2578/#2219).
+- PRs : body avec `Closes #N`, CHANGELOG sous `## [Unreleased]`, garde anti-doublon vérifiée
+  (aucune branche/PR existante sur ces issues au moment de la création).


### PR DESCRIPTION
## Contenu
- `.specify/features/qa-expert-2026-08-15/{spec,plan,tasks}.md` : méthodologie spec kit pour la vague de test expert (5 findings : #2829-#2833)
- `docs/qa/QA_SESSION_2026-08-15-expert.md` : rapport complet — surfaces testées (vitrine/web/admin/mobiles/API/onboarding), findings nouveaux, renvois anti-doublon vers les ~180 issues existantes

Aucun changement de code applicatif.