### PR TITLE
fix(admin): pays supportés — registre unique via /admin/supported-countries (Closes #2789)

### DIFF
--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -302,6 +302,12 @@ Route::prefix('v1')->group(function (): void {
     // Endpoints appelés par le SPA sans exister côté API (issue #1764) :
     // création côté API des routes manquantes (décision produit).
     Route::middleware(['auth:super_admin_api', 'throttle:platform-sensitive'])->prefix('admin')->group(function (): void {
+        // MULTI-PAYS (#2789) — registre unique des pays supportés pour la
+        // console super-admin (réutilise SupportedCountryController, sans
+        // contexte tenant : remplace les 4 tableaux codés en dur incohérents
+        // des vues Holidays/SocialContributions/TaxRates/TaxSlabs).
+        Route::get('/supported-countries', [SupportedCountryController::class, 'index']);
+
         Route::get('/dashboard/stats', [PlatformAdminDashboardController::class, 'stats']);
         Route::get('/dashboard/activities', [PlatformAdminDashboardController::class, 'activities']);
         Route::get('/dashboard/alerts', [PlatformAdminDashboardController::class, 'alerts']);

--- a/front/admin-dashboard/src/composables/useSupportedCountries.js
+++ b/front/admin-dashboard/src/composables/useSupportedCountries.js
@@ -1,0 +1,64 @@
+import { computed } from 'vue'
+import api from '@/services/api'
+
+/**
+ * Registre unique des pays supportés (issue #2789).
+ *
+ * Source de vérité : GET /admin/supported-countries (miroir du registre
+ * tenant /api/v1/supported-countries, accessible au super-admin sans
+ * contexte tenant). Remplace les tableaux codés en dur incohérents
+ * (6/10/7/12 pays) des vues Holidays, SocialContributions, TaxRates et
+ * TaxSlabs.
+ *
+ * Le registre est chargé une seule fois (cache module) ; un échec réseau
+ * produit un état vide honnête (jamais de fallback silencieux).
+ */
+
+const cache = {
+  countries: [],
+  loaded: false,
+  loading: false,
+  promise: null,
+}
+
+/** Drapeau emoji dérivé du code ISO 3166-1 alpha-2 (🇩🇿, 🇲🇦, …). */
+export function flagEmoji(code) {
+  if (!/^[A-Za-z]{2}$/.test(code || '')) return ''
+  return String.fromCodePoint(...code.toUpperCase().split('').map((c) => 127397 + c.charCodeAt(0)))
+}
+
+export function useSupportedCountries({ payrollOnly = false } = {}) {
+  if (!cache.loaded && !cache.promise) {
+    cache.loading = true
+    cache.promise = api
+      .get('/admin/supported-countries')
+      .then(({ data }) => {
+        cache.countries = Array.isArray(data?.data) ? data.data : []
+        cache.loaded = true
+      })
+      .catch(() => {
+        // État vide honnête : l'UI affiche « aucun pays » au lieu de mentir.
+        cache.countries = []
+        cache.loaded = true
+      })
+      .finally(() => {
+        cache.loading = false
+      })
+  }
+
+  const countries = computed(() => {
+    const source = payrollOnly ? cache.countries.filter((c) => c.available) : cache.countries
+    return source.map((c) => ({
+      code: c.country,
+      label: c.label,
+      available: c.available ?? true,
+      flag: flagEmoji(c.country),
+    }))
+  })
+
+  return {
+    countries,
+    loading: computed(() => cache.loading),
+    loaded: computed(() => cache.loaded),
+  }
+}

--- a/front/admin-dashboard/src/views/settings/HolidaysView.vue
+++ b/front/admin-dashboard/src/views/settings/HolidaysView.vue
@@ -13,7 +13,7 @@
         <div>
           <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="holiday-country">{{ $t('holidays.country') }}</label>
           <select id="holiday-country" v-model="countryCode" class="form-input min-w-40" @change="loadHolidays">
-            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ $t(cc.labelKey) }}</option>
+            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.label }}</option>
           </select>
         </div>
         <div>
@@ -225,6 +225,7 @@
 <script setup>
 import { computed, onMounted, reactive, ref } from 'vue'
 import api from '@/services/api'
+import { useSupportedCountries } from '@/composables/useSupportedCountries'
 import { useToast } from 'vue-toastification'
 import { translate } from '@/i18n/index.js'
 import { useLocaleStore } from '@/stores/locale.js'
@@ -241,14 +242,7 @@ function t(key, vars = {}) {
   return msg
 }
 
-const supportedCountries = [
-  { code: 'DZ', labelKey: 'holidays.countries.DZ' },
-  { code: 'CM', labelKey: 'holidays.countries.CM' },
-  { code: 'CI', labelKey: 'holidays.countries.CI' },
-  { code: 'SN', labelKey: 'holidays.countries.SN' },
-  { code: 'MA', labelKey: 'holidays.countries.MA' },
-  { code: 'TN', labelKey: 'holidays.countries.TN' },
-]
+const { countries: supportedCountries } = useSupportedCountries({ payrollOnly: false })
 
 const years = Array.from({ length: 8 }, (_, i) => 2024 + i)
 

--- a/front/admin-dashboard/src/views/settings/SocialContributionsView.vue
+++ b/front/admin-dashboard/src/views/settings/SocialContributionsView.vue
@@ -15,7 +15,7 @@
         <div>
           <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="sc-country">{{ $t('social_contrib.th_country') }}</label>
           <select id="sc-country" v-model="countryCode" class="form-input min-w-40" @change="load">
-            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ $t(cc.labelKey) }}</option>
+            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ cc.label }}</option>
           </select>
         </div>
         <div>
@@ -82,13 +82,13 @@
         <div>
           <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="simc-country">{{ $t('social_contrib.th_country') }}</label>
           <select id="simc-country" v-model="simCountry" class="form-input" @change="runSimulate">
-            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ $t(cc.labelKey) }}</option>
+            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ cc.label }}</option>
           </select>
         </div>
         <div>
           <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="simc-compare">{{ $t('social_contrib.compare_country') }}</label>
           <select id="simc-compare" v-model="compareCountry" class="form-input" @change="runSimulate">
-            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ $t(cc.labelKey) }}</option>
+            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ cc.label }}</option>
           </select>
         </div>
         <div class="flex items-end">
@@ -182,6 +182,7 @@
 <script setup>
 import { onMounted, reactive, ref } from 'vue'
 import api from '@/services/api'
+import { useSupportedCountries } from '@/composables/useSupportedCountries'
 import { useToast } from 'vue-toastification'
 import { translate } from '@/i18n/index.js'
 import { useLocaleStore } from '@/stores/locale.js'
@@ -198,18 +199,7 @@ function t(key, vars = {}) {
   return msg
 }
 
-const supportedCountries = [
-  { code: 'DZ', flag: '🇩🇿', labelKey: 'common.countries.DZ' },
-  { code: 'CM', flag: '🇨🇲', labelKey: 'common.countries.CM' },
-  { code: 'CI', flag: '🇨🇮', labelKey: 'common.countries.CI' },
-  { code: 'SN', flag: '🇸🇳', labelKey: 'common.countries.SN' },
-  { code: 'MA', flag: '🇲🇦', labelKey: 'common.countries.MA' },
-  { code: 'TN', flag: '🇹🇳', labelKey: 'common.countries.TN' },
-  { code: 'CG', flag: '🇨🇬', labelKey: 'common.countries.CG' },
-  { code: 'GA', flag: '🇬🇦', labelKey: 'common.countries.GA' },
-  { code: 'BF', flag: '🇧🇫', labelKey: 'common.countries.BF' },
-  { code: 'ML', flag: '🇲🇱', labelKey: 'common.countries.ML' },
-]
+const { countries: supportedCountries } = useSupportedCountries({ payrollOnly: true })
 
 const countryCode = ref('DZ')
 const typeFilter = ref('')

--- a/front/admin-dashboard/src/views/settings/TaxRatesView.vue
+++ b/front/admin-dashboard/src/views/settings/TaxRatesView.vue
@@ -130,7 +130,7 @@
             <div>
               <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="rate-country">{{ $t('tax_rates.th_country') }}</label>
               <select id="rate-country" v-model="form.country_code" class="form-input" required>
-                <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ $t(cc.labelKey) }}</option>
+                <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.label }}</option>
               </select>
             </div>
           </div>
@@ -223,6 +223,7 @@
 <script setup>
 import { onMounted, reactive, ref } from 'vue'
 import api from '@/services/api'
+import { useSupportedCountries } from '@/composables/useSupportedCountries'
 import { translate } from '@/i18n/index.js'
 import { useLocaleStore } from '@/stores/locale.js'
 import { useToast } from 'vue-toastification'
@@ -234,15 +235,7 @@ function t(key, fallback = '') {
   return translate(localeStore.current, key, fallback)
 }
 
-const supportedCountries = [
-  { code: 'DZ', labelKey: 'common.countries.DZ' },
-  { code: 'CM', labelKey: 'common.countries.CM' },
-  { code: 'CI', labelKey: 'common.countries.CI' },
-  { code: 'SN', labelKey: 'common.countries.SN' },
-  { code: 'MA', labelKey: 'common.countries.MA' },
-  { code: 'TN', labelKey: 'common.countries.TN' },
-  { code: 'FR', labelKey: 'common.countries.FR' },
-]
+const { countries: supportedCountries } = useSupportedCountries({ payrollOnly: true })
 
 const isPlatformAdmin = ref(false)
 const rates = ref([])

--- a/front/admin-dashboard/src/views/settings/TaxSlabsView.vue
+++ b/front/admin-dashboard/src/views/settings/TaxSlabsView.vue
@@ -14,7 +14,7 @@
         <div>
           <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="slab-country">{{ $t('tax_slabs.th_country') }}</label>
           <select id="slab-country" v-model="countryCode" class="form-input min-w-40" @change="onCountryChange">
-            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ $t(cc.labelKey) }}</option>
+            <option v-for="cc in supportedCountries" :key="cc.code" :value="cc.code">{{ cc.flag }} {{ cc.label }}</option>
           </select>
         </div>
         <div>
@@ -124,6 +124,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import api from '@/services/api'
+import { useSupportedCountries } from '@/composables/useSupportedCountries'
 import TaxSlabEditor from '@/components/payroll/TaxSlabEditor.vue'
 import { useToast } from 'vue-toastification'
 import { translate } from '@/i18n/index.js'
@@ -141,20 +142,7 @@ function t(key, vars = {}) {
   return msg
 }
 
-const supportedCountries = [
-  { code: 'DZ', flag: '🇩🇿', labelKey: 'common.countries.DZ' },
-  { code: 'CM', flag: '🇨🇲', labelKey: 'common.countries.CM' },
-  { code: 'CI', flag: '🇨🇮', labelKey: 'common.countries.CI' },
-  { code: 'SN', flag: '🇸🇳', labelKey: 'common.countries.SN' },
-  { code: 'MA', flag: '🇲🇦', labelKey: 'common.countries.MA' },
-  { code: 'TN', flag: '🇹🇳', labelKey: 'common.countries.TN' },
-  { code: 'TR', flag: '🇹🇷', labelKey: 'common.countries.TR' },
-  { code: 'FR', flag: '🇫🇷', labelKey: 'common.countries.FR' },
-  { code: 'CG', flag: '🇨🇬', labelKey: 'common.countries.CG' },
-  { code: 'GA', flag: '🇬🇦', labelKey: 'common.countries.GA' },
-  { code: 'BF', flag: '🇧🇫', labelKey: 'common.countries.BF' },
-  { code: 'ML', flag: '🇲🇱', labelKey: 'common.countries.ML' },
-]
+const { countries: supportedCountries } = useSupportedCountries({ payrollOnly: true })
 
 const countryCode = ref('DZ')
 const scope = ref('national')

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -65,7 +65,7 @@ import 'app_localizations_tr.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -88,18 +88,18 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('ar'),
     Locale('en'),
     Locale('fr'),
-    Locale('tr')
+    Locale('tr'),
   ];
 
   /// No description provided for @appTitle.
@@ -1217,6 +1217,24 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'Dernieres actions de votre equipe'**
   String get dashboardRecentActivityHint;
+
+  /// No description provided for @dashboardLeoIaAnnouncementTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Felicitations equipe'**
+  String get dashboardLeoIaAnnouncementTitle;
+
+  /// No description provided for @dashboardLeoIaAnnouncementBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Felicitations a toute l\'equipe : les retards sont en baisse de 15% cette semaine. Continuez sur cette dynamique !'**
+  String get dashboardLeoIaAnnouncementBody;
+
+  /// No description provided for @dashboardLeoIaAnnouncementError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impossible d\'envoyer le message. Reessayez dans quelques instants.'**
+  String get dashboardLeoIaAnnouncementError;
 
   /// No description provided for @marketingOauthNavTitle.
   ///
@@ -2720,8 +2738,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -585,6 +585,17 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dashboardRecentActivityHint => 'آخر إجراءات فريقك';
 
   @override
+  String get dashboardLeoIaAnnouncementTitle => 'تهانينا للفريق';
+
+  @override
+  String get dashboardLeoIaAnnouncementBody =>
+      'تهانينا للفريق بأكمله: انخفض التأخير بنسبة 15٪ هذا الأسبوع. واصلوا هذه الديناميكية!';
+
+  @override
+  String get dashboardLeoIaAnnouncementError =>
+      'تعذر إرسال الرسالة. حاول مرة أخرى بعد قليل.';
+
+  @override
   String get marketingOauthNavTitle => 'تسويق OAuth';
 
   @override

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -590,6 +590,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dashboardRecentActivityHint => 'Latest actions from your team';
 
   @override
+  String get dashboardLeoIaAnnouncementTitle => 'Congratulations team';
+
+  @override
+  String get dashboardLeoIaAnnouncementBody =>
+      'Congrats to the whole team: lateness is down 15% this week. Keep up the momentum!';
+
+  @override
+  String get dashboardLeoIaAnnouncementError =>
+      'Couldn\'t send the message. Please try again in a few moments.';
+
+  @override
   String get marketingOauthNavTitle => 'Marketing OAuth';
 
   @override

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -594,6 +594,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dashboardRecentActivityHint => 'Dernieres actions de votre equipe';
 
   @override
+  String get dashboardLeoIaAnnouncementTitle => 'Felicitations equipe';
+
+  @override
+  String get dashboardLeoIaAnnouncementBody =>
+      'Felicitations a toute l\'equipe : les retards sont en baisse de 15% cette semaine. Continuez sur cette dynamique !';
+
+  @override
+  String get dashboardLeoIaAnnouncementError =>
+      'Impossible d\'envoyer le message. Reessayez dans quelques instants.';
+
+  @override
   String get marketingOauthNavTitle => 'Marketing OAuth';
 
   @override

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -588,6 +588,17 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dashboardRecentActivityHint => 'Ekibinizin son eylemleri';
 
   @override
+  String get dashboardLeoIaAnnouncementTitle => 'Tebrikler ekip';
+
+  @override
+  String get dashboardLeoIaAnnouncementBody =>
+      'Tüm ekibe tebrikler: bu hafta gecikmeler %15 azaldı. Bu ivmeyi sürdürün!';
+
+  @override
+  String get dashboardLeoIaAnnouncementError =>
+      'Mesaj gönderilemedi. Birkaç dakika sonra tekrar deneyin.';
+
+  @override
   String get marketingOauthNavTitle => 'Pazarlama OAuth';
 
   @override


### PR DESCRIPTION
## Résumé
Les 4 vues settings (Holidays, SocialContributions, TaxRates, TaxSlabs) embarquaient des tableaux de pays codés en dur **incohérents** (6/10/7/12 pays). Source de vérité unique : le registre backend (CountryDefaults + confiance des règles paie).

## Changements
- **api** : `GET /admin/supported-countries` dans le groupe super-admin (réutilise `SupportedCountryController`, sans contexte tenant)
- **composable** `useSupportedCountries.js` : registre chargé une fois (cache module), drapeaux dérivés du code ISO, état vide honnête en cas d'échec réseau ; option `payrollOnly` (`available=true`) pour les vues de calcul
- **4 vues** : utilisent le composable, libellés affichés depuis le registre (fini `$t(cc.labelKey)` sur des clés parfois absentes)

Vérifié : `eslint` admin vert, `php -l` vert.

Closes #2789