### PR TITLE
docs(qa): vague complète 2026-08-15 — spec kit (plan/spec/tasks) + session QA (#2628-#2645)

### DIFF
--- a/.specify/features/qa-wave-2026-08-15/plan.md
+++ b/.specify/features/qa-wave-2026-08-15/plan.md
@@ -1,0 +1,103 @@
+# Plan: Vague QA Complète 2026-08-15 — Vitrine, Web, Admin, Mobile, API, Onboarding
+
+**Input**: spec.md (US1-US6) + Constitution + constats live/statiques (session 2026-08-15)
+
+## Architecture / Décisions techniques
+
+### Backend (api/)
+
+- **Checkout (US1, #2628)** : la décision sandbox est côté Next (route handler). Garde
+  stricte : `isSandbox = process.env.SANDBOX_CHECKOUT === 'true'` — plus jamais de
+  déduction depuis `!STRIPE_SECRET_KEY`. Sans clé Stripe et sans flag sandbox → 503
+  `CHECKOUT_UNAVAILABLE`. La route `/api/v1/billing/checkout` (backend) reste le chemin
+  réel du paiement.
+- **Trial guidé (US2, #2629)** : `ProvisionDemoTenantJob` — remplacer le TODO par
+  l'appel à `issueDemoAccess()` (ou un email dédié via `Mail`/`Notification`) contenant
+  un magic link (token à usage unique lié au manager provisionné, route
+  `/onboarding/invitation/{token}` ou `/auth/magic-link` existante si compatible) ;
+  `ProvisionGuidedTrial` génère un token récupérable ; `trial/status` n'expose `ready`
+  que si `provisioned_at && access_sent_at`.
+- **Auth statut (US3, #2630)** : centraliser dans un trait/service `AssertActiveAccount`
+  (status employé `users.status`, société active, super-admin actif) utilisé par
+  `UserAuthService::login/googleSignIn`, `PlatformAuthController::login` et les 2
+  handlers Google. Révocation : à la suspension (PlatformUserController), `delete()` des
+  tokens Sanctum du user (`$user->tokens()->delete()`). Erreur normalisée
+  `ACCOUNT_SUSPENDED` (403) — suivre le format d'erreur existant (error/message/
+  localized_message).
+- **Organigramme (US4, #2633)** : nouveau contrôleur `DepartmentHierarchyController` ou
+  méthode sur le contrôleur existant — arbre récursif `departments.parent_id` (children
+  + `employees_count`), scope `company_id`, middleware `api.manager`. Route
+  `GET /api/v1/departments/{department}/hierarchy` dans `routes/modules/rh.php` (groupe
+  tenant existant).
+- **Console admin (US5, #2634)** : étendre le groupe `/admin` de `routes/api.php` avec
+  `/admin/training/sessions`, `/admin/training/enrollments`, `/admin/webhooks` (CRUD),
+  `/admin/webhooks/{id}/test` — contrôleurs adossés aux mêmes services que les routes
+  tenant, policy `super_admin_api` (pattern existant du groupe admin). Ne PAS toucher
+  aux routes tenant.
+- **Middleware tenant (US3, #2635)** : ajouter `tenant` (+ `token.refresh`,
+  `throttle:api-plan` selon le groupe standard) sur `routes/ai.php` et
+  `routes/modules/growth.php` ; aligner `routes/modules/sso.php` sur le groupe standard.
+  Vérifier que les contrôleurs AI supportent le scope tenant réel (pas de régression
+  sur `AITenantInjector`).
+- **/auth/register (US3, #2636)** : supprimer la route publique (le parcours officiel
+  est `/user/register` + company-request / invitation) ou la verrouiller (403
+  `REGISTRATION_DISABLED`). Supprimer l'action orpheline si plus référencée.
+- **Invitations (US3, #2637)** : dans `UserInvitationService::accept()`, vérifier
+  `$company->status === 'active'` avant activation ; 403 `COMPANY_SUSPENDED` sinon.
+
+### Web / vitrine (front/web/)
+
+- **Checkout UI (US1, #2628)** : prop/env `NEXT_PUBLIC_CHECKOUT_SANDBOX` pour afficher
+  la carte test seulement en sandbox ; état d'erreur 503 avec message clair ; le bouton
+  « Démarrer l'essai » reste fonctionnel si le backend trial est joignable.
+- **Robots (US6, #2643)** : retirer la ligne `Sitemap: …/api/sitemap` de
+  `app/api/robots/route.ts` ; vérifier la redondance avec `app/robots.ts` (supprimer la
+  route dupliquée si non utilisée).
+- **i18n (US6, #2642, volet minimal)** : router les pages FR-only sur
+  `useVitrineLocale` (fallback FR), localiser `OnboardingWizard` via les locales
+  dashboard existantes.
+
+### Admin (front/admin-dashboard/)
+
+- **Training/Webhooks (US5, #2634)** : basculer `TrainingView`/`WebhooksView` sur les
+  routes `/admin/*` ; garder le fallback tenant si l'utilisateur est manager.
+- **Handlers réels (US5, #2641)** : `EditUserModal` → endpoints `/admin/users/{id}`
+  (PATCH), reset password via endpoint admin existant ou état « non disponible » ;
+  `SystemAlertsOverlay` → endpoint réel de maintenance (ou suppression du faux toggle).
+- **Palette/i18n (US5, #2640, #2639)** : corriger les cibles de la palette, filtrer les
+  routes tenant pour super-admin, traduire `meta.title`, ajouter les 2 clés manquantes.
+
+### Mobile (front/mobile_apps/)
+
+- **Onboarding (US4, #2631)** : `leopardo_employee` + `leopardo_hr`
+  `onboarding_repository.dart` — `method: 'PATCH'` et `stepKey` (string) au lieu de
+  l'id ; aligner sur `leopardo_manager` (déjà correct).
+- **Organigramme (US4, #2633)** : aucune modif client nécessaire si la route backend
+  respecte le contrat attendu (`data: { department, children: [...] }`) — vérifier le
+  parsing Dart avant de figer le contrat.
+
+### Ops (US—, #2632)
+
+- Documenter l'état des 3 déploiements (Render stale, Pages stale, Vercel failed) dans
+  `docs/qa/QA_SESSION_2026-08-15.md` ; PR possible : healthcheck de version
+  (`/api/v1/health` + build marker) pour détecter les déploiements stale à l'avenir.
+  Le redéploiement effectif reste une action manuelle/ops hors périmètre code.
+
+## Risques
+
+- **Conflits routes** : T010/T013/T014/T015 touchent `api/routes/` → une PR par issue,
+  branches `fix/<issue>-<slug>`, rebase sur main avant push (protocole #2400).
+- **Régression checkout** : la garde sandbox doit rester fonctionnelle en dev
+  (documenter `SANDBOX_CHECKOUT=true` dans `.env.example`).
+- **Google auth** : les gardes `AuthService` exigent un employé scopé — vérifier le
+  comportement `withoutGlobalScopes` actuel avant de brancher les checks (ne pas casser
+  le SSO employé).
+- **Flutter** : pas de run local — les changements Dart sont minimaux et vérifiés par
+  analyse statique + CI mobile.
+
+## Validation
+
+- Backend : `php artisan test` ciblé + `phpstan-strict.neon` (level 8) + `pint --test`.
+- Front web : `npm run lint` + `tsc --noEmit` + build.
+- Admin : `npm run lint` + build.
+- Mobile : CI Flutter (analyze + tests).

--- a/.specify/features/qa-wave-2026-08-15/spec.md
+++ b/.specify/features/qa-wave-2026-08-15/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: Vague QA Complète 2026-08-15 — Vitrine, Web, Admin, Mobile, API, Onboarding
+
+**Feature Branch**: `qa-wave-2026-08-15`
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Input**: Mission de test exhaustive de la plateforme (session 2026-08-15) — vitrine
+web (live), console admin (live), API (live + statique), apps mobiles (cross-check
+statique), workflows, onboarding, logique métier et cohérence docs ↔ code. 18 constats
+confirmés, chacun tracé par une issue GitHub (#2628–#2645).
+
+## User Scenarios & Testing
+
+### User Story 1 — Le parcours d'achat/essai vitrine est honnête et fonctionnel (Priority: P1)
+
+Un prospect clique « Démarrer l'essai » sur la vitrine, choisit un plan payant, saisit
+ses coordonnées de paiement… et doit soit réellement être débité (Stripe live), soit
+recevoir une erreur explicite. Aujourd'hui, en production, le checkout répond
+`sandbox:true` (« Paiement simulé — aucune carte débitée »), la page succès annonce
+« Simulation réussie — Mode sandbox » et aucun compte n'est provisionné
+(`provisioned:false`) : le visiteur croit avoir souscrit, il n'a rien.
+
+**Pourquoi P1** : monétisation et acquisition (source principale d'onboarding
+self-service) cassées en production ; un faux succès de paiement est pire qu'une erreur
+(Crédibilité + RGPD des données de carte collectées par une UI décorative).
+
+**Test indépendant** : le déploiement production ne retourne jamais `sandbox:true`
+(sauf flag explicite `SANDBOX_CHECKOUT=true`) ; l'UI n'affiche la carte test que si le
+mode sandbox est actif ; le parcours sandbox de dev reste fonctionnel.
+
+**Acceptance Scenarios**:
+
+1. **Given** un déploiement sans `STRIPE_SECRET_KEY` live, **When** un prospect POST
+   `/api/billing/checkout`, **Then** réponse 503 `CHECKOUT_UNAVAILABLE` explicite (pas
+   de faux succès), et la page affiche une erreur claire.
+2. **Given** `STRIPE_SECRET_KEY` live, **When** checkout, **Then** session Stripe réelle
+   créée via `/api/v1/billing/checkout` (backend) et redirection vers Stripe.
+3. **Given** le mode sandbox explicitement activé (dev/staging), **When** checkout,
+   **Then** le flux simulé fonctionne mais la page succès l'annonce clairement et le
+   provisioning trial réel s'exécute.
+
+### User Story 2 — L'essai guidé (guided trial) provisionne un tenant utilisable (Priority: P1)
+
+Un prospect s'inscrit via `POST /trial/signup` (workflow `guided_trial`), le tenant est
+provisionné en arrière-plan, et `GET /trial/status` finit par dire `ready` avec un
+login **utilisable**. Aujourd'hui le manager est créé avec un mot de passe aléatoire
+jamais communiqué, `ProvisionDemoTenantJob::issueDemoAccess()` (magic link) n'est jamais
+appelée (TODO dans `handle()`), donc « ready » ne mène nulle part.
+
+**Pourquoi P1** : l'onboarding self-service est le parcours d'acquisition principal ;
+un essai « prêt » inutilisable est un tunnel de conversion cassé.
+
+**Acceptance Scenarios**:
+
+1. **Given** un signup `guided_trial`, **When** le job de provisioning s'exécute,
+   **Then** un email de magic link (ou credentials provisoires) est réellement envoyé au
+   manager.
+2. **Given** un trial non provisionné, **When** `GET /trial/status`, **Then** jamais
+   `ready` tant que les credentials ne sont pas communicables.
+3. **Given** la dead code `issueDemoAccess()`, **When** revue, **Then** supprimée ou
+   câblée — plus de TODO.
+
+### User Story 3 — Un compte suspendu ne peut plus se connecter nulle part (Priority: P1)
+
+Un administrateur suspend un compte (employé `users.status`, ou `super_admins.status`).
+Le compte ne doit plus pouvoir obtenir de token via aucun chemin (user, super-admin,
+Google), et ses tokens existants doivent être révoqués. Aujourd'hui `UserAuthService`
+ignore `status`, le login super-admin ignore `super_admins.status`, les callbacks Google
+bypassent totalement les gardes, et la suspension ne révoque pas les tokens Sanctum.
+
+**Pourquoi P1** : sécurité/RGPD — un compte suspendu (départ, incident) conserve un
+accès complet à la paie et aux données RH.
+
+**Acceptance Scenarios**:
+
+1. **Given** un user `status=suspended`, **When** `POST /user/login`, **Then** 403
+   `ACCOUNT_SUSPENDED`.
+2. **Given** un super-admin désactivé, **When** `POST /platform/auth/login`, **Then**
+   403.
+3. **Given** un compte suspendu avec un token existant, **When** `GET /auth/me`,
+   **Then** 401 (tokens révoqués à la suspension).
+4. **Given** un employé suspendu, **When** callback/token Google, **Then** 403.
+
+### User Story 4 — L'onboarding mobile fonctionne (employee/HR/manager) (Priority: P1)
+
+Un employé ou un RH complète/skippe une étape d'onboarding depuis l'app mobile. Les apps
+employee et HR envoient `POST /onboarding-setup/{id}/complete|skip` alors que le backend
+ne déclare que `PATCH` → 405 : les étapes ne peuvent jamais être validées. Par ailleurs
+l'organigramme HR/Manager appelle `GET /departments/{departmentId}/hierarchy`, route
+inexistante → 404.
+
+**Pourquoi P1** : fonctionnalité annoncée (onboarding guidé mobile, organigramme) qui
+échoue systématiquement dans les apps les plus utilisées.
+
+**Acceptance Scenarios**:
+
+1. **Given** l'app employee (ou HR) connectée, **When** compléter une étape, **Then**
+   2xx (le client envoie PATCH avec le stepKey string).
+2. **Given** un manager RH, **When** ouvrir l'organigramme d'un département, **Then**
+   l'arbre (enfants + effectif) est affiché (nouvelle route backend scopée tenant).
+
+### User Story 5 — La console admin plateforme est complète et honnête (Priority: P2)
+
+Le super-admin doit pouvoir gérer trainings et webhooks depuis la console, sans handlers
+factices ni impasses. Aujourd'hui `GET /v1/training/sessions|enrollments` et tout le CRUD
+`/v1/webhooks*` (+ test) n'existent qu'en scope tenant → 401 super-admin (3 des 8 gaps
+QA-8 restants) ; `EditUserModal` (4 actions) et la maintenance `SystemAlertsOverlay`
+sont des faux handlers (setTimeout + toast) ; la command palette pointe `/vehicles`
+(404) et 7 entrées tenant redirigent vers `/` ; 2 clés i18n manquantes et des clés
+brutes dans `document.title`.
+
+**Pourquoi P2** : le cockpit admin est une surface de vente (démo) ; des actions
+factices ou des 401 silencieux détruisent la crédibilité (règle cockpit : jamais de
+données/actions fabriquées).
+
+**Acceptance Scenarios**:
+
+1. **Given** un super-admin connecté, **When** ouvrir TrainingView/WebhooksView, **Then**
+   données réelles (routes `/admin/*` dédiées, policy admin).
+2. **Given** la console, **When** modifier un user / reset password, **Then** appel API
+   réel (réseau) et erreurs backend affichées.
+3. **Given** Ctrl+K, **When** chercher « vehicles », **Then** route `/fleet` existante.
+
+### User Story 6 — Le référentiel API et les docs sont cohérents avec le code (Priority: P3)
+
+L'OpenAPI (contrat public, 424 chemins) doit couvrir l'implémentation (543 chemins) ;
+119 chemins de code sont absents de la spec (drift). Les routes robots annoncent un
+sitemap mort ; des pages vitrine sont FR-only malgré le sélecteur EN/TR/AR ; le
+`updateCountry` est dupliqué (artefact de merge).
+
+**Pourquoi P3** : dette de cohérence — impacts SEO, intégrations tierces (OpenAPI) et
+maintenabilité.
+
+**Acceptance Scenarios**:
+
+1. **Given** le script `check-openapi-route-coverage.py`, **When** exécuté, **Then** 0
+   route de code absente de la spec (ou blocs marqués hors contrat).
+2. **Given** `GET /api/robots`, **When** parsé, **Then** plus de référence `/api/sitemap`.
+3. **Given** la page `/contact` en EN, **When** sélecteur de langue, **Then** contenu EN
+   (ou fallback assumé).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Le checkout production ne doit jamais simuler un paiement sans flag explicite (`SANDBOX_CHECKOUT`).
+- **FR-002**: Le workflow `guided_trial` doit envoyer un magic link / credentials au manager provisionné.
+- **FR-003**: Tous les chemins d'authentification doivent rejeter les comptes non-actifs (403) et révoquer les tokens à la suspension.
+- **FR-004**: Les apps mobile employee/HR doivent utiliser `PATCH /onboarding-setup/{stepKey}/complete|skip`.
+- **FR-005**: `GET /departments/{department}/hierarchy` doit exister (scopé tenant, RBAC manager).
+- **FR-006**: La console admin doit disposer de routes `/admin/training/*` et `/admin/webhooks*` (policy admin).
+- **FR-007**: Les groupes `/ai/*` et `/growth/partner/*` doivent porter le middleware tenant complet (statut société/employé).
+- **FR-008**: `/auth/register` ne doit plus créer de compte activable sans `company_id`.
+- **FR-009**: `UserInvitationService::accept()` doit rejeter les invitations de sociétés non actives.
+- **FR-010**: Les actions admin doivent appeler des endpoints réels (pas de setTimeout+toast factice).
+- **FR-011**: La command palette et les titres d'onglets admin doivent être cohérents (routes existantes, clés i18n traduites).
+- **FR-012**: L'OpenAPI doit couvrir les routes de code (drift → 0).
+- **FR-013**: Les routes robots ne doivent pas référencer de sitemap inexistant.
+
+### Key Entities
+
+- **Trial/Onboarding**: `trial_signups`, `ProvisionDemoTenantJob`, `ProvisionGuidedTrial`, `user_lookups`, invitations.
+- **Auth**: `users.status`, `super_admins.status`, tokens Sanctum, `UserAuthService`, `AuthService`, callbacks Google.
+- **Admin**: routes `/admin/*`, policies, views Vue (`TrainingView`, `WebhooksView`, `EditUserModal`, `SystemAlertsOverlay`, `CommandPalette`).
+- **Mobile**: `smart_attendance_repository`, `onboarding_repository`, `organigramme_repository` (apps employee/hr/manager).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `curl /api/billing/checkout` en production → jamais `sandbox:true`.
+- **SC-002**: Parcours trial guidé → l'utilisateur reçoit un email avec un login utilisable (test d'intégration).
+- **SC-003**: 4 tests de login (user/super-admin/Google) avec compte suspendu → 403 ; suspension → tokens révoqués.
+- **SC-004**: Cross-check mobile (407 appels Dart) → 0 appel vers une route/méthode inexistante.
+- **SC-005**: Console admin Training/Webhooks → données réelles (tests super-admin 200).
+- **SC-006**: `check-openapi-route-coverage.py` → 0 route manquante.
+- **SC-007**: PHPStan strict level 8 + Pint + ESLint/tsc + tests ciblés verts sur chaque PR.
+
+## Assumptions
+
+- Le produit n'a pas de clé Stripe live en production aujourd'hui (constaté) — la garde sandbox est donc la priorité ; la clé elle-même est un sujet ops.
+- Les changements backend PHP seront validés par CI (tests + PHPStan) ; les changements front par lint/build local.
+- Le mobile est audité statiquement (pas de run Flutter dans cette session) ; les correctifs Dart sont minimalistes et vérifiés par analyse.

--- a/.specify/features/qa-wave-2026-08-15/tasks.md
+++ b/.specify/features/qa-wave-2026-08-15/tasks.md
@@ -1,0 +1,102 @@
+# Tasks: Vague QA Complète 2026-08-15 — Vitrine, Web, Admin, Mobile, API, Onboarding
+
+**Input**: spec.md + plan.md + issues #2628–#2645
+
+**Prerequisites**: plan.md (required), spec.md (required)
+
+**Issues couvertes** : #2628 (checkout sandbox) · #2629 (trial guidé) · #2630 (auth
+statut) · #2631 (mobile onboarding 405) · #2632 (déploiements stale) · #2633
+(organigramme hierarchy) · #2634 (admin training/webhooks /admin) · #2635 (middleware
+tenant /ai + /growth) · #2636 (/auth/register orphelin) · #2637 (invitation société
+suspendue) · #2638 (drift OpenAPI) · #2639 (i18n admin) · #2640 (command palette) ·
+#2641 (handlers factices) · #2642 (pages FR-only) · #2643 (robots /api/sitemap) ·
+#2644 (updateCountry dupliqué) · #2645 (orphelins admin)
+
+## Phase 1 — P1 : Monétisation & Onboarding (US1, US2)
+
+- [ ] T001 [P1] US1 Checkout : `front/web/src/app/api/billing/checkout/route.ts` —
+      sandbox uniquement si `SANDBOX_CHECKOUT=true` ; sinon 503 `CHECKOUT_UNAVAILABLE`
+      (Closes #2628). Exposer `NEXT_PUBLIC_CHECKOUT_SANDBOX` au client pour l'UI.
+- [ ] T002 [P1] US1 Checkout UI : masquer « Remplir avec la carte test » / carte 4242
+      hors mode sandbox (`checkout/page.tsx`), message d'erreur 503 propre.
+- [ ] T003 [P1] US2 Trial guidé : câbler `ProvisionDemoTenantJob::handle()` — envoi du
+      magic link via `issueDemoAccess()` (ou équivalent email) ; supprimer le TODO et
+      `login_url` hardcodé (Closes #2629).
+- [ ] T004 [P1] US2 Trial guidé : `ProvisionGuidedTrial.php` — communiquer le mot de
+      passe provisoire (email) ou générer un magic link ; `trial/status` ne dit `ready`
+      que si credentials communicables. Test d'intégration du parcours complet.
+
+## Phase 2 — P1 : Auth & Mobile (US3, US4)
+
+- [ ] T005 [P1] US3 `UserAuthService::login()/googleSignIn()` : vérifier `status ===
+      'active'` → 403 `ACCOUNT_SUSPENDED` (Closes #2630).
+- [ ] T006 [P1] US3 `PlatformAuthController` : vérifier `super_admins.status` ; les
+      endpoints deactivate/suspend révoquent les tokens Sanctum du compte.
+- [ ] T007 [P1] US3 `AuthController::handleGoogleCallback/handleGoogleToken` :
+      réutiliser les gardes `AuthService` (statut employé + société).
+- [ ] T008 [P1] US3 Tests : 4 chemins de login avec compte suspendu → 403 ; token
+      existant suspendu → 401.
+- [ ] T009 [P1] US4 `leopardo_employee` + `leopardo_hr`
+      `onboarding_repository.dart` : `POST` → `PATCH`, param `stepKey` string
+      (Closes #2631).
+- [ ] T010 [P2] US4 Backend : route `GET /departments/{department}/hierarchy`
+      (scopée tenant, `api.manager`) + contrôleur (arbre récursif enfants + effectif)
+      + test cross-tenant 404 (Closes #2633).
+
+## Phase 3 — P2 : Console admin & Sécurité (US5)
+
+- [ ] T011 [P2] US5 Backend : routes `/admin/training/sessions`,
+      `/admin/training/enrollments`, `/admin/webhooks*` (CRUD + test) avec policy
+      admin ; tests super-admin 200 / tenant 401 (Closes #2634).
+- [ ] T012 [P2] US5 Front : `TrainingView.vue`, `WebhooksView.vue` pointent vers les
+      routes `/admin/*`.
+- [ ] T013 [P2] US3 Middleware : ajouter le middleware tenant complet sur
+      `routes/ai.php` + `routes/modules/growth.php` ; aligner `routes/modules/sso.php`
+      (token.refresh, throttle api-plan) (Closes #2635).
+- [ ] T014 [P2] US3 `/auth/register` : supprimer la route ou bloquer la création sans
+      company_id (403 explicite) ; éviter le probing cross-tenant (Closes #2636).
+- [ ] T015 [P2] US3 `UserInvitationService::accept()` : vérifier le statut société
+      (Closes #2637).
+- [ ] T016 [P2] US5 Admin : brancher `EditUserModal` (update, reset password, welcome
+      email, force logout) + `SystemAlertsOverlay` (maintenance) sur des endpoints
+      réels, sinon état « non disponible » explicite (Closes #2641).
+- [ ] T017 [P3] US5 Admin : `CommandPalette` — vehicles → /fleet, settings → /settings,
+      filtrer entrées tenant (Closes #2640) ; clés i18n manquantes + `document.title`
+      traduit (Closes #2639).
+- [ ] T018 [P3] US5 Admin : orphelins — brancher ou supprimer `useNotificationStream`,
+      16 composants non importés, Alt+R (Closes #2645).
+
+## Phase 4 — P3 : Cohérence docs/code & vitrine (US6)
+
+- [ ] T019 [P3] US6 robots : supprimer la ligne `/api/sitemap` (ou la route dupliquée)
+      (Closes #2643).
+- [ ] T020 [P3] US6 `updateCountry` : dé-dupliquer le corps dans
+      `PlatformCompanyController` (Closes #2644).
+- [ ] T021 [P3] US6 OpenAPI : documenter les blocs manquants (priorité : /admin/*,
+      /trial/*, /onboarding/invitation/*, /webhooks/*, /health/*) ; garde
+      `check-openapi-route-coverage.py` à 0 (Closes #2638, volet code).
+- [ ] T022 [P3] US6 Vitrine : router `/contact`, `/docs`, `/guides/*` sur
+      `useVitrineLocale` (fallback FR) ; localiser l'OnboardingWizard (Closes #2642,
+      volet minimal).
+
+## Phase 5 — Ops (issue #2632)
+
+- [ ] T023 [P1] Déploiements : documenter l'état stale (Render /api-explorer 500,
+      Pages login href="#", Vercel deploy 06:23Z failed) + redéployer + vérifier
+      (Closes #2632). Action manuelle/ops — PR si un script de vérification peut être
+      ajouté (healthcheck version).
+
+## Dependencies & Execution Order
+
+- Phase 1 (US1/US2) et Phase 2 (US3/US4) sont indépendantes et prioritaires (P1).
+- Phase 3 (P2) dépend du backend pour T011/T012 (routes /admin avant le front).
+- Phase 4 (P3) indépendante.
+- T010, T013, T014, T015 touchent tous `api/routes/` → attention aux conflits de
+  branches (une PR = une issue, marker branch `fix/<issue>-<slug>`).
+
+## Notes
+
+- [P] = parallélisable (fichiers disjoints).
+- Chaque tâche → PR unique avec `Closes #<issue>` ; CHANGELOG.md mis à jour.
+- Backend : PHPStan strict level 8 + Pint + tests ciblés avant merge (Constitution §IV).
+- Front : ESLint + tsc verts. Mobile : analyse statique (pas de run Flutter ici).

--- a/docs/qa/QA_SESSION_2026-08-15.md
+++ b/docs/qa/QA_SESSION_2026-08-15.md
@@ -1,0 +1,83 @@
+# QA Leopardo HR — Session du 2026-08-15 (audit externe complet)
+
+Mission : tester la plateforme dans tous les sens (vitrine, web, admin, mobile,
+workflows, API, logique, onboarding, cohérence), documenter chaque manquement, créer
+les tickets/tasks/incidences selon la méthode spec kit, puis implémenter les correctifs.
+
+## Méthode
+1. Tests **live** des surfaces déployées : vitrine (Vercel), console admin (Cloudflare
+   Pages), API (Render) — curl + navigateur.
+2. Revue **statique** parallèle (4 agents) : API Laravel (auth/onboarding/tenancy),
+   front/web Next.js, admin-dashboard Vue, apps Flutter (cross-check des 407 appels
+   Dart vs routes backend).
+3. Chaque constat confirmé → issue GitHub (`[QA][P#]`) + feature spec kit
+   `.specify/features/qa-wave-2026-08-15/` (plan/spec/tasks).
+4. Implémentation des correctifs (PR par issue, `Closes #X`).
+
+## Constats confirmés (live + code)
+
+### LIVE — Production
+| ID | Sévérité | Constat | Preuve |
+|----|----------|---------|--------|
+| OPS-1 | CRITIQUE | `/api-explorer` → **500** en prod (fix #2287 merged 06:22Z non déployé — Render stale) | curl onrender |
+| OPS-2 | CRITIQUE | Checkout prod → **`sandbox:true`**, « Aucune carte débitée », `provisioned:false` → faux succès de paiement, aucun compte créé | curl Vercel `/api/billing/checkout` |
+| OPS-3 | MAJEUR | Admin login Pages → « Mot de passe oublié ? »/« Sécurité »/« Support » en `href="#"` (fix #2243/#2323 non déployés — build stale) | bundle LoginView-BXZeeAzT.js + navigateur |
+| OPS-4 | MAJEUR | Déploiement Vercel Production 06:23:35Z en **failure** (sha d821326515) | GitHub deployments API |
+| OPS-5 | INFO | `/api/v1/demo-users` → 404 (attendu, `DISABLE_DEMO_SEEDING=true`) | curl |
+
+### API (code)
+| ID | Sévérité | Constat | Réf |
+|----|----------|---------|-----|
+| API-1 | CRITIQUE | Login ignore `status` : `UserAuthService`, `PlatformAuthController`, callbacks Google ; suspension ne révoque pas les tokens | #2630 |
+| API-2 | MAJEUR | `/auth/register` crée un employé sans `company_id` → login impossible + probing cross-tenant | #2636 |
+| API-3 | MAJEUR | `/ai/*` et `/growth/partner/*` sans middleware tenant complet ; `/sso` management incomplet | #2635 |
+| API-4 | MAJEUR | Trial guidé : magic link jamais envoyé (TODO), mot de passe manager jamais communiqué, `trial/status` dit `ready` sans credentials | #2629 |
+| API-5 | MAJEUR | `UserInvitationService::accept()` sans check statut société | #2637 |
+| API-6 | MOYEN | Drift OpenAPI : 119 chemins de code absents de la spec | #2638 |
+| API-7 | MINEUR | `updateCountry` dupliqué (artefact merge, code mort) | #2644 |
+
+### Mobile (apps Flutter)
+| ID | Sévérité | Constat | Réf |
+|----|----------|---------|-----|
+| MOB-1 | MAJEUR | `POST /onboarding-setup/{id}/complete\|skip` (employee + HR) vs backend `PATCH` → **405** (manager OK) | #2631 |
+| MOB-2 | MAJEUR | `GET /departments/{id}/hierarchy` (HR + Manager) → **route inexistante 404** | #2633 |
+| MOB-3 | INFO | `leopardo.local:7878` (HTTP) hardcodé dans sync edge (confirmé non utilisé pour le trafic tenant release — à surveiller) | — |
+
+### Web vitrine (Next.js)
+| ID | Sévérité | Constat | Réf |
+|----|----------|---------|-----|
+| WEB-1 | MAJEUR | Checkout : sandbox en prod + carte test affichée en permanence | #2628 |
+| WEB-2 | MINEUR | `app/api/robots/route.ts` annonce `/api/sitemap` (404) ; doublon avec `app/robots.ts` | #2643 |
+| WEB-3 | MOYEN | ~15 pages FR-only (contact, docs, guides, about, checkout…) malgré sélecteur EN/TR/AR ; OnboardingWizard FR hardcodé | #2642 |
+| WEB-4 | INFO | 3 routes API mortes supprimées (docs obsolètes uniquement) | — |
+
+### Admin (Vue)
+| ID | Sévérité | Constat | Réf |
+|----|----------|---------|-----|
+| ADM-1 | MAJEUR | 3/8 gaps QA-8 restants : training sessions/enrollments + webhooks CRUD/test sans `/admin` → 401 super-admin | #2634 |
+| ADM-2 | MINEUR | Handlers factices EditUserModal (4 actions) + maintenance SystemAlertsOverlay (setTimeout+toast) | #2641 |
+| ADM-3 | MINEUR | Palette : `/vehicles` → 404, 7 entrées tenant → `/`, settings → `/system` | #2640 |
+| ADM-4 | MINEUR | 2 clés i18n manquantes + clés brutes dans `document.title` | #2639 |
+| ADM-5 | MINEUR | Orphelins : useNotificationStream non branché, 16 composants non importés, Alt+R → route tenant | #2645 |
+
+## Issues créées (spec-first)
+#2628 checkout sandbox (P1) · #2629 trial guidé (P1) · #2630 auth statut (P1) · #2631
+mobile onboarding 405 (P1) · #2632 déploiements stale (P1) · #2633 organigramme
+hierarchy (P2) · #2634 admin training/webhooks /admin (P2) · #2635 middleware tenant
+ai/growth (P2) · #2636 /auth/register orphelin (P2) · #2637 invitation société suspendue
+(P2) · #2638 drift OpenAPI (P3) · #2639 i18n admin (P3) · #2640 command palette (P3) ·
+#2641 handlers factices (P3) · #2642 pages FR-only (P3) · #2643 robots (P3) · #2644
+updateCountry dupliqué (P3) · #2645 orphelins admin (P3)
+
+Feature spec kit : `.specify/features/qa-wave-2026-08-15/` (plan.md, spec.md, tasks.md).
+
+## Implémentation (PRs)
+| Issue | PR | Statut |
+|-------|----|--------|
+| … | … | à remplir en fin de session |
+
+## Notes
+- Pas de run backend local (pas de PHP/Postgres dans le sandbox) : les changements PHP
+  sont validés par CI (tests + PHPStan) ; revue statique attentive avant push.
+- Déploiement stale = incident ops prioritaire : les utilisateurs voient une version
+  antérieure aux correctifs QA mergés.

--- a/docs/qa/QA_SESSION_2026-08-15.md
+++ b/docs/qa/QA_SESSION_2026-08-15.md
@@ -74,7 +74,26 @@ Feature spec kit : `.specify/features/qa-wave-2026-08-15/` (plan.md, spec.md, ta
 ## Implémentation (PRs)
 | Issue | PR | Statut |
 |-------|----|--------|
-| … | … | à remplir en fin de session |
+| #2628 checkout sandbox | #2665 | ✅ mergé |
+| #2629 trial guidé magic link | #2864 | ⏳ PR ouverte |
+| #2630 auth statut (tokens + Google + super-admin) | #2860 | ⏳ PR ouverte (statut login déjà couvert par #2816) |
+| #2631 mobile onboarding 405 | #2663 | ✅ mergé |
+| #2632 déploiements stale | — | 📋 ops (documenté) |
+| #2633 organigramme hierarchy | #2861 | ⏳ PR ouverte |
+| #2634 admin training/webhooks /admin | #2862 | ⏳ PR ouverte |
+| #2635 middleware tenant ai/growth/sso | #2863 | ⏳ PR ouverte (growth partiellement couvert par #2818) |
+| #2636 /auth/register orphelin | — | ✅ couvert par #2617 (mergé) |
+| #2637 invitation société suspendue | #2865 | ⏳ PR ouverte |
+| #2638 drift OpenAPI | — | 📋 P3 (tasks spec kit) |
+| #2639 i18n admin (clés) | #2866 | ⏳ PR ouverte (document.title via #2862) |
+| #2640 command palette | #2866 | ⏳ PR ouverte |
+| #2641 handlers factices admin | #2875 | ⏳ PR ouverte |
+| #2642 pages vitrine FR-only | — | 📋 P3 (tasks spec kit) |
+| #2643 robots /api/sitemap | #2664 | ✅ mergé |
+| #2644 updateCountry dupliqué | #2871 | ⏳ PR ouverte |
+| #2645 orphelins admin | — | 📋 P3 (tasks spec kit) |
+
+13 PRs au total (3 mergées, 10 ouvertes) — détails : `git log` des branches `fix/<issue>-<slug>` / PRs #2663-#2876.
 
 ## Notes
 - Pas de run backend local (pas de PHP/Postgres dans le sandbox) : les changements PHP


### PR DESCRIPTION
## Contenu
Feature spec kit `.specify/features/qa-wave-2026-08-15/` (plan.md, spec.md, tasks.md) couvrant les 18 issues créées (#2628–#2645) + rapport de session `docs/qa/QA_SESSION_2026-08-15.md` (constats live + statiques, méthode, tableau des PRs).

Sans impact code — documentation de la vague QA.