### PR TITLE
fix(phpstan): main vert — 6 erreurs Strict level 8 réparées (RegisterAction, AuthController, PlatformCompanyController, Export, PayrollRun) (Closes #2893)

### DIFF
--- a/api/app/Core/Auth/Application/Actions/RegisterAction.php
+++ b/api/app/Core/Auth/Application/Actions/RegisterAction.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Facades\Hash;
 final class RegisterAction
 {
     /**
-     * @param  array{first_name: string, last_name: string, email: string, password: string, invitation_token: string, device_name?: string}  $data
+     * @param  array{first_name: string, last_name: string, email: string, password: string, invitation_token?: string|null, device_name?: string}  $data
      * @return array{employee: Employee, token: string, token_type: string}
      */
     public function execute(array $data): array

--- a/api/app/Core/Auth/Application/Actions/RegisterAction.php
+++ b/api/app/Core/Auth/Application/Actions/RegisterAction.php
@@ -30,7 +30,7 @@ final class RegisterAction
     {
         $invitationToken = $data['invitation_token'] ?? null;
         if (! is_string($invitationToken) || $invitationToken === '') {
-            throw new RegistrationNotAvailableException();
+            throw new RegistrationNotAvailableException;
         }
 
         $email = strtolower(trim($data['email']));
@@ -45,18 +45,18 @@ final class RegisterAction
         if ($invitation === null) {
             // Token absent, expiré, déjà consommé ou email différent : on ne
             // dit pas lequel (pas de fuite d'information sur les invitations).
-            throw new RegistrationNotAvailableException();
+            throw new RegistrationNotAvailableException;
         }
 
         /** @var Employee $employee */
         $employee = Employee::create([
-            'first_name'    => $data['first_name'],
-            'last_name'     => $data['last_name'],
-            'email'         => $email,
+            'first_name' => $data['first_name'],
+            'last_name' => $data['last_name'],
+            'email' => $email,
             'password_hash' => Hash::make($data['password']),
-            'role'          => $invitation->role ?? 'ordinary',
-            'status'        => 'active',
-            'company_id'    => $invitation->company_id,
+            'role' => $invitation->role ?? 'ordinary',
+            'status' => 'active',
+            'company_id' => $invitation->company_id,
         ]);
 
         // Invitation consommée (idempotence : seule la première passe).
@@ -68,8 +68,8 @@ final class RegisterAction
         $token = $employee->createToken($tokenName);
 
         return [
-            'employee'   => $employee,
-            'token'      => $token->plainTextToken,
+            'employee' => $employee,
+            'token' => $token->plainTextToken,
             'token_type' => 'Bearer',
         ];
     }

--- a/api/app/Core/Auth/Interfaces/Api/V1/AuthController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/AuthController.php
@@ -57,7 +57,10 @@ class AuthController extends Controller
 
     public function register(StoreRegistrationRequest $request): JsonResponse
     {
-        $result = $this->registerAction->execute($request->validated());
+        /** @var array{first_name: string, last_name: string, email: string, password: string, invitation_token?: string|null, device_name?: string} $validated */
+        $validated = $request->validated();
+
+        $result = $this->registerAction->execute($validated);
 
         return (new EmployeeResource($result['employee']))
             ->additional([

--- a/api/app/Http/Controllers/Web/PlatformCompanyController.php
+++ b/api/app/Http/Controllers/Web/PlatformCompanyController.php
@@ -324,187 +324,125 @@ class PlatformCompanyController extends Controller
         $hasPayrollData = false;
         DB::statement('SET search_path TO '.$company->getSafeSearchPath());
         try {
-                    DB::statement('SET search_path TO public');
+            DB::statement('SET search_path TO public');
 
-                    $company = Company::query()->findOrFail($companyId);
+            $company = Company::query()->findOrFail($companyId);
 
-                    $validated = $request->validate([
-                        'country' => ['required', 'string', 'size:2'],
-                    ]);
+            $validated = $request->validate([
+                'country' => ['required', 'string', 'size:2'],
+            ]);
 
-                    $countryDefaults = CountryDefaults::find($validated['country']);
-                    if ($countryDefaults === null) {
-                        $message = 'Le pays est invalide ou non supporte ('.implode(', ', array_column(CountryDefaults::all(), 'country')).').';
-                        if ($request->expectsJson()) {
-                            return new JsonResponse([
-                                'message' => $message,
-                                'errors' => ['country' => [$message]],
-                            ], 422);
-                        }
+            $countryDefaults = CountryDefaults::find($validated['country']);
+            if ($countryDefaults === null) {
+                $message = 'Le pays est invalide ou non supporte ('.implode(', ', array_column(CountryDefaults::all(), 'country')).').';
+                if ($request->expectsJson()) {
+                    return new JsonResponse([
+                        'message' => $message,
+                        'errors' => ['country' => [$message]],
+                    ], 422);
+                }
 
-                        return back()->withInput()->withErrors(['country' => $message]);
-                    }
+                return back()->withInput()->withErrors(['country' => $message]);
+            }
 
-                    // INVARIANT 9 : verrouillage du pays après création de données de paie.
-                    // Les tables `payroll_runs`/`salary_structures` vivent dans le schéma
-                    // du TENANT (pas dans public) : bascule sur le search_path du tenant
-                    // pour le check, puis RESTAURATION en `finally` (une session restée
-                    // sur le schéma tenant fuirait vers les requêtes suivantes — même
-                    // garde que `withTenantSearchPath()` de PlatformCompanyHealthService).
-                    $searchPathRow = DB::selectOne('SHOW search_path');
-                    $previousSearchPath = is_object($searchPathRow) && property_exists($searchPathRow, 'search_path')
-                        ? (string) $searchPathRow->search_path
-                        : 'public';
+            // INVARIANT 9 : verrouillage du pays après création de données de paie.
+            // Les tables `payroll_runs`/`salary_structures` vivent dans le schéma
+            // du TENANT (pas dans public) : bascule sur le search_path du tenant
+            // pour le check, puis RESTAURATION en `finally` (une session restée
+            // sur le schéma tenant fuirait vers les requêtes suivantes — même
+            // garde que `withTenantSearchPath()` de PlatformCompanyHealthService).
+            $searchPathRow = DB::selectOne('SHOW search_path');
+            $previousSearchPath = is_object($searchPathRow) && property_exists($searchPathRow, 'search_path')
+                ? (string) $searchPathRow->search_path
+                : 'public';
 
-                    $hasPayrollData = false;
-                    DB::statement('SET search_path TO '.$company->getSafeSearchPath());
-                    try {
-                        $hasPayrollData = PayrollRun::query()->where('company_id', $company->id)->exists()
-                            || SalaryStructure::query()->where('company_id', $company->id)->exists();
-                    } finally {
-                        DB::statement('SET search_path TO '.$previousSearchPath);
-                    }
+            $hasPayrollData = false;
+            DB::statement('SET search_path TO '.$company->getSafeSearchPath());
+            try {
+                $hasPayrollData = PayrollRun::query()->where('company_id', $company->id)->exists()
+                    || SalaryStructure::query()->where('company_id', $company->id)->exists();
+            } finally {
+                DB::statement('SET search_path TO '.$previousSearchPath);
+            }
 
-                    if ($hasPayrollData) {
-                        $message = 'Le pays d\'un tenant avec des donnees de paie (runs ou structures salariales) ne peut pas etre modifie (invariant 9). Purge/export prealable requis.';
-                        if ($request->expectsJson()) {
-                            return new JsonResponse([
-                                'message' => $message,
-                                'errors' => ['country' => [$message]],
-                            ], 422);
-                        }
+            if ($hasPayrollData) {
+                $message = 'Le pays d\'un tenant avec des donnees de paie (runs ou structures salariales) ne peut pas etre modifie (invariant 9). Purge/export prealable requis.';
+                if ($request->expectsJson()) {
+                    return new JsonResponse([
+                        'message' => $message,
+                        'errors' => ['country' => [$message]],
+                    ], 422);
+                }
 
-                        return back()->withInput()->withErrors(['country' => $message]);
-                    }
+                return back()->withInput()->withErrors(['country' => $message]);
+            }
 
-                    // Issue #1873 — toute modification du pays d'un tenant est journalisée
-                    // (audit trail : avant/après, acteur, IP) pour traçabilité complète.
-                    $oldCountry = $company->country;
-                    $oldCurrency = $company->currency;
-                    $oldTimezone = $company->timezone;
-                    $oldLanguage = $company->language;
+            // Issue #1873 — toute modification du pays d'un tenant est journalisée
+            // (audit trail : avant/après, acteur, IP) pour traçabilité complète.
+            $oldCountry = $company->country;
+            $oldCurrency = $company->currency;
+            $oldTimezone = $company->timezone;
+            $oldLanguage = $company->language;
 
-                    $company->country = $countryDefaults['country'];
-                    // La devise/fuseau/langue suivent le pays (réparation cohérente).
-                    $company->currency = strtoupper($countryDefaults['currency']);
-                    $company->timezone = $countryDefaults['timezone'];
-                    $company->language = strtolower($countryDefaults['language']);
-                    $company->save();
+            $company->country = $countryDefaults['country'];
+            // La devise/fuseau/langue suivent le pays (réparation cohérente).
+            $company->currency = strtoupper($countryDefaults['currency']);
+            $company->timezone = $countryDefaults['timezone'];
+            $company->language = strtolower($countryDefaults['language']);
+            $company->save();
 
-                    // Issue #1873 — toute modification du pays d'un tenant est journalisée.
-                    // `audit_logs` vit dans le schéma du tenant (shared_tenants en mode
-                    // partagé), or ce contrôleur s'exécute avec search_path=public (ligne
-                    // 288) → l'INSERT non qualifié échoue (relation audit_logs introuvable).
-                    // Bascule temporaire sur le schéma du tenant, puis restauration en
-                    // `finally` (même garde que le bloc INVARIANT 9 ci-dessus).
-                    $auditPathRow = DB::selectOne('SHOW search_path');
-                    $previousAuditPath = is_object($auditPathRow) && property_exists($auditPathRow, 'search_path')
-                        ? (string) $auditPathRow->search_path
-                        : 'public';
-                    DB::statement('SET search_path TO '.$company->getSafeSearchPath());
-                    try {
-                        AuditLog::create([
-                            'company_id' => $company->id,
-                            'user_id' => $request->user()?->id,
-                            'action' => 'tenant_country_changed',
-                            'auditable_type' => $company->getMorphClass(),
-                            'auditable_id' => $company->id,
-                            'old_values' => [
-                                'country' => $oldCountry,
-                                'currency' => $oldCurrency,
-                                'timezone' => $oldTimezone,
-                                'language' => $oldLanguage,
-                            ],
-                            'new_values' => [
-                                'country' => $company->country,
-                                'currency' => $company->currency,
-                                'timezone' => $company->timezone,
-                                'language' => $company->language,
-                            ],
-                            'ip_address' => $request->ip(),
-                            'user_agent' => $request->userAgent(),
-                        ]);
-                    } finally {
-                        DB::statement('SET search_path TO '.$previousAuditPath);
-                    }
+            // Issue #1873 — toute modification du pays d'un tenant est journalisée.
+            // `audit_logs` vit dans le schéma du tenant (shared_tenants en mode
+            // partagé), or ce contrôleur s'exécute avec search_path=public (ligne
+            // 288) → l'INSERT non qualifié échoue (relation audit_logs introuvable).
+            // Bascule temporaire sur le schéma du tenant, puis restauration en
+            // `finally` (même garde que le bloc INVARIANT 9 ci-dessus).
+            $auditPathRow = DB::selectOne('SHOW search_path');
+            $previousAuditPath = is_object($auditPathRow) && property_exists($auditPathRow, 'search_path')
+                ? (string) $auditPathRow->search_path
+                : 'public';
+            DB::statement('SET search_path TO '.$company->getSafeSearchPath());
+            try {
+                AuditLog::create([
+                    'company_id' => $company->id,
+                    'user_id' => $request->user()?->id,
+                    'action' => 'tenant_country_changed',
+                    'auditable_type' => $company->getMorphClass(),
+                    'auditable_id' => $company->id,
+                    'old_values' => [
+                        'country' => $oldCountry,
+                        'currency' => $oldCurrency,
+                        'timezone' => $oldTimezone,
+                        'language' => $oldLanguage,
+                    ],
+                    'new_values' => [
+                        'country' => $company->country,
+                        'currency' => $company->currency,
+                        'timezone' => $company->timezone,
+                        'language' => $company->language,
+                    ],
+                    'ip_address' => $request->ip(),
+                    'user_agent' => $request->userAgent(),
+                ]);
+            } finally {
+                DB::statement('SET search_path TO '.$previousAuditPath);
+            }
 
-                    if ($request->expectsJson()) {
-                        return new JsonResponse([
-                            'data' => [
-                                'company' => $company->fresh(),
-                            ],
-                        ]);
-                    }
+            if ($request->expectsJson()) {
+                return new JsonResponse([
+                    'data' => [
+                        'company' => $company->fresh(),
+                    ],
+                ]);
+            }
 
-                    return redirect()
-                        ->route('platform.companies.edit', ['company' => $company->id])
-                        ->with('status', 'Pays du tenant mis a jour.');
+            return redirect()
+                ->route('platform.companies.edit', ['company' => $company->id])
+                ->with('status', 'Pays du tenant mis a jour.');
         } finally {
             DB::statement('SET search_path TO '.$originalSearchPath);
         }
 
-        if ($hasPayrollData) {
-            $message = 'Le pays d\'un tenant avec des donnees de paie (runs ou structures salariales) ne peut pas etre modifie (invariant 9). Purge/export prealable requis.';
-            if ($request->expectsJson()) {
-                return new JsonResponse([
-                    'message' => $message,
-                    'errors' => ['country' => [$message]],
-                ], 422);
-            }
-
-            return back()->withInput()->withErrors(['country' => $message]);
-        }
-
-        // Issue #1873 — toute modification du pays d'un tenant est journalisée
-        // (audit trail : avant/après, acteur, IP) pour traçabilité complète.
-        $oldCountry = $company->country;
-        $oldCurrency = $company->currency;
-        $oldTimezone = $company->timezone;
-        $oldLanguage = $company->language;
-
-        $company->country = $countryDefaults['country'];
-        // La devise/fuseau/langue suivent le pays (réparation cohérente).
-        $company->currency = strtoupper($countryDefaults['currency']);
-        $company->timezone = $countryDefaults['timezone'];
-        $company->language = strtolower($countryDefaults['language']);
-        $company->save();
-
-        AuditLog::create([
-            'company_id' => $company->id,
-            'user_id' => $request->user()?->id,
-            'action' => 'tenant_country_changed',
-            'auditable_type' => $company->getMorphClass(),
-            // auditable_id est unsignedBigInteger (schéma legacy) ; Company.id
-            // est un UUID → null ici (company_id identifie déjà le tenant,
-            // avant/après portés par old_values/new_values).
-            'auditable_id' => null,
-            'old_values' => [
-                'country' => $oldCountry,
-                'currency' => $oldCurrency,
-                'timezone' => $oldTimezone,
-                'language' => $oldLanguage,
-            ],
-            'new_values' => [
-                'country' => $company->country,
-                'currency' => $company->currency,
-                'timezone' => $company->timezone,
-                'language' => $company->language,
-            ],
-            'ip_address' => $request->ip(),
-            'user_agent' => $request->userAgent(),
-        ]);
-
-        if ($request->expectsJson()) {
-            return new JsonResponse([
-                'data' => [
-                    'company' => $company->fresh(),
-                ],
-            ]);
-        }
-
-        return redirect()
-            ->route('platform.companies.edit', ['company' => $company->id])
-            ->with('status', 'Pays du tenant mis a jour.');
     }
 
     /**

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ExportController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ExportController.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Auth\Infrastructure\Services\DataAccessAuditLogger;
+use App\Http\Controllers\Controller;
 use App\Modules\HR\Domain\Models\ExportHistory;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -263,7 +264,7 @@ class ExportController extends Controller
             $query->where('type', $validated['type']);
         }
 
-        /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, ExportHistory> $history */
+        /** @var LengthAwarePaginator<int, ExportHistory> $history */
         $history = $query->paginate((int) ($validated['per_page'] ?? 20));
 
         $items = collect($history->items())->map(static fn (ExportHistory $row): array => [
@@ -272,7 +273,7 @@ class ExportController extends Controller
             'format' => $row->format,
             'record_count' => $row->record_count,
             'filename' => $row->filename,
-            'created_at' => $row->created_at?->toIso8601String(),
+            'created_at' => $row->created_at->toIso8601String(),
         ])->all();
 
         return response()->json([
@@ -297,7 +298,7 @@ class ExportController extends Controller
         $this->auditLogger->recordSensitive($request, $user, 'payroll.accounting_export', null, ['report' => 'payroll_journal']);
 
         $records = $this->tableForCompany('pay_slips', $user->company_id, [
-            'id', 'employee_id', 'payroll_run_id', 'gross_salary', 'net_salary', 'status', 'period_start', 'period_end'
+            'id', 'employee_id', 'payroll_run_id', 'gross_salary', 'net_salary', 'status', 'period_start', 'period_end',
         ]);
 
         return $this->exportResponse($request, $records, 'payroll_journal');
@@ -315,9 +316,9 @@ class ExportController extends Controller
 
         // Summary representation for ledger
         $records = $this->tableForCompany('pay_slips', $user->company_id, [
-            'payroll_run_id', 'gross_salary', 'net_salary'
+            'payroll_run_id', 'gross_salary', 'net_salary',
         ]);
-        
+
         // Group by payroll_run_id for the ledger
         $grouped = $records->groupBy('payroll_run_id')->map(function ($group, $runId): \stdClass {
             $row = new \stdClass;
@@ -343,43 +344,43 @@ class ExportController extends Controller
         $this->auditLogger->recordSensitive($request, $user, 'payroll.accounting_export', null, ['report' => 'accounting_od']);
 
         $records = $this->tableForCompany('pay_slips', $user->company_id, [
-            'payroll_run_id', 'gross_salary', 'net_salary', 'period_end'
+            'payroll_run_id', 'gross_salary', 'net_salary', 'period_end',
         ]);
-        
+
         $grouped = $records->groupBy('payroll_run_id');
         $odEntries = collect();
-        
+
         foreach ($grouped as $runId => $group) {
             $date = $group->first()->period_end ?? now()->toDateString();
             $totalGross = $group->sum('gross_salary');
             $totalNet = $group->sum('net_salary');
             $totalSocial = $totalGross - $totalNet;
-            
+
             // 641 - Remuneration du personnel (Debit)
-            $odEntries->push((object)[
+            $odEntries->push((object) [
                 'date' => $date,
                 'account' => '641000',
                 'label' => 'Rémunérations',
                 'debit' => $totalGross,
-                'credit' => 0
+                'credit' => 0,
             ]);
-            
+
             // 431 - Securite Sociale (Credit)
-            $odEntries->push((object)[
+            $odEntries->push((object) [
                 'date' => $date,
                 'account' => '431000',
                 'label' => 'Charges Sociales',
                 'debit' => 0,
-                'credit' => $totalSocial
+                'credit' => $totalSocial,
             ]);
-            
+
             // 421 - Personnel remu dues (Credit)
-            $odEntries->push((object)[
+            $odEntries->push((object) [
                 'date' => $date,
                 'account' => '421000',
                 'label' => 'Rémunérations Dues',
                 'debit' => 0,
-                'credit' => $totalNet
+                'credit' => $totalNet,
             ]);
         }
 

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollRunController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PayrollRunController.php
@@ -126,7 +126,7 @@ class PayrollRunController extends Controller
                 'run_id' => $payrollRun->id,
                 'company_id' => $payrollRun->company_id,
                 'country_code' => $payrollRun->country_code,
-                'period' => $payrollRun->period_start?->toDateString(),
+                'period' => $payrollRun->period_start->toDateString(),
                 'error' => $e->getMessage(),
             ]);
 


### PR DESCRIPTION
QA 2026-08-15 [P1][CI] #2893 : le job requis « PHPStan — Strict (level 8) » était rouge sur main (depuis les merges swarm d'aujourd'hui) → toutes les PRs bloquées.

Correctifs :
- `RegisterAction` : docblock `invitation_token?: string|null` aligné sur le guard défensif.
- `AuthController::register` : `@var` de shape sur `validated()` avant `execute()`.
- `PlatformCompanyController` : suppression de la queue morte post-try/finally (doublon d'artefact de merge du garde INVARIANT 9 + de la mise à jour pays) — 2 blocs dupliqués.
- `ExportController` / `PayrollRunController` : `?->` sur Carbon non-nullable → `->`.

Validation : `phpstan analyse phpstan-strict.neon app/` → **0 erreur** ; pint PASS ; 22 tests Feature verts (PlatformCompany + auth).

Closes #2893