### PR TITLE
docs(speckit): session QA agent 2026-08-15 — spec + findings-registry + tasks

### DIFF
--- a/.specify/features/qa-agent-session-2026-08-15/findings-registry.md
+++ b/.specify/features/qa-agent-session-2026-08-15/findings-registry.md
@@ -1,0 +1,45 @@
+# Registre des manquements — Session QA agent 2026-08-15
+
+> Session de test de la plateforme Leopardo RH (repo kitokoh/leopardo-hr).
+> Mission : tester la vitrine, le web, l'admin, les mobiles, les workflows, les APIs, les
+> logiques, l'onboarding et la cohérence — tout manquement → spec + tasks + issues (méthode
+> Spec Kit) puis implémentation. Anti-doublon : les constats déjà couverts par les vagues
+> QA existantes (#2600–#2813, missions 2026-08-14/15) sont exclus ou référencés.
+
+## A. Vérifications runtime effectuées (prod live)
+
+- [x] API Render live (`gestionemployerbackend.onrender.com`, health v4.23.5) :
+      `/health/live` 200 · login démo manager **200** (token + data) · login super-admin → 401
+      `INVALID_CREDENTIALS` (démo désactivée en prod, cf. #2646) · `/i18n/catalog/fr` **500** ·
+      `/supported-countries` **404** · `/api-explorer` **404** · `/dashboard/kpi` **500** ·
+      `/employees/{id}` **500** · `POST /payroll/simulate` **404** (route présente sur main).
+      → déploiement Render obsolète vs main (#2812/#2632 — les 500 sont déjà corrigés sur main).
+- [x] Vitrine Vercel live : `/` 200 · `/pricing` 200 · `/blog` **404** · sitemap.xml contient
+      **50 URLs `/blog/*`** → blog 404 + sitemap stale (#2813, fix #2943 pas encore déployé).
+      `/robots.txt` OK · `/api/sitemap` **404** (legacy robots route supprimée sur main).
+- [x] Admin `leo-admin.pages.dev` : 200 (login OK).
+
+## B. Findings — Audit statique main (post-merges #2944/#2891/#2936/#2935)
+
+| ID | Sév | Constat | Preuve | Statut |
+|----|-----|---------|--------|--------|
+| S1 | P1 | Checkout : clés fantômes `starter`/`business` RÉ-MERGÉES dans main par #2944 (résolution de conflits perdue) ; fallback plan `'business'` ; label Enterprise alias `scale` présent | `front/web/src/app/(landing)/checkout/page.tsx` sur main : `starter:`/`business:`/`scale:` | Corrigé sur `fix/2909-pricing-trial-copy` (PR #2972) |
+| S2 | P3 | BOM U+FEFF en tête de `checkout/page.tsx` sur main | `od -tx1` 1er octet = `ef bb bf` | Corrigé (PR #2972) |
+| S3 | P2 | `seo.pricing.description` : clé absente des catalogues i18n → le fallback FR (`t()` 3e arg) est toujours utilisé, meta en/tr/ar non traduites | grep catalogues : 0 occurrence | Ouvert → issue |
+| S4 | P2 | Codes de plan incohérents backend/frontend : `FeaturePlanMatrixSeeder` (`trial/starter/business/enterprise`) vs checkout (`free/pilot/operations/enterprise`) | `api/database/seeders/FeaturePlanMatrixSeeder.php:13-20` | Ouvert → issue |
+| S5 | P3 | `branding/page.tsx` : 3e schéma de nommage « Starter/Pro/Enterprise » (ni pricing ni matrice backend) | `front/web/src/app/(landing)/branding/page.tsx:106-121` | Ouvert → issue |
+| S6 | P2 | `SignupForm.test.tsx` : 5 tests échouent sur main (flow OTP « vérifiez votre email ») — hors CI (jest ne tourne pas en CI vitrine) | `npm run test` → 15/16 suites, 5 failed | Ouvert → issue |
+| S7 | P1 | Prod : `/dashboard/kpi` 500 + `/employees/{id}` 500 + `/payroll/simulate` 404 (corrigés sur main, non déployés) | smoke `scripts/qa_api_smoke.py` live | Traçé (#2812/#2632) |
+| S8 | P1 | Locales en/tr/ar : « 14-day/14 gün/14 يوم » + stats hero `{ value: 14 }` (essai) — #2753 n'avait corrigé que le FR | grep vitrine | Corrigé (PR #2972) |
+| S9 | P2 | `(dashboard)/billing/page.tsx` : `PLAN_LABELS` starter/business → labels faux pour codes canoniques | ligne 34-35 | Corrigé (PR #2972) |
+| S10 | P2 | `src/app/api/robots/route.ts` legacy supprimée sur main ✅ mais issue #2608 ouverte (partie « ajouter /blog, /signup, /checkout à robots.txt » reste à faire) | robots.ts vs #2608 | Ouvert → issue reste |
+
+## C. Actions session (branches/PRs)
+
+- [x] PR #2944 mise à jour (résolution conflits plans canoniques + 30j) → mergée par le propriétaire
+      SANS la résolution (conflits ré-apparus) → S1/S2.
+- [x] PR #2891 mise à jour (résolution conflits, robots route + dead blog code supprimés) → mergée.
+- [x] PR #2972 ouverte : `fix/2909-pricing-trial-copy` — S1, S2, S8, S9 + contenu #2909.
+- [ ] Branches `fix/2604-2606-web-accents`, `fix/2607-2608-web-seo-cleanup`, `fix/2789-admin-supported-countries`
+      à mettre à jour + PR (issues ouvertes #2604/#2606/#2607/#2608/#2789).
+- [ ] PR #2306 (`qa-hardening-wave-2026-08-14`, draft) : à réconcilier avec main (298 commits de retard).

--- a/.specify/features/qa-agent-session-2026-08-15/spec.md
+++ b/.specify/features/qa-agent-session-2026-08-15/spec.md
@@ -1,0 +1,90 @@
+# Feature Specification: Session QA agent 2026-08-15 (live + main)
+
+**Feature Branch**: `fix/2909-pricing-trial-copy` (PR #2972) + branches par issue
+
+**Created**: 2026-08-15 | **Status**: Draft → Implémentation en cours
+
+**Input**: Mission du propriétaire (session 2026-08-15) — tester la plateforme dans tous les sens
+(vitrine, web, admin, mobiles, workflows, APIs, logiques, onboarding, cohérence) ; tout manquement
+→ spec + tasks (méthode Spec Kit) ; implémenter les manquements en fin de test ; implémenter le max
+d'issues ouvertes ; merger le max de branches.
+
+**Contexte**: La mission exhaustive 2026-08-15 (`qa-mission-exhaustive-2026-08-15`) couvre le socle.
+Cette spec couvre les constats NOUVEAUX de la session live + audit main post-merges (#2944/#2891/#2936/#2935).
+
+## User Stories & Testing
+
+### User Story 1 — Le checkout n'expose plus de plans fantômes (P1)
+
+Un visiteur qui clique « Start for free » (plan Free) ou un slug legacy arrive sur le checkout du bon plan ;
+le JSON de `PLAN_CONFIG` ne contient que les clés canoniques `free/pilot/operations/enterprise`.
+
+**Pourquoi P1** : la PR #2944 (Closes #2908) a été mergée SANS la résolution des conflits — les clés
+`starter`/`business` sont réapparues dans main (constat sur `origin/main`), avec fallback `'business'`.
+
+**Acceptance Scenarios**:
+1. **Given** `PLAN_CONFIG` sur main, **When** inspection, **Then** seules les clés `free/pilot/operations/enterprise` existent (plus `starter`/`business`/`scale`).
+2. **Given** l'URL `/checkout?plan=starter`, **When** navigation, **Then** le plan résolu est `pilot` (alias doux), jamais un plan inconnu.
+3. **Given** le fichier checkout, **When** vérification octets, **Then** aucun BOM U+FEFF en tête (régression introduite au merge).
+
+### User Story 2 — L'essai est de 30 jours sur TOUTES les surfaces et locales (P1)
+
+Aucune chaîne « 14 jours »/« 14-day »/« 14 gün »/« 14 يوم » ne subsiste dans la vitrine (en/tr/ar incluses).
+
+**Pourquoi P1** : #2753 n'a corrigé que les chaînes FR — les locales en/tr/ar et les stats hero
+(`{ value: 14 }`) affichaient encore 14 jours (incohérence produit).
+
+**Acceptance Scenarios**:
+1. **Given** le code vitrine, **When** grep `14 jours|14-day|14 gün|14 يوم|14 يوما`, **Then** 0 occurrence (hors docs/comments historiques).
+2. **Given** la page pricing, **When** lecture de la meta description, **Then** plans Pilot/Operations + « 30 jours » (plus Starter/Business/14 jours).
+
+### User Story 3 — Les codes de plan sont cohérents entre backend et frontend (P2)
+
+La matrice `feature_plan_matrix` (backend) et le checkout (frontend) utilisent le MÊME jeu de codes.
+
+**Pourquoi P2** : le seeder backend utilise `trial/starter/business/enterprise` alors que le frontend
+utilise `free/pilot/operations/enterprise` — toute logique de droits branchée sur les codes backend
+ne correspond pas à l'UI (constat FeaturePlanMatrixSeeder.php + checkout PLAN_CONFIG).
+
+**Acceptance Scenarios**:
+1. **Given** `api/database/seeders/FeaturePlanMatrixSeeder.php`, **When** inspection, **Then** les codes de plan sont les canoniques (ou un mapping documenté vers eux).
+2. **Given** le billing dashboard, **When** un abonnement avec code `pilot`/`operations` arrive, **Then** le label affiché est correct (Pilot/Operations) — jamais la clé brute.
+
+### User Story 4 — Les tests vitrine reflètent la réalité (P2)
+
+La suite jest de la vitrine est verte localement (ou chaque échec est tracé avec issue).
+
+**Pourquoi P2** : `SignupForm.test.tsx` — 5 tests échouent sur main (flow OTP « vérifiez votre email »),
+hors CI (seuls lint/build/playwright tournent) → dette invisible.
+
+**Acceptance Scenarios**:
+1. **Given** `npm run test` sur main, **Then** 0 échec OU chaque échec a une issue ouverte référencée.
+2. **Given** la CI vitrine, **When** PR vitrine, **Then** lint + mojibake + build + playwright s'exécutent.
+
+### User Story 5 — Les clés i18n SEO existent dans les catalogues (P3)
+
+`seo.pricing.description` et les clés `t()` utilisées dans seo.ts sont présentes dans les 4 catalogues
+ou documentées comme volontairement en fallback.
+
+**Pourquoi P3** : le fallback FR est toujours utilisé (clé absente des catalogues) → les meta
+descriptions en/tr/ar ne sont pas réellement traduites.
+
+**Acceptance Scenarios**:
+1. **Given** les catalogues i18n de la vitrine, **When** grep `seo.pricing.description`, **Then** la clé existe (4 locales) ou un commentaire explique le fallback assumé.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Le checkout ne contient que les clés de plan canoniques ; les slugs legacy sont des alias doux.
+- **FR-002**: Toute chaîne d'essai visible affiche 30 jours (toutes locales).
+- **FR-003**: Les labels de plan du billing dashboard couvrent les codes canoniques + alias.
+- **FR-004**: La matrice de plans backend et l'UI partagent le même vocabulaire de plans (ou mapping documenté).
+- **FR-005**: La suite jest vitrine est verte ou ses échecs sont tracés.
+
+## Success Criteria
+
+- **SC-001**: 0 occurrence « 14 » dans les chaînes d'essai de la vitrine (grep reproductible).
+- **SC-002**: Checkout `PLAN_CONFIG` = 4 clés canoniques, fallback `operations`, pas de BOM.
+- **SC-003**: PR #2972 mergée avec CI verte (lint/build/mojibake).
+- **SC-004**: Issues créées pour les constats non couverts (codes backend, i18n SEO, tests jest).

--- a/.specify/features/qa-agent-session-2026-08-15/tasks.md
+++ b/.specify/features/qa-agent-session-2026-08-15/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Session QA agent 2026-08-15
+
+**Input**: spec.md + findings-registry.md (`.specify/features/qa-agent-session-2026-08-15/`)
+
+**Anti-duplication (#2400)** : constats couverts par #2600–#2813 / missions 2026-08-14/15 exclus.
+
+## Phase 1 — Correctifs web pricing/cohérence (US1/US2) — PR #2972
+
+- [x] T001 [P1] US1 Checkout `PLAN_CONFIG` : clés canoniques `free/pilot/operations/enterprise`,
+      alias doux `starter→pilot`, `business→operations`, `scale→enterprise`, fallback `operations`
+      (régression #2944 — ré-applique #2908).
+- [x] T002 [P3] US1 Retirer le BOM U+FEFF de `checkout/page.tsx`.
+- [x] T003 [P1] US2 30 jours sur toutes les locales : `vitrine-locale.ts` (stats hero `value:14`→30,
+      CTA fr/en/tr/ar), `pricing.ts` (en/tr/ar priceNote), `faq/page.tsx`, `checkout/success`,
+      `about/case-studies/testimonials`, FAQ schema layouts, `OperationalProofSection` (fr/en/tr/ar),
+      `seo.ts`/`seo-metadata.ts` (plans Pilot/Operations + 30j).
+- [x] T004 [P2] US3 `billing/page.tsx` : PLAN_LABELS canoniques + alias.
+- [x] T005 [P2] Validation : lint + mojibake + build + jest (15/16 — échecs SignupForm préexistants).
+- [ ] T006 [P2] Merge de la PR #2972 (CI verte requise).
+
+## Phase 2 — Issues nouveaux constats (US3/US4/US5)
+
+- [ ] T010 [P1] US1 Issue régression : clés starter/business ré-mergées + fallback `business` (réf. #2908/#2780).
+- [ ] T011 [P2] US5 Issue i18n : `seo.pricing.description` + clés `t()` de seo.ts absentes des catalogues (S3).
+- [ ] T012 [P2] US3 Issue cohérence plans : `FeaturePlanMatrixSeeder` trial/starter/business vs
+      free/pilot/operations frontend (S4) — décision clés canoniques + mapping.
+- [ ] T013 [P3] US3 Issue branding : `branding/page.tsx` « Starter/Pro/Enterprise » (S5).
+- [ ] T014 [P2] US4 Issue tests : `SignupForm.test.tsx` 5 échecs sur main + proposition d'ajouter jest
+      à la CI vitrine ou documenter (S6).
+
+## Phase 3 — Branches/issues ouvertes restantes (implémentation)
+
+- [ ] T020 [P2] `fix/2604-2606-web-accents` : mise à jour + PR (Closes #2604, #2606).
+- [ ] T021 [P2] `fix/2607-2608-web-seo-cleanup` : mise à jour + PR (Closes #2607, #2608 — robots.txt
+      /blog /signup /checkout).
+- [ ] T022 [P2] `fix/2789-admin-supported-countries` : mise à jour + PR (Closes #2788/#2789).
+- [ ] T023 [P3] `qa-hardening-wave-2026-08-14` (#2306 draft) : réconcilier avec main ou fermer avec
+      renvoi si contenu absorbé.
+- [ ] T024 [P3] Nettoyage branches mergées : `fix/2631-mobile-onboarding-patch`, `fix/2650-agents-demo-users`,
+      `fix/2680-api-trial-password-leak`, `fix/2719-web-ssr-lang-dir`, `fix/2882-2905-web-vitrine-links`
+      (issues closes, contenu dans main) → supprimer ou documenter.
+
+## Convergence
+
+- [ ] T030 Mettre à jour CHANGELOG.md, `.specify/memory/project-state.md`, cocher les tâches après merge.


### PR DESCRIPTION
Session QA agent 2026-08-15 (méthode Spec Kit) : constats live (prod Render/Vercel) + audit main post-merges #2944/#2891/#2936/#2935. Registre S1-S10 + spec + tasks. Issues liées : #2975-#2979.