### PR TITLE
fix(mail): durée d'essai réelle dans l'email de bienvenue — 30j codé en dur → durée provisionnée

### DIFF
--- a/api/app/Mail/TrialWelcomeMail.php
+++ b/api/app/Mail/TrialWelcomeMail.php
@@ -7,17 +7,23 @@ use App\Core\Auth\Domain\Models\Employee;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class TrialWelcomeMail extends Mailable
 {
     use Queueable;
     use SerializesModels;
 
+    public readonly int $trialDays;
+
     public function __construct(
         public readonly Company $company,
         public readonly Employee $manager,
         public readonly string $tempPassword,
-    ) {}
+    ) {
+        $this->trialDays = $this->resolveTrialDays();
+    }
 
     public function build(): self
     {
@@ -36,8 +42,37 @@ class TrialWelcomeMail extends Mailable
                 'manager' => $this->manager,
                 'tempPassword' => $this->tempPassword,
                 'locale' => $locale,
-                'trialDays' => 30,
+                'trialDays' => $this->trialDays,
             ]);
+    }
+
+
+    /**
+     * Durée d'essai réelle affichée dans l'email : dérivée du provisioning
+     * (subscription_start → subscription_end), avec repli sur le plan.
+     */
+    private function resolveTrialDays(): int
+    {
+        $start = $this->company->subscription_start
+            ? Carbon::parse($this->company->subscription_start)->startOfDay()
+            : Carbon::today();
+
+        $end = $this->company->subscription_end
+            ? Carbon::parse($this->company->subscription_end)->startOfDay()
+            : null;
+
+        if ($end !== null && $end->greaterThan($start)) {
+            return (int) $start->diffInDays($end);
+        }
+
+        if ($this->company->plan_id) {
+            $planDays = DB::table('plans')->where('id', $this->company->plan_id)->value('trial_days');
+            if (is_numeric($planDays) && (int) $planDays > 0) {
+                return (int) $planDays;
+            }
+        }
+
+        return 14;
     }
 
     private function resolveSubject(string $locale): string

--- a/api/tests/Feature/SelfServiceTrialTest.php
+++ b/api/tests/Feature/SelfServiceTrialTest.php
@@ -124,7 +124,8 @@ class SelfServiceTrialTest extends TestCase
 
         // Verify Welcome Mail sent after verification
         Mail::assertSent(TrialWelcomeMail::class, function ($mail) {
-            return $mail->hasTo('founder@newtech.dz');
+            return $mail->hasTo('founder@newtech.dz')
+                && $mail->trialDays === 14;
         });
     }
 


### PR DESCRIPTION
## Problème (P2 — cohérence)
`TrialWelcomeMail` passait `'trialDays' => 30` **en dur** dans la vue, alors que le tenant est provisionné pour la durée réelle du plan (**14 jours** — `VerifyTrialSignup`, `ProvisionGuidedTrial`, `CompanyProvisioningService` défaut 14).

**Conséquence** : l'email de bienvenue promet 30 jours d'essai à des comptes provisionnés 14 jours — incohérence produit (connexe #3012/#3056) et risque de support/chargebacks.

## Correctif
- `TrialWelcomeMail::resolveTrialDays()` : durée dérivée du provisioning réel (`subscription_start → subscription_end`), repli sur `plans.trial_days`, puis 14.
- Propriété publique `$trialDays` (assertable).
- Test renforcé : `SelfServiceTrialTest` vérifie `$mail->trialDays === 14`.

## Vérification
- `SelfServiceTrialTest` : 7/7 pass (52 assertions) sur PG16 + bootstrap CI.
