### PR TITLE
fix(mobile): platform_admin imports + manager DateTime? (Closes #3154, #3157)

### DIFF
--- a/front/mobile_apps/leopardo_manager/lib/features/attendance/data/attendance_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/attendance/data/attendance_repository.dart
@@ -543,7 +543,9 @@ class AttendanceCorrection {
       id: _asInt(json['id']),
       employeeName: employee['name']?.toString() ?? 'Employe',
       date: json['date']?.toString() ?? '',
-      requestedCheckIn: DateTime.tryParse(json['requested_check_in']?.toString() ?? ''),
+      requestedCheckIn:
+          DateTime.tryParse(json['requested_check_in']?.toString() ?? '') ??
+              DateTime.utc(1970),
       requestedCheckOut: json['requested_check_out'] != null
           ? DateTime.tryParse(json['requested_check_out'].toString())
           : null,

--- a/front/mobile_apps/leopardo_platform_admin/lib/src/platform_admin_app.dart
+++ b/front/mobile_apps/leopardo_platform_admin/lib/src/platform_admin_app.dart
@@ -8,6 +8,13 @@ import 'package:leopardo_core/core/storage/app_preferences.dart';
 
 import 'core/platform_providers.dart';
 import 'features/auth/platform_auth_controller.dart';
+import 'features/companies/company_detail_screen.dart';
+import 'features/auth/platform_login_screen.dart';
+import 'features/companies/company_create_screen.dart';
+import 'features/companies/company_requests_screen.dart';
+import 'features/companies/company_screen.dart';
+import 'features/dashboard/platform_dashboard_screen.dart';
+
 
 /// Issue #2761 — résout la locale depuis les préférences (langue choisie),
 /// sinon null (locale de l'appareil).
@@ -15,13 +22,6 @@ Locale? _resolvedLocale(Ref ref) {
   final code = ref.read(appPreferencesProvider).preferredLanguage.trim();
   return code.isEmpty ? null : Locale(code);
 }
-
-import 'features/companies/company_detail_screen.dart';
-import 'features/auth/platform_login_screen.dart';
-import 'features/companies/company_create_screen.dart';
-import 'features/companies/company_requests_screen.dart';
-import 'features/companies/company_screen.dart';
-import 'features/dashboard/platform_dashboard_screen.dart';
 
 final platformRouterProvider = Provider<GoRouter>((ref) {
   final authListenable = ValueNotifier<PlatformAuthState>(


### PR DESCRIPTION
## Vague QA expert v3 — constats F-V3-15 + F-V3-17

Closes #3154, #3157

- **#3154** : `leopardo_platform_admin/lib/src/platform_admin_app.dart` — 6 imports `features/*` déclarés APRÈS `_resolvedLocale()` (`directive_after_declaration` ×5, flutter analyze KO). Déplacés en tête de fichier.
- **#3157** : `leopardo_manager/.../attendance_repository.dart` — `AttendanceCorrection.requestedCheckIn` (non-nullable `DateTime`) recevait `DateTime.tryParse(...)` (`DateTime?`) → erreur de type à l'analyse. Fallback `DateTime.utc(1970)`, aligné sur l'app HR.

### Validation
- CHANGELOG mis à jour. Analyse Flutter validée par la CI mobile.