### PR TITLE
fix(web): PWA — précache pages publiques + sync tag canonique (Closes #2983)

### DIFF
--- a/front/web/public/sw.js
+++ b/front/web/public/sw.js
@@ -7,13 +7,12 @@ const CACHE_NAME = 'leopardo-edge-v1';
 const OFFLINE_URL = '/offline';
 
 // Assets to pre-cache on install
+// Issue #2983 : les routes dashboard/attendance/absences/employees sont des
+// routes AUTHENTIFIÉES — les précacher expose la page de login en cache et
+// stocke du HTML privé côté client. On ne précache que les pages publiques.
 const PRECACHE_ASSETS = [
   '/',
   '/offline',
-  '/dashboard',
-  '/attendance',
-  '/absences',
-  '/employees',
   '/favicon.ico',
 ];
 

--- a/front/web/src/components/PWAProvider.tsx
+++ b/front/web/src/components/PWAProvider.tsx
@@ -113,17 +113,14 @@ export function PWAProvider({ children }: { children: React.ReactNode }) {
     if (!swRegistration) return;
 
     try {
-      // Sync forms
+      // Issue #2983 : le service worker n'écoute QUE le tag 'leopardo-sync'
+      // (relecture de la file d'opérations hors-ligne). Les tags
+      // 'sync-forms'/'sync-analytics' enregistrés ici n'étaient écoutés par
+      // personne → le background sync ne se déclenchait jamais.
       const syncRegistration = swRegistration as SyncCapableRegistration;
       if (syncRegistration.sync) {
-        await syncRegistration.sync.register('sync-forms');
-        safeLog('[PWA] Sync forms registered');
-      }
-
-      // Sync analytics
-      if (syncRegistration.sync) {
-        await syncRegistration.sync.register('sync-analytics');
-        safeLog('[PWA] Sync analytics registered');
+        await syncRegistration.sync.register('leopardo-sync');
+        safeLog('[PWA] Sync registered (leopardo-sync)');
       }
     } catch (error) {
       safeLog('[PWA] Sync registration failed:', error);


### PR DESCRIPTION
## Contexte
Issue #2983 (T143, QA 2026-08-15) : le service worker précachait des routes dashboard authentifiées (login page mise en cache sous /dashboard, /attendance…) et le client enregistrait des tags background-sync (`sync-forms`/`sync-analytics`) que le SW n'écoute pas.

## Correctifs
- `public/sw.js` : `PRECACHE_ASSETS` réduit aux pages publiques (/, /offline, /favicon.ico) — les routes authentifiées ne sont plus précachées.
- `src/components/PWAProvider.tsx` : enregistre `leopardo-sync` (le seul tag que le SW écoute) au lieu de deux tags morts → le background-sync se déclenche enfin.

## Validation
- `npm run lint` vert (max-warnings 0).

Closes #2983