### PR TITLE
fix(api): races trial/verify + bulk-pay, essai 14j cohérent (Closes #2996, #2997, #3012)

### DIFF
--- a/api/app/Jobs/ProcessBulkPaymentJob.php
+++ b/api/app/Jobs/ProcessBulkPaymentJob.php
@@ -119,8 +119,36 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
 
         $this->updateProgress(0, 'processing', $total);
 
+        // QA #2997 — idempotence : chaque slip est CLAIMÉ en Redis (SET NX EX)
+        // avant traitement. Un retry ($tries=3) ou un second job concurrent ne
+        // re-traite jamais un slip déjà traité (les documents de paiement ne
+        // sont pas générés 2×/3×) ; en cas d'échec le claim est libéré pour
+        // permettre le retry de CE slip uniquement.
+        $claimPrefix = "bulk_pay:slip:{$run->id}:";
+        $redis = Redis::connection('default');
+
         foreach ($slips as $slip) {
             try {
+                $claimed = false;
+                try {
+                    $claimed = (bool) $redis->set($claimPrefix.$slip->id, '1', ['EX' => 21600, 'NX' => true]);
+                } catch (Throwable $redisError) {
+                    // Redis indisponible : on traite sans garde (comportement
+                    // historique) mais on le trace pour l'observabilité.
+                    Log::warning('ProcessBulkPaymentJob: Redis claim unavailable, processing without guard', [
+                        'payroll_run_id' => $run->id,
+                        'pay_slip_id' => $slip->id,
+                        'error' => $redisError->getMessage(),
+                    ]);
+                    $claimed = true;
+                }
+
+                if (! $claimed) {
+                    // Slip déjà traité par une tentative précédente → skip.
+                    $done++;
+                    continue;
+                }
+
                 $this->processSlip($run, $slip);
             } catch (Throwable $e) {
                 Log::error('ProcessBulkPaymentJob: failed to process pay slip', [
@@ -129,6 +157,13 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
                     'employee_id' => $slip->employee_id,
                     'error' => $e->getMessage(),
                 ]);
+
+                // Libérer le claim : un retry pourra re-tenter CE slip.
+                try {
+                    $redis->del($claimPrefix.$slip->id);
+                } catch (Throwable) {
+                    // non bloquant
+                }
 
                 $failures[] = [
                     'pay_slip_id' => $slip->id,

--- a/api/app/Modules/Billing/Application/Actions/VerifyTrialSignup.php
+++ b/api/app/Modules/Billing/Application/Actions/VerifyTrialSignup.php
@@ -187,7 +187,7 @@ class VerifyTrialSignup
                 'tenancy_type' => 'shared',
                 'status' => 'trial',
                 'subscription_start' => now()->toDateString(),
-                'subscription_end' => now()->addDays(30)->toDateString(),
+                'subscription_end' => now()->addDays(14)->toDateString(),
                 'language' => $payload['language'],
                 'timezone' => $payload['timezone'],
                 'currency' => $payload['currency'],
@@ -271,7 +271,7 @@ class VerifyTrialSignup
                     'attendance' => true,
                     'mobile_apps' => true,
                 ], JSON_THROW_ON_ERROR),
-                'trial_days' => 30,
+                'trial_days' => 14,
                 'is_active' => true,
             ]);
 

--- a/api/app/Modules/Billing/Application/Actions/VerifyTrialSignup.php
+++ b/api/app/Modules/Billing/Application/Actions/VerifyTrialSignup.php
@@ -40,14 +40,47 @@ class VerifyTrialSignup
             DB::statement('SET search_path TO public');
         }
 
-        $companyRequest = CompanyRequest::query()
-            ->where('email', $email)
-            ->where('status', 'pending')
-            ->where('verification_token', $code)
-            ->where('verification_expires_at', '>=', now())
-            ->first();
+        // QA #2996 — verrou atomique anti double-provisioning : deux POST
+        // /trial/verify simultanés avec le même OTP valide créaient 2 tenants
+        // + 2 managers pour le même email (lecture pending → provisioning →
+        // approved sans verrou). La CompanyRequest est maintenant CLAIMÉE en
+        // `processing` sous transaction (lockForUpdate) : le 2e appel voit un
+        // statut non-pending et refuse, sans jamais provisionner deux fois.
+        $claimed = DB::transaction(function () use ($email, $code): ?CompanyRequest {
+            $request = CompanyRequest::query()
+                ->where('email', $email)
+                ->where('status', 'pending')
+                ->where('verification_token', $code)
+                ->where('verification_expires_at', '>=', now())
+                ->lockForUpdate()
+                ->first();
 
-        if (! $companyRequest) {
+            if ($request === null) {
+                return null;
+            }
+
+            $request->update(['status' => 'processing']);
+
+            return $request;
+        });
+
+        if ($claimed === null) {
+            // Distinguer « code invalide/expiré » de « déjà traité » : un
+            // code valide déjà consommé ne doit pas dire INVALID au client.
+            $existing = CompanyRequest::query()
+                ->where('email', $email)
+                ->where('verification_token', $code)
+                ->first();
+
+            if ($existing !== null && $existing->status !== 'pending') {
+                return [
+                    'success' => false,
+                    'error' => 'ALREADY_PROCESSED',
+                    'message' => 'Cette demande d\'essai a déjà été traitée.',
+                    'status' => 409,
+                ];
+            }
+
             return [
                 'success' => false,
                 'error' => 'INVALID_OR_EXPIRED_CODE',
@@ -56,6 +89,7 @@ class VerifyTrialSignup
             ];
         }
 
+        $companyRequest = $claimed;
         $payload = $companyRequest->signup_payload ?? [];
         $companyName = (string) ($companyRequest->company_name ?? '');
 
@@ -116,6 +150,17 @@ class VerifyTrialSignup
                 'company' => $companyName,
                 'error' => $e->getMessage(),
             ]);
+
+            // QA #2996 — libérer la demande pour permettre un retry (le claim
+            // `processing` ne doit pas bloquer définitivement le parcours).
+            try {
+                $companyRequest->update(['status' => 'pending']);
+            } catch (\Throwable $revertError) {
+                Log::error('SelfServiceTrial: Failed to revert claim after provisioning failure', [
+                    'email' => $email,
+                    'error' => $revertError->getMessage(),
+                ]);
+            }
 
             return [
                 'success' => false,

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/BulkPaymentController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/BulkPaymentController.php
@@ -56,17 +56,29 @@ class BulkPaymentController extends Controller
         $paySlipIds = $validated['pay_slip_ids'] ?? null;
 
         // Prevent double-dispatch if already processing
+        // QA #2997 : garde ATOMIQUE (SET NX EX) — avant, un `get` puis
+        // `dispatch` (TOCTOU) laissait passer deux dispatches simultanés.
         $progressKey = "bulk_pay:run:{$payrollRun->id}";
+        $claimPayload = json_encode([
+            'status' => 'starting',
+            'started_at' => now()->toIso8601String(),
+            'triggered_by' => $actor->id,
+        ]);
         try {
-            $existing = Redis::connection('default')->get($progressKey);
-            if ($existing) {
-                $progress = json_decode($existing, true);
+            $acquired = Redis::connection('default')
+                ->set($progressKey, $claimPayload, ['EX' => 21600, 'NX' => true]);
+
+            if (! $acquired) {
+                $existing = Redis::connection('default')->get($progressKey);
+                $progress = $existing ? json_decode($existing, true) : [];
                 if (in_array($progress['status'] ?? '', ['starting', 'processing'], true)) {
                     return response()->json([
                         'message' => 'Bulk payment already in progress.',
                         'progress' => $progress,
                     ], 409);
                 }
+                // Statut stale (completed*/crash) : on reprend la main.
+                Redis::connection('default')->set($progressKey, $claimPayload, ['EX' => 21600]);
             }
         } catch (Throwable) {
             // Redis unavailable — allow dispatch to continue

--- a/api/tests/Feature/BulkPaymentControllerTest.php
+++ b/api/tests/Feature/BulkPaymentControllerTest.php
@@ -126,4 +126,28 @@ class BulkPaymentControllerTest extends TestCase
 
         return [$company, $manager, $run, $slipA, $slipB];
     }
+
+    public function test_double_dispatch_is_rejected_with_409(): void
+    {
+        // QA #2997 — garde ATOMIQUE (SET NX) : un second dispatch pendant un
+        // bulk-pay en cours est refusé en 409 (avant : fenêtre TOCTOU entre
+        // le get et le dispatch → deux jobs pouvaient traiter les mêmes slips).
+        Bus::fake();
+
+        [$company, $manager, $run, $slipA, $slipB] = $this->fixture();
+        Sanctum::actingAs($manager);
+
+        // 1er dispatch → accepté (claim posé en Redis, statut 'starting')
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/bulk-pay")
+            ->assertAccepted()
+            ->assertJsonPath('status', 'accepted');
+
+        // 2e dispatch immédiat → 409 (claim déjà posé)
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/bulk-pay")
+            ->assertStatus(409)
+            ->assertJsonPath('message', 'Bulk payment already in progress.');
+
+        // Un seul job dispatché au total
+        Bus::assertDispatchedTimes(ProcessBulkPaymentJob::class, 1);
+    }
 }

--- a/api/tests/Feature/SelfServiceTrialTest.php
+++ b/api/tests/Feature/SelfServiceTrialTest.php
@@ -193,4 +193,85 @@ class SelfServiceTrialTest extends TestCase
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['email', 'company']);
     }
+
+    public function test_second_verify_with_same_otp_does_not_double_provision()
+    {
+        // QA #2996 — race double-provisioning : deux verify avec le même OTP
+        // valide ne doivent créer qu'UN SEUL tenant/manager.
+        Mail::fake();
+
+        $this->postJson('/api/v1/trial/signup', [
+            'email' => 'founder@race-test.dz',
+            'company' => 'Race Test Algeria',
+            'role' => 'founder',
+            'employees' => '11-50',
+            'country' => 'DZ',
+        ])->assertStatus(200);
+
+        $otp = CompanyRequest::where('email', 'founder@race-test.dz')
+            ->where('status', 'pending')->first()->verification_token;
+
+        // 1er verify → succès + provisioning
+        $this->postJson('/api/v1/trial/verify', [
+            'email' => 'founder@race-test.dz',
+            'code' => $otp,
+        ])->assertStatus(201);
+
+        // 2e verify (simule la 2e requête concurrente) → refus, aucun second tenant
+        $this->postJson('/api/v1/trial/verify', [
+            'email' => 'founder@race-test.dz',
+            'code' => $otp,
+        ])->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error' => 'INVALID_OR_EXPIRED_CODE',
+            ]);
+
+        // Un seul tenant créé pour cet email
+        $this->assertSame(
+            1,
+            \Illuminate\Support\Facades\DB::table('companies')
+                ->where('name', 'Race Test Algeria')
+                ->count(),
+            'Le double verify ne doit pas créer deux tenants.'
+        );
+    }
+
+    public function test_verify_returns_409_when_request_already_claimed()
+    {
+        // QA #2996 — une demande déjà claimée (statut processing, verrou
+        // posé par une requête concurrente) → 409 ALREADY_PROCESSED, sans
+        // aucun provisioning.
+        Mail::fake();
+
+        $this->postJson('/api/v1/trial/signup', [
+            'email' => 'founder@claimed.dz',
+            'company' => 'Claimed Test',
+            'country' => 'DZ',
+        ])->assertStatus(200);
+
+        $request = CompanyRequest::where('email', 'founder@claimed.dz')
+            ->where('status', 'pending')->first();
+        $otp = $request->verification_token;
+
+        // Simule le claim d'une requête concurrente (fenêtre de provisioning)
+        $request->update(['status' => 'processing']);
+
+        $this->postJson('/api/v1/trial/verify', [
+            'email' => 'founder@claimed.dz',
+            'code' => $otp,
+        ])->assertStatus(409)
+            ->assertJson([
+                'success' => false,
+                'error' => 'ALREADY_PROCESSED',
+            ]);
+
+        $this->assertSame(
+            0,
+            \Illuminate\Support\Facades\DB::table('companies')
+                ->where('name', 'Claimed Test')
+                ->count(),
+            'Aucun tenant ne doit être créé pour une demande déjà claimée.'
+        );
+    }
 }


### PR DESCRIPTION
Vague mission QA 2026-08-15 — bloc API.
- #2996 : VerifyTrialSignup — verrou atomique (`lockForUpdate` + statut `processing`) : 2 POST /trial/verify simultanés ne créent plus 2 tenants pour 1 email. Réponse 409 ALREADY_PROCESSED si déjà claimé ; revert `pending` sur échec de provisioning (retry possible). Tests de régression ajoutés.
- #2997 : BulkPaymentController + ProcessBulkPaymentJob — garde ATOMIQUE SET NX (TOCTOU fermé) + claims Redis par slip avec libération sur échec : un retry ne re-traite que les slips en échec, plus de doubles documents de paiement. Test 409 ajouté.
- #3012 : durée d'essai alignée sur PlanSeeder (14 j) — fallback 30 de VerifyTrialSignup corrigé.

Closes #2996, #2997, #3012