### PR TITLE
fix(admin): cockpit — CompanyDetailView crash, DashboardView données réelles (Closes #3034, #3036, #3037)

### DIFF
--- a/front/admin-dashboard/src/components/users/UserTable.vue
+++ b/front/admin-dashboard/src/components/users/UserTable.vue
@@ -118,7 +118,7 @@
 
           <!-- Created At -->
           <td class="whitespace-nowrap px-6 py-5 text-sm font-medium text-slate-500 dark:text-slate-400">
-            {{ formatDate(user.created_at) }}
+            {{ formatDate(user.createdAt) }}
           </td>
 
           <!-- Actions -->
@@ -186,7 +186,7 @@ const columns = [
   { key: 'name', label: 'Utilisateur', sortable: true },
   { key: 'status', label: 'Statut', sortable: true },
   { key: 'company', label: 'Entreprise', sortable: true },
-  { key: 'created_at', label: 'Inscription', sortable: true }
+  { key: 'createdAt', label: 'Inscription', sortable: true }
 ]
 
 const isAllSelected = computed(() => {
@@ -209,7 +209,7 @@ const sortedUsers = computed(() => {
       bValue = b.company_name || ''
     }
 
-    if (sortBy.value === 'created_at') {
+    if (sortBy.value === 'createdAt') {
       aValue = aValue ? new Date(aValue) : new Date(0)
       bValue = bValue ? new Date(bValue) : new Date(0)
     }

--- a/front/admin-dashboard/src/components/users/UserTable.vue
+++ b/front/admin-dashboard/src/components/users/UserTable.vue
@@ -118,7 +118,7 @@
 
           <!-- Created At -->
           <td class="whitespace-nowrap px-6 py-5 text-sm font-medium text-slate-500 dark:text-slate-400">
-            {{ formatDate(user.createdAt) }}
+            {{ formatDate(user.created_at) }}
           </td>
 
           <!-- Actions -->
@@ -186,7 +186,7 @@ const columns = [
   { key: 'name', label: 'Utilisateur', sortable: true },
   { key: 'status', label: 'Statut', sortable: true },
   { key: 'company', label: 'Entreprise', sortable: true },
-  { key: 'createdAt', label: 'Inscription', sortable: true }
+  { key: 'created_at', label: 'Inscription', sortable: true }
 ]
 
 const isAllSelected = computed(() => {
@@ -209,7 +209,7 @@ const sortedUsers = computed(() => {
       bValue = b.company_name || ''
     }
 
-    if (sortBy.value === 'createdAt') {
+    if (sortBy.value === 'created_at') {
       aValue = aValue ? new Date(aValue) : new Date(0)
       bValue = bValue ? new Date(bValue) : new Date(0)
     }

--- a/front/admin-dashboard/src/views/DashboardView.vue
+++ b/front/admin-dashboard/src/views/DashboardView.vue
@@ -85,8 +85,8 @@
                       <BuildingOfficeIcon class="h-full w-full text-slate-400" />
                     </div>
                     <div class="ml-4">
-                      <div class="text-sm font-bold text-slate-900 dark:text-white">{{ item.name }}</div>
-                      <div class="text-[10px] font-medium text-slate-400 uppercase tracking-widest">{{ item.slug }}</div>
+                      <div class="text-sm font-bold text-slate-900 dark:text-white">{{ item.company.name }}</div>
+                      <div class="text-[10px] font-medium text-slate-400 uppercase tracking-widest">{{ item.company.slug }}</div>
                     </div>
                   </div>
                 </td>
@@ -106,10 +106,10 @@
                   <span :class="riskClass(item.risk_level)">{{ riskLabel(item.risk_level) }}</span>
                 </td>
                 <td class="whitespace-nowrap px-6 py-4 text-sm font-black text-slate-950 dark:text-white">
-                  {{ formatCurrency(item.mrr_eur, 'EUR') }}
+                  {{ formatCurrency(item.subscription.mrr, item.subscription.currency) }}
                 </td>
                 <td class="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
-                  <router-link :to="`/companies/${item.id}`" class="text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 font-bold">
+                  <router-link :to="`/companies/${item.company.id}`" class="text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 font-bold">
                     Détails
                   </router-link>
                 </td>
@@ -130,8 +130,8 @@
           <div v-for="request in pendingCompanyRequests" :key="request.id" class="p-6 transition-colors hover:bg-white/5 dark:hover:bg-slate-900/5">
             <div class="flex items-start justify-between">
               <div class="space-y-1">
-                <h3 class="text-sm font-bold text-slate-950 dark:text-white uppercase tracking-tight">{{ request.name }}</h3>
-                <p class="text-xs font-medium text-slate-500 dark:text-slate-400">{{ request.manager_email }}</p>
+                <h3 class="text-sm font-bold text-slate-950 dark:text-white uppercase tracking-tight">{{ request.company_name }}</h3>
+                <p class="text-xs font-medium text-slate-500 dark:text-slate-400">{{ request.email }}</p>
                 <div class="pt-1 flex items-center text-[10px] font-black uppercase tracking-widest text-slate-400">
                   <GlobeAltIcon class="mr-1.5 h-3 w-3" />
                   {{ request.city }}, {{ request.country }}

--- a/front/admin-dashboard/src/views/companies/CompanyDetailView.vue
+++ b/front/admin-dashboard/src/views/companies/CompanyDetailView.vue
@@ -75,11 +75,8 @@
                   <dd class="mt-2 text-2xl font-black text-emerald-600 dark:text-emerald-400">{{ health.adoption.employees.payroll_ready }}</dd>
                 </div>
                 <div class="rounded-2xl bg-slate-50 p-4 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 transition-transform hover:scale-[1.02]">
-                  <dt class="text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-400">Kiosk</dt>
-                  <dd class="mt-2 flex items-center text-sm font-bold text-slate-900 dark:text-white">
-                    <div :class="['mr-2 h-2.5 w-2.5 rounded-full', health.adoption.kiosk.active ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' : 'bg-slate-300']"></div>
-                    {{ health.adoption.kiosk.active ? 'Actif' : 'Inactif' }}
-                  </dd>
+                  <dt class="text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-400">Employés Actifs (30j)</dt>
+                  <dd class="mt-2 text-2xl font-black text-slate-900 dark:text-white">{{ health.adoption.attendance.active_employees_30d ?? 0 }}</dd>
                 </div>
               </div>
 


### PR DESCRIPTION
## Audit expert 3 — session QA 2026-08-15 (bloc admin données réelles)

Closes #3034, #3036, #3037

> Note anti-doublon : la colonne « Inscription » de UserTable (#3038) est corrigée par la PR #3124 (`fix/2988-2990-admin-table-i18n`) — aucun changement UserTable ici.

- **#3034 (P1)** : `CompanyDetailView` lisait `health.adoption.kiosk.active` — clé jamais renvoyée par le backend → erreur de rendu / fiche blanche. Carte « Kiosk » factice remplacée par une métrique réelle (`adoption.attendance.active_employees_30d`).
- **#3036** : « Priorités Portefeuille » lisait `item.name/slug/mrr_eur/id` (inexistants) → noms vides, MRR 0 €, lien `/companies/undefined`. Réaligné sur `item.company.*` + `item.subscription.mrr/currency`.
- **#3037** : « Inscriptions en attente » lisait `request.name/manager_email` → titres vides. Réaligné sur `company_name`/`email` (contrat API).

### Validation
- CHANGELOG mis à jour.