### PR TITLE
fix(admin): recherche sans routes tenant + maintenance mort retiré (Closes #3042, #3043)

### DIFF
--- a/front/admin-dashboard/src/components/alerts/SystemAlertsOverlay.vue
+++ b/front/admin-dashboard/src/components/alerts/SystemAlertsOverlay.vue
@@ -39,47 +39,12 @@
     </div>
   </div>
 
-  <!-- System maintenance banner -->
-  <div
-    v-if="isMaintenanceMode"
-    class="fixed inset-x-0 top-0 z-40"
-    :class="{ 'mt-16': showCriticalAlert }"
-  >
-    <div class="bg-yellow-400">
-      <div class="mx-auto max-w-7xl py-2 px-3 sm:px-6 lg:px-8">
-        <div class="flex flex-wrap items-center justify-between">
-          <div class="flex w-0 flex-1 items-center">
-            <span class="flex rounded-lg bg-yellow-600 p-2">
-              <WrenchScrewdriverIcon class="h-5 w-5 text-white" />
-            </span>
-            <p class="ml-3 font-medium text-yellow-900">
-              <span class="md:hidden">Mode maintenance</span>
-              <span class="hidden md:inline">
-                Le système est en mode maintenance. Certaines fonctionnalités peuvent être indisponibles.
-              </span>
-            </p>
-          </div>
-          <div class="order-2 flex-shrink-0 sm:ml-3">
-            <button
-              @click="disableMaintenanceMode"
-              class="flex items-center justify-center rounded-md border border-transparent bg-yellow-600 px-4 py-1 text-sm font-medium text-white shadow-sm hover:bg-yellow-700"
-            >
-              Désactiver
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <!-- Connection status banner -->
   <div
     v-if="!realtimeStore.isConnected"
     class="fixed inset-x-0 top-0 z-30"
     :class="{
-      'mt-16': showCriticalAlert && !isMaintenanceMode,
-      'mt-12': !showCriticalAlert && isMaintenanceMode,
-      'mt-28': showCriticalAlert && isMaintenanceMode
+      'mt-16': showCriticalAlert
     }"
   >
     <div class="bg-gray-600">
@@ -121,7 +86,6 @@ import { useRouter } from 'vue-router'
 import {
   ExclamationTriangleIcon,
   XMarkIcon,
-  WrenchScrewdriverIcon,
   WifiIcon
 } from '@heroicons/vue/24/outline'
 import { useDashboardStore } from '@/stores/dashboard'
@@ -134,7 +98,6 @@ const realtimeStore = useRealtimeStore()
 const toast = useToast()
 
 const showCriticalAlert = ref(false)
-const isMaintenanceMode = ref(false)
 const currentCriticalAlert = ref(null)
 
 // Auto-check for critical alerts
@@ -205,20 +168,10 @@ function viewSystemAlerts() {
   dismissCriticalAlert()
 }
 
-async function disableMaintenanceMode() {
-  // Issue #2693 (QA 2026-08-15) — aucun endpoint admin de maintenance
-  // n'existe : l'action était simulée (setTimeout + toast de succès).
-  // Désormais, état honnête : on ne peut pas désactiver le mode depuis l'UI.
-  toast.info('Mode maintenance : désactivation non disponible depuis la console (aucun endpoint admin).')
-  isMaintenanceMode.value = false
-}
 
 // Expose methods for external control
 defineExpose({
   showCriticalAlertBanner,
-  dismissCriticalAlert,
-  setMaintenanceMode: (enabled) => {
-    isMaintenanceMode.value = enabled
-  }
+  dismissCriticalAlert
 })
 </script>

--- a/front/admin-dashboard/src/components/layout/Header.vue
+++ b/front/admin-dashboard/src/components/layout/Header.vue
@@ -277,7 +277,11 @@ function handleSearch() {
   const router = useRouter()
   const normalized = query.toLowerCase()
   const matches = router.getRoutes().filter((route) => {
+    // Issue #3042 : les routes tenant (requiresTenant: true — Paie, Congés,
+    // RH…) sont gardées pour le super-admin : y naviguer depuis la recherche
+    // rebondit en silence. On les exclut du périmètre de recherche.
     if (!route.path.startsWith('/') || route.path.includes(':') || route.path === '/') return false
+    if (route.meta?.requiresTenant) return false
     const haystack = `${route.path} ${route.meta?.title ?? ''} ${route.name ?? ''}`.toLowerCase()
     return haystack.includes(normalized)
   })
@@ -286,7 +290,7 @@ function handleSearch() {
     router.push(matches[0].path)
   } else {
     // Aucune route : cible la vue liste la plus proche par mot-clé du path.
-    const fallback = router.getRoutes().find((r) => r.path.includes(normalized) && !r.path.includes(':'))
+    const fallback = router.getRoutes().find((r) => r.path.includes(normalized) && !r.path.includes(':') && !r.meta?.requiresTenant)
     if (fallback) router.push(fallback.path)
   }
 }

--- a/front/admin-dashboard/src/views/settings/TaxRatesView.vue
+++ b/front/admin-dashboard/src/views/settings/TaxRatesView.vue
@@ -349,13 +349,6 @@ function statusLabel(status) {
     superseded: t('tax_rates.status_superseded'),
   }
   return map[status] || status
-}function formatDate(iso) {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleString(localeStore.current === 'fr' ? 'fr-FR' : localeStore.current)
-  } catch {
-    return iso
-  }
 }
 
 onMounted(async () => {

--- a/front/admin-dashboard/src/views/training/TrainingView.vue
+++ b/front/admin-dashboard/src/views/training/TrainingView.vue
@@ -242,12 +242,17 @@ function closeDetail() {
 async function fetchData() {
   loading.value = true
   error.value = ''
+  // Issue #3143 : les échecs (401 tenant sur /v1/training/courses, etc.)
+  // étaient avalés silencieusement → onglet Catalogue vide sans aucun signal.
+  const failures = []
   try {
     const [coursesRes, sessionsRes, enrollRes] = await Promise.all([
       // #2634 : sessions/enrollments en vue cross-tenant console (routes /admin/*).
-      api.get('/admin/training/courses').catch(() => ({ data: { data: [] } })),
-      api.get('/admin/training/sessions').catch(() => ({ data: { data: [] } })),
-      api.get('/admin/training/enrollments').catch(() => ({ data: { data: [] } })),
+      // #2634/#3143 : routes cross-tenant console (/admin/*) ; les échecs
+      // résiduels sont remontés dans `error` au lieu d'être avalés.
+      api.get('/admin/training/courses').catch((e) => { failures.push('catalogue'); return { data: { data: [] } } }),
+      api.get('/admin/training/sessions').catch(() => { failures.push('sessions'); return { data: { data: [] } } }),
+      api.get('/admin/training/enrollments').catch(() => { failures.push('inscriptions'); return { data: { data: [] } } }),
     ])
     courses.value = coursesRes.data.data || coursesRes.data || []
     sessions.value = sessionsRes.data.data || sessionsRes.data || []
@@ -259,8 +264,11 @@ async function fetchData() {
       total_enrollments: enrollments.value.length,
       completion_rate: enrollments.value.length > 0 ? Math.round(completed.length / enrollments.value.length * 100) : 0,
     }
+    if (failures.length > 0) {
+      error.value = `Certaines données n'ont pas pu être chargées (${failures.join(', ')}). Vérifiez les droits de la console.`
+    }
   } catch {
-    error.value = 'Impossible de charger les donnees de formation.'
+    error.value = 'Impossible de charger les données de formation.'
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
## Contexte
Vague QA expert 2026-08-15 — manquements admin non couverts par les PRs parallèles.

## Correctifs
- **#3042 Header search** : les routes tenant gardées (`meta.requiresTenant` — Paie, Congés, RH…) sont exclues du périmètre de recherche (fini le rebond muet).
- **#3043 SystemAlertsOverlay** : bandeau « Mode maintenance » mort retiré (aucun endpoint admin — cf. #2693), `setMaintenanceMode` expose nettoyé.
- **TrainingView** (bonus, #3143 déjà clos par PR parallèle) : les échecs résiduels par onglet remontent dans `error`.
- **TaxRatesView** (bonus) : fragment cassé laissé par un merge retiré.

## Validation
- `npm run build` vert, `eslint .` 0 erreur (7 warnings pré-existants).

Closes #3042, Closes #3043