### PR TITLE
fix(web+admin): OTP i18n brutes, CSV injection AnalyticsView, raccourci Alt+R (Closes #3022, #3031, #3045, #3041)

### DIFF
--- a/front/admin-dashboard/src/composables/useKeyboardShortcuts.js
+++ b/front/admin-dashboard/src/composables/useKeyboardShortcuts.js
@@ -48,10 +48,6 @@ export function useKeyboardShortcuts() {
           e.preventDefault()
           router.push('/subscriptions')
           break
-        case 'r':
-          e.preventDefault()
-          router.push('/recruitment')
-          break
       }
       return
     }
@@ -80,7 +76,6 @@ export function useKeyboardShortcuts() {
       { keys: 'Alt+U', description: 'Utilisateurs' },
       { keys: 'Alt+C', description: 'Entreprises' },
       { keys: 'Alt+S', description: 'Abonnements' },
-      { keys: 'Alt+R', description: 'Recrutement' },
       { keys: '?', description: 'Aide raccourcis' },
     ],
   }

--- a/front/admin-dashboard/src/views/analytics/AnalyticsView.vue
+++ b/front/admin-dashboard/src/views/analytics/AnalyticsView.vue
@@ -231,9 +231,16 @@ function formatDate(date) {
 
 async function exportReport() {
   try {
+    // Issue #3045 — échappement anti-injection de formule (cellules = + - @),
+    // cohérent avec UsersView (#2700).
+    const escapeCell = (value) => {
+      const str = value === null || value === undefined ? '' : String(value)
+      if (/^[=+\-@]/.test(str)) return `'${str}`
+      return `"${str.replace(/"/g, '""')}"`
+    }
     const csvContent = "data:text/csv;charset=utf-8," +
       "Type,Message,Date\n" +
-      activities.value.map(a => `${a.type || ''},${String(a.message || '').replace(/,/g, ';')},${a.created_at || ''}`).join('\n')
+      activities.value.map(a => [a.type || '', a.message || '', a.created_at || ''].map(escapeCell).join(',')).join('\n')
     const link = document.createElement("a")
     link.setAttribute("href", encodeURI(csvContent))
     link.setAttribute("download", "analytics-activities.csv")

--- a/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
@@ -270,7 +270,7 @@ export function SignupForm({
   const handleVerify = async () => {
     const code = otpValues.join('');
     if (code.length !== 6) {
-      setOtpError('c.otpInvalidLength');
+      setOtpError(c.otpInvalidLength);
       return;
     }
 
@@ -286,10 +286,10 @@ export function SignupForm({
         reset();
         onSuccess?.({} as SignupFormData);
       } else {
-        setOtpError(response.message || 'c.otpInvalidCode');
+        setOtpError(response.message || c.otpInvalidCode);
       }
     } catch (error) {
-      setOtpError('c.otpVerifyError');
+      setOtpError(c.otpVerifyError);
     } finally {
       setIsVerifying(false);
     }
@@ -753,7 +753,7 @@ export function SignupForm({
               <div className="flex items-center gap-3 bg-emerald-500/10 px-5 py-3 dark:bg-emerald-500/5">
                 <Rocket className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                 <h3 className="text-lg font-black text-emerald-900 dark:text-emerald-100">
-                  Votre espace est pret !
+                  {c.successTitle}
                 </h3>
               </div>
 


### PR DESCRIPTION
## Audit expert 3 — session QA 2026-08-15 (bloc vitrine + admin mineurs)\n\nCloses #3022, #3031, #3045, #3041\n\n- **#3022** : le flux OTP du signup affichait les littéraux `c.otpInvalidLength`/`c.otpInvalidCode`/`c.otpVerifyError` (clés stockées avec préfixe `c.`) → résolution via le catalogue localisé.\n- **#3031** : titre de l'étape success codé en dur en FR → `c.successTitle` (4 locales).\n- **#3045** : export CSV `AnalyticsView` sans échappement anti-injection de formule → `escapeCell` (cohérent UsersView #2700).\n- **#3041** : raccourci `Alt+R` → `/recruitment` (route tenant gardée, rebond muet) retiré.\n\n### Validation\n- CHANGELOG mis à jour.