### PR TITLE
docs(qa): vague audit expert 2026-08-15 — spec-kit features + conclusions

### DIFF
--- a/.specify/features/qa-audit-expert-admin-2026-08-15/plan.md
+++ b/.specify/features/qa-audit-expert-admin-2026-08-15/plan.md
@@ -1,0 +1,50 @@
+# Plan: Audit expert Admin — 2026-08-15
+
+**Input**: spec.md (US B1-B7) + Constitution + audit 2026-08-15
+
+## Architecture / Décisions techniques
+
+- **B1 Impersonation** : corriger le chemin côté front → constante API (ex. `API.impersonate`) pointant sur `POST /platform/impersonations` (endpoint réel existant, cf. `api/routes/api.php:284`). Alternative rejetée : ajouter une route alias `/admin/impersonations` (doublon de surface). Vérifier `normalizeApiPath` dans `api.js` (préfixe `/api/v1`).
+- **B2 Suppression des simulations** :
+  - `SystemAlertsOverlay` : le bouton « Désactiver la maintenance » est retiré (aucun endpoint admin maintenance n'existe — état « non disponible » documenté) ; `isMaintenanceMode` alimenté par une vraie source si disponible, sinon retiré.
+  - `EditUserModal` / `CreateUserModal` : composants **non atteignables** (aucun `@edit` branché) → supprimer les fichiers morts + leurs imports (`UsersView` `showEditModal`, `UserTable` émission `edit`) ; l'édition utilisateur plateforme passe par les endpoints réels `PATCH /platform/users/{id}` si on la branche (hors périmètre — retirer le bouton).
+  - `MiniGlobe` : sans données socket → état vide honnête ; « Actualiser » ne re-randomise plus.
+- **B3 Identifiants démo** : retirer les identifiants en dur du bundle (`LoginView`) ; bouton démo supprimé (le backend n'expose pas d'endpoint démo admin).
+- **B4 UsersView** : pagination réelle (`page`/`per_page` passés à l'API, slicing server-side), filtre statut mappé ou retiré, mapping rôle/entreprise depuis le payload (`role`, `company`), CSV exporte les champs mappés (`createdAt`/`lastLoginAt` formatés) + échappement anti-injection, bouton Éditer retiré (pas de modale réelle).
+- **B5 Interactions globales** : recherche header → navigation `/users?search=` (ou retrait) ; `CommandPalette` filtrée par routes accessibles (même source que sidebar) + route `/vehicles` corrigée/retirée ; carte dashboard → `/system` ou retrait.
+- **B6 Notifications** : `_skipAuthRedirect: true` sur les deux appels + avaler les 401 (pattern `pollNotifications`) ; propager l'id serveur depuis le payload socket (ne plus générer d'id synthétique).
+- **B7 Hygiène** : `MetricCard` — `trendValue` numérique + slot label ; titres de routes traduits dans le garde ; suppression des composants morts (vérifier `rg` imports) ; `ExportsView` état réel + erreurs affichées ; toasts à la place des `alert()` ; try/catch + état de chargement `runSimulate` ; delete user → `POST /platform/users/{id}/deactivate` + confirmation explicite ; `money()` → `toIntlLocale(localeStore.current)` ; écouter l'état du store (watch) au lieu de `$subscribe` ; ajouter un sélecteur de langue minimal (ou documenter) + router les chaînes via le catalogue i18n.
+
+## Phases
+
+### Phase 1 — P1 (B1, B2, B3)
+- Impersonation → `/platform/impersonations` (constante API).
+- Suppression/état-honnête des simulations (maintenance, modales mortes, globe).
+- Retrait des identifiants démo de LoginView.
+
+### Phase 2 — P2 (B4, B5, B6)
+- UsersView (pagination, filtre, mapping, CSV, bouton éditer).
+- Recherche header, palette, carte dashboard.
+- Notifications (skipAuthRedirect + ids serveur).
+
+### Phase 3 — P3 (B7)
+- MetricCard, titres, composants morts, exports, alertes, runSimulate, deactivate, money(), subscribe, i18n.
+
+## Fichiers touchés (référence)
+
+- `front/admin-dashboard/src/views/users/UsersView.vue`, `components/users/{UserTable,EditUserModal,CreateUserModal}.vue`
+- `front/admin-dashboard/src/components/alerts/SystemAlertsOverlay.vue`, `components/globe/MiniGlobe.vue`
+- `front/admin-dashboard/src/views/auth/LoginView.vue`
+- `front/admin-dashboard/src/components/layout/Header.vue`, `components/common/CommandPalette.vue`
+- `front/admin-dashboard/src/views/DashboardView.vue`, `components/analytics/MetricCard.vue`, `views/analytics/AnalyticsView.vue`
+- `front/admin-dashboard/src/stores/realtime.js`, `src/services/api.js`
+- `front/admin-dashboard/src/router/index.js`
+- `front/admin-dashboard/src/views/{exports,settings,growth}/**`
+- Suppressions : `components/system/**`, `components/analytics/*Widget.vue` morts (vérifier imports)
+
+## Contraintes
+
+- Garde-fous existants : garde `requiresTenant` du routeur et filtre sidebar = source de vérité unique — ne pas casser la cohérence.
+- API layer `api.js` ne pas modifier (sauf si nécessaire pour `_skipAuthRedirect`).
+- Ne pas réintroduire de mocks (Constitution §V) — état vide honnête si pas de backend.
+- Vérifier `rg` avant suppression de composants ; ESLint + build Vite verts.

--- a/.specify/features/qa-audit-expert-admin-2026-08-15/spec.md
+++ b/.specify/features/qa-audit-expert-admin-2026-08-15/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Audit expert Admin — 2026-08-15
+
+**Feature Branch**: `qa-audit-expert-admin-2026-08-15`
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Input**: Mission de test expert de la plateforme (session 2026-08-15) — audit du cockpit super-admin `front/admin-dashboard` (Vue 3, Vite) : vues, boutons, liens, données simulées, chemins API, i18n, logique. Base : `main` (`8a57dbf8`).
+
+## User Stories & Testing
+
+### User Story B1 — L'impersonation super-admin fonctionne réellement (Priority: P1)
+
+`UsersView.vue:435` appelle `POST /admin/impersonations` — le backend n'expose l'impersonation que sous `POST /api/v1/platform/impersonations` (groupe `prefix('platform')`, `api/routes/api.php:284`) ; le groupe `/admin` (api.php:301) n'a **aucune** route impersonation → bouton « Imiter » → **404** systématique.
+
+**Pourquoi P1** : feature de sécurité livrée (#2518/#2547) mais inutilisable dans la console super-admin.
+
+**Test indépendant** : smoke API `POST /admin/impersonations` → 200 (ou route déléguée) ; Playwright : clic « Imiter » → écran de session d'impersonation (pas d'erreur).
+
+**Acceptance Scenarios**:
+1. **Given** le cockpit admin, **When** on clique « Imiter » sur un utilisateur, **Then** la requête part vers un endpoint existant (200) et la session d'impersonation s'affiche.
+2. **Given** la route, **When** le token est super-admin valide, **Then** l'endpoint est le même pour tous les clients (constante API partagée pour éviter la dérive).
+
+### User Story B2 — Aucune action simulée dans la console super-admin (Priority: P1)
+
+- `SystemAlertsOverlay.vue:206-210` : « Désactiver la maintenance » = `setTimeout` 1000 ms + toast de succès, **aucun appel API** ; `setMaintenanceMode` n'a aucun appelant → l'état de maintenance n'est jamais réel.
+- `EditUserModal.vue:304-355` : save / reset-password / welcome-email / force-logout **simulés** (`setTimeout` + toasts), sociétés codées en dur (« Acme Corp », « TechStart Inc ») — composant mort mais dangereux s'il est réactivé.
+- `MiniGlobe.vue:51-73` : points « Activité en temps réel » **fabriqués** (Paris/Istanbul/Casablanca) quand le socket n'a pas de données ; « Actualiser » re-randomise des points fictifs.
+
+**Pourquoi P1** : Constitution §V — des actions/états fabriqués dans une console ops donnent une fausse image de la plateforme.
+
+**Test indépendant** : aucun `setTimeout(...)` simulant une action dans les composants atteignables ; le bouton maintenance appelle un endpoint réel ou est retiré ; le globe affiche un état vide honnête.
+
+**Acceptance Scenarios**:
+1. **Given** l'overlay d'alertes système, **When** on clique « Désactiver la maintenance », **Then** un appel API réel est effectué (ou l'action est retirée avec un état « non disponible »).
+2. **Given** `EditUserModal`, **When** on l'ouvre, **Then** soit il est branché sur `PATCH /admin/users/{id}` + endpoints réels, soit il est supprimé (jamais simulé).
+3. **Given** le globe, **When** aucun événement socket, **Then** état vide explicite (« aucune activité temps réel ») — jamais de points fictifs.
+
+### User Story B3 — Plus d'identifiants de démonstration en dur sur la page de connexion (Priority: P1)
+
+`LoginView.vue:207` embarque les identifiants super-admin `admin@leopardo-rh.com` / `password123` et les poste vers le **vrai** `POST /platform/auth/login` — n'importe qui peut les lire dans le source de la page et tenter l'authentification.
+
+**Test indépendant** : aucune chaîne `password123` / `@leopardo-rh.com` dans le bundle admin ; le bouton démo est soit retiré, soit gaté `DEMO_MODE_ENABLED` avec identifiants fournis par le backend.
+
+**Acceptance Scenarios**:
+1. **Given** la page de connexion admin, **When** on inspecte le source, **Then** aucun identifiant réel en dur.
+2. **Given** un environnement de démo, **When** le mode démo est actif, **Then** les identifiants viennent d'un endpoint dédié (jamais du bundle).
+
+### User Story B4 — La liste des utilisateurs dit la vérité (Priority: P2)
+
+`UsersView.vue` : pagination **décorative** (tous les utilisateurs affichés, `per_page` codé à 100, compteur « X à Y sur 100 » faux), filtre statut « En attente » **silencieusement ignoré**, rôle codé `'admin'` et `company: null` pour chaque ligne, export CSV qui lit `user.created_at` alors que le mapping produit `createdAt` (colonnes dates **toujours vides**) + aucun échappement CSV (injection de formule), bouton « Éditer » sans listener (`UserTable.vue:135` → `@edit` jamais branché).
+
+**Test indépendant** : Playwright — pagination réelle (server-side), filtre pending appliqué, dates exportées, rôle/entreprise affichés depuis l'API, clic Éditer → modale.
+
+**Acceptance Scenarios**:
+1. **Given** la vue Users, **When** on change de page, **Then** les données changent (paramètres `page`/`per_page` réels).
+2. **Given** le filtre « En attente », **When** on le sélectionne, **Then** seuls les utilisateurs en attente sont listés (ou l'option est retirée).
+3. **Given** l'export CSV, **When** on exporte, **Then** les colonnes dates contiennent les valeurs réelles et les cellules sont échappées.
+4. **Given** la liste, **When** on clique le crayon, **Then** une modale d'édition réelle s'ouvre (ou le bouton est retiré).
+
+### User Story B5 — Les interactions globales ne sont pas mortes (Priority: P2)
+
+- Recherche globale du header (`Header.vue:237-241`) : `console.log('Searching for:')` + TODO — aucune recherche.
+- `CommandPalette.vue:105-123` : liste des routes gatées tenant (payroll/leaves/recruitment/training/exports/webhooks/chat) que le garde du routeur redirige + `route: '/vehicles'` inexistant (404).
+- `DashboardView.vue:154-160` : carte « Préparer intégrations partenaires » → `/webhooks` (requiresTenant) → toast + redirection : carte morte sur la page d'accueil.
+
+**Test indépendant** : saisie dans la recherche → navigation ou retrait ; palette filtrée par routes réellement accessibles ; carte dashboard → cible réelle.
+
+**Acceptance Scenarios**:
+1. **Given** le header, **When** on tape une recherche, **Then** on navigue vers une liste filtrée (ou le champ est retiré).
+2. **Given** la palette, **When** on liste les entrées, **Then** aucune route inexistante ni route tenant-gatée.
+
+### User Story B6 — Les notifications ne détruisent plus la session (Priority: P2)
+
+`stores/realtime.js:330-357` : `markNotificationAsRead` / `markAllNotificationsAsRead` appellent les routes **tenant** `/v1/notifications/...` **sans** `_skipAuthRedirect` → en super-admin, un 401 déclenche l'intercepteur (suppression du token + redirection `/login`) : un clic sur « Tout marquer comme lu » peut détruire la session. De plus les notifications push reçoivent des ids **synthétiques** (`Date.now()+Math.random()` à :306) → `PATCH /v1/notifications/{id}/read` 404 systématique.
+
+**Test indépendant** : clic « Tout marquer comme lu » en super-admin → aucun wipe de session ; notification push → le `PATCH .../read` utilise l'id serveur réel.
+
+**Acceptance Scenarios**:
+1. **Given** le store realtime, **When** une notification arrive par socket, **Then** elle porte l'id serveur réel (pas d'id synthétique).
+2. **Given** un 401 sur une route tenant, **When** on marque comme lu, **Then** l'erreur est avalée comme dans `pollNotifications` (pas de redirect).
+
+### User Story B7 — Petits défauts de logique et d'i18n (Priority: P2/P3)
+
+- `MetricCard.vue:116` + `AnalyticsView.vue:225-231` : la prop `trend` (validée `up|down|stable`) reçoit des **libellés** (« +5 aujourd'hui », « €1 234 », « Health: good ») → le chip affiche toujours « 0% ».
+- Titres d'onglets : `meta.title` = clés i18n brutes (`marketing.oauth.nav_title`, `holidays.nav.title`) → l'onglet du navigateur affiche la clé littérale.
+- 18 composants morts (system/analytics) dont `RevenueForecastWidget` (génère des données `Math.random()`), `BackupManagement`, `ApiTesterModal`, `ImportConfigModal`… — jamais importés : supprimer ou brancher.
+- `ExportsView.vue:170,189` : état de téléchargement simulé + `fetchHistory` avale les erreurs → un échec backend ressemble à « aucun export ».
+- `GrowthDashboardView.vue:168,177` : `alert()` natif pour les erreurs API.
+- `SocialContributionsView.vue:314-326` : `runSimulate` sans try/catch ni état de chargement.
+- `UsersView.vue:463-469` : `deleteUser` = `DELETE /platform/users/{id}` (destruction physique) alors que l'UI/toast dit « désactivation ».
+- `money()` codé `fr-FR` (`TaxSlabsView:242`, `SocialContributionsView:346`) → ignorer la locale active.
+- `NotificationPanel.vue:94` / `SystemAlertsOverlay.vue:151` : filtre `$subscribe` sur `mutation.events` — les mutations directes Pinia émettent `events: null` → les listeners realtime ne se déclenchent jamais.
+- Pas de sélecteur de langue ; dictionnaires ar/tr/en (55k clés) morts ; vues en français codé en dur.
+
+**Test indépendant** : titres d'onglets traduits ; `rg "RevenueForecastWidget|BackupManagement"` → aucune référence morte ou composants supprimés ; erreurs API → toasts ; `money()` suit la locale ; delete user → endpoint de désactivation.
+
+**Acceptance Scenarios**:
+1. **Given** le cockpit, **When** on navigue, **Then** l'onglet affiche un titre traduit.
+2. **Given** une erreur API sur Export/Growth/SocialContributions, **When** elle survient, **Then** un feedback utilisateur s'affiche (jamais `alert()` ni silence).
+3. **Given** la suppression d'un utilisateur, **When** on clique, **Then** l'intention destructive est explicite ou l'appel passe par `/platform/users/{id}/deactivate`.
+
+## Edge Cases
+
+- Impersonation : garder le motif obligatoire (≥5 chars), le token à usage unique, l'horodatage serveur — ne changer que le chemin.
+- Notifications : les routes tenant ne doivent jamais déclencher le wipe de session super-admin (même pattern `_skipAuthRedirect` que `pollNotifications`).
+- CSV : échapper les cellules commençant par `=`, `+`, `-`, `@` (injection de formule).
+- Suppression de composants morts : vérifier les imports avant suppression (`rg`).

--- a/.specify/features/qa-audit-expert-admin-2026-08-15/tasks.md
+++ b/.specify/features/qa-audit-expert-admin-2026-08-15/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Audit expert Admin — 2026-08-15
+
+**Input**: spec.md + plan.md
+
+**Prerequisites**: plan.md (required), spec.md (required)
+
+> Conversion en issues GitHub : label `qa-audit-2026-08-15`, méthode Spec Kit taskstoissues.
+> **Sessions précédentes (canoniques, à ne pas dupliquer)** : série web/admin #2602-#2613 — edge-nodes page, quick-action links, script accents, i18n pages, lint/build, SITE_URL (#2607), robots (#2643), blog mort (#2609), EditUserModal (#2610), header search (#2611), composants orphelins (#2612), clés i18n users (#2613). Mes T032/T034/T042/T049 (doublons) fermés en faveur de #2624/#2610/#2611/#2612.
+
+## Phase 1 — P1 (US B1, B2, B3)
+
+- [x] T032 [P1] B1 Impersonation — **doublon fermé** : canonique #2624 (T011 backend : endpoints /admin/impersonations). (issue #2692)
+- [x] T033 [P1] B2 `SystemAlertsOverlay.vue:206-210` : retirer la simulation de maintenance (état « non disponible » honnête). (issue #2693)
+- [x] T034 [P1] B2 EditUserModal — **doublon fermé** : canonique #2610 (T009 web). (issue #2694)
+- [x] T035 [P1] B3 `LoginView.vue:207` : retirer les identifiants démo en dur. (issue #2695)
+- [x] T036 [P1] B2 `MiniGlobe.vue:51-73` : état vide honnête sans données socket (plus de points fictifs). (issue #2696)
+
+## Phase 2 — P2 (US B4, B5, B6)
+
+- [x] T037 [P2] B4 `UserTable.vue:135` : bouton Éditer mort → retirer (avec `showEditModal`/modales). (issue #2697)
+- [x] T038 [P2] B4 `UsersView.vue` : pagination réelle (`page`/`per_page` server-side). (issue #2698)
+- [x] T039 [P2] B4 `UsersView.vue:306-309` : filtre statut « En attente » mappé ou retiré. (issue #2699)
+- [x] T040 [P2] B4 `UsersView.vue:485` : export CSV — champs mappés (`createdAt`/`lastLoginAt`) + échappement anti-injection de formule. (issue #2700)
+- [x] T041 [P2] B4 `UsersView.vue:319-321` : mapping rôle/entreprise réels depuis le payload. (issue #2701)
+- [x] T042 [P2] B5 Header search — **doublon fermé** : canonique #2611 (T010 web). (issue #2702)
+- [x] T043 [P2] B5 `CommandPalette.vue` : filtrer par routes accessibles + corriger/retirer `/vehicles`. (issue #2703)
+- [x] T044 [P2] B5 `DashboardView.vue:154-160` : carte « intégrations partenaires » → cible réelle ou retrait. (issue #2704)
+- [x] T045 [P2] B6 `stores/realtime.js:330-357` : `_skipAuthRedirect` + avaler les 401 (pattern `pollNotifications`). (issue #2705)
+- [x] T046 [P2] B6 `MetricCard.vue`/`AnalyticsView.vue` : prop `trend` — valeurs numériques + slot libellé. (issue #2706)
+- [x] T047 [P2] B6 Notifications push : propager l'id serveur du payload socket (supprimer l'id synthétique). (issue #2707)
+
+## Phase 3 — P3 (US B7)
+
+- [x] T048 [P3] B7 Titres d'onglets : traduire `meta.title` (`marketing.oauth.nav_title`, `holidays.nav.title`) dans le garde. (issue #2708)
+- [x] T049 [P3] B7 Composants morts — **doublon fermé** : canonique #2612 (T011 web). (issue #2709)
+- [x] T050 [P3] B7 `ExportsView` : état de téléchargement réel + erreurs affichées (plus de `setTimeout` ni catch silencieux). (issue #2710)
+- [x] T051 [P3] B7 `GrowthDashboardView` : `alert()` → toast. (issue #2711)
+- [x] T052 [P3] B7 `SocialContributionsView.runSimulate` : try/catch + état de chargement. (issue #2712)
+- [ ] T053 [P3] B7 Sélecteur de langue + router les chaînes codées en dur via le catalogue i18n (défaut : sélecteur + échantillon des vues principales). (issue #2713)
+- [x] T054 [P3] B7 `UsersView.deleteUser` : `POST /platform/users/{id}/deactivate` (désactivation réelle) + confirmation explicite. (issue #2714)
+- [x] T055 [P3] B7 `money()` → locale active (`toIntlLocale`). (issue #2715)
+- [x] T056 [P3] B7 Real-time : watcher d'état (`watch(notifications[0])`) au lieu de `$subscribe(events)`. (issue #2716)
+
+## Convergence
+
+- [ ] T057 Mettre à jour `.specify/memory/project-state.md`, `CHANGELOG.md`, `AGENTS.md`, cocher les tâches après merge.

--- a/.specify/features/qa-audit-expert-api-2026-08-15/plan.md
+++ b/.specify/features/qa-audit-expert-api-2026-08-15/plan.md
@@ -1,0 +1,54 @@
+# Plan: Audit expert API — 2026-08-15
+
+**Input**: spec.md (US A1-A11) + Constitution + audit 2026-08-15 (routes, logiques, sécurité, i18n, config)
+
+## Architecture / Décisions techniques
+
+- **A1 Solde de congés — snapshot = source de vérité** : `AbsenceService::approve()` vérifie désormais `LeaveBalance` (snapshot, même source que `currentAvailableBalance`) avec `lockForUpdate` dans la transaction ; `LeaveBalanceLog` reste une piste d'audit (log `absence_approved` écrit après déduction). Le lookup de la balance est scopé `(employee_id, company_id, absence_type_id)` — jamais la dernière ligne globale (mélange de types/entreprises).
+- **A2 Webhook email-bounce — fail-closed** : ajouter `services.mail_bounce_webhook.secret` dans `config/services.php` + clé `MAIL_BOUNCE_WEBHOOK_SECRET` dans `.env.example` ; si non configuré → `403` + `Log::warning`. Ne jamais `== ''` bypass.
+- **A3 Stripe webhook** : seules les erreurs de signature → 400/401 ; toute exception de traitement → 500 (retry Stripe) ou enqueue.
+- **A4 Pointage** : `lockForUpdate` sur la recherche de session ouverte (check-in/check-out) dans la transaction + migration index unique partiel `(employee_id, date, session_number)` si table compatible.
+- **A5 leave-balances** : lire le paramètre de route `{employeeId}` (fallback query `employee_id` pour rétro-compat) → scope employé.
+- **A6 jours ouvrés** : réutiliser le calendrier entreprise (`PublicHolidayService`) pour `days_count`, ou documenter la convention par type d'absence (décision produit à confirmer — défaut : jours ouvrés).
+- **A7 payroll clipping** : `sumApprovedLeaveDays` clippe `days_count` sur `[period_start, period_end]`.
+- **A8 OpenAPI** : script de comparaison routes↔paths (parseur déjà existant dans l'audit) ; aligner les noms de paramètres sur les routes ; ajouter les opérations manquantes prioritaires (webhooks publics, trial, user, onboarding invitation) ; régénérer le SDK via `generate-openapi-sdk.mjs` si la garde l'exige.
+- **A9 verrous & transitions** : `create()` absence → transaction + `lockForUpdate` sur `LeaveBalance` ; `ExpenseClaim` → validation de transition (map états autorisés) ; `RequestTrialSignup` → rethrow / échec explicite si OTP ou CompanyRequest échoue (transaction).
+- **A10 1/10e** : `referenceGross12Months` compte `calculated` + `validated`.
+- **A11 hygiène** : retirer `temp_password` du JSON de verify ; labels via `lang/*` ; clamp `per_page` (1-100) ; clés ar/tr ; un seul verbe par action (PUT) ; précision complète overtime ; `NON_WORK_TYPES` étendu ; chunking `executeCalculateRun` ; log fail-open marketing ; `try/finally` kiosk search_path ; binding `current_company` middleware AI ; URLs env ; supprimer route dupliquée webhook test ; canonicaliser notifications (PATCH + POST mark-all-read, documenter).
+
+## Phases
+
+### Phase 1 — P1 bloquants (A1, A2)
+- `AbsenceService::approve()` + tests (`LeaveApprovalAfterCreditTest`, race, isolation).
+- Webhook email-bounce fail-closed + config + `.env.example` + tests.
+
+### Phase 2 — P2 données & contrat (A3-A10)
+- Stripe webhook 500, pointage lock, leave-balances scope, jours ouvrés, clipping paie, route dupliquée webhook test, notifications canonicales, OpenAPI (paths + param names), verrous absence/expense/trial, 1/10e calculated.
+
+### Phase 3 — P3 hygiène (A11)
+- temp_password, labels lang, per_page, clés ar/tr, verbes uniques, overtime, NON_WORK_TYPES, chunking, marketing secret, kiosk search_path, middleware AI, URLs env.
+
+## Fichiers touchés (référence)
+
+- `api/app/Modules/Planning/Infrastructure/Services/AbsenceService.php`
+- `api/app/Modules/Planning/Interfaces/Api/V1/LeavePolicyController.php`
+- `api/app/Modules/Notification/Interfaces/Api/V1/Controllers/EmailBounceWebhookController.php`
+- `api/app/Modules/Billing/Interfaces/Api/V1/StripeWebhookController.php`
+- `api/app/Modules/Attendance/Infrastructure/Services/AttendanceService.php` + migrations tenant
+- `api/app/Modules/Expense/Interfaces/Api/V1/Controllers/ExpenseClaimController.php`
+- `api/app/Modules/Payroll/Infrastructure/Services/PayrollCalculator.php`
+- `api/app/Modules/Billing/Application/Actions/{RequestTrialSignup,VerifyTrialSignup}.php`
+- `api/routes/modules/*.php`, `api/routes/api.php`
+- `api/openapi.yaml`, `api/config/services.php`, `.env.example`
+- `api/lang/{ar,tr,fr,en}/payroll.php`, `api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php`
+- `api/app/Modules/Marketing/Interfaces/Api/V1/Controllers/MarketingLeadController.php`
+- `api/app/Modules/Attendance/Interfaces/Api/V1/KioskController.php`
+- `api/routes/ai.php`, `api/config/cameras.php`, `api/config/demo.php`
+
+## Contraintes
+
+- Constitution §IV : PHPStan strict level 8 vert, Pint, tests avant/avec implémentation, isolation tenant testée sur tout endpoint sensible.
+- Constitution §II : toute requête tenant scopée `company_id` ; migrations tenant dans `database/migrations/tenant/`.
+- Constitution §VII : PR par issue avec `Closes #N`, CHANGELOG, branche supprimée après merge ; auto-assignation + marker branch avant de coder.
+- Rétro-compat : ne pas casser `/me/leave-balances`, `/notifications/read-all`, `{webhookEndpoint}` (alias si nécessaire).
+- Ne pas toucher aux branches/PR en cours des autres agents.

--- a/.specify/features/qa-audit-expert-api-2026-08-15/spec.md
+++ b/.specify/features/qa-audit-expert-api-2026-08-15/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Audit expert API — 2026-08-15
+
+**Feature Branch**: `qa-audit-expert-api-2026-08-15`
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Input**: Mission de test expert de la plateforme (session 2026-08-15) — audit du backend Laravel (`api/`) : routes vs contrôleurs vs OpenAPI, logiques métier, sécurité, i18n, cohérence config. Base : `main` (`8a57dbf8`).
+
+Méthode : constitution `.specify/constitution.md` (spec-first, isolation multi-tenant, PHPStan strict level 8, PR = issue avec `Closes #`), workflow Spec Kit `specify → plan → tasks → implement`, conversion des tâches en issues GitHub (`qa-audit-2026-08-15`).
+
+## User Stories & Testing
+
+### User Story A1 — Le cycle approbation de congé fonctionne avec des soldes crédités (Priority: P1)
+
+Aujourd'hui `AbsenceService::approve()` vérifie le solde sur la **chaîne de logs** (`LeaveBalanceLog`, dernier `balance_after`) alors que tous les chemins de **crédit** (`LeavePolicyController::credit()` → `LeaveBalance::increment('balance')`, accruals, carry-forward) n'écrivent **jamais** de log. Résultat : la **première** approbation d'un congé après n'importe quel crédit lève `INSUFFICIENT_LEAVE_BALANCE` (0.0 < days) — workflow RH de base cassé.
+
+**Pourquoi P1** : aucune approbation de congé payé ne peut aboutir après un crédit de solde manuel/automatique.
+
+**Test indépendant** : test Feature « crédit de solde puis approbation » → 200 et solde décrémenté ; la vérification utilise la même source que `currentAvailableBalance` (snapshot `LeaveBalance`) avec `lockForUpdate` dans la transaction ; les logs restent une piste d'audit.
+
+**Acceptance Scenarios**:
+1. **Given** un employé avec un solde crédité (via `POST /leave-balances/credit` ou job d'accrual), **When** un manager approuve une absence `deducts_leave`, **Then** l'approbation réussit (200), le solde est décrémenté, et un log d'audit `absence_approved` est écrit.
+2. **Given** un solde insuffisant, **When** on approuve, **Then** `422 INSUFFICIENT_LEAVE_BALANCE` est retourné (comportement conservé).
+3. **Given** deux approbations simultanées, **When** elles se chevauchent, **Then** aucune ne dépasse le solde (verrouillage `lockForUpdate`).
+4. **Given** une absence d'un type qui ne déduit pas, **When** on approuve, **Then** aucun contrôle de solde n'est appliqué (inchangé).
+
+### User Story A2 — Le webhook email-bounce est authentifié et fail-closed (Priority: P1)
+
+`POST /api/v1/webhooks/email-bounce` compare le secret à `config('services.mail_bounce_webhook.secret')` — clé **absente** de `config/services.php` et de `.env.example` → `$configuredSecret === ''` → le contrôle est **toujours contourné** : n'importe qui peut marquer un employé `email_bounced_at` (lookup email non scopé tenant) et injecter des `CommunicationEvents` factices.
+
+**Pourquoi P1** : sécurité — endpoint public non authentifié avec impact données RH.
+
+**Test indépendant** : envoi sans header secret → 403 ; avec mauvais secret → 403 ; avec bon secret → 200 ; `config/services.php` contient la clé et `.env.example` la variable.
+
+**Acceptance Scenarios**:
+1. **Given** la clé `MAIL_BOUNCE_WEBHOOK_SECRET` absente de l'environnement, **When** un POST arrive sur `/webhooks/email-bounce`, **Then** réponse `403` (fail-closed) + log warning explicite.
+2. **Given** la clé configurée, **When** un POST sans/mauvais secret, **Then** `403` ; avec le bon secret, **Then** traitement normal (200).
+3. **Given** une requête valide, **When** l'email appartient à un autre tenant, **Then** aucune modification cross-tenant.
+
+### User Story A3 — Les webhooks Stripe ne perdent plus d'événements en silence (Priority: P2)
+
+`StripeWebhookController` renvoie `200` sur toute erreur de **traitement** (« prevent Stripe from retrying ») : une erreur transitoire (DB, fournisseur) fait disparaître l'événement sans retry ni dead-letter.
+
+**Test indépendant** : test avec erreur simulée pendant le traitement → réponse 500 (Stripe retente) ; seule une signature invalide → 400/401.
+
+**Acceptance Scenarios**:
+1. **Given** un événement valide, **When** le traitement échoue (exception), **Then** réponse `500` pour déclencher le retry Stripe (ou enqueue vers une file de retry).
+2. **Given** une signature invalide, **When** le webhook reçoit le POST, **Then** `400/401` (inchangé).
+
+### User Story A4 — Le pointage est protégé contre les courses (race conditions) (Priority: P2)
+
+`AttendanceService::checkIn/checkOut` est en check-then-act sans transaction/verrou/contrainte unique : deux check-in parallèles créent deux sessions ouvertes ; deux check-out parallèles ferment la même session (last-write-wins, heures recalculées avec des `now()` différents).
+
+**Test indépendant** : test parallèle (deux requêtes simultanées) → une seule session ouverte ; index unique partiel `(employee_id, date, session_number)` ou `lockForUpdate` sur la session ouverte.
+
+**Acceptance Scenarios**:
+1. **Given** un employé sans session ouverte, **When** deux check-in arrivent en parallèle, **Then** une seule session est créée, l'autre reçoit un conflit (409/422).
+2. **Given** une session ouverte, **When** deux check-out arrivent en parallèle, **Then** une seule fermeture aboutit, l'autre reçoit un état clair.
+
+### User Story A5 — Le solde de congés est scopé à l'employé demandé (Priority: P2)
+
+`GET /employees/{employeeId}/leave-balances` **ignore le paramètre de route** `{employeeId}` : le contrôleur lit `$request->get('employee_id')` — un manager qui demande le solde d'un employé reçoit **tous** les soldes de l'entreprise (exposition cross-team, contrat cassé).
+
+**Test indépendant** : `GET /employees/42/leave-balances` → uniquement le solde de l'employé 42 ; l'ancien comportement (paramètre `employee_id` en query) est documenté/rétro-compatible.
+
+**Acceptance Scenarios**:
+1. **Given** un manager, **When** il appelle `/employees/{employeeId}/leave-balances`, **Then** seuls les soldes de cet employé sont retournés.
+2. **Given** un employé d'une autre équipe, **When** on demande son solde sans permission, **Then** `404/403` (pas d'exposition).
+
+### User Story A6 — Les jours de congé sont comptés selon la convention métier (Priority: P2)
+
+`days_count = diffInDays(start, end) + 1` compte les **jours calendaires** (week-ends, fériés) à la fois pour la déduction du solde et l'indemnité — un congé vendredi→lundi consomme 4 jours alors que l'employé ne travaille que 2.
+
+**Test indépendant** : test avec congé vendredi→lundi → `days_count` = jours ouvrés (calendrier entreprise) ; la convention est documentée par type d'absence.
+
+### User Story A7 — La paie ne compte pas deux fois un congé chevauchant deux périodes (Priority: P2)
+
+`PayrollCalculator::sumApprovedLeaveDays` additionne `days_count` **entier** de chaque absence approuvée chevauchant la période, sans clipping à `[period_start, period_end]` — une absence 25 janv. → 5 févr. est comptée en **totalité** dans les runs de janvier ET février (double déduction dans le prorata).
+
+**Test indépendant** : golden test — absence chevauchante → jours comptés uniquement sur l'intersection.
+
+### User Story A8 — Le contrat OpenAPI reflète les routes réelles (Priority: P2)
+
+`openapi.yaml` est ~26 % derrière le routeur : 134 groupes de chemins non documentés (webhooks publics, `/public/careers/*`, `/trial/*`, `/user/*`, `/onboarding/invitation/{token}`, departments, payrolls, reports, conversations, announcements, marketing/posts) et des **noms de paramètres divergents** (`{webhook}` vs `{webhookEndpoint}`, `{loan}` vs `{loanId}`, `{session}` vs `{sessionId}`, `{employee}` vs `{employeeId}`, `{jobPosting}` vs `{id}`) qui cassent les clients générés.
+
+**Test indépendant** : `check-openapi-coverage.sh` / parseur route↔OpenAPI → écart documenté en-deçà d'un seuil ; les noms de paramètres alignés sur les routes.
+
+### User Story A9 — Les transitions de statut et les verrous protègent les données (Priority: P2)
+
+- `AbsenceService::create()` : garde de solde en check-then-insert sans verrou → deux requêtes simultanées dépassent le solde.
+- `ExpenseClaimController::approve()/reject()` : aucun contrôle de transition — un brouillon peut être approuvé, une demande approuvée peut être rejetée.
+- `RequestTrialSignup` : `catch(Throwable)` avale les échecs d'envoi d'OTP et de création de `CompanyRequest` → l'utilisateur reçoit un OTP sans demande en attente (verify échoue ensuite) ou l'entreprise est créée deux fois.
+
+**Test indépendant** : tests de concurrence (2 requêtes simultanées), tests de transitions (chaque état → états autorisés), test d'échec simulé d'envoi OTP → échec du signup (pas de demi-état).
+
+### User Story A10 — Indemnité 1/10e paie : les bulletins « calculés » comptent (Priority: P2)
+
+`referenceGross12Months` ne somme que les bulletins `status='validated'` alors que `calculateRun` crée des bulletins `'calculated'` — une entreprise qui ne valide jamais retombe en silence sur base×12 pour l'indemnité de congés.
+
+**Test indépendant** : run avec bulletins `calculated` → indemnité 1/10e calculée sur la somme réelle.
+
+### User Story A11 — Hygiène API : pas de fuite, pas de labels codés, des listes bornées (Priority: P3)
+
+- `VerifyTrialSignup` renvoie le `temp_password` du manager dans le JSON (fuite potentielle via logs/proxy) → lien/token de reset à la place.
+- Labels `work_state_label` codés en français (« Hors ligne », « En conge », « Absent ») dans `EmployeeController` → fichiers `lang/*.php`.
+- `per_page` non borné sur leave-balances/accruals/payroll/expense → clamp min/max.
+- `lang/ar/payroll.php` et `lang/tr/payroll.php` : 2 clés manquantes (`public_holidays_admin_only`, `public_holidays_company_only`).
+- Routes `approve/reject/submit` enregistrées en PUT **et** POST → garder un seul verbe.
+- `computeOvertimePay` arrondit le taux horaire à 2 décimales AVANT les multiplicateurs 1.25/1.5 (sous-paiement systématique) → précision complète jusqu'à l'arrondi final.
+- `NON_WORK_TYPES` ne contient que `'break'` → une session fermée en `leave`/`holiday` compte dans `hours_worked`/heures sup.
+- `executeCalculateRun` : ~5 requêtes par employé dans une transaction sans chunking → chunker/batch.
+- `MarketingLeadController` : secret partagé fail-open si non configuré → loguer bruyamment au minimum.
+- `KioskController::resolveAuthorizedKiosk` : `SET search_path TO shared_tenants,public` sans reset (`try/finally` manquant) → fuite d'état de connexion.
+- Routes `/ai/*` : middleware `AITenantInjector` (attribute) remplace le middleware tenant → lier `current_company`.
+- URLs de prod codées en dur (`wss://proxy.leopardo-rh.com` dans `config/cameras.php`, `admin@leopardo-rh.com` dans `config/demo.php`) → env uniquement.
+- `POST /webhooks/{webhookEndpoint}/test` enregistré **deux fois** (ombre) → supprimer le doublon.
+- Routes de notifications dupliquées (`PUT /notifications/read-all` vs `POST /notifications/mark-all-read`, `PUT .../read` vs `PATCH .../read`) → canonicaliser (une paire).
+
+## Edge Cases
+
+- Solde crédité par plusieurs chemins (credit manuel, accrual mensuel, carry-forward annuel) sans logs → la source de vérité du solde courant est `LeaveBalance.balance`.
+- Webhook email-bounce : secret absent en local → 403 fail-closed + warning ; ne jamais casser la CI par manque de clé (tester avec clé factice).
+- `leave-balances` : rétro-compat du paramètre `employee_id` en query si des clients l'utilisent.
+- Webhook Stripe : les erreurs de signature doivent rester 400/401 (Stripe n'attend pas de retry) — seules les erreurs de traitement passent en 500.
+- Paramètres OpenAPI : ne renommer que côté spec (aligner sur les routes), vérifier la génération SDK (`generate-openapi-sdk.mjs`).

--- a/.specify/features/qa-audit-expert-api-2026-08-15/tasks.md
+++ b/.specify/features/qa-audit-expert-api-2026-08-15/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Audit expert API — 2026-08-15
+
+**Input**: spec.md + plan.md
+
+**Prerequisites**: plan.md (required), spec.md (required)
+
+> Conversion en issues GitHub : label `qa-audit-2026-08-15`, méthode Spec Kit taskstoissues.
+> **Sessions précédentes (canoniques, à ne pas dupliquer)** : série backend #2614-#2626 (T001-T013) — Stripe signature fail-closed, Chargily, email-bounce, register invitation-only, suspended login, OAuth Google state, magic link, trial/status limiter, growth/partner middleware, calendar OAuth scope, impersonation /admin, webhook test doublon, forgot-password. Mes tâches T006/T012 (doublons) ont été fermées en faveur de #2616/#2625.
+
+## Phase 1 — P1 bloquants (US A1, A2)
+
+- [x] T005 [P1] A1 `AbsenceService::approve()` : vérifier/déduire sur `LeaveBalance` (snapshot, `lockForUpdate`, scopé employee+company+absence_type) au lieu de la chaîne `LeaveBalanceLog` ; log d'audit conservé. Tests : crédit→approbation OK, solde insuffisant 422, race, isolation tenant. (issue #2666)
+- [x] T006 [P1] A2 Webhook email-bounce fail-closed — **doublon fermé** : canonique #2616 (T003 backend). (issue #2667)
+
+## Phase 2 — P2 données & contrat (US A3-A10)
+
+- [x] T007 [P2] A3 `StripeWebhookController` : erreurs de traitement → 500 (retry Stripe) ; signature seule → 400/401. Test erreur simulée. (issue #2668)
+- [x] T008 [P2] A4 Pointage : `lockForUpdate` session ouverte + index unique partiel `(employee_id, date, session_number)`. Tests parallèles check-in/check-out. (issue #2669)
+- [x] T009 [P2] A5 `GET /employees/{employeeId}/leave-balances` : utiliser le paramètre de route (fallback query rétro-compat). Test scope employé + 404 cross-équipe. (issue #2670)
+- [ ] T010 [P2] A6 `days_count` : convention jours ouvrés (calendrier entreprise) ou convention documentée par type. Tests vendredi→lundi. (issue #2671)
+- [x] T011 [P2] A7 `PayrollCalculator::sumApprovedLeaveDays` : clipping sur `[period_start, period_end]`. Golden test absence chevauchante. (issue #2672)
+- [x] T012 [P2] A8 Route webhook test dupliquée — **doublon fermé** : canonique #2625 (T012 backend). (issue #2673)
+- [x] T013 [P2] A8 Notifications : canonicaliser les verbes (une paire PATCH `{id}/read` + POST `mark-all-read`), documenter. (issue #2674)
+- [ ] T014 [P2] A8 OpenAPI : aligner noms de paramètres (webhookEndpoint, loanId, sessionId, employee, id) + documenter les groupes manquants prioritaires. (issue #2675)
+- [x] T015 [P2] A9 `AbsenceService::create()` : garde de solde en transaction avec `lockForUpdate`. Test concurrence. (issue #2676)
+- [x] T016 [P2] A9 `ExpenseClaim` : validation des transitions de statut. Tests draft→approved interdit, approved→rejected interdit. (issue #2677)
+- [x] T017 [P2] A9 `RequestTrialSignup` : échec OTP/CompanyRequest → échec explicite (rethrow/transaction). Tests. (issue #2678)
+- [x] T018 [P2] A10 `referenceGross12Months` : compter `calculated` + `validated`. Golden test indemnité 1/10e. (issue #2679)
+
+## Phase 3 — P3 hygiène (US A11)
+
+- [ ] T019 [P3] A11 `VerifyTrialSignup` : ne plus renvoyer `temp_password` (lien/token de reset). (issue #2680)
+- [x] T020 [P3] A11 Labels `work_state_label` → `lang/*.php` (EmployeeController). (issue #2681)
+- [x] T021 [P3] A11 Clamp `per_page` (1-100) sur leave-balances/accruals/payroll/expense. (issue #2682)
+- [x] T022 [P3] A11 `lang/ar|tr/payroll.php` : ajouter les 2 clés manquantes. (issue #2683)
+- [x] T023 [P3] A11 Un seul verbe par action approve/reject/submit (PUT). (issue #2684)
+- [x] T024 [P3] A11 `computeOvertimePay` : pas d'arrondi avant multiplicateur (précision finale seule). Golden test. (issue #2685)
+- [x] T025 [P3] A11 `NON_WORK_TYPES` étendu (`leave`, `holiday`, …) pour `hours_worked`/overtime. (issue #2686)
+- [ ] T026 [P3] A11 `executeCalculateRun` : chunk/batch des agrégats (N+1). (issue #2687)
+- [x] T027 [P3] A11 `MarketingLeadController` : log bruyant si secret non configuré (fail-open documenté). (issue #2688)
+- [x] T028 [P3] A11 `KioskController` : `search_path` dans `try/finally` (reset). (issue #2689)
+- [x] T029 [P3] A11 Middleware `/ai/*` : lier `current_company` (pas seulement l'attribut). (issue #2690)
+- [x] T030 [P3] A11 URLs prod codées en dur (`config/cameras.php` wss, `config/demo.php` admin@) → env. (issue #2691)
+
+## Convergence
+
+- [ ] T031 Mettre à jour `.specify/memory/project-state.md`, `CHANGELOG.md`, `AGENTS.md` (leçons QA), cocher les tâches après merge.

--- a/.specify/features/qa-audit-expert-mobile-2026-08-15/plan.md
+++ b/.specify/features/qa-audit-expert-mobile-2026-08-15/plan.md
@@ -1,0 +1,48 @@
+# Plan: Audit expert Mobile — 2026-08-15
+
+**Input**: spec.md (US M1-M9 + T001-T004) + Constitution + audit 2026-08-15
+
+## Architecture / Décisions techniques
+
+- **M1 Onboarding** : changement **mobile d'abord** (le backend PATCH + `step_key` est l'API canonique) :
+  - `OnboardingStep` (leopardo_core) : ajouter `stepKey` (parse de `step_key`).
+  - `OnboardingRepository` (employee/manager/hr) : `PATCH /onboarding-setup/{stepKey}/complete|skip`.
+  - Corriger le test de contrat `leopardo_hr/test/repositories/repository_contract_test.dart` (PATCH + step_key).
+- **M2 Cabinet manager** : renommer la route manager en `/cabinet/folder/:folderId` (alignement employee/HR) — `app.dart:179` inchangé.
+- **M3 Session** : `checkAuth()` ne supprime le token que sur 401 ; brancher `onUnauthorized` → `authProvider.logout()` dans les 3 apps (`apiClientProvider`).
+- **M4 Double auth** : clés SecureStorage distinctes (`auth_token_employee` / `auth_token_user`) avec migration de lecture (ancienne clé en fallback).
+- **M5 i18n/mojibake** : ré-encoder les fichiers concernés en UTF-8 ; router les chaînes dures via `context.l10n` (échantillon prioritaire : attendance, welcome, onboarding, payroll, expenses, evaluations) ; labels mixtes → clés.
+- **M6 Monnaie** : dériver la devise du payload (`employee.currency`, summary) avec fallback pays du tenant ; `NumberFormat.currency(locale, symbol)` partout ; `detail_schema`/`list_schema` acceptent devise/locale en paramètre.
+- **M7 Idempotence & erreurs** : `maxRetriesOverride: 0` sur `POST /salary-advances` (et l'appel IA) ; interprétation du 403 selon payload (`suspended`) ; offline detection standardisée (types DioException dans le core, partagée par employee/manager).
+- **M8 Android** : `android:foregroundServiceType="location"` + permission `FOREGROUND_SERVICE_LOCATION` (employee) ; `usesCleartextTraffic` dans le manifest **debug** seulement ; `Locale` de platform_admin résolue depuis préférences (comme les autres apps).
+- **M9 Hygiène** : supprimer l'écran mort `company_request_screen` ; `String.fromEnvironment` pour le client ID Google + masquer le bouton démo en release ; `tracesSampleRate: 0.2` + exclusions PII ; `tryParse` pour `requested_check_in` ; retirer les méthodes mortes (ou les router via `/me/*`) ; finir ou retirer le stub marketing (T002).
+
+## Phases
+
+### Phase 1 — P1 (M1, M2 + T001-T004)
+- Onboarding PATCH + step_key (3 apps + contrat) ; route cabinet manager ; T001 (départements hierarchy), T003 (expense catch), T004 (AI voice).
+
+### Phase 2 — P2 (M3-M8)
+- Session (token 401-only + onUnauthorized), double auth (clés), mojibake + i18n, monnaie/formatage, idempotence/403/offline, Android manifest + locale platform_admin.
+
+### Phase 3 — P3 (M9)
+- Écran mort, client ID/creds, Sentry sampling, tryParse, méthodes mortes, T002 (stats marketing réelles).
+
+## Fichiers touchés (référence)
+
+- `front/mobile_apps/leopardo_core/lib/models/onboarding_step.dart`, `core/api/api_client.dart`, `core/storage/secure_storage.dart`, `core/models/{detail_schema,list_schema}.dart`
+- `front/mobile_apps/leopardo_{employee,manager,hr}/lib/features/onboarding/data/onboarding_repository.dart`
+- `front/mobile_apps/leopardo_hr/test/repositories/repository_contract_test.dart`
+- `front/mobile_apps/leopardo_manager/lib/app.dart` (+ routeurs cabinet des 3 apps)
+- `front/mobile_apps/leopardo_employee/lib/features/auth/data/auth_repository.dart`, `user_auth/data/user_auth_repository.dart`
+- `front/mobile_apps/leopardo_{employee,manager,hr}/lib/features/{evaluations,expenses,personal_space,smart_attendance,attendance,payrolls,salary_advances,welcome,onboarding}/**`
+- `front/mobile_apps/leopardo_employee/android/app/src/{main,debug}/AndroidManifest.xml`
+- `front/mobile_apps/leopardo_platform_admin/lib/src/platform_admin_app.dart`
+- `front/mobile_apps/leopardo_marketing/lib/features/marketing/screens/stats_dashboard_screen.dart`
+
+## Contraintes
+
+- `leopardo_core` : toute modification partagée va dans le core (règle README mobile).
+- Garder les garde-fous CI : `validate-mobile-apps-split.ps1`, `validate-mobile-workflow-contracts.ps1`, `check-mobile-manifest-routes.sh` verts.
+- Pas de Dart SDK dans l'environnement de test → vérification par lecture + contrats ; `flutter analyze` à passer en CI.
+- Rétro-compat : ne pas casser `/me/trainings`, `getChecklist()`, la lecture des anciens tokens (fallback).

--- a/.specify/features/qa-audit-expert-mobile-2026-08-15/spec.md
+++ b/.specify/features/qa-audit-expert-mobile-2026-08-15/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Audit expert Mobile — 2026-08-15
+
+**Feature Branch**: `qa-audit-expert-mobile-2026-08-15`
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Input**: Mission de test expert de la plateforme (session 2026-08-15) — audit des applications mobiles Flutter (`front/mobile_apps` : leopardo_core, employee, manager, hr, platform_admin, marketing) : endpoints, onboarding, authentification, i18n, logique, config plateforme. Base : `main` (`8a57dbf8`). Suite de l'audit expert mobile initié dans la même session (issues #2594-#2597, T001-T004).
+
+## User Stories & Testing
+
+### User Story M1 — L'onboarding mobile complète réellement les étapes (Priority: P1)
+
+Les boutons « Terminer »/« Passer » des apps employee/manager/hr appellent `POST /onboarding-setup/{idNumérique}/complete|skip` — le backend n'enregistre que `PATCH /onboarding-setup/{stepKey}/complete|skip` (route par `step_key` **chaîne** : `company_info`, `first_department`, …) → **405** (verbe) et **404** (id vs clé). Le test de contrat `leopardo_hr/test/repositories/repository_contract_test.dart:181-182` codifie même le mauvais POST.
+
+**Pourquoi P1** : le parcours d'onboarding employeur (étapes obligatoires) ne peut jamais se terminer depuis le mobile.
+
+**Test indépendant** : `flutter test` des repos + smoke : `PATCH /onboarding-setup/company_info/complete` → 200 ; vérification du contrat `validate-mobile-workflow-contracts.ps1`.
+
+**Acceptance Scenarios**:
+1. **Given** un employeur sur l'écran d'onboarding, **When** il termine une étape, **Then** la requête est `PATCH /onboarding-setup/{step.key}/complete` et la progression augmente.
+2. **Given** le modèle `OnboardingStep`, **When** il parse le checklist, **Then** il expose `stepKey` (champ serveur `step_key`) en plus de l'id.
+3. **Given** le test de contrat, **When** il s'exécute, **Then** il valide le PATCH (pas le POST).
+
+### User Story M2 — La navigation cabinet fonctionne dans l'app Manager (Priority: P1)
+
+`leopardo_manager/lib/app.dart:179` pousse `'/cabinet/folder/${folder.id}'` mais le routeur manager ne déclare que `'/cabinet/:folderId'` (un seul segment) — les apps employee/HR utilisent correctement `/cabinet/folder/:folderId` → **GoRouter no-match**, l'exploration des dossiers du cabinet est morte dans l'app Manager.
+
+**Test indépendant** : `check-mobile-manifest-routes.sh` + test de navigation (pousser `/cabinet/folder/1` → route trouvée).
+
+**Acceptance Scenarios**:
+1. **Given** l'app Manager, **When** on tape un dossier du cabinet, **Then** le routeur résout `/cabinet/folder/:folderId` (fini le no-match).
+2. **Given** les 3 apps, **When** on compare les routeurs, **Then** le même pattern de route cabinet est utilisé partout.
+
+### User Story M3 — La session mobile survit aux pannes réseau (Priority: P2)
+
+`checkAuth()` (`auth_repository.dart:142,165`) **supprime le token à la moindre erreur**, y compris timeout/réseau : lancer l'app hors-ligne détruit la session et renvoie au `/welcome` — ce qui casse le pointage hors-ligne (#1290) qui exige un état authentifié. Par ailleurs l'intercepteur 401 (`api_client.dart:44-52`) appelle `onUnauthorized` mais **aucune app ne le branche** → après révocation de session, l'app reste dans un état « authentifié » où toutes les requêtes échouent.
+
+**Test indépendant** : lancement hors-ligne → le token est conservé ; révocation serveur → l'app se déconnecte (pas d'UI fantôme).
+
+**Acceptance Scenarios**:
+1. **Given** un téléphone hors-ligne, **When** on ouvre l'app, **Then** le token est conservé et l'utilisateur reste connecté (mode hors-ligne).
+2. **Given** une session révoquée (mot de passe changé), **When** une requête répond 401, **Then** l'app déconnecte proprement (logout local).
+
+### User Story M4 — Un seul système d'authentification, sans écrasement (Priority: P2)
+
+Deux flux d'auth (employé sanctum + `auth:user_api` régulier) partagent la **même clé** `auth_token` dans SecureStorage → se connecter via `/user-login` écrase silencieusement la session employé (et vice-versa) ; un token utilisateur périmé fait échouer `/auth/me` et peut tout effacer.
+
+**Test indépendant** : connexion user puis employee → les deux sessions coexistent (clés distinctes) ou un flux unique est documenté.
+
+**Acceptance Scenarios**:
+1. **Given** un utilisateur connecté via `/user-login`, **When** il se connecte aussi en employé, **Then** les deux jetons sont stockés séparément (ou le flux user est explicitement séparé).
+
+### User Story M5 — Les textes affichés sont encodés et localisés (Priority: P2)
+
+- Chaînes **mojibake** rendues littéralement : « Aucune Ã©valuation », « PÃ©riode: », « Sessions rÃ©centes », « â€” » (evaluations, expenses, personal_space, smart_attendance + copies manager/hr).
+- ~1 300 chaînes françaises codées en dur dans employee/manager/hr qui contournent le système ARB 4-locales (les écrans AR/TU/EN affichent du français).
+- Labels mixtes dans un même écran (« Employe », « min », « Francais » vs « Français »).
+
+**Test indépendant** : `rg` des motifs mojibake (`Ã©`, `â€™`, `â€”`) → 0 dans `lib/` ; échantillon d'écrans via `context.l10n`.
+
+**Acceptance Scenarios**:
+1. **Given** l'app employé, **When** on ouvre Évaluations, **Then** « Aucune évaluation » s'affiche correctement (UTF-8).
+2. **Given** une locale AR/TU/EN, **When** on navigue, **Then** les libellés suivent la locale (pas de français codé en dur).
+
+### User Story M6 — La monnaie et les nombres suivent le tenant (Priority: P2)
+
+Fallback `'DZD'` codé en dur (`attendance_screen.dart:142,148,608`, `salary_advance_list_screen.dart:401`, manager `team_screen.dart:307,790`) : une entreprise FR/MA/SN (multi-pays activé côté backend) voit des DZD. Formatage `toStringAsFixed` sans séparateurs ni locale (`payroll_list_screen.dart:184,561`) ; `detail_schema.dart:208`/`list_schema.dart:167` codent `€` + « Oui »/« Non ».
+
+**Test indépendant** : payload `employee.currency`/summary → symbole correct ; formatage `NumberFormat.currency(locale)`.
+
+**Acceptance Scenarios**:
+1. **Given** une entreprise marocaine, **When** on affiche une avance, **Then** le symbole est MAD (dérivé du payload tenant).
+2. **Given** un montant 1234567.89, **When** on l'affiche, **Then** il est formaté selon la locale (séparateurs inclus).
+
+### User Story M7 — Pas de doublons ni de fausses alertes (Priority: P2)
+
+- `POST /salary-advances` hérite de 2 retries automatiques (timeout/502/503/504) → une requête réussie côté serveur mais timeout côté client crée une **demande d'avance en double** (la copie manager est correctement à 0 ; `ai_chat_repository` hérite aussi des retries pour un appel IA payant).
+- Tout 403 → « Compte suspendu - contactez votre employeur » (mauvais diagnostic pour un simple défaut de permission) et le token est conservé → utilisateur bloqué dans une impasse.
+- Détection hors-ligne incohérente : le repo manager ne matche que les messages contenant 'connexion'/'internet' alors que le repo employé teste les types `DioException` → le même pointage hors-ligne est mis en file dans une app et pas dans l'autre.
+
+**Test indépendant** : `maxRetriesOverride: 0` sur les POST non idempotents ; payload 403 → message différencié ; test offline manager avec timeout Dio.
+
+**Acceptance Scenarios**:
+1. **Given** une avance soumise avec timeout, **When** la requête a réussi côté serveur, **Then** aucune seconde demande n'est créée.
+2. **Given** un 403 pour permission manquante, **When** l'utilisateur agit, **Then** le message explique le défaut de permission (pas « compte suspendu »).
+
+### User Story M8 — La config plateforme Android est correcte (Priority: P2)
+
+`AndroidManifest.xml` (employee) déclare `FOREGROUND_SERVICE` sans `android:foregroundServiceType` ni `FOREGROUND_SERVICE_LOCATION` → crash Android 14+ pour le service de localisation smart-attendance ; le manifest **debug** n'autorise pas `cleartextTraffic` → l'URL de dev documentée `http://10.0.2.2:8000` échoue sur Android 9+. L'app platform_admin force `Locale('fr')` (locale utilisateur ignorée).
+
+**Test indépendant** : `aapt dump` du manifest (ou lecture) — service type présent ; `Locale` résolu depuis les préférences.
+
+**Acceptance Scenarios**:
+1. **Given** Android 14, **When** le service de localisation démarre, **Then** aucun crash (type déclaré).
+2. **Given** un build debug, **When** on pointe vers `http://10.0.2.2:8000`, **Then** le trafic clair est autorisé (debug uniquement).
+
+### User Story M9 — Hygiène mobile (Priority: P3)
+
+- `company_request_screen.dart:59-76` (écran mort) : poste `/company-requests` sans le champ `email` requis par le backend → 422 systématique s'il était branché.
+- `main.dart:59` : Google web client ID codé en dur (non configurable par environnement) + identifiants démo `admin@leopardo-rh.com/password123` embarqués (bouton no-op en release).
+- `main.dart:26` : `tracesSampleRate = 1.0` Sentry → 100 % des traces (PII potentielle) → 0.1-0.3 + scrub.
+- `attendance_repository.dart:552,554` : `DateTime.parse(...)` sans garde null → crash sur données malformées.
+- Méthodes mortes : `getMyPayrolls()` → `/payrolls` (manager-scope, inutilisé), `getDailySummary(employeeId)` jamais appelées — risque de dérive de contrat.
+- `leopardo_marketing/stats_dashboard_screen.dart` : écran `/stats` = TODO stub avec données placeholder (déjà T002).
+- `detail_schema.dart`/`list_schema.dart` : €/français codés en dur (code mort via Feature schema).
+
+**Test indépendant** : `rg` des références mortes ; lecture manifest/main.dart.
+
+**Acceptance Scenarios**:
+1. **Given** la release, **When** on inspecte le bundle, **Then** aucun identifiant démo ni client ID d'environnement dev.
+2. **Given** un événement Sentry, **When** il est envoyé, **Then** l'échantillonnage est borné et les PII exclusions actives.
+
+## Edge Cases
+
+- Onboarding : garder `GET /onboarding-setup/checklist` intact ; le modèle doit supporter id + step_key (champ additif).
+- Cabinet : la route manager doit accepter `:folderId` quel que soit le type (string ou int).
+- Offline : ne supprimer le token que sur 401 explicite ; les autres erreurs → « mode hors-ligne ».
+- 403 : si le payload contient `suspended: true`, garder le message de suspension ; sinon permission.
+- Android 14 : `FOREGROUND_SERVICE_LOCATION` + type `location` — ne pas autoriser le cleartext en release.

--- a/.specify/features/qa-audit-expert-mobile-2026-08-15/tasks.md
+++ b/.specify/features/qa-audit-expert-mobile-2026-08-15/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Audit expert Mobile — 2026-08-15
+
+**Input**: spec.md + plan.md
+
+**Prerequisites**: plan.md (required), spec.md (required)
+
+> Conversion en issues GitHub : label `qa-audit-2026-08-15`, méthode Spec Kit taskstoissues.
+> **Sessions précédentes (canoniques, à ne pas dupliquer)** : série mobile #2594-#2601 (T001 departments hierarchy, T002 stats marketing, T003 expense catch, T004 AI voice, T005 base URLs onrender, T006 password123 core, T007 offline drift, T008 hr/manager dedup) + #2631 onboarding PATCH (PR #2663 en cours). Mon T079 (doublon) fermé en faveur de #2631.
+
+## Tâches des sessions précédentes (issues #2594-#2601, #2631)
+
+- [ ] T001 [P3] `GET /departments/{department}/hierarchy` (issue #2594)
+- [ ] T002 [P3] Stats marketing réelles (issue #2595)
+- [ ] T003 [P3] Expense submit catch (issue #2596)
+- [ ] T004 [P3] AI Voice placeholders (issue #2597)
+- [ ] T005 [P3] URLs de base onrender (issue #2598)
+- [ ] T006 [P3] password123 démo core (issue #2599)
+- [ ] T007 [P3] Offline drift (issue #2600)
+- [ ] T008 [P3] Dé-duplication hr/manager (issue #2601)
+- [ ] T009 [P1] Onboarding PATCH + stepKey (issue #2631 — PR #2663 en cours)
+
+## Phase 1 — P1 (US M2)
+
+- [x] T079 [P1] M1 Onboarding — **doublon fermé** : canonique #2631 (PR #2663 en cours). (issue #2734)
+- [x] T080 [P1] M2 Cabinet manager : route `/cabinet/folder/:folderId` (alignement employee/HR) — fini le no-match GoRouter. (issue #2735)
+
+## Phase 2 — P2 (US M3-M8)
+
+- [x] T081 [P2] M3 `checkAuth()` : ne supprimer le token que sur 401 (les erreurs réseau conservent la session). (issue #2736)
+- [x] T082 [P2] M3 Brancher `onUnauthorized` → logout local dans les 3 apps (fini l'UI authentifiée fantôme). (issue #2737)
+- [x] T083 [P2] M5 Ré-encoder les fichiers mojibake (evaluations, expenses, personal_space, smart_attendance + copies manager/hr). (issue #2738)
+- [x] T084 [P2] M4 Double auth : clés SecureStorage distinctes (`auth_token_employee`/`auth_token_user`) + migration lecture. (issue #2739)
+- [ ] T085 [P2] M5 i18n : router les chaînes codées en dur via `context.l10n` (échantillon prioritaire des écrans principaux). (issue #2740)
+- [ ] T086 [P2] M6 Devise : dériver du payload tenant (fini `DZD` codé en dur) + `NumberFormat.currency(locale)`. (issue #2741)
+- [x] T087 [P2] M7 `POST /salary-advances` + appel IA : `maxRetriesOverride: 0` (fini les doublons). (issue #2742)
+- [x] T088 [P2] M7 403 : différencier `suspended` (payload) du défaut de permission ; message correct. (issue #2743)
+- [ ] T089 [P2] M6/M7 Formatage nombres + `detail_schema`/`list_schema` (devise/locale en paramètre, fini €/Oui/Non). (issue #2744)
+- [ ] T090 [P2] M7 Offline manager : même détection que l'app employé (types DioException). (issue #2745)
+- [x] T091 [P2] M8 `Locale` platform_admin résolue depuis les préférences (fini `Locale('fr')` codé). (issue #2761)
+- [x] T092 [P2] M8 Android : `foregroundServiceType="location"` + `FOREGROUND_SERVICE_LOCATION` (employee) ; `cleartextTraffic` debug seulement. (issue #2762)
+
+## Phase 3 — P3 (US M9)
+
+- [x] T093 [P3] M9 Supprimer `company_request_screen.dart` (écran mort, 422 garanti). (issue #2763)
+- [ ] T094 [P3] M9 `detail_schema`/`list_schema` : devise/locale en paramètre (code mort €). (issue #2764)
+- [ ] T095 [P3] M9 `main.dart` : Google client ID via `String.fromEnvironment` + masquer le bouton démo en release. (issue #2765)
+- [x] T096 [P3] M9 Sentry : `tracesSampleRate` borné (0.2) + exclusions PII. (issue #2766)
+- [x] T097 [P3] M9 `DateTime.parse(requested_check_in)` → `tryParse` null-safe. (issue #2767)
+- [x] T098 [P3] M9 Méthodes mortes payroll/`getDailySummary` : retirer ou router via `/me/*`. (issue #2769)
+
+## Convergence
+
+- [ ] T099 Mettre à jour `.specify/memory/project-state.md`, `CHANGELOG.md`, `AGENTS.md`, cocher les tâches après merge.

--- a/.specify/features/qa-audit-expert-web-2026-08-15/plan.md
+++ b/.specify/features/qa-audit-expert-web-2026-08-15/plan.md
@@ -1,0 +1,43 @@
+# Plan: Audit expert Web & Vitrine — 2026-08-15
+
+**Input**: spec.md (US C1-C6) + Constitution + audit 2026-08-15
+
+## Architecture / Décisions techniques
+
+- **C1 Checkout honnête** : quand `STRIPE_SECRET_KEY` est absent ou `sk_test_` → le tunnel **payant** affiche un état « paiement non disponible » explicite (pas de formulaire carte, pas de succès simulé, pas de promesse d'email) ; le plan **gratuit** reste fonctionnel avec le parcours OTP complet (`requestedWorkflow=guided_trial`). Quand une clé **live** est configurée → Stripe Checkout réel (session serveur + redirect), le formulaire carte local est retiré (Stripe.js gère le paiement). Le endpoint `/api/billing/checkout` ne renvoie plus jamais de « succès » sandbox.
+- **C2 Identité & données** : un résolveur `siteUrl` unique (`src/lib/site-url.ts`) utilisé par layout/sitemap/robots/seo (fallback prod sûr) ; canonical blog depuis `siteUrl` ; `lang`/`dir` calculés par requête (cookie/header) dans le root layout ; stat « Live: 18 » retiré ou branché sur un endpoint réel ; témoignages marqués démo (`noindex` + bandeau) ou retirés ; `generateProductSchema` sans rating fabriqué.
+- **C3 SEO/PWA** : `ogImage` → route générée `/opengraph-image` (ou ajouter `public/og/*.png` générés) ; `sw.js` : précache = `/`, `/offline` + routes réelles uniquement ; manifest : 30 jours + icône `icon.svg`/existant ; suppression de la route orpheline `/api/robots` (ou pointe sur `/sitemap.xml`).
+- **C4 OAuth** : `googleAuthHref()` du checkout → même proxy same-origin que login (`/api/v1/auth/google`).
+- **C5 i18n** : `SignupForm`, checkout, logout, bannière login, carrières → catalogue i18n (copies existantes par locale) ; le POST d'inscription envoie la locale réelle ; relecture des chaînes arabes.
+- **C6 Fallbacks** : section démo du login rendue uniquement si `/demo-users` répond des utilisateurs ; blog : retirer/rafraîchir les posts 2023-24 ; `vercel.json` : redirect mort supprimé, CSP gardé à un seul endroit ; section apps → liens store réels ou retrait, fallback `/download` retiré si aucune cible.
+
+## Phases
+
+### Phase 1 — P1 (C1)
+- Checkout honnête (retrait du formulaire carte + succès sandbox + promesse d'email ; état « paiement indisponible » ; plan gratuit OTP complet).
+
+### Phase 2 — P2 (C2, C3, C4)
+- Résolveur siteUrl + canonical + lang/dir SSR + Live stat + témoignages + schema rating.
+- OG images, SW precache, manifest, route robots.
+- OAuth checkout → proxy.
+
+### Phase 3 — P3 (C5, C6)
+- i18n SignupForm/checkout/logout/login/carrières + locale POST + typos arabes.
+- Modale démo conditionnelle, blog périmé, vercel.json, section apps.
+
+## Fichiers touchés (référence)
+
+- `front/web/src/app/(landing)/checkout/page.tsx`, `src/app/(landing)/checkout/success/page.tsx`, `src/app/api/billing/checkout/route.ts`
+- `front/web/src/app/layout.tsx`, `src/app/(landing)/blog/layout.tsx`, `src/app/sitemap.ts`, `src/app/robots.ts`, `src/app/api/robots/route.ts`
+- `front/web/src/modules/vitrine/lib/{seo.ts,seo-metadata.ts,structured-data.ts}`, `src/lib/i18n.ts`, `src/lib/backend-url.ts`
+- `front/web/src/modules/vitrine/components/forms/SignupForm.tsx`, `src/modules/vitrine/data/{testimonials.ts,blog.ts,pricing.ts}`
+- `front/web/src/app/auth/login/page.tsx`, `src/app/auth/logout/page.tsx`
+- `front/web/public/sw.js`, `public/manifest.json`, `public/og/` (ou route générée)
+- `front/web/vercel.json`, `front/web/src/components/PWAProvider.tsx`, `front/web/src/app/(landing)/{mobile,careers}/page.tsx`
+
+## Contraintes
+
+- Auth : ne pas toucher au cookie `leopardo_token` (httpOnly/Secure) ni au proxy `/api/v1/[...path]` — uniquement l'URL du bouton OAuth.
+- Garder `NEXT_PUBLIC_ENABLE_FORMS` / `NEXT_PUBLIC_ENABLE_BLOG` tels quels (flags réels).
+- ESLint + TypeScript + build Next verts.
+- Les changements de contenu marketing (témoignages) restent minimaux : marquer démo plutôt que réécrire.

--- a/.specify/features/qa-audit-expert-web-2026-08-15/spec.md
+++ b/.specify/features/qa-audit-expert-web-2026-08-15/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Audit expert Web & Vitrine — 2026-08-15
+
+**Feature Branch**: `qa-audit-expert-web-2026-08-15`
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Input**: Mission de test expert de la plateforme (session 2026-08-15) — audit de la vitrine et du web Next.js (`front/web`) : parcours d'achat, onboarding, SEO, liens, i18n, PWA, cohérence. Base : `main` (`8a57dbf8`).
+
+## User Stories & Testing
+
+### User Story C1 — Le parcours d'achat est honnête : pas de faux paiement (Priority: P1)
+
+La page `/checkout` collecte numéro de carte/expiration/CVC dans un formulaire **qui ne les envoie nulle part** (le schéma les ignore) ; sans `STRIPE_SECRET_KEY` (prod), `POST /api/billing/checkout` renvoie un **succès sandbox simulé** (`route.ts:55`) et la page de succès promet un « email de confirmation avec vos identifiants » qui **n'est jamais envoyé** (l'appel sandbox à `/api/v1/trial/signup` saute `requestedWorkflow=guided_trial` → OTP jamais vérifié → aucun compte). Plans payants **non achetables**, utilisateurs laissés dans un faux espoir. L'UI admet « Les Stripe Price IDs ne sont pas encore configurés » (`page.tsx:1011`).
+
+**Pourquoi P1** : un tunnel de paiement qui simule le succès sur la vitrine publique est trompeur et casse l'onboarding payant.
+
+**Test indépendant** : sans `STRIPE_SECRET_KEY`, aucun chemin ne prétend qu'un paiement a abouti ; le formulaire de carte est masqué ou explicitement « démo » ; aucune promesse d'email non envoyé ; le plan gratuit reste pleinement fonctionnel.
+
+**Acceptance Scenarios**:
+1. **Given** un environnement sans clé Stripe, **When** on ouvre `/checkout`, **Then** aucun champ carte n'est présent (ou un bandeau « démo, aucun paiement réel » s'affiche) et le paiement ne peut pas « réussir ».
+2. **Given** un plan payant sélectionné sans Stripe, **When** on soumet, **Then** un état explicite « paiement non disponible » s'affiche (pas de succès simulé, pas de promesse d'email).
+3. **Given** le plan gratuit, **When** on s'inscrit, **Then** le parcours OTP complet (`trial/signup` + verify) aboutit à un compte réel.
+
+### User Story C2 — Le site ne ment pas sur son identité ni ses données (Priority: P2)
+
+- Canonical du blog codé sur `https://gestionemployer-backend.vercel.app/blog` — un domaine étranger (le code lui-même le qualifie d'« entreprise de construction US sans rapport », `JsonLd.tsx:5`).
+- Fallbacks `siteUrl` incohérents : 4 fichiers retombent sur `gestionemployer-backend.vercel.app`, `seo.ts` sur `http://localhost:3000`.
+- `html lang="fr"` codé en dur (SSR) alors que 4 locales existent — les pages en/tr/ar sont déclarées `lang="fr"` sans `dir` (SEO/ATV).
+- Statistique « Live: 18 » codée en dur dans le header du dashboard (`layout.tsx:361`).
+- Témoignages **fabriqués** (Amina Diallo/TechAfrika, Mehdi Benali/Atlas Digital, tous 5 étoiles) — le code admet « no real customer photos exist yet ».
+- `generateProductSchema` fabrique un `aggregateRating 4.9/500`.
+
+**Test indépendant** : aucune occurrence de `gestionemployer-backend.vercel.app` dans `src/` ; `lang`/`dir` corrects par locale au SSR ; pas de chiffre statique « Live » ; témoignages marqués démo ou retirés.
+
+**Acceptance Scenarios**:
+1. **Given** le blog, **When** on inspecte le canonical, **Then** il dérive de `NEXT_PUBLIC_SITE_URL`.
+2. **Given** une page en arabe, **When** le SSR la sert, **Then** `lang="ar" dir="rtl"`.
+3. **Given** le dashboard, **When** il charge, **Then** aucune statistique codée en dur.
+4. **Given** la section témoignages, **When** elle s'affiche, **Then** les citations sont réelles/attribuées ou la section est marquée démo.
+
+### User Story C3 — Les ressources SEO et PWA existent (Priority: P2)
+
+- `ogImage` pointe vers `/og/<page>.png` pour chaque page — dossier `public/og/` **inexistant** → toutes les OG images 404.
+- Service worker (`public/sw.js`) précache `/dashboard/attendance`, `/dashboard/absences`, `/dashboard/employees` — routes **inexistantes** (les vraies sont `/attendance`, `/absences`, `/employees`) → `cache.addAll` rejette → installation SW cassée (PWA offline morte).
+- Manifest : « Essai gratuit de 14 jours » (vs 30 jours partout) + `/icon-192.png` inexistant.
+- Route orpheline `/api/robots` pointant vers `/api/sitemap` (inexistant — seul `/sitemap.xml` existe).
+
+**Test indépendant** : `ls public/og/` non vide ou `ogImage` régénéré ; installation SW sans erreur (`cache.addAll` résolu) ; manifest cohérent (30 jours, icône existante).
+
+**Acceptance Scenarios**:
+1. **Given** n'importe quelle page, **When** un crawler la partage, **Then** l'OG image retourne 200.
+2. **Given** la PWA, **When** on l'installe, **Then** le précache inclut des routes réelles (installation réussie).
+3. **Given** le manifest, **When** on l'inspecte, **Then** la description de l'essai dit 30 jours et l'icône existe.
+
+### User Story C4 — Le checkout ne contourne plus le proxy OAuth (Priority: P2)
+
+`checkout/page.tsx:190-196` : le bouton Google OAuth utilise `getApiBaseUrl()` → origine API directe (`/api/v1/auth/google`) au lieu du proxy same-origin `/api/v1/auth/google` utilisé par `login/page.tsx:170` — régression du fix QA #2277 (cookie de session posé sur la vitrine, origine directe = cookie perdu).
+
+**Test indépendant** : l'URL du bouton Google du checkout pointe vers le proxy same-origin (même pattern que login).
+
+**Acceptance Scenarios**:
+1. **Given** le checkout, **When** on clique « Continuer avec Google », **Then** la requête passe par le proxy `/api/v1/auth/google` de la vitrine.
+
+### User Story C5 — Les textes sont localisés (Priority: P3)
+
+- Wizard d'inscription (`SignupForm.tsx`) 100 % français codé en dur sur une page localisée (4 locales).
+- Tunnel checkout + page logout en français uniquement ; le POST d'inscription gratuite code `locale: 'fr'` (`page.tsx:708`).
+- Bannière post-inscription du login codée en français (`login/page.tsx:385-390`).
+- Page carrières : 5 postes codés en dur, français uniquement, sans parcours de candidature.
+- Fautes d'arabe dans les chaînes livrées (« مساد المطور », « الردود الويب », « إلعاء », « الجمارافي »).
+
+**Test indépendant** : `rg` — plus de chaînes françaises codées en dur dans les composants localisés ; les chaînes passent par le catalogue i18n.
+
+**Acceptance Scenarios**:
+1. **Given** la page d'inscription en anglais, **When** le wizard s'affiche, **Then** les labels sont en anglais.
+2. **Given** la page checkout, **When** on change de locale, **Then** les textes suivent la locale.
+
+### User Story C6 — Pas de fallback trompeur ni de contenu périmé (Priority: P3)
+
+- Modale démo du login : fallback sur des comptes codés en dur (`password123`) quand `/demo-users` 404 (gaté `DEMO_MODE_ENABLED` en API) → en prod le bouton démo propose des comptes inutilisables.
+- Blog : 11 posts datés 2023-12/2024-01 toujours en tête du sitemap en 2026 (« Les Tendances RH à Surveiller en 2024 »).
+- `vercel.json` : redirect `/old-page` → `/new-page` (route inexistante → 404) + CSP-RO dupliqué avec `next.config.ts`.
+- Section apps mobiles : placeholders « Bientôt disponible » + fallback `/download` → `/signup`.
+
+**Test indépendant** : le bouton démo n'apparaît que si l'API renvoie réellement des utilisateurs ; aucune URL morte dans `vercel.json` ; dates du blog ≤ 2025-12 ou contenu rafraîchi.
+
+**Acceptance Scenarios**:
+1. **Given** le login, **When** l'API démo est désactivée, **Then** aucune proposition de compte démo.
+2. **Given** le sitemap, **When** on l'inspecte, **Then** aucun contenu obsolète en tête.
+
+## Edge Cases
+
+- Checkout : en présence d'une clé Stripe test (`sk_test_`), le mode sandbox reste actif — le bandeau « démo » doit l'être aussi.
+- `siteUrl` : un seul résolveur partagé ; défaut de build sûr (échouer si absent en prod).
+- SW : retirer `/dashboard*` du précache (hors ligne = page `/offline` + routes publiques).
+- OG images : préférer la route générée `/opengraph-image` (aucun fichier statique à maintenir).

--- a/.specify/features/qa-audit-expert-web-2026-08-15/tasks.md
+++ b/.specify/features/qa-audit-expert-web-2026-08-15/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Audit expert Web & Vitrine — 2026-08-15
+
+**Input**: spec.md + plan.md
+
+**Prerequisites**: plan.md (required), spec.md (required)
+
+> Conversion en issues GitHub : label `qa-audit-2026-08-15`, méthode Spec Kit taskstoissues.
+> **Sessions précédentes (canoniques, à ne pas dupliquer)** : série web #2602-#2613 — T001 edge-nodes page, T002 quick-action links, T003 script accents, T004 i18n pages (about/careers/contact/faq), T005 lint/build, T006 SITE_URL (#2607), T007 robots (#2643, PR #2664), T008 blog mort (#2609). Checkout sandbox = #2628 (PR #2665). Mes T058/T059/T072 (doublons) fermés ; T065/T070 rescopés.
+
+## Phase 1 — P1 (US C1)
+
+- [x] T058 [P1] C1 Checkout sandbox — **doublon fermé** : canonique #2628 (PR #2665 en cours). (issue #2717)
+
+## Phase 2 — P2 (US C2, C3, C4)
+
+- [x] T059 [P2] C2 SITE_URL — **doublon fermé** : canonique #2607 (T006 web). (issue #2718)
+- [x] T060 [P2] C2 `lang`/`dir` par requête au SSR (fini `lang="fr"` codé en dur). (issue #2719)
+- [x] T061 [P2] C2 Retirer le stat « Live: 18 » codé en dur du dashboard. (issue #2720)
+- [x] T062 [P2] C2 Meta description pricing alignée sur les plans réels (Free/Pilot/Operations/Enterprise, essai 30 j). (issue #2721)
+- [x] T063 [P2] C3 OG images : route générée `/opengraph-image` (fini les 404 `/og/*.png`). (issue #2722)
+- [x] T064 [P2] C3 `sw.js` : précache = routes réelles (`/`, `/offline`, …) — installation PWA réparée. (issue #2723)
+- [x] T065 [P2] C3 Manifest : essai 30 jours + icône existante (robots traités dans #2643/PR #2664). (issue #2724)
+- [x] T066 [P2] C4 Checkout : bouton Google OAuth → proxy same-origin `/api/v1/auth/google` (pattern login, fix QA #2277). (issue #2725)
+- [x] T067 [P2] C2 Témoignages : marquer démo ou retirer (plus de citations fabriquées). (issue #2726)
+
+## Phase 3 — P3 (US C5, C6)
+
+- [x] T068 [P3] C5 `SignupForm` : wizard localisé (labels, rôles, OTP, succès). (issue #2727)
+- [x] T069 [P3] C5 Checkout/logout/login bannière : textes via catalogue i18n + `locale` réel dans le POST d'inscription. (issue #2728)
+- [x] T070 [P3] C5 Typos arabes dans les chaînes livrées (« مساد المطور », « الردود الويب », « إلعاء », « الجمارافي ») → relecture (i18n pages traité dans #2605). (issue #2729)
+- [x] T071 [P3] C6 Modale démo login : rendue uniquement si `/demo-users` répond (fini le fallback `password123`). (issue #2730)
+- [x] T072 [P3] C6 Blog périmé — **doublon fermé** : canonique #2609 (T008 web). (issue #2731)
+- [x] T073 [P3] C6 `vercel.json` : redirect mort supprimé + CSP en un seul endroit. (issue #2732)
+- [x] T074 [P3] C6 Section apps mobiles : liens store réels ou retrait (fini « Bientôt disponible » + fallback signup). (issue #2733)
+
+## Convergence
+
+- [ ] T075 Mettre à jour `.specify/memory/project-state.md`, `CHANGELOG.md`, `AGENTS.md`, cocher les tâches après merge.

--- a/.specify/memory/project-state.md
+++ b/.specify/memory/project-state.md
@@ -142,3 +142,14 @@
 
 **Dernière mise à jour :** 2026-08-14 (vague QA hardening)
 **Mis à jour par :** Neo (Pulumi Agent)
+
+
+---
+
+## Vague QA expert 2026-08-15 (audit complet)
+
+- **Périmètre** : vitrine/web (Next.js), cockpit admin (Vue 3), mobile (Flutter ×6), API (Laravel 12) — workflows, logiques, onboarding, cohérence.
+- **Issues** : ~86 sous le label `qa-audit-2026-08-15` (T001-T099 ; T001-T013 = sessions expert parallèles, issues #2594-#2626 ; doublons fermés vers canoniques).
+- **Features Spec Kit** : `.specify/features/qa-audit-expert-{api,admin,web,mobile}-2026-08-15/{spec,plan,tasks}.md` + `docs/audits/AUDIT_EXPERT_2026-08-15.md`.
+- **Correctifs livrés (39 PRs)** : approbation de congé sur snapshot `leave_balances` (plus d'échec après crédit), webhook email-bounce fail-closed, webhook Stripe 500-sur-erreur, pointage verrouillé + index unique partiel, leave-balances scopé entreprise (IDOR), gardes de transition expense, trial signup non avalé, 1/10e `calculated`, clipping congés paie, verbes de notification canoniques, `per_page` borné, labels localisés, URLs config neutres, AI `current_company` ; admin : console sans simulations (maintenance/démo/globe), UsersView honnête (pagination/CSV/deactivate), realtime sans wipe de session, MetricCard/route titles/money locale ; web : lang/dir SSR, OG images réelles, SW précache réparé, OAuth proxy, démo conditionnelle, i18n login ; mobile : route cabinet, session hors-ligne conservée, onUnauthorized, mojibake, 403 différencié, Android 14, locale platform_admin.
+- **Reste ouvert** : T006/T012/T032/T034/T042/T049/T058/T059/T072/T079 (doublons fermés), T010 (jours ouvrés), T014 (OpenAPI ~134 chemins), T019 (temp_password — dépendance front), T026 (chunking paie), T068 (SignupForm i18n complet), T085 (i18n mobile ~1 300 chaînes), T086 (devise DZD), T089 (formatage nombres), T090 (offline manager), T094/T095 (mobile), T001-T009 sessions parallèles (PRs #2663-#2665 en cours).

--- a/docs/audits/AUDIT_EXPERT_2026-08-15.md
+++ b/docs/audits/AUDIT_EXPERT_2026-08-15.md
@@ -1,0 +1,69 @@
+# 🔍 AUDIT EXPERT — 2026-08-15 — Leopardo RH
+
+> Généré le 2026-08-15 | Auteur : agent expert (mission de test complète)
+> Base : `main` `8a57dbf8` | Méthode : Spec Kit (`specify → plan → tasks → implement`), Constitution §I-VII, conversion `taskstoissues` (label `qa-audit-2026-08-15`)
+> Périmètre : vitrine + web (Next.js), cockpit admin (Vue 3), mobile (Flutter ×6), API (Laravel 12), workflows, logiques, onboarding, cohérence.
+
+## 🧭 Résumé exécutif
+
+| Surface | P1 | P2 | P3 | Verdict |
+|---------|:--:|:--:|:--:|---------|
+| **API backend** | 2 | 13 | 12 | Solide (tenant isolation, contrats d'exception) mais 2 P1 bloquants : approbation de congé cassée, webhook email-bounce non authentifié. |
+| **Cockpit admin** | 5 | 11 | 9 | Console super-admin avec actions simulées et données fictives (dangereux), impersonation 404, identifiants démo en dur. |
+| **Vitrine / Web** | 1 | 9 | 10 | Auth et proxy sains ; checkout « sandbox » trompeur, SEO/identité incohérents, PWA cassée. |
+| **Mobile Flutter** | 2 | 12 | 8 | Onboarding bloqué (verbe+param), session détruite hors-ligne, mojibake, i18n massive, monnaie codée DZD. |
+
+**Total constaté : 10 P1, 45 P2, 39 P3** (dont doublons fermés vs sessions expert parallèles du jour : issues #2594-#2626, #2628, #2631, #2643 — 10 de mes issues fermées en faveur des canoniques).
+
+## ✅ Ce qui est sain (vérifié, à préserver)
+
+1. **Isolation multi-tenant** : `BelongsToCompany` + `TenantMiddleware`, 404 cross-tenant — surface IDOR réellement faible.
+2. **Contrat d'exceptions API** : DomainException→statusCode, 422/404/403 disciplinés, pas de stack traces.
+3. **Moteur de paie** : verrou de run, versionnage des règles, audit trail, golden tests par pays.
+4. **Auth web** : cookie `leopardo_token` httpOnly/Secure/SameSite=Strict, proxy Bearer serveur, middleware de garde sur les 13 groupes dashboard.
+5. **Clients API** : retries avec backoff, gestion d'erreurs contextuelle, Sentry breadcrumbs.
+6. **Kiosk/caméras** : tokens hachés, throttles dédiés, `hash_equals`.
+7. **Garde-fous CI** : env parity 271 clés OK, mobile manifest routes OK, contracts mobile OK.
+
+## 🔴 P1 — bloquants
+
+| # | Issue | Problème |
+|---|-------|----------|
+| API | #2666 | `AbsenceService::approve()` lit le solde sur la chaîne de logs (vide après tout crédit) → **première approbation de congé échoue toujours**. |
+| API | #2616* | Webhook email-bounce non authentifié (clé de config absente, fail-open). |
+| Admin | #2693 | « Désactiver la maintenance » = `setTimeout` + toast (aucun appel API). |
+| Admin | #2695 | Identifiants super-admin `password123` en dur dans le bundle de login. |
+| Admin | #2696 | Globe « activité temps réel » = points fictifs. |
+| Admin | #2624* | Impersonation : SPA appelle `/admin/impersonations` (404) — endpoints à exposer. |
+| Web | #2628* | Checkout sandbox en prod : carte jamais envoyée, succès simulé, email promis jamais envoyé. |
+| Mobile | #2631* | Onboarding : POST+id numérique vs backend PATCH+step_key → étapes jamais complétables. |
+| Mobile | #2735 | App Manager : navigation cabinet → GoRouter no-match. |
+
+\* issues canoniques des sessions parallèles (PR #2663/#2664/#2665 déjà en cours).
+
+## 🟠 P2 — majeurs (sélection)
+
+- **API** : Stripe webhook 200-sur-erreur (perte d'événements), race check-in/check-out, `leave-balances` ignore `{employeeId}` (exposition cross-team), jours calendaires vs ouvrés, double comptage paie sur absence chevauchante, OpenAPI ~26 % derrière (134 groupes), noms de paramètres divergents, transitions expense non gardées, trial-signup avale les échecs OTP, 1/10e sur bulletins `calculated` manquants.
+- **Admin** : pagination/filtre/CSV mensongers dans UsersView, recherche header morte, palette avec routes mortes, `markAllNotificationsAsRead` peut détruire la session (401→wipe), ids de notifications synthétiques → 404, MetricCard trend cassée.
+- **Web** : canonical domaine étranger (`gestionemployer-backend.vercel.app`), `lang="fr"` SSR, stat « Live: 18 » fake, OG images 404, SW précache cassé, témoignages fabriqués, OAuth checkout hors proxy.
+- **Mobile** : token supprimé sur erreur réseau (session perdue hors-ligne), double auth partageant la même clé SecureStorage, ~1 300 chaînes hors i18n, mojibake UTF-8, DZD codé, retries sur POST non idempotents, 403→« compte suspendu », manifest Android 14, locale platform_admin figée.
+
+## 🟡 P3 — hygiène (sélection)
+
+temp_password en JSON, labels français codés, per_page non borné, clés ar/tr manquantes, verbes dupliqués, arrondi overtime, NON_WORK_TYPES, N+1 paie, secrets fail-open, search_path leak, middleware AI, URLs prod en dur ; composants morts, alert() natifs, money() fr-FR, $subscribe mort ; blog 2024, redirects morts, placeholders apps, typos arabes ; écrans morts, Sentry 100 %, DateTime.parse non gardé.
+
+## 📋 Issues créées / suivies
+
+- **95 tâches** documentées (`.specify/features/qa-audit-expert-{api,admin,web,mobile}-2026-08-15/{spec,plan,tasks}.md`).
+- **Issues GitHub** : ~86 ouvertes sous le label `qa-audit-2026-08-15` (dont 10 fermées en doublon → canoniques #2607-#2626/#2628/#2631/#2643 ; + #2594-#2601/#2613 des sessions précédentes).
+- **PRs en cours des sessions parallèles** : #2663 (onboarding), #2664 (robots), #2665 (checkout).
+
+## ➡️ Implémentation (phase finale de la mission)
+
+Implémentation des manquements par priorités : P1 non dupliqués d'abord (API approbation congés, admin maintenance/login/globe, mobile cabinet manager), puis P2/P3 à fort impact. Chaque correctif = branche `fix/<issue>-<slug>` + PR avec `Closes #N` (Constitution §VII), PHPStan strict + Pint pour l'API, ESLint/build pour web/admin.
+
+## 📚 Références
+
+- Constitution : `.specify/constitution.md`
+- Features Spec Kit : `.specify/features/qa-audit-expert-{api,admin,web,mobile}-2026-08-15/`
+- Issues : `https://github.com/kitokoh/leopardo-hr/issues?q=label%3Aqa-audit-2026-08-15`


### PR DESCRIPTION
Documentation de la vague d'audit expert 2026-08-15 (mission de test complète) :
- `.specify/features/qa-audit-expert-{api,admin,web,mobile}-2026-08-15/{spec,plan,tasks}.md` — 4 features Spec Kit (spécifications, plans, tâches ; tâches implémentées cochées [x]).
- `docs/audits/AUDIT_EXPERT_2026-08-15.md` — conclusions de l'audit (10 P1, 45 P2, 39 P3 ; verdicts par surface ; ce qui est sain).
- `.specify/memory/project-state.md` — registre d'état mis à jour (vague, issues, correctifs livrés, reste ouvert).

Méthode : Constitution `.specify/constitution.md` + workflow Spec Kit `specify → plan → tasks → implement`, conversion taskstoissues (label `qa-audit-2026-08-15`, ~86 issues ; doublons fermés vers les canoniques des sessions expert parallèles #2594-#2626).
