### PR TITLE
docs(speckit): feature qa-new-findings-2026-08-15 (issues #2746-#2757)

### DIFF
--- a/.specify/features/qa-new-findings-2026-08-15/plan.md
+++ b/.specify/features/qa-new-findings-2026-08-15/plan.md
@@ -1,0 +1,30 @@
+# Feature Specification: QA complet plateforme 2026-08-15 — nouveaux constats (issues #2746–#2757)
+
+**Feature Branch**: `fix/<issue>-<slug>` (une PR par issue, Closes #N)
+
+**Created**: 2026-08-15
+
+**Status**: Implementé (PRs ouvertes/mergées)
+
+**Input**: Mission QA complète de la session 2026-08-15 (vitrine, web client, admin, mobile ×5, kiosk, edge, API, onboarding, cohérence). Les constats déjà couverts par la vague parallèle (#2600–#2665) sont exclus (anti-doublon §I constitution). Ce feature regroupe les **nouveaux** constats : 12 issues.
+
+## User Stories
+
+| US | Issue | Surface | Priorité |
+|----|-------|---------|----------|
+| US1 | #2746 | Web (e2e) | P1 — middleware dashboard casse 13 specs mockées (CI rouge) ; SW contourne les mocks |
+| US2 | #2747 | Admin | P1 — enveloppe `{data:[...]}` non déballée → TypeError header alertes |
+| US3 | #2748 | Mobile manager | P1 — navigation dossier Cabinet cassée + errorBuilder routeurs |
+| US4 | #2749 | API payroll | P2 — lectures paie mobiles 403 pour rôle RH |
+| US5 | #2750 | Kiosk | P1 — globals `__KIOSK_*` jamais injectées → fonctions cloud 404 |
+| US6 | #2751 | Edge | P1 — docker-compose inutilisable + install.sh cassé |
+| US7 | #2752 | Web (SEO) | P2 — OG images `/og/*.png` inexistantes |
+| US8 | #2753 | Web (content) | P2 — essai « 14 jours » vs « 30 jours » |
+| US9 | #2754 | Mobile (CI) | P2 — mobile-workflow-contracts.json périmé (garde rouge) |
+| US10 | #2755 | i18n | P2 — 8 983 chaînes hardcodées (chantier) |
+| US11 | #2756 | Web (PWA) | P3 — icônes PNG absentes |
+| US12 | #2757 | Docs/kiosk | P3 — cohérence RBAC/CSRF/CI, clés tr/ar, CSS kiosk |
+
+## Acceptance (global)
+- Chaque issue fermée par sa PR (`Closes #N` dans le body), checks CI verts.
+- Gardes : `npm run lint`/`build` (web+admin), tests e2e vitrine 21/21 (chromium), simulation contrat mobile 0 échec, `php -l` (routes/tests), `bash -n` + parse YAML (edge).

--- a/.specify/features/qa-new-findings-2026-08-15/spec.md
+++ b/.specify/features/qa-new-findings-2026-08-15/spec.md
@@ -1,0 +1,30 @@
+# Feature Specification: QA complet plateforme 2026-08-15 — nouveaux constats (issues #2746–#2757)
+
+**Feature Branch**: `fix/<issue>-<slug>` (une PR par issue, Closes #N)
+
+**Created**: 2026-08-15
+
+**Status**: Implementé (PRs ouvertes/mergées)
+
+**Input**: Mission QA complète de la session 2026-08-15 (vitrine, web client, admin, mobile ×5, kiosk, edge, API, onboarding, cohérence). Les constats déjà couverts par la vague parallèle (#2600–#2665) sont exclus (anti-doublon §I constitution). Ce feature regroupe les **nouveaux** constats : 12 issues.
+
+## User Stories
+
+| US | Issue | Surface | Priorité |
+|----|-------|---------|----------|
+| US1 | #2746 | Web (e2e) | P1 — middleware dashboard casse 13 specs mockées (CI rouge) ; SW contourne les mocks |
+| US2 | #2747 | Admin | P1 — enveloppe `{data:[...]}` non déballée → TypeError header alertes |
+| US3 | #2748 | Mobile manager | P1 — navigation dossier Cabinet cassée + errorBuilder routeurs |
+| US4 | #2749 | API payroll | P2 — lectures paie mobiles 403 pour rôle RH |
+| US5 | #2750 | Kiosk | P1 — globals `__KIOSK_*` jamais injectées → fonctions cloud 404 |
+| US6 | #2751 | Edge | P1 — docker-compose inutilisable + install.sh cassé |
+| US7 | #2752 | Web (SEO) | P2 — OG images `/og/*.png` inexistantes |
+| US8 | #2753 | Web (content) | P2 — essai « 14 jours » vs « 30 jours » |
+| US9 | #2754 | Mobile (CI) | P2 — mobile-workflow-contracts.json périmé (garde rouge) |
+| US10 | #2755 | i18n | P2 — 8 983 chaînes hardcodées (chantier) |
+| US11 | #2756 | Web (PWA) | P3 — icônes PNG absentes |
+| US12 | #2757 | Docs/kiosk | P3 — cohérence RBAC/CSRF/CI, clés tr/ar, CSS kiosk |
+
+## Acceptance (global)
+- Chaque issue fermée par sa PR (`Closes #N` dans le body), checks CI verts.
+- Gardes : `npm run lint`/`build` (web+admin), tests e2e vitrine 21/21 (chromium), simulation contrat mobile 0 échec, `php -l` (routes/tests), `bash -n` + parse YAML (edge).

--- a/.specify/features/qa-new-findings-2026-08-15/tasks.md
+++ b/.specify/features/qa-new-findings-2026-08-15/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: QA complet plateforme 2026-08-15 — nouveaux constats
+
+**Input**: spec.md (`.specify/features/qa-new-findings-2026-08-15/`)
+
+**Tests**: gardes par surface (voir plan.md « Validation ») + CI PR
+
+## Phase 1 — Correctifs P1 (code)
+
+- [x] T001 US1 #2746 — e2e vitrine : cookie `leopardo_token` dans les specs mockées + `serviceWorkers: 'block'` + mock demo-users (PR #2878)
+- [x] T002 US2 #2747 — admin `stores/dashboard.js` : déballage `data?.data ?? []` + gardes `Array.isArray` + `$subscribe` (PR #2790, **mergée**)
+- [x] T003 US3 #2748 — route `/cabinet/folder/:folderId` manager + `errorBuilder` ×3 routeurs (PR #2815, **mergée**)
+- [x] T004 US5 #2750 — bridge kiosk : injection globals + bloc edge mort retiré + test python (PR #2873)
+- [x] T005 US6 #2751 — edge compose/install.sh : chemins, `/api/v1`, chmod, domaine (PR #2877)
+
+## Phase 2 — Correctifs P2/P3
+
+- [x] T006 US4 #2749 — RBAC payroll : lectures mobiles `principal,comptable,rh` + tests (PR #2834)
+- [x] T007 US7 #2752 — OG images réelles + fallback (PR #2889)
+- [x] T008 US8 #2753 — durée d'essai unifiée 30 jours (PR #2888)
+- [x] T009 US9 #2754 — mobile-workflow-contracts.json aligné (PR #2890)
+- [x] T010 US11 #2756 — icônes PNG PWA (PR #2892)
+- [x] T011 US12 #2757 — docs/cohérence + clés tr/ar + CSS kiosk (PR #2898)
+
+## Phase 3 — Backlog
+
+- [ ] T012 US10 #2755 — chantier i18n 8 983 chaînes (lots par app, voir issue)
+
+## Dependencies & Execution Order
+- T001–T011 indépendants ; T012 suit la décision de lots de l'issue #2755.


### PR DESCRIPTION
## Docs — Spec Kit

Feature spec/plan/tasks pour les 12 nouveaux constats de la mission QA 2026-08-15 (`#2746`–`#2757`), chacun référencé par sa user story — hors vague parallèle `#2600`–`#2665` (anti-doublon constitution §I). Une PR par issue avec `Closes #N` ; 2 PRs déjà mergées (#2790, #2815).