### PR TITLE
docs(qa): specs/plan/tasks expert #2 2026-08-15 — 43 findings (#3021-#3065)

### DIFF
--- a/.specify/features/qa-expert2-admin-2026-08-15/plan.md
+++ b/.specify/features/qa-expert2-admin-2026-08-15/plan.md
@@ -1,0 +1,52 @@
+# Plan: QA Expert #2 — Admin (front/admin-dashboard) (2026-08-15)
+
+**Input**: spec.md — 12 findings.
+
+## Stratégie
+
+1. Corriger par priorité : P1 d'abord (bloquants build/rendu), puis P2 (UX/contrats), puis P3 (hygiène).
+2. Chaque correctif : branche `fix/<issue>-<slug>` depuis `origin/main` récent, PR avec `Closes #N`, CHANGELOG sous `## [Unreleased]`.
+3. Vérifications : lint + build pour web/admin ; `flutter analyze`/contrats pour mobile (CI) ; Pint/PHPStan/tests via CI pour API.
+4. Anti-régression : vérifier que les fichiers touchés ne réécrasent pas des fixes plus récents de main (`git diff origin/main...HEAD`).
+
+## Phases
+
+### Phase 1 — #3033 [P1] Admin — build prod cassé : DocumentReportIcon inexistant dans @heroicons/vue → vite build échoue (de
+- [ ] Branche `fix/3033-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3033`.
+
+### Phase 2 — #3034 [P1] Admin — CompanyDetailView crashe : lit health.adoption.kiosk.active jamais renvoyé par le backend → 
+- [ ] Branche `fix/3034-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3034`.
+
+### Phase 3 — #3036 [P2] Admin — DashboardView « Priorités Portefeuille » : lit item.name/slug/mrr_eur au lieu de company.*/s
+- [ ] Branche `fix/3036-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3036`.
+
+### Phase 4 — #3037 [P2] Admin — DashboardView « Inscriptions en attente » : lit request.name/manager_email au lieu de compan
+- [ ] Branche `fix/3037-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3037`.
+
+### Phase 5 — #3038 [P2] Admin — UsersView : colonne « Inscription » toujours « - » (mapping createdAt vs created_at) alors q
+- [ ] Branche `fix/3038-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3038`.
+
+### Phase 6 — #3039 [P3] Admin — 16 clés i18n manquantes dans les 4 locales (users.impersonation.*, users.toast.bulkDone) → f
+- [ ] Branche `fix/3039-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3039`.
+
+### Phase 7 — #3041 [P3] Admin — raccourci Alt+R pointe /recruitment (route tenant gardée) → rebond systématique + toast
+- [ ] Branche `fix/3041-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3041`.
+
+### Phase 8 — #3042 [P3] Admin — recherche header peut naviguer vers des routes tenant gardées (Paie, Congés…) → rebond muet
+- [ ] Branche `fix/3042-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3042`.
+
+### Phase 9 — #3043 [P3] Admin — bandeau « Mode maintenance » jamais déclenchable : setMaintenanceMode exposé mais aucun appe
+- [ ] Branche `fix/3043-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3043`.
+
+### Phase 10 — #3044 [P3] Admin — boutons d'action des notifications jamais affichés (aucune notification ne porte le champ ac
+- [ ] Branche `fix/3044-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3044`.
+
+### Phase 11 — #3045 [P3] Admin — export CSV AnalyticsView sans échappement anti-injection de formule (incohérent avec UsersVi
+- [ ] Branche `fix/3045-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3045`.
+
+### Phase 12 — #3046 [P3] Admin — 6 imports d'icônes inutilisés dans CommandPalette (résidu du retrait des entrées tenant)
+- [ ] Branche `fix/3046-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3046`.
+
+## Finalisation
+- [ ] Mise à jour `docs/qa/QA_SESSION_2026-08-15-expert2.md` (bilan par surface).
+- [ ] CHANGELOG.md : entrée `### Fixed` par PR.

--- a/.specify/features/qa-expert2-admin-2026-08-15/spec.md
+++ b/.specify/features/qa-expert2-admin-2026-08-15/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: QA Expert #2 — Admin (front/admin-dashboard) (2026-08-15)
+
+**Feature**: `qa-expert2-admin-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + revue statique experte (rg/scripts) + cross-check issues existantes.
+
+## Contexte
+
+Deuxième vague de test expert de la mission propriétaire (tester « dans tous les sens », consigner chaque manquement selon la méthode Spec Kit, puis implémenter). Les findings ci-dessous sont **nouveaux** : vérifiés contre les ~140 issues ouvertes et les branches/PRs existantes (règle anti-doublon #2400).
+
+## Findings non couverts (issues créées)
+
+### #3033 [P1] Admin — build prod cassé : DocumentReportIcon inexistant dans @heroicons/vue → vite build échoue (deploy Cloudflare bloqué)
+
+> **Constat** : `CommandPalette.vue` importe `DocumentReportIcon` qui **n'existe pas** dans `@heroicons/vue` 2.x → `vite build` échoue (MISSING_EXPORT). Tout déploiement admin est bloqué.
+> **Preuve** : - `front/admin-dashboard/src/components/common/CommandPalette.vue:45,94,124`
+- `grep DocumentReportIcon node_modules/@heroicons/vue/24/outline/esm/` → vide
+- `npm run build` → erreur MISSING_EXPORT reproduite
+> **Impact** : P1 : CI/deploy Cloudflare Pages cassé ; impossible de livrer les correctifs admin.
+
+### #3034 [P1] Admin — CompanyDetailView crashe : lit health.adoption.kiosk.active jamais renvoyé par le backend → fiche entreprise blanche
+
+> **Constat** : `CompanyDetailView` lit `health.adoption.kiosk.active` (et `company.slug`/`created_at`) que le backend ne renvoie jamais → exception au rendu → page détail entreprise vide/blanche.
+> **Preuve** : - `front/admin-dashboard/src/views/companies/CompanyDetailView.vue:80-81,301,309`
+- Backend `/platform/companies/{company}/health` : shape sans `kiosk`
+> **Impact** : P1 : la fiche client (action « Activer client », abonnement) est inutilisable.
+
+### #3036 [P2] Admin — DashboardView « Priorités Portefeuille » : lit item.name/slug/mrr_eur au lieu de company.*/subscription.mrr → noms vides, MRR 0€, lien /companies/undefined
+
+> **Constat** : Le widget « Priorités Portefeuille » mappe des champs inexistants du payload → noms vides, MRR 0 €, lien Détails → `/companies/undefined`.
+> **Preuve** : - `front/admin-dashboard/src/views/DashboardView.vue:81,88-89,109,112`
+> **Impact** : Widget principal du cockpit inexploitable.
+
+### #3037 [P2] Admin — DashboardView « Inscriptions en attente » : lit request.name/manager_email au lieu de company_name/email → titres vides
+
+> **Constat** : Le widget « Inscriptions en attente » lit `request.name`/`request.manager_email` alors que l'API renvoie `company_name`/`email` → titres vides.
+> **Preuve** : - `front/admin-dashboard/src/views/DashboardView.vue:133-134`
+> **Impact** : Demandes entrantes illisibles dans le cockpit.
+
+### #3038 [P2] Admin — UsersView : colonne « Inscription » toujours « - » (mapping createdAt vs created_at) alors que la date existe côté API
+
+> **Constat** : `UsersView` mappe `createdAt`/`lastLoginAt` mais `UserTable` lit `created_at`/`last_login_at` → la colonne « Inscription » affiche toujours « - ».
+> **Preuve** : - `front/admin-dashboard/src/views/users/UsersView.vue:317`
+- `front/admin-dashboard/src/components/users/UserTable.vue:121,189`
+> **Impact** : Donnée existante invisible.
+
+### #3039 [P3] Admin — 16 clés i18n manquantes dans les 4 locales (users.impersonation.*, users.toast.bulkDone) → fallback FR en ar/tr
+
+> **Constat** : 16 clés i18n utilisées par UsersView sont absentes des catalogues → les locales ar/tr affichent du français.
+> **Preuve** : - `front/admin-dashboard/src/views/users/UsersView.vue:155-195,374,423-451` (clés `users.impersonation.*`, `users.toast.bulkDone`…)
+- Catalogues `src/i18n/locales/*.json` sans ces clés
+> **Impact** : Incohérence i18n admin (connexe #2639/#2613).
+
+### #3041 [P3] Admin — raccourci Alt+R pointe /recruitment (route tenant gardée) → rebond systématique + toast
+
+> **Constat** : Le raccourci Alt+R navigue vers `/recruitment`, route tenant gardée par design (#2272) → rebond muet systématique.
+> **Preuve** : - `front/admin-dashboard/src/composables/useKeyboardShortcuts.js:51-53`
+> **Impact** : Raccourci inutile/bruyant.
+
+### #3042 [P3] Admin — recherche header peut naviguer vers des routes tenant gardées (Paie, Congés…) → rebond muet
+
+> **Constat** : La recherche globale du header propose des routes tenant gardées (Paie, Congés…) → navigation → rebond silencieux.
+> **Preuve** : - `front/admin-dashboard/src/components/layout/Header.vue:148-163`
+> **Impact** : UX dégradée (connexe #2611/#2787).
+
+### #3043 [P3] Admin — bandeau « Mode maintenance » jamais déclenchable : setMaintenanceMode exposé mais aucun appelant
+
+> **Constat** : `SystemAlertsOverlay` expose `setMaintenanceMode` mais aucun composant ne l'appelle → le bandeau « Mode maintenance » est mort.
+> **Preuve** : - `front/admin-dashboard/src/components/alerts/SystemAlertsOverlay.vue:227-230`
+> **Impact** : Fonctionnalité annoncée inatteignable.
+
+### #3044 [P3] Admin — boutons d'action des notifications jamais affichés (aucune notification ne porte le champ action)
+
+> **Constat** : `NotificationPanel` affiche conditionnellement des boutons d'action sur `notification.action` mais l'API n'envoie jamais ce champ → boutons morts.
+> **Preuve** : - `front/admin-dashboard/src/components/notifications/NotificationPanel.vue:38-50,151-152`
+> **Impact** : Code mort / promesse UI non tenue.
+
+### #3045 [P3] Admin — export CSV AnalyticsView sans échappement anti-injection de formule (incohérent avec UsersView)
+
+> **Constat** : L'export CSV d'AnalyticsView ne protège pas les cellules commençant par =,+,-,@ → injection de formule possible ; UsersView a déjà le garde.
+> **Preuve** : - `front/admin-dashboard/src/views/analytics/AnalyticsView.vue:234-239`
+> **Impact** : Sécurité desktop (Excel/Sheets) — classe #2700 non couverte ici.
+
+### #3046 [P3] Admin — 6 imports d'icônes inutilisés dans CommandPalette (résidu du retrait des entrées tenant)
+
+> **Constat** : CommandPalette importe 6 icônes inutilisées (warnings lint) — résidu du retrait des entrées tenant.
+> **Preuve** : - `front/admin-dashboard/src/components/common/CommandPalette.vue:81-88`
+> **Impact** : Hygiène (warnings lint).
+
+## Règles d'implémentation
+- Une PR par issue avec `Closes #N` dans le body (Constitution §VII).
+- Pas de données fabriquées : endpoint réel ou état vide honnête.
+- i18n : les 4 locales FR/EN/TR/AR dans le même changement ; jamais de clés brutes affichées.
+- Vérifier la garde anti-doublon avant push : `git ls-remote --heads origin | grep <issue>`.

--- a/.specify/features/qa-expert2-admin-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert2-admin-2026-08-15/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: QA Expert #2 — Admin (front/admin-dashboard) (2026-08-15)
+
+**Input**: spec.md + plan.md — chaque tâche correspond à une issue GitHub ouverte (label `qa-expert2-2026-08-15`).
+
+## Phase 1 — #3033 [P1] Admin — build prod cassé : DocumentReportIcon inexistant dans @heroicons/vue → vite build échoue (de
+- [ ] T001 [#3033] Implémenter le correctif (détails dans le corps de l'issue #3033)
+- [ ] T002 [#3033] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 2 — #3034 [P1] Admin — CompanyDetailView crashe : lit health.adoption.kiosk.active jamais renvoyé par le backend → 
+- [ ] T003 [#3034] Implémenter le correctif (détails dans le corps de l'issue #3034)
+- [ ] T004 [#3034] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 3 — #3036 [P2] Admin — DashboardView « Priorités Portefeuille » : lit item.name/slug/mrr_eur au lieu de company.*/s
+- [ ] T005 [#3036] Implémenter le correctif (détails dans le corps de l'issue #3036)
+- [ ] T006 [#3036] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 4 — #3037 [P2] Admin — DashboardView « Inscriptions en attente » : lit request.name/manager_email au lieu de compan
+- [ ] T007 [#3037] Implémenter le correctif (détails dans le corps de l'issue #3037)
+- [ ] T008 [#3037] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 5 — #3038 [P2] Admin — UsersView : colonne « Inscription » toujours « - » (mapping createdAt vs created_at) alors q
+- [ ] T009 [#3038] Implémenter le correctif (détails dans le corps de l'issue #3038)
+- [ ] T010 [#3038] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 6 — #3039 [P3] Admin — 16 clés i18n manquantes dans les 4 locales (users.impersonation.*, users.toast.bulkDone) → f
+- [ ] T011 [#3039] Implémenter le correctif (détails dans le corps de l'issue #3039)
+- [ ] T012 [#3039] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 7 — #3041 [P3] Admin — raccourci Alt+R pointe /recruitment (route tenant gardée) → rebond systématique + toast
+- [ ] T013 [#3041] Implémenter le correctif (détails dans le corps de l'issue #3041)
+- [ ] T014 [#3041] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 8 — #3042 [P3] Admin — recherche header peut naviguer vers des routes tenant gardées (Paie, Congés…) → rebond muet
+- [ ] T015 [#3042] Implémenter le correctif (détails dans le corps de l'issue #3042)
+- [ ] T016 [#3042] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 9 — #3043 [P3] Admin — bandeau « Mode maintenance » jamais déclenchable : setMaintenanceMode exposé mais aucun appe
+- [ ] T017 [#3043] Implémenter le correctif (détails dans le corps de l'issue #3043)
+- [ ] T018 [#3043] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 10 — #3044 [P3] Admin — boutons d'action des notifications jamais affichés (aucune notification ne porte le champ ac
+- [ ] T019 [#3044] Implémenter le correctif (détails dans le corps de l'issue #3044)
+- [ ] T020 [#3044] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 11 — #3045 [P3] Admin — export CSV AnalyticsView sans échappement anti-injection de formule (incohérent avec UsersVi
+- [ ] T021 [#3045] Implémenter le correctif (détails dans le corps de l'issue #3045)
+- [ ] T022 [#3045] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 12 — #3046 [P3] Admin — 6 imports d'icônes inutilisés dans CommandPalette (résidu du retrait des entrées tenant)
+- [ ] T023 [#3046] Implémenter le correctif (détails dans le corps de l'issue #3046)
+- [ ] T024 [#3046] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG

--- a/.specify/features/qa-expert2-api-2026-08-15/plan.md
+++ b/.specify/features/qa-expert2-api-2026-08-15/plan.md
@@ -1,0 +1,49 @@
+# Plan: QA Expert #2 — API (api/) (2026-08-15)
+
+**Input**: spec.md — 11 findings.
+
+## Stratégie
+
+1. Corriger par priorité : P1 d'abord (bloquants build/rendu), puis P2 (UX/contrats), puis P3 (hygiène).
+2. Chaque correctif : branche `fix/<issue>-<slug>` depuis `origin/main` récent, PR avec `Closes #N`, CHANGELOG sous `## [Unreleased]`.
+3. Vérifications : lint + build pour web/admin ; `flutter analyze`/contrats pour mobile (CI) ; Pint/PHPStan/tests via CI pour API.
+4. Anti-régression : vérifier que les fichiers touchés ne réécrasent pas des fixes plus récents de main (`git diff origin/main...HEAD`).
+
+## Phases
+
+### Phase 1 — #3055 [P2] API — GET /employees/{id}/leave-balances sans garde de rôle : un employé lit les soldes de tout coll
+- [ ] Branche `fix/3055-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3055`.
+
+### Phase 2 — #3056 [P2] API — essai self-service : réponse verify annonce 14 jours alors que le tenant est provisionné 30 j 
+- [ ] Branche `fix/3056-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3056`.
+
+### Phase 3 — #3057 [P2] API — échec d'envoi OTP trial avalé → 200 « Code envoyé » sans code, aucun resend (résiduel #2678)
+- [ ] Branche `fix/3057-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3057`.
+
+### Phase 4 — #3058 [P2] API — webhook email-bounce : services.mail_bounce_webhook.secret défini nulle part → 503 permanent (
+- [ ] Branche `fix/3058-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3058`.
+
+### Phase 5 — #3059 [P3] API — per_page/limit non bornés sur 11 endpoints (approvals, billing, ai-gateway, audit-log, cabinet
+- [ ] Branche `fix/3059-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3059`.
+
+### Phase 6 — #3060 [P3] API — clé de signature QR onboarding en fallback codée en dur (fail-open si APP_KEY vide → QR forgea
+- [ ] Branche `fix/3060-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3060`.
+
+### Phase 7 — #3061 [P3] API — drift OpenAPI résiduel : groupes PA2/platform à 0% (announcements, conversations, impersonatio
+- [ ] Branche `fix/3061-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3061`.
+
+### Phase 8 — #3062 [P3] API — méthode morte TrainingController::indexSessionsAll jamais routée (la route utilise indexAllSes
+- [ ] Branche `fix/3062-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3062`.
+
+### Phase 9 — #3063 [P3] API — LeavePolicyController dupliqué (modules Absence vs Planning) : la copie Absence est celle non 
+- [ ] Branche `fix/3063-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3063`.
+
+### Phase 10 — #3064 [P3] API — drift docs↔code : RBAC_ROUTE_MATRIX documente /onboarding-setup* sous api.manager, le code l'o
+- [ ] Branche `fix/3064-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3064`.
+
+### Phase 11 — #3065 [P3] API — POST /employees/link-user : employee_id non validé comme appartenant à la société de l'acteur 
+- [ ] Branche `fix/3065-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3065`.
+
+## Finalisation
+- [ ] Mise à jour `docs/qa/QA_SESSION_2026-08-15-expert2.md` (bilan par surface).
+- [ ] CHANGELOG.md : entrée `### Fixed` par PR.

--- a/.specify/features/qa-expert2-api-2026-08-15/spec.md
+++ b/.specify/features/qa-expert2-api-2026-08-15/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: QA Expert #2 — API (api/) (2026-08-15)
+
+**Feature**: `qa-expert2-api-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + revue statique experte (rg/scripts) + cross-check issues existantes.
+
+## Contexte
+
+Deuxième vague de test expert de la mission propriétaire (tester « dans tous les sens », consigner chaque manquement selon la méthode Spec Kit, puis implémenter). Les findings ci-dessous sont **nouveaux** : vérifiés contre les ~140 issues ouvertes et les branches/PRs existantes (règle anti-doublon #2400).
+
+## Findings non couverts (issues créées)
+
+### #3055 [P2] API — GET /employees/{id}/leave-balances sans garde de rôle : un employé lit les soldes de tout collègue (copie Planning gardée)
+
+> **Constat** : `GET /api/v1/employees/{employeeId}/leave-balances` n'a aucun garde de rôle : tout utilisateur authentifié du tenant lit les soldes de n'importe quel employé. La copie Planning (gardée) scoping self/manager.
+> **Preuve** : - `api/routes/modules/absence.php:30-33` (middleware auth+tenant seulement)
+- `api/app/Modules/Absence/Interfaces/Api/V1/Controllers/LeavePolicyController.php:17-35` — `balances()` sans `hasManagerRole`, sans scope `actor`/`manager_id`
+- Copie gardée : `api/app/Modules/Planning/.../LeavePolicyController.php` (`myBalances`, `hasManagerRole('principal','rh')`)
+> **Impact** : Exposition cross-employé des soldes de congés dans le tenant (PII RH) — même société, mais violation du principe du moindre privilège.
+
+### #3056 [P2] API — essai self-service : réponse verify annonce 14 jours alors que le tenant est provisionné 30 j (parcours guidé 30 j)
+
+> **Constat** : Le self-service trial annonce 14 jours (`trial_days_left=14` dans la réponse verify) alors que le tenant est provisionné à 30 jours ; le parcours guidé dit 30 j.
+> **Preuve** : - `api/app/.../SelfServiceTrialController.php:221-222` (14)
+- `api/app/.../VerifyTrialSignup.php:191` (14)
+- `api/app/.../ProvisionGuidedTrial.php:56` (30)
+> **Impact** : Message contractuel incohérent entre les deux parcours d'essai.
+
+### #3057 [P2] API — échec d'envoi OTP trial avalé → 200 « Code envoyé » sans code, aucun resend (résiduel #2678)
+
+> **Constat** : En cas d'échec d'envoi de l'OTP (mail), `RequestTrialSignup` avale l'erreur et répond 200 « code envoyé » — l'utilisateur ne reçoit jamais de code et il n'y a pas de resend.
+> **Preuve** : - `api/app/.../RequestTrialSignup.php:41-48` (try/catch silencieux)
+> **Impact** : Parcours d'essai bloqué sans message (résiduel de #2678 dont le fix n'a pas touché le mail).
+
+### #3058 [P2] API — webhook email-bounce : services.mail_bounce_webhook.secret défini nulle part → 503 permanent (fix fail-closed #2616 incomplet)
+
+> **Constat** : Le controller email-bounce exige `services.mail_bounce_webhook.secret` qui n'est défini ni dans `config/services.php` ni dans `.env.example` → 503 permanent, la feature est morte (fix #2616 fail-closed incomplet).
+> **Preuve** : - `api/app/.../EmailBounceWebhookController.php:32-43`
+- `api/config/services.php`, `api/.env.example` : clé absente
+> **Impact** : Les rebonds email ne sont jamais traités (hygiène d'expéditeur dégradée).
+
+### #3059 [P3] API — per_page/limit non bornés sur 11 endpoints (approvals, billing, ai-gateway, audit-log, cabinet-documents, contracts, vehicles, vehicle-alerts, vehicle-maintenance, vehicle-trips, payroll-cycles)
+
+> **Constat** : `per_page`/`limit` acceptés sans borne supérieure sur 11 endpoints (hors périmètre de #2682) → un client peut demander des pages énormes.
+> **Preuve** : - `ApprovalController.php:116,203`, `BillingController.php:134`, `AIGatewayController.php:57`, `AuditLogController.php:61`, `CabinetDocumentController.php:59`, `ContractController.php:39`, `VehicleController.php:36,186,199,212`, `VehicleAlertController.php:33`, `VehicleMaintenanceController.php:30`, `VehicleTripController.php:36`, `PayrollCycleController.php:206`
+> **Impact** : Perf/abus (classe #2682 étendue).
+
+### #3060 [P3] API — clé de signature QR onboarding en fallback codée en dur (fail-open si APP_KEY vide → QR forgeables)
+
+> **Constat** : `OnboardingQrService` a un fallback de clé HMAC codé en dur : si `APP_KEY` est vide, les QR d'onboarding deviennent forgeables.
+> **Preuve** : - `api/app/.../OnboardingQrService.php:144-148`
+> **Impact** : Sécurité onboarding si mauvaise config (devrait fail-closed).
+
+### #3061 [P3] API — drift OpenAPI résiduel : groupes PA2/platform à 0% (announcements, conversations, impersonations, support-tickets, observability, crm/pipeline, edge/health, onboarding/steps, cabinet/stats, webhooks test)
+
+> **Constat** : Des groupes entiers de routes (pour la plupart récents, PA2) restent absents de `api/openapi.yaml`.
+> **Preuve** : - `api/openapi.yaml` vs `api/routes/**` (comparaison scriptée) : announcements, conversations, impersonations, support-tickets, observability, crm/pipeline, edge/health, onboarding/steps, cabinet/stats, webhooks test
+> **Impact** : Contrat public incomplet (extension #2662/#2675/#2638).
+
+### #3062 [P3] API — méthode morte TrainingController::indexSessionsAll jamais routée (la route utilise indexAllSessions)
+
+> **Constat** : `TrainingController::indexSessionsAll` n'est routée nulle part ; la route utilise `indexAllSessions`.
+> **Preuve** : - `api/app/Modules/.../TrainingController.php:142` vs routes `training.php`
+> **Impact** : Code mort.
+
+### #3063 [P3] API — LeavePolicyController dupliqué (modules Absence vs Planning) : la copie Absence est celle non gardée (source de la fuite leave-balances)
+
+> **Constat** : `LeavePolicyController` existe en double : modules Absence (non gardé, source de la fuite RBAC) et modules Planning (gardé). Duplication source de drift.
+> **Preuve** : - `api/app/Modules/Absence/Interfaces/Api/V1/Controllers/LeavePolicyController.php` vs `api/app/Modules/Planning/.../LeavePolicyController.php`
+> **Impact** : Maintenance/risque de régression (connexe au finding RBAC leave-balances).
+
+### #3064 [P3] API — drift docs↔code : RBAC_ROUTE_MATRIX documente /onboarding-setup* sous api.manager, le code l'ouvre à tous les auth (T118) sans mise à jour
+
+> **Constat** : `docs/security/RBAC_ROUTE_MATRIX.md` documente `/onboarding-setup*` sous `api.manager`, mais le code l'expose à tous les utilisateurs authentifiés — la matrice n'a pas été mise à jour.
+> **Preuve** : - `docs/security/RBAC_ROUTE_MATRIX.md:70,138` vs `api/routes/modules/billing.php:20-31`
+> **Impact** : Garde de sécurité documentaire obsolète (la garde CI ne détecte pas).
+
+### #3065 [P3] API — POST /employees/link-user : employee_id non validé comme appartenant à la société de l'acteur (FK cross-tenant)
+
+> **Constat** : `POST /api/v1/employees/link-user` ne vérifie pas que l'`employee_id` appartient à la société de l'acteur → un manager peut lier un utilisateur à un employé d'une autre société (le scope global `BelongsToCompany` dépend du tenant courant, mais le lien `user_employee_links` peut croiser les tenants).
+> **Preuve** : - `api/app/.../UserEmployeeLinkController.php:20,47-57`
+> **Impact** : Lien cross-tenant potentiel (intégrité des données + confusions de comptes).
+
+## Règles d'implémentation
+- Une PR par issue avec `Closes #N` dans le body (Constitution §VII).
+- Pas de données fabriquées : endpoint réel ou état vide honnête.
+- i18n : les 4 locales FR/EN/TR/AR dans le même changement ; jamais de clés brutes affichées.
+- Vérifier la garde anti-doublon avant push : `git ls-remote --heads origin | grep <issue>`.

--- a/.specify/features/qa-expert2-api-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert2-api-2026-08-15/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: QA Expert #2 — API (api/) (2026-08-15)
+
+**Input**: spec.md + plan.md — chaque tâche correspond à une issue GitHub ouverte (label `qa-expert2-2026-08-15`).
+
+## Phase 1 — #3055 [P2] API — GET /employees/{id}/leave-balances sans garde de rôle : un employé lit les soldes de tout coll
+- [ ] T001 [#3055] Implémenter le correctif (détails dans le corps de l'issue #3055)
+- [ ] T002 [#3055] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 2 — #3056 [P2] API — essai self-service : réponse verify annonce 14 jours alors que le tenant est provisionné 30 j 
+- [ ] T003 [#3056] Implémenter le correctif (détails dans le corps de l'issue #3056)
+- [ ] T004 [#3056] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 3 — #3057 [P2] API — échec d'envoi OTP trial avalé → 200 « Code envoyé » sans code, aucun resend (résiduel #2678)
+- [ ] T005 [#3057] Implémenter le correctif (détails dans le corps de l'issue #3057)
+- [ ] T006 [#3057] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 4 — #3058 [P2] API — webhook email-bounce : services.mail_bounce_webhook.secret défini nulle part → 503 permanent (
+- [ ] T007 [#3058] Implémenter le correctif (détails dans le corps de l'issue #3058)
+- [ ] T008 [#3058] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 5 — #3059 [P3] API — per_page/limit non bornés sur 11 endpoints (approvals, billing, ai-gateway, audit-log, cabinet
+- [ ] T009 [#3059] Implémenter le correctif (détails dans le corps de l'issue #3059)
+- [ ] T010 [#3059] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 6 — #3060 [P3] API — clé de signature QR onboarding en fallback codée en dur (fail-open si APP_KEY vide → QR forgea
+- [ ] T011 [#3060] Implémenter le correctif (détails dans le corps de l'issue #3060)
+- [ ] T012 [#3060] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 7 — #3061 [P3] API — drift OpenAPI résiduel : groupes PA2/platform à 0% (announcements, conversations, impersonatio
+- [ ] T013 [#3061] Implémenter le correctif (détails dans le corps de l'issue #3061)
+- [ ] T014 [#3061] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 8 — #3062 [P3] API — méthode morte TrainingController::indexSessionsAll jamais routée (la route utilise indexAllSes
+- [ ] T015 [#3062] Implémenter le correctif (détails dans le corps de l'issue #3062)
+- [ ] T016 [#3062] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 9 — #3063 [P3] API — LeavePolicyController dupliqué (modules Absence vs Planning) : la copie Absence est celle non 
+- [ ] T017 [#3063] Implémenter le correctif (détails dans le corps de l'issue #3063)
+- [ ] T018 [#3063] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 10 — #3064 [P3] API — drift docs↔code : RBAC_ROUTE_MATRIX documente /onboarding-setup* sous api.manager, le code l'o
+- [ ] T019 [#3064] Implémenter le correctif (détails dans le corps de l'issue #3064)
+- [ ] T020 [#3064] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 11 — #3065 [P3] API — POST /employees/link-user : employee_id non validé comme appartenant à la société de l'acteur 
+- [ ] T021 [#3065] Implémenter le correctif (détails dans le corps de l'issue #3065)
+- [ ] T022 [#3065] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG

--- a/.specify/features/qa-expert2-mobile-2026-08-15/plan.md
+++ b/.specify/features/qa-expert2-mobile-2026-08-15/plan.md
@@ -1,0 +1,40 @@
+# Plan: QA Expert #2 — Mobile (front/mobile_apps) (2026-08-15)
+
+**Input**: spec.md — 8 findings.
+
+## Stratégie
+
+1. Corriger par priorité : P1 d'abord (bloquants build/rendu), puis P2 (UX/contrats), puis P3 (hygiène).
+2. Chaque correctif : branche `fix/<issue>-<slug>` depuis `origin/main` récent, PR avec `Closes #N`, CHANGELOG sous `## [Unreleased]`.
+3. Vérifications : lint + build pour web/admin ; `flutter analyze`/contrats pour mobile (CI) ; Pint/PHPStan/tests via CI pour API.
+4. Anti-régression : vérifier que les fichiers touchés ne réécrasent pas des fixes plus récents de main (`git diff origin/main...HEAD`).
+
+## Phases
+
+### Phase 1 — #3047 [P2] Mobile — notifications « marquer lu/lues » : PUT au lieu de POST/PATCH → 405 garanti (employee, mana
+- [ ] Branche `fix/3047-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3047`.
+
+### Phase 2 — #3048 [P2] Mobile — POST /user/company-requests sans maxRetriesOverride → demande doublée sur timeout (classe #
+- [ ] Branche `fix/3048-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3048`.
+
+### Phase 3 — #3049 [P3] Mobile manager — GoRoute /cabinet/folder/:folderId déclarée 2× (résidu fix #2748)
+- [ ] Branche `fix/3049-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3049`.
+
+### Phase 4 — #3050 [P3] Mobile — écran mort PersonalSpaceScreen (« Créer mon entreprise » inaccessible) dans employee/manage
+- [ ] Branche `fix/3050-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3050`.
+
+### Phase 5 — #3051 [P3] Mobile — leopardo_hr sans ShellRoute/bottom-nav (employee/manager en ont une)
+- [ ] Branche `fix/3051-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3051`.
+
+### Phase 6 — #3052 [P3] Mobile — cast direct data['data']['id'] as String alors que le backend renvoie un int (AttendanceLog
+- [ ] Branche `fix/3052-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3052`.
+
+### Phase 7 — #3053 [P3] Mobile — ThemeMode.dark forcé dans les 5 apps → lightTheme mort
+- [ ] Branche `fix/3053-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3053`.
+
+### Phase 8 — #3054 [P3] Mobile — DateTime.parse non gardés résiduels : hr attendance_repository:552 + cabinet/monthly_summar
+- [ ] Branche `fix/3054-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3054`.
+
+## Finalisation
+- [ ] Mise à jour `docs/qa/QA_SESSION_2026-08-15-expert2.md` (bilan par surface).
+- [ ] CHANGELOG.md : entrée `### Fixed` par PR.

--- a/.specify/features/qa-expert2-mobile-2026-08-15/spec.md
+++ b/.specify/features/qa-expert2-mobile-2026-08-15/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: QA Expert #2 — Mobile (front/mobile_apps) (2026-08-15)
+
+**Feature**: `qa-expert2-mobile-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + revue statique experte (rg/scripts) + cross-check issues existantes.
+
+## Contexte
+
+Deuxième vague de test expert de la mission propriétaire (tester « dans tous les sens », consigner chaque manquement selon la méthode Spec Kit, puis implémenter). Les findings ci-dessous sont **nouveaux** : vérifiés contre les ~140 issues ouvertes et les branches/PRs existantes (règle anti-doublon #2400).
+
+## Findings non couverts (issues créées)
+
+### #3047 [P2] Mobile — notifications « marquer lu/lues » : PUT au lieu de POST/PATCH → 405 garanti (employee, manager, hr)
+
+> **Constat** : Les repos mobiles marquent les notifications comme lues avec `PUT` alors que le backend n'expose que `POST /notifications/read-all` et `PATCH /notifications/{notification}/read` → **405 garanti**.
+> **Preuve** : - `front/mobile_apps/leopardo_employee/lib/features/notifications/data/notification_repository.dart:24,32` (`method: 'PUT'`)
+- `front/mobile_apps/leopardo_manager/lib/features/modules/data/modules_repository.dart:272,281` (idem)
+- Backend : `api/routes/modules/rh.php:175-176`, `api/routes/modules/dashboard.php:34-35`
+> **Impact** : Toute action « tout marquer lu » ou « marquer lu » échoue en 405 sur les 3 apps tenant.
+
+### #3048 [P2] Mobile — POST /user/company-requests sans maxRetriesOverride → demande doublée sur timeout (classe #2742 non couverte)
+
+> **Constat** : `POST /user/company-requests` hérite des retries automatiques → si le serveur a réussi mais le client timeout, la demande de rattachement est créée en double.
+> **Preuve** : - `front/mobile_apps/leopardo_{employee,manager,hr}/lib/features/user_auth/data/user_auth_repository.dart:141` (pas de `maxRetriesOverride: 0`)
+> **Impact** : Doublons de company_requests (classe #2742 appliquée aux avances mais pas ici).
+
+### #3049 [P3] Mobile manager — GoRoute /cabinet/folder/:folderId déclarée 2× (résidu fix #2748)
+
+> **Constat** : La route `/cabinet/folder/:folderId` est déclarée deux fois dans le GoRouter du manager.
+> **Preuve** : - `front/mobile_apps/leopardo_manager/lib/app.dart:209,220`
+> **Impact** : Hygiène router (résidu #2748).
+
+### #3050 [P3] Mobile — écran mort PersonalSpaceScreen (« Créer mon entreprise » inaccessible) dans employee/manager/hr
+
+> **Constat** : `PersonalSpaceScreen` propose « Créer mon entreprise » mais n'est atteignable depuis aucune navigation des 3 apps.
+> **Preuve** : - `front/mobile_apps/leopardo_{employee,manager,hr}/lib/features/personal_space/screens/personal_space_screen.dart:8`
+> **Impact** : Écran mort annonçant une capacité inexistante.
+
+### #3051 [P3] Mobile — leopardo_hr sans ShellRoute/bottom-nav (employee/manager en ont une)
+
+> **Constat** : L'app `leopardo_hr` ne définit aucune `ShellRoute` (bottom navigation), contrairement à employee et manager — navigation principale absente.
+> **Preuve** : - `front/mobile_apps/leopardo_hr/lib/app.dart:118+` (0 ShellRoute)
+> **Impact** : Expérience RH sans navigation par onglets (incohérence entre apps).
+
+### #3052 [P3] Mobile — cast direct data['data']['id'] as String alors que le backend renvoie un int (AttendanceLogResource)
+
+> **Constat** : `attendance_offline_service.dart` caste `data['data']['id'] as String` mais `AttendanceLogResource` renvoie l'id en **int** → TypeError latent.
+> **Preuve** : - `front/mobile_apps/leopardo_core/lib/offline/services/attendance_offline_service.dart:65`
+- `api/app/.../AttendanceLogResource.php:41` (int)
+> **Impact** : Crash possible sur certaines données de pointage offline.
+
+### #3053 [P3] Mobile — ThemeMode.dark forcé dans les 5 apps → lightTheme mort
+
+> **Constat** : Les 5 apps forcent `ThemeMode.dark`, rendant les thèmes clairs morts (aucune préférence utilisateur).
+> **Preuve** : - employee:313, manager:367, hr:344, platform_admin:97, marketing:126 (main.dart)
+> **Impact** : Hygiène/thème non configurable.
+
+### #3054 [P3] Mobile — DateTime.parse non gardés résiduels : hr attendance_repository:552 + cabinet/monthly_summary/absence/geo-sessions
+
+> **Constat** : Des `DateTime.parse` sans garde subsistent (fix #2767 incomplet) : hr:552, cabinet_folder:31, cabinet_document:31, monthly_summary:60-61,103, absence:56-57, geo_attendance_session:48-56.
+> **Preuve** : - `front/mobile_apps/leopardo_hr/lib/features/attendance/data/attendance_repository.dart:552`
+- cabinet/…, monthly_summary/…, absence/…, geo_attendance_session/…
+> **Impact** : Crash sur données malformées.
+
+## Règles d'implémentation
+- Une PR par issue avec `Closes #N` dans le body (Constitution §VII).
+- Pas de données fabriquées : endpoint réel ou état vide honnête.
+- i18n : les 4 locales FR/EN/TR/AR dans le même changement ; jamais de clés brutes affichées.
+- Vérifier la garde anti-doublon avant push : `git ls-remote --heads origin | grep <issue>`.

--- a/.specify/features/qa-expert2-mobile-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert2-mobile-2026-08-15/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: QA Expert #2 — Mobile (front/mobile_apps) (2026-08-15)
+
+**Input**: spec.md + plan.md — chaque tâche correspond à une issue GitHub ouverte (label `qa-expert2-2026-08-15`).
+
+## Phase 1 — #3047 [P2] Mobile — notifications « marquer lu/lues » : PUT au lieu de POST/PATCH → 405 garanti (employee, mana
+- [ ] T001 [#3047] Implémenter le correctif (détails dans le corps de l'issue #3047)
+- [ ] T002 [#3047] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 2 — #3048 [P2] Mobile — POST /user/company-requests sans maxRetriesOverride → demande doublée sur timeout (classe #
+- [ ] T003 [#3048] Implémenter le correctif (détails dans le corps de l'issue #3048)
+- [ ] T004 [#3048] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 3 — #3049 [P3] Mobile manager — GoRoute /cabinet/folder/:folderId déclarée 2× (résidu fix #2748)
+- [ ] T005 [#3049] Implémenter le correctif (détails dans le corps de l'issue #3049)
+- [ ] T006 [#3049] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 4 — #3050 [P3] Mobile — écran mort PersonalSpaceScreen (« Créer mon entreprise » inaccessible) dans employee/manage
+- [ ] T007 [#3050] Implémenter le correctif (détails dans le corps de l'issue #3050)
+- [ ] T008 [#3050] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 5 — #3051 [P3] Mobile — leopardo_hr sans ShellRoute/bottom-nav (employee/manager en ont une)
+- [ ] T009 [#3051] Implémenter le correctif (détails dans le corps de l'issue #3051)
+- [ ] T010 [#3051] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 6 — #3052 [P3] Mobile — cast direct data['data']['id'] as String alors que le backend renvoie un int (AttendanceLog
+- [ ] T011 [#3052] Implémenter le correctif (détails dans le corps de l'issue #3052)
+- [ ] T012 [#3052] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 7 — #3053 [P3] Mobile — ThemeMode.dark forcé dans les 5 apps → lightTheme mort
+- [ ] T013 [#3053] Implémenter le correctif (détails dans le corps de l'issue #3053)
+- [ ] T014 [#3053] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 8 — #3054 [P3] Mobile — DateTime.parse non gardés résiduels : hr attendance_repository:552 + cabinet/monthly_summar
+- [ ] T015 [#3054] Implémenter le correctif (détails dans le corps de l'issue #3054)
+- [ ] T016 [#3054] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG

--- a/.specify/features/qa-expert2-web-2026-08-15/plan.md
+++ b/.specify/features/qa-expert2-web-2026-08-15/plan.md
@@ -1,0 +1,52 @@
+# Plan: QA Expert #2 — Vitrine / Web (front/web) (2026-08-15)
+
+**Input**: spec.md — 12 findings.
+
+## Stratégie
+
+1. Corriger par priorité : P1 d'abord (bloquants build/rendu), puis P2 (UX/contrats), puis P3 (hygiène).
+2. Chaque correctif : branche `fix/<issue>-<slug>` depuis `origin/main` récent, PR avec `Closes #N`, CHANGELOG sous `## [Unreleased]`.
+3. Vérifications : lint + build pour web/admin ; `flutter analyze`/contrats pour mobile (CI) ; Pint/PHPStan/tests via CI pour API.
+4. Anti-régression : vérifier que les fichiers touchés ne réécrasent pas des fixes plus récents de main (`git diff origin/main...HEAD`).
+
+## Phases
+
+### Phase 1 — #3021 [P2] Vitrine — og:image 404 sur ~20 pages : fix #2752 appliqué dans seo-metadata.ts mort, seo.ts vivant r
+- [ ] Branche `fix/3021-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3021`.
+
+### Phase 2 — #3022 [P2] Vitrine — clés i18n brutes affichées dans le flux OTP du signup (c.otpInvalidLength, c.otpVerifyErro
+- [ ] Branche `fix/3022-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3022`.
+
+### Phase 3 — #3023 [P2] Vitrine — /pricing masque le surcoût par employé actif que la home affiche (+2 EUR/employé)
+- [ ] Branche `fix/3023-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3023`.
+
+### Phase 4 — #3024 [P2] Vitrine — tableau comparatif pricing incohérent avec les cartes de plans (Pilot, Operations, multi-p
+- [ ] Branche `fix/3024-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3024`.
+
+### Phase 5 — #3025 [P2] Vitrine — plan Pilot AR : features promises absentes des cartes fr/en/tr (bulletins PDF, portail cli
+- [ ] Branche `fix/3025-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3025`.
+
+### Phase 6 — #3026 [P2] Vitrine — stats fabriquées dans l'image OG générée (500+ entreprises, 50K+ employés, 99.9%)
+- [ ] Branche `fix/3026-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3026`.
+
+### Phase 7 — #3027 [P2] Dashboard client — carte « Leo IA » factice (retards -15%) + « Présence hebdo +12% » à barres codées
+- [ ] Branche `fix/3027-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3027`.
+
+### Phase 8 — #3028 [P3] Vitrine — tags background-sync PWA incompatibles : client enregistre sync-forms/sync-analytics, le S
+- [ ] Branche `fix/3028-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3028`.
+
+### Phase 9 — #3029 [P3] Vitrine — le service worker précache des routes dashboard authentifiées (login page cachée sous /das
+- [ ] Branche `fix/3029-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3029`.
+
+### Phase 10 — #3030 [P3] Dashboard client — page /edge-nodes toujours routée et protégée par middleware malgré #2602 fermée (
+- [ ] Branche `fix/3030-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3030`.
+
+### Phase 11 — #3031 [P3] Vitrine — SignupForm : étapes pending/success encore 100% FR malgré #2727 fermée
+- [ ] Branche `fix/3031-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3031`.
+
+### Phase 12 — #3032 [P3] Vitrine — contenu FAQ incohérent : paie « 6 pays (…Sénégal) » vs demo 5 pays ; Sage/QuickBooks vendu
+- [ ] Branche `fix/3032-slug` depuis origin/main ; implémentation minimale ; tests/checks ; PR `Closes #3032`.
+
+## Finalisation
+- [ ] Mise à jour `docs/qa/QA_SESSION_2026-08-15-expert2.md` (bilan par surface).
+- [ ] CHANGELOG.md : entrée `### Fixed` par PR.

--- a/.specify/features/qa-expert2-web-2026-08-15/spec.md
+++ b/.specify/features/qa-expert2-web-2026-08-15/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: QA Expert #2 — Vitrine / Web (front/web) (2026-08-15)
+
+**Feature**: `qa-expert2-web-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + revue statique experte (rg/scripts) + cross-check issues existantes.
+
+## Contexte
+
+Deuxième vague de test expert de la mission propriétaire (tester « dans tous les sens », consigner chaque manquement selon la méthode Spec Kit, puis implémenter). Les findings ci-dessous sont **nouveaux** : vérifiés contre les ~140 issues ouvertes et les branches/PRs existantes (règle anti-doublon #2400).
+
+## Findings non couverts (issues créées)
+
+### #3021 [P2] Vitrine — og:image 404 sur ~20 pages : fix #2752 appliqué dans seo-metadata.ts mort, seo.ts vivant référence 20 PNG inexistants
+
+> **Constat** : Le fix #2752 (#2889) a remplacé les refs `/og/*.png` dans `src/modules/vitrine/lib/seo-metadata.ts` qui est **mort** (0 import). Le fichier **vivant** `src/modules/vitrine/lib/seo.ts` (importé par les layouts landing) référence 20 images `og/*.png` inexistantes — seul `public/og/default.png` existe.
+> **Preuve** : - `front/web/src/modules/vitrine/lib/seo.ts:94-355` : `og/about.png`, `og/blog.png`, `og/pricing.png`, `og/signup.png`… (20 refs)
+- `front/web/public/og/` : seul `default.png` présent
+- `seo-metadata.ts` : 0 import (`rg seo-metadata src/` vide)
+> **Impact** : Les social cards (LinkedIn/X/WhatsApp) affichent une image 404 sur ~20 pages de la vitrine. SEO/social proof dégradé.
+
+### #3022 [P2] Vitrine — clés i18n brutes affichées dans le flux OTP du signup (c.otpInvalidLength, c.otpVerifyError, c.pendingFallback)
+
+> **Constat** : Le formulaire de signup affiche des **clés i18n brutes** à l'utilisateur dans le parcours OTP au lieu des traductions (pourtant présentes dans le catalogue).
+> **Preuve** : - `front/web/src/modules/vitrine/components/forms/SignupForm.tsx:291` → `setOtpError('c.otpInvalidLength')`
+- `:307` → `'c.otpInvalidCode'` ; `:310` → `'c.otpVerifyError'` ; `:228` → `"c.pendingFallback"`
+- Les traductions existent dans le catalogue i18n (clés `c.otpInvalidLength` etc.) — il manque la résolution.
+> **Impact** : Erreur OTP illisible (clé crue) dans le parcours de conversion principal — régression de #2727.
+
+### #3023 [P2] Vitrine — /pricing masque le surcoût par employé actif que la home affiche (+2 EUR/employé)
+
+> **Constat** : La page /pricing affiche « 29€/mois » sans le surcoût « +2 EUR/employé actif » pourtant affiché sur la home ; la page rend `copy.plans.period*` générique au lieu de `plan.period`/`annualPeriod`.
+> **Preuve** : - `front/web/src/app/(landing)/pricing/page.tsx:910` (rend `copy.plans.period*`, jamais `plan.period`/`annualPeriod`)
+- La home (`OperationalProofSection`/pricing teaser) affiche le surcoût
+> **Impact** : Promesse tarifaire incomplète sur la page de conversion la plus importante ; risque d'objection au checkout.
+
+### #3024 [P2] Vitrine — tableau comparatif pricing incohérent avec les cartes de plans (Pilot, Operations, multi-pays)
+
+> **Constat** : Le tableau comparatif de /pricing contredit les cartes de plans : Pilot y a « paie automatisée + bulletins PDF » (absent de sa carte) ; Operations y a la paie mais le tableau réserve « multi-pays » à Enterprise.
+> **Preuve** : - `front/web/src/app/(landing)/pricing/page.tsx:120-124` (tableau)
+- `front/web/src/data/pricing.ts:74` (cartes)
+> **Impact** : Confusion acheteur sur les différences de plans — incohérence commerciale (connexe #2649 fermé).
+
+### #3025 [P2] Vitrine — plan Pilot AR : features promises absentes des cartes fr/en/tr (bulletins PDF, portail client)
+
+> **Constat** : La copie arabe du plan Pilot vante « bulletins de paie PDF » et « portail client » — features absentes des cartes fr/en/tr. Promesse commerciale différente par locale.
+> **Preuve** : - `front/web/src/data/pricing.ts:312-313` (copie AR Pilot)
+> **Impact** : Engagement contractuel incohérent entre locales ; risque juridique/commercial.
+
+### #3026 [P2] Vitrine — stats fabriquées dans l'image OG générée (500+ entreprises, 50K+ employés, 99.9%)
+
+> **Constat** : L'image Open Graph générée (`opengraph-image.tsx`) affiche des statistiques **fabriquées** (« 500+ entreprises », « 50K+ employés », « 99.9% ») — exactement les chiffres retirés de `SocialProofMetrics` (PA2-MKT-006, 0 client payant).
+> **Preuve** : - `front/web/src/app/opengraph-image.tsx:99-101`
+> **Impact** : Même classe que #2720/#2726 (données fictives présentées comme réelles) mais dans le canal social partagé.
+
+### #3027 [P2] Dashboard client — carte « Leo IA » factice (retards -15%) + « Présence hebdo +12% » à barres codées en dur, sans endpoint
+
+> **Constat** : Le dashboard client affiche une carte « Leo IA » avec des insights factices (« retards en baisse de 15% ») et un widget « Présence hebdo +12% » à barres codées en dur — aucun endpoint ne fournit ces données.
+> **Preuve** : - `front/web/src/app/(dashboard)/dashboard/page.tsx:566` (carte Leo IA), `:634-638` (+12% et barres)
+> **Impact** : Données fictives présentées à des clients réels — extension de #2720 (Live: 18 retiré mais remplacé par d'autres fakes).
+
+### #3028 [P3] Vitrine — tags background-sync PWA incompatibles : client enregistre sync-forms/sync-analytics, le SW n'écoute que leopardo-sync
+
+> **Constat** : Le client PWA enregistre des tags de background sync (`sync-forms`, `sync-analytics`) que le service worker n'écoute pas (`leopardo-sync` seul) → la sync en arrière-plan n'est jamais traitée.
+> **Preuve** : - `front/web/src/components/PWAProvider.tsx:119,125` (enregistrement tags)
+- `front/web/public/sw.js:85` (écoute `leopardo-sync`)
+> **Impact** : Formulaires/événements mis en file ne remontent jamais quand le réseau revient.
+
+### #3029 [P3] Vitrine — le service worker précache des routes dashboard authentifiées (login page cachée sous /dashboard, /attendance…)
+
+> **Constat** : Le service worker précache à l'install des routes authentifiées du dashboard (`/dashboard`, `/attendance`…) — le cache embarque la page de login à la place du contenu réel.
+> **Preuve** : - `front/web/public/sw.js:10-16` (précache install)
+> **Impact** : Résiduel de #2723/#2939 : contenu protégé en cache + expérience offline fausse.
+
+### #3030 [P3] Dashboard client — page /edge-nodes toujours routée et protégée par middleware malgré #2602 fermée (retrait jamais livré)
+
+> **Constat** : L'issue #2602 demandait le retrait de la page edge-nodes du dashboard client ; elle a été fermée mais la page est **toujours présente**.
+> **Preuve** : - `front/web/src/app/(dashboard)/edge-nodes/page.tsx` (toujours là)
+- `front/web/src/middleware.ts:40` (route protégée)
+> **Impact** : Surface super-admin exposée dans le dashboard tenant (même si le middleware renvoie vers la plateforme, la route existe et le sitemap peut la référencer).
+
+### #3031 [P3] Vitrine — SignupForm : étapes pending/success encore 100% FR malgré #2727 fermée
+
+> **Constat** : Les états pending/success du signup restent 100% en français (« Votre espace est pret ! », « Se connecter », paragraphe cold-start) — fix #2727 incomplet.
+> **Preuve** : - `front/web/src/modules/vitrine/components/forms/SignupForm.tsx:774,632,845`
+> **Impact** : Utilisateurs EN/TR/AR voient du français dans le parcours de conversion.
+
+### #3032 [P3] Vitrine — contenu FAQ incohérent : paie « 6 pays (…Sénégal) » vs demo 5 pays ; Sage/QuickBooks vendus comme disponibles alors que coming_soon
+
+> **Constat** : La FAQ vend « paie 6 pays » (liste incluant le Sénégal) alors que la démo annonce 5 pays ; la FAQ présente Sage/QuickBooks comme disponibles alors qu'ils sont « coming_soon » sur /integrations.
+> **Preuve** : - `front/web/src/app/(landing)/faq/page.tsx:44,74`
+- `front/web/src/app/(landing)/demo/page.tsx:74`
+- `front/web/src/app/(landing)/integrations/page.tsx:51-52`
+> **Impact** : Incohérence commerciale entre pages de conversion.
+
+## Règles d'implémentation
+- Une PR par issue avec `Closes #N` dans le body (Constitution §VII).
+- Pas de données fabriquées : endpoint réel ou état vide honnête.
+- i18n : les 4 locales FR/EN/TR/AR dans le même changement ; jamais de clés brutes affichées.
+- Vérifier la garde anti-doublon avant push : `git ls-remote --heads origin | grep <issue>`.

--- a/.specify/features/qa-expert2-web-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert2-web-2026-08-15/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: QA Expert #2 — Vitrine / Web (front/web) (2026-08-15)
+
+**Input**: spec.md + plan.md — chaque tâche correspond à une issue GitHub ouverte (label `qa-expert2-2026-08-15`).
+
+## Phase 1 — #3021 [P2] Vitrine — og:image 404 sur ~20 pages : fix #2752 appliqué dans seo-metadata.ts mort, seo.ts vivant r
+- [ ] T001 [#3021] Implémenter le correctif (détails dans le corps de l'issue #3021)
+- [ ] T002 [#3021] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 2 — #3022 [P2] Vitrine — clés i18n brutes affichées dans le flux OTP du signup (c.otpInvalidLength, c.otpVerifyErro
+- [ ] T003 [#3022] Implémenter le correctif (détails dans le corps de l'issue #3022)
+- [ ] T004 [#3022] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 3 — #3023 [P2] Vitrine — /pricing masque le surcoût par employé actif que la home affiche (+2 EUR/employé)
+- [ ] T005 [#3023] Implémenter le correctif (détails dans le corps de l'issue #3023)
+- [ ] T006 [#3023] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 4 — #3024 [P2] Vitrine — tableau comparatif pricing incohérent avec les cartes de plans (Pilot, Operations, multi-p
+- [ ] T007 [#3024] Implémenter le correctif (détails dans le corps de l'issue #3024)
+- [ ] T008 [#3024] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 5 — #3025 [P2] Vitrine — plan Pilot AR : features promises absentes des cartes fr/en/tr (bulletins PDF, portail cli
+- [ ] T009 [#3025] Implémenter le correctif (détails dans le corps de l'issue #3025)
+- [ ] T010 [#3025] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 6 — #3026 [P2] Vitrine — stats fabriquées dans l'image OG générée (500+ entreprises, 50K+ employés, 99.9%)
+- [ ] T011 [#3026] Implémenter le correctif (détails dans le corps de l'issue #3026)
+- [ ] T012 [#3026] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 7 — #3027 [P2] Dashboard client — carte « Leo IA » factice (retards -15%) + « Présence hebdo +12% » à barres codées
+- [ ] T013 [#3027] Implémenter le correctif (détails dans le corps de l'issue #3027)
+- [ ] T014 [#3027] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 8 — #3028 [P3] Vitrine — tags background-sync PWA incompatibles : client enregistre sync-forms/sync-analytics, le S
+- [ ] T015 [#3028] Implémenter le correctif (détails dans le corps de l'issue #3028)
+- [ ] T016 [#3028] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 9 — #3029 [P3] Vitrine — le service worker précache des routes dashboard authentifiées (login page cachée sous /das
+- [ ] T017 [#3029] Implémenter le correctif (détails dans le corps de l'issue #3029)
+- [ ] T018 [#3029] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 10 — #3030 [P3] Dashboard client — page /edge-nodes toujours routée et protégée par middleware malgré #2602 fermée (
+- [ ] T019 [#3030] Implémenter le correctif (détails dans le corps de l'issue #3030)
+- [ ] T020 [#3030] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 11 — #3031 [P3] Vitrine — SignupForm : étapes pending/success encore 100% FR malgré #2727 fermée
+- [ ] T021 [#3031] Implémenter le correctif (détails dans le corps de l'issue #3031)
+- [ ] T022 [#3031] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG
+
+## Phase 12 — #3032 [P3] Vitrine — contenu FAQ incohérent : paie « 6 pays (…Sénégal) » vs demo 5 pays ; Sage/QuickBooks vendu
+- [ ] T023 [#3032] Implémenter le correctif (détails dans le corps de l'issue #3032)
+- [ ] T024 [#3032] Vérification : build/lint (web/admin) ou contrat/analyse (mobile/api) + CHANGELOG

--- a/docs/qa/QA_SESSION_2026-08-15-expert2.md
+++ b/docs/qa/QA_SESSION_2026-08-15-expert2.md
@@ -1,0 +1,42 @@
+# QA Leopardo RH — Session expert #2 du 2026-08-15
+
+Mission (propriétaire) : tester la plateforme dans tous les sens — vitrine, web app, admin,
+mobiles, workflows, API, logiques, onboarding, cohérence — consigner chaque manquement selon la
+méthode Spec Kit (issue + spec/plan/tasks), implémenter les manquements, puis traiter le backlog
+d'issues ouvertes et merger le maximum de branches.
+
+## Méthode
+1. Revue statique experte par surface (4 agents parallèles) + cross-check automatisé
+   (endpoints SPA vs routes Laravel, appels Dart vs routes, routes vs OpenAPI, clés i18n vs catalogues).
+2. Builds/lints réels : `npm run lint` + `tsc` + `npm run build` (web vitrine ✅, admin ❌ — voir #3033).
+3. Anti-doublon #2400 : chaque finding vérifié contre les issues ouvertes et les branches avant création.
+
+## Findings NOUVEAUX (issues créées, label `qa-expert2-2026-08-15`)
+
+| Surface | P1 | P2 | P3 | Issues |
+|---|---|---|---|---|
+| Vitrine/Web | 0 | 7 | 5 | #3021–#3032 |
+| Admin | 2 | 3 | 7 | #3033,#3034,#3036–#3039,#3041–#3046 |
+| Mobile | 0 | 2 | 6 | #3047–#3054 |
+| API | 0 | 4 | 7 | #3055–#3065 |
+| **Total** | **2** | **16** | **25** | **43** |
+
+## P1 (bloquants)
+- **#3033** Admin — build prod cassé : `DocumentReportIcon` inexistant dans @heroicons/vue → `vite build` échoue → deploy Cloudflare bloqué.
+- **#3034** Admin — CompanyDetailView crashe au rendu (`health.adoption.kiosk.active` jamais renvoyé) → fiche entreprise blanche.
+
+## P2 notables
+- **#3021** og:image 404 sur ~20 pages (fix #2752 livré dans un fichier mort).
+- **#3022** clés i18n brutes affichées dans le flux OTP signup.
+- **#3026/#3027** stats fabriquées (OG image, carte Leo IA dashboard) — classe #2720/#2726.
+- **#3047** mobile : notifications « marquer lu/lues » en PUT → 405 garanti (backend POST/PATCH).
+- **#3055** API : `GET /employees/<built-in function id>/leave-balances` sans garde de rôle (tout employé lit les soldes d'un collègue).
+- **#3056/#3057/#3058** trial : 14j vs 30j, OTP avalé, webhook email-bounce mort (secret jamais défini).
+
+## Implémentation
+Chaque issue → branche `fix/<issue>-<slug>` + PR `Closes #N` (Constitution §VII), CHANGELOG sous
+`## [Unreleased]`. Spec Kit : `.specify/features/qa-expert2-{web,admin,mobile,api}-2026-08-15/`.
+
+## Backlog & merges
+- Issues ouvertes restantes hors vagues QA : triées par priorité (P1/P2/Agent-Ready d'abord).
+- Branches à merger : 5 PRs ouvertes (toutes `dirty`) + branches sans PR — rebase sur main, checks verts, merge.


### PR DESCRIPTION
## Documentation Spec Kit — vague expert #2 (2026-08-15)

Ajoute les specs/plans/tasks de la vague de test expert #2 (43 findings nouveaux, issues #3021-#3065, label `qa-expert2-2026-08-15`) :

- `.specify/features/qa-expert2-web-2026-08-15/{spec,plan,tasks}.md` (12 findings)
- `.specify/features/qa-expert2-admin-2026-08-15/{spec,plan,tasks}.md` (12 findings)
- `.specify/features/qa-expert2-mobile-2026-08-15/{spec,plan,tasks}.md` (8 findings)
- `.specify/features/qa-expert2-api-2026-08-15/{spec,plan,tasks}.md` (11 findings)
- `docs/qa/QA_SESSION_2026-08-15-expert2.md` (rapport de session)

Docs-only PR (aucun code applicatif). Les correctifs seront livrés par les PRs d'implémentation dédiées.