### PR TITLE
docs(qa): vague audit expert 5 2026-08-15 — spec/plan/tasks (62 constats #3231-#3294)

### DIFF
--- a/.specify/features/qa-expert5-2026-08-15/plan.md
+++ b/.specify/features/qa-expert5-2026-08-15/plan.md
@@ -1,0 +1,29 @@
+# Plan: QA Expert #5 — Test exhaustif plateforme (2026-08-15)
+
+**Input**: spec.md
+
+## Stratégie
+
+1. **Audit** (terminé) : 4 subagents experts (api/web/admin/mobile) + tests live HTTP (Render/Vercel/CF Pages). 62 nouveaux constats, tous dédupliqués contre les issues/branches existantes (#2400).
+2. **Tickets** (terminé) : 62 issues GitHub créées (#3231-#3294), label `qa-expert5-2026-08-15`, format `[QA][Px][surface]`.
+3. **Implémentation** : par vagues P1 → P2 → P3, chaque correctif en branche `fix/<issue>-<slug>` + PR avec `Closes #N` + CHANGELOG. Priorité aux P1 sécurité (IDOR, SSRF, messages bruts) et aux parcours mobiles cassés (#3282, #3283).
+4. **En parallèle** : campagne de merge des 22 PRs ouvertes (dont les waves QA précédentes) — vérifier les checks, merger les vertes, réparer/fermer les rouges (#3111, #3125, #3128).
+5. **Garde** : main doit rester vert (5 checks requis) ; vérifier les runs post-merge avant d'annoncer.
+
+## Ordre d'exécution conseillé
+
+| Vague | Contenu | Issues |
+|---|---|---|
+| 0 | Merge campaign PRs vertes + réparation des PRs cassées | — |
+| 1 | P1 API (company_id, policy, per_page, messages bruts) | #3231 #3232 #3234 #3235 |
+| 2 | P1 mobile (GoRoutes manager, 405 read-all) | #3282 #3283 |
+| 3 | P1 admin (WebhooksView, UsersView, realtime, i18n) | #3267 #3268 #3269 #3270 |
+| 4 | P1 vitrine (preuve sociale, tarifs, FR-only) | #3246 #3247 #3248 |
+| 5 | P2 quick wins (throttle, Log, FR API, sitemap, ancres…) | #3236 #3237 #3241 #3252 #3253 #3255… |
+| 6 | P3 cleanup | restantes |
+
+## Risques
+
+- **CI saturée** : 22 PRs × ~20 workflows — merger par vagues, prioriser les vertes, éviter de créer des PRs concurrentes sur les mêmes fichiers.
+- **Régression par branches périmées** (leçon 2026-08-15) : avant merge d'une vieille branche, vérifier `git diff origin/main...HEAD` sur les fichiers partagés.
+- **Anti-doublon** : un seul `fix/<issue>-*` par issue ; vérifier les branches avant de coder.

--- a/.specify/features/qa-expert5-2026-08-15/spec.md
+++ b/.specify/features/qa-expert5-2026-08-15/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: QA Expert #5 — Test exhaustif plateforme (2026-08-15)
+
+**Feature**: `qa-expert5-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + revue experte statique (subagents par surface) + tests live HTTP (Render/Vercel/Cloudflare Pages) + cross-check des ~128 issues ouvertes et 22 PRs (règle anti-doublon #2400).
+
+## Contexte
+
+Cinquième vague de test expert de la mission propriétaire : tester l'app « dans tous les sens » (vitrine, web, admin, mobile, workflows, API, logiques, onboarding, cohérence), consigner chaque manquement selon la méthode Spec Kit, puis implémenter. Les findings ci-dessous sont **nouveaux** : dédupliqués contre les issues ouvertes existantes.
+
+## Findings non couverts (issues créées — label `qa-expert5-2026-08-15`)
+
+### API / Backend (#3231-#3245)
+- #3231 [P1] index() manager sans scope company_id sur 6 contrôleurs (IDOR cross-tenant)
+- #3232 [P1] EmployeePolicy aveugle au company_id (view/update/archive)
+- #3233 [P1] Drift OpenAPI : ~165 routes live absentes de la spec
+- #3234 [P1] per_page non borné sur ~40 endpoints (extension #3059)
+- #3235 [P1] Messages d'erreur bruts exposés à des callers anonymes (SSO public, auth Google)
+- #3236 [P2] Catches silencieux sans Log sur les chemins argent (checkout/portal, import, taux)
+- #3237 [P2] ~36 chaînes FR codées en dur dans les réponses API
+- #3238 [P2] Races check-then-create (évaluations, paie employé/mois)
+- #3239 [P2] Checklist onboarding dupliquée : deux moteurs divergents, 403 employé
+- #3240 [P2] Module Training squelette mort
+- #3241 [P2] Endpoints publics sans throttle (/health*, /sso/providers)
+- #3242 [P2] SSRF config-driven dans le flux OIDC (tokenUrl/jwksUri sans allowlist)
+- #3243 [P2] Fail-open : mot de passe demo password123 + decryptField clair
+- #3244 [P3] POST /employees/link-user hors groupe api.manager
+- #3245 [P3] Logique self-service dupliquée MeController/Estimation/HrController
+
+### Vitrine Web (#3246-#3262)
+- #3246 [P1] Preuve sociale fabriquée sur 4 surfaces (50K utilisateurs, cas clients inventés, démo présentée comme réelle)
+- #3247 [P1] Tarifs déconnectés du backend (Enterprise sur devis/299€ vs 199€, Free inexistant, trial 14 vs 30 j)
+- #3248 [P1] 10+ pages servies 100% FR en dur aux 4 locales
+- #3249 [P2] Accents systématiquement supprimés (fr.json, vitrine-locale.ts, pricing, faq)
+- #3250 [P2] Pas de hreflang ; alternates ?lang= soft-duplicates
+- #3251 [P2] Domaine divergent sitemap vs robots (complément #3190)
+- #3252 [P2] Sitemap : /share (405) et /offline non crawlables
+- #3253 [P2] Ancre footer morte /#fonctionnalites vs id="fonctionnalités"
+- #3254 [P2] Paramètres contact cassés (?type=, ?topic=enterprise, « Forum » sans forum)
+- #3255 [P2] /contact FR affiche {copy.info.responseTime} littéral
+- #3257 [P2] Produit fantôme « Leopardo Desktop Windows/macOS »
+- #3258 [P2] Boutons téléchargement sans liens store réels, iOS sans fallback
+- #3260 [P2] JSON-LD offre 0-99€/3 offres fausse
+- #3261 [P2] Image OG FR en dur + « 5 apps mobiles » vs 3 réelles
+- #3262 [P2] PWA manifest/PWAProvider FR + leopardo.local hors ligne
+- #3263 [P2] Blog : 10 articles 2023-2024 présentés comme actuels (archived inutilisé)
+- #3264 [P2] /faq catégories dupliquées + pays 6/5 vs 9 moteurs backend
+- #3265 [P3] Orphelin structured-data.ts
+- #3266 [P3] Badges « Leo IA 2.0 » TR/AR seulement + suffixe AR « 14ي »
+
+### Admin Dashboard (#3267-#3281)
+- #3267 [P1] WebhooksView lit des champs jamais renvoyés (4 colonnes mortes + toggle Actif mort)
+- #3268 [P1] UsersView détail/impersonation interroge la mauvaise table (super_admins vs users)
+- #3269 [P1] Stack temps réel morte en prod (ws://localhost:6001) + bandeaux permanents trompeurs
+- #3270 [P1] Console ~90% FR codé en dur (i18n contourné)
+- #3271 [P2] ChatView ne peut jamais envoyer (501 backend)
+- #3272 [P2] Guard requiresTenant bloque /exports et /fleet (endpoints existent)
+- #3273 [P2] CompanyDetailView lit slug/created_at jamais envoyés
+- #3274 [P2] Échecs de chargement silencieux (KPIs, santé « good » par défaut, Prédictions/Rapports)
+- #3275 [P2] KeyboardShortcutsModal annonce Alt+R jamais implémenté (2 listes désynchronisées)
+- #3276 [P2] SystemView : 6 sections « Non disponible » permanentes
+- #3277 [P2] Formatage fr-FR/EUR en dur malgré toIntlLocale
+- #3278 [P3] Tokens legacy rounded-lg bg-white dans 14 fichiers + 2 MetricCard
+- #3279 [P3] DashboardView carte « Préparer intégrations » pointe /system
+- #3280 [P3] Route morte /users/:id + UserDetailView jamais liée
+- #3281 [P3] Valeurs i18n FR dans en/tr/ar, EN dans fr.json
+
+### Mobile (#3282-#3294)
+- #3282 [P1] Manager : 9 routes GoRouter manquantes → écran d'erreur
+- #3283 [P1] Employee : POST /notifications/read-all → 405 (backend PUT)
+- #3284 [P2] HR : 9 routes GoRouter mortes
+- #3285 [P2] Manager : 6 routes GoRouter mortes
+- #3286 [P2] POST non-idempotents sous retry auto (register, google-signin, AI chat, publish)
+- #3287 [P3] FCFA codé en dur (modules_screen manager/hr)
+- #3288 [P3] Aucun widget n'utilise AppLocalizations (l10n mort)
+- #3289 [P3] dio.download ×12 hors requestWithRetry
+- #3290 [P3] Dio() sans timeout (core_providers employee)
+- #3291 [P3] smart_attendance : query string dans le path + cast as List
+- #3292 [P3] platform_admin tracesSampleRate 1.0 vs #2766 (0.2)
+- #3293 [P3] Marketing : onglet Publier hors ShellRoute → écran bloqué
+- #3294 [P3] Client ID Google OAuth debug committé (3 apps)
+
+## Méthode de test utilisée
+
+1. **Statique par surface** : 4 subagents experts (api, web, admin, mobile) — diff routes↔openapi↔repositories, grep patterns interdits (dd/dump, catch vides, per_page, withOpacity, dio.*, FR en dur), dead code, contrats.
+2. **Live** : requêtes HTTP réelles sur Render (API), Vercel (vitrine), Cloudflare Pages (admin) — health, plans, sso/providers, robots.txt, sitemap.xml, hreflang, /share, /faq, /fr.
+3. **Dédup** : vérification contre les issues ouvertes, branches et PRs existantes (#2400).

--- a/.specify/features/qa-expert5-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert5-2026-08-15/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: QA Expert #5 — Test exhaustif plateforme (2026-08-15)
+
+**Input**: spec.md — chaque tâche correspond à une issue GitHub ouverte (label `qa-expert5-2026-08-15`).
+
+## Phase 1 — P1 (sécurité & parcours critiques)
+- [ ] T001 [#3231] API — scopes company_id manquants sur 6 contrôleurs (IDOR) + test isolation
+- [ ] T002 [#3232] API — EmployeePolicy company_id + test
+- [ ] T003 [#3233] API — drift OpenAPI : aligner spec sur routes live (ou déprécier)
+- [ ] T004 [#3234] API — clamp per_page uniforme (helper max(1,min(100)))
+- [ ] T005 [#3235] API — masquer messages bruts (SSO, auth Google, import) + Log
+- [ ] T006 [#3282] Mobile manager — déclarer les 9 GoRoutes manquantes
+- [ ] T007 [#3283] Mobile employee — PUT /notifications/read-all
+- [ ] T008 [#3267] Admin — WebhooksView : aligner contrat (active, company_name)
+- [ ] T009 [#3268] Admin — UsersView : détail depuis /platform/users (company.employee_id)
+- [ ] T010 [#3269] Admin — stack temps réel : neutraliser bandeaux/mark-all-read ou provisionner Reverb
+- [ ] T011 [#3270] Admin — migrer les vues accessibles vers $t
+- [ ] T012 [#3246] Vitrine — marquer témoignages/cas comme démo, retirer chiffres invérifiables
+- [ ] T013 [#3247] Vitrine — source unique des plans (aligner pricing.ts/checkout/PlanSeeder)
+- [ ] T014 [#3248] Vitrine — localiser les 10+ pages FR-only
+
+## Phase 2 — P2 (cohérence, i18n, fiabilité)
+- [ ] T015 [#3236] API — Log::error sur catches argent (billing, import, taux, auth Google)
+- [ ] T016 [#3237] API — messages via __()/lang files (~36 chaînes)
+- [ ] T017 [#3238] API — firstOrCreate/unique sur évaluations + paie
+- [ ] T018 [#3239] API — fusionner les 2 moteurs de checklist onboarding
+- [ ] T019 [#3240] API — supprimer squelette Training mort
+- [ ] T020 [#3241] API — throttle /health* + /sso/providers
+- [ ] T021 [#3242] API — SSRF guard sur tokenUrl/jwksUri OIDC
+- [ ] T022 [#3243] API — fail-closed demo password + decryptField
+- [ ] T023 [#3284] Mobile HR — retirer 9 routes mortes
+- [ ] T024 [#3285] Mobile manager — retirer 6 routes mortes
+- [ ] T025 [#3286] Mobile — maxRetriesOverride:0 sur register/google-signin/publish
+- [ ] T026 [#3249] Vitrine — restaurer les accents FR/TR
+- [ ] T027 [#3250] Vitrine — hreflang/x-default (ou localisation par chemin)
+- [ ] T028 [#3251] Vitrine — fusionner site.ts/site-url.ts
+- [ ] T029 [#3252] Vitrine — retirer /share et /offline du sitemap
+- [ ] T030 [#3253] Vitrine — aligner l'ancre fonctionnalités
+- [ ] T031 [#3254] Vitrine — corriger ?topic=enterprise + renommer Forum
+- [ ] T032 [#3255] Vitrine — corriger {copy.info.responseTime}
+- [ ] T033 [#3257] Vitrine — retirer/transformer la page Desktop fantôme
+- [ ] T034 [#3258] Vitrine — étiqueter honnêtement les boutons de téléchargement
+- [ ] T035 [#3260] Vitrine — générer JSON-LD offers depuis la source pricing
+- [ ] T036 [#3261] Vitrine — OG par locale + comptes d'apps corrigés
+- [ ] T037 [#3262] Vitrine — localiser manifest/PWAProvider, masquer leopardo.local
+- [ ] T038 [#3263] Vitrine — badge « Archivé » sur les vieux posts blog
+- [ ] T039 [#3264] Vitrine — liste unique des pays + catégories FAQ dédoublonnées
+- [ ] T040 [#3271] Admin — ChatView : état honnête « indisponible »
+- [ ] T041 [#3272] Admin — débloquer /exports et /fleet, stubler 10 routes tenant
+- [ ] T042 [#3273] Admin — ajouter slug/created_at au payload health (ou retirer)
+- [ ] T043 [#3274] Admin — états d'erreur visibles + santé par défaut unknown
+- [ ] T044 [#3275] Admin — source unique des raccourcis (Alt+R)
+- [ ] T045 [#3276] Admin — SystemView : supprimer ou brancher les 6 sections
+- [ ] T046 [#3277] Admin — toIntlLocale partout
+
+## Phase 3 — P3 (hygiène, cleanup)
+- [ ] T047 [#3244] API — /employees/link-user sous api.manager
+- [ ] T048 [#3245] API — dédupliquer MeController/HrController
+- [ ] T049 [#3265] Vitrine — supprimer structured-data.ts
+- [ ] T050 [#3266] Vitrine — uniformiser badges Leo IA + suffixe AR
+- [ ] T051 [#3278] Admin — migrer 14 fichiers vers glass tokens, fusionner MetricCard
+- [ ] T052 [#3279] Admin — corriger CTA intégrations
+- [ ] T053 [#3280] Admin — supprimer route /users/:id morte
+- [ ] T054 [#3281] Admin — nettoyer les valeurs i18n
+- [ ] T055 [#3287] Mobile — currencySuffix au lieu de FCFA
+- [ ] T056 [#3288] Mobile — amorcer la migration l10n (ou retirer locales annoncées)
+- [ ] T057 [#3289] Mobile — downloadWithRetry
+- [ ] T058 [#3290] Mobile — timeouts Dio core_providers
+- [ ] T059 [#3291] Mobile — smart_attendance queryParameters + extractDataList
+- [ ] T060 [#3292] Mobile — tracesSampleRate 0.2 platform_admin
+- [ ] T061 [#3293] Mobile — /create-post dans le ShellRoute marketing
+- [ ] T062 [#3294] Mobile — retirer client ID Google OAuth debug
+
+## Vérification globale
+- [ ] Chaque PR : `Closes #N` dans le body + entrée CHANGELOG.md
+- [ ] Checks requis main verts (Backend Coverage, PHPStan Strict L8, Module Structure, ESLint+TS, actionlint)
+- [ ] Nettoyage des branches après merge


### PR DESCRIPTION
docs(qa): vague audit expert 5 2026-08-15 — spec/plan/tasks/findings

## Contenu
- `.specify/features/qa-expert5-2026-08-15/spec.md` — 62 constats nouveaux (dédupliqués #2400) : API (15), Vitrine (19), Admin (15), Mobile (13).
- `plan.md` — stratégie d'implémentation par vagues P1→P3.
- `tasks.md` — une tâche par issue.

## Issues créées
62 issues GitHub `[QA][Px][surface]` (#3231-#3294), label `qa-expert5-2026-08-15`.

## Méthode
4 audits experts par surface (api/web/admin/mobile) + tests live HTTP (Render/Vercel/Cloudflare Pages). P1 sécurité : IDOR cross-tenant (company_id manquants, EmployeePolicy), messages d'erreur bruts, SSRF OIDC, per_page non borné ; P1 parcours : 9 routes GoRouter manager manquantes, 405 read-all employee, WebhooksView/UsersView admin, preuve sociale et tarifs vitrine faux.
