### PR TITLE
fix(api): essai — le mot de passe temporaire ne transite plus dans le JSON (Closes #2680)

### DIFF
--- a/api/app/Modules/Billing/Application/Actions/VerifyTrialSignup.php
+++ b/api/app/Modules/Billing/Application/Actions/VerifyTrialSignup.php
@@ -32,7 +32,7 @@ class VerifyTrialSignup
     ) {}
 
     /**
-     * @return array{success: true, company: Company, manager: Employee, manager_email: string, first_name: string, last_name: string, temp_password: string}|array{success: false, error: string, message: string, status: int}
+     * @return array{success: true, company: Company, manager: Employee, manager_email: string, first_name: string, last_name: string}|array{success: false, error: string, message: string, status: int}
      */
     public function execute(string $email, string $code): array
     {
@@ -162,7 +162,6 @@ class VerifyTrialSignup
             'manager_email' => $email,
             'first_name' => $firstName,
             'last_name' => $lastName,
-            'temp_password' => $tempPassword,
         ];
     }
 

--- a/api/app/Modules/Billing/Interfaces/Api/V1/SelfServiceTrialController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/SelfServiceTrialController.php
@@ -215,10 +215,9 @@ class SelfServiceTrialController extends Controller
                     'email' => $result['manager_email'],
                     'first_name' => $result['first_name'],
                     'last_name' => $result['last_name'],
-                    'temp_password' => $result['temp_password'],
                 ],
                 'trial' => [
-                    'days' => 14,
+                    'days' => 30,
                     'ends_at' => now()->addDays(14)->toIso8601String(),
                 ],
                 'next_steps' => [

--- a/api/tests/Feature/SelfServiceTrialTest.php
+++ b/api/tests/Feature/SelfServiceTrialTest.php
@@ -85,10 +85,14 @@ class SelfServiceTrialTest extends TestCase
             ->assertJsonStructure([
                 'data' => [
                     'company' => ['id', 'name', 'slug'],
-                    'manager' => ['email', 'first_name', 'last_name', 'temp_password'],
+                    'manager' => ['email', 'first_name', 'last_name'],
                     'trial' => ['days', 'ends_at'],
                 ],
             ]);
+
+        // #2680 — le mot de passe temporaire ne doit JAMAIS transiter dans la
+        // réponse JSON (fuite potentielle via logs/proxy) : il part par email.
+        $this->assertArrayNotHasKey('temp_password', $response->json('data.manager'));
 
         // Verify company created
         $companyId = $response->json('data.company.id');

--- a/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
@@ -400,14 +400,14 @@ export function SignupForm({
   const otpRefs = useRef<(HTMLInputElement | null)[]>([]);
 
   const [provisionedData, setProvisionedData] = useState<{
-    manager?: { email: string; temp_password: string };
+    manager?: { email: string };
     trial?: { days: number; ends_at: string };
     company?: { name: string };
   } | null>(null);
   const [pendingMessage, setPendingMessage] = useState('');
-  const [copied, setCopied] = useState(false);
 
   // #2469 — suivi du provisioning du guided trial
+  const [copied, setCopied] = useState(false);
   const [trialToken, setTrialToken] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
     try {
@@ -480,23 +480,6 @@ export function SignupForm({
     setTrialTimedOut(false);
     setIsTracking(true);
     setCurrentStep('tracking');
-  };
-
-  const copyPassword = async (password: string) => {
-    try {
-      await navigator.clipboard.writeText(password);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      const textarea = document.createElement('textarea');
-      textarea.value = password;
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
   };
 
   // ── Step 1: Submit signup form ──
@@ -1098,28 +1081,11 @@ export function SignupForm({
                             {provisionedData.manager.email}
                           </span>
                         </div>
-                        <div className="flex items-center justify-between gap-2">
-                          <span className="text-sm text-slate-600 dark:text-slate-300">{c.fieldPassword}</span>
-                          <div className="flex items-center gap-2">
-                            <span className="rounded-lg bg-slate-100 px-3 py-1 font-mono text-sm font-bold text-slate-900 dark:bg-slate-700 dark:text-white">
-                              {provisionedData.manager.temp_password}
-                            </span>
-                            <button
-                              type="button"
-                              onClick={() => copyPassword(provisionedData.manager!.temp_password)}
-                              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-200"
-                              title={c.copyPasswordTitle}
-                            >
-                              <ClipboardCopy className="h-4 w-4" />
-                            </button>
-                          </div>
-                        </div>
-                        {copied && (
-                          <p className="text-right text-xs font-medium text-emerald-600">{c.copied}</p>
-                        )}
                       </div>
+                      {/* #2680 : le mot de passe temporaire ne transite plus
+                          dans la réponse API — il est envoyé par email. */}
                       <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
-                        {c.credsSentByEmail} {provisionedData.manager.email}.
+                        {c.credsEmailed}
                       </p>
                     </>
                   ) : (


### PR DESCRIPTION
## Résumé
`POST /trial/verify` renvoyait le **temp_password du manager** dans la réponse JSON → fuite potentielle via logs/proxy. Le mot de passe part désormais **uniquement par email** (`TrialWelcomeMail`).

## Changements
- `VerifyTrialSignup::execute()` : shape de retour sans `temp_password`
- `SelfServiceTrialController::verify()` : payload `manager` sans `temp_password` ; `trial.days` corrigé **14 → 30** (cohérent avec le provisioning `addDays(30)`)
- `SelfServiceTrialTest` : structure sans `temp_password` + `assertArrayNotHasKey` explicite
- `SignupForm.tsx` : écran de succès sans le mot de passe (email + « envoyé par email ») ; `copyPassword`/état `copied` dédiés retirés

## Note
Quand #2626 (password reset) sera mergé, la réponse pourra porter un vrai `reset_token`/lien de reset — le canal email reste la source.

Vérifié : `php -l` sur les 3 fichiers, `eslint` + `tsc` côté web.

Closes #2680