### PR TITLE
fix(admin): CompanyDetailView ne crashe plus — adoption.kiosk null-safe (Closes #3034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+### Fixed
+- **fix(admin): CompanyDetailView ne crashe plus sur adoption.kiosk absent (Closes #3034).** Le template lisait `health.adoption.kiosk.active` sans garde alors que le payload backend n'inclut jamais `kiosk` → fiche entreprise blanche. Affichage null-safe avec état honnête « Non disponible » (règle : jamais de données fabriquées).
 - **fix(kiosk): état non configuré localisé quand apiBaseUrl ou deviceCode manque (Closes #2911).** La borne n’essaie plus d’appeler une URL `/api/v1/kiosks/` invalide : les actions distantes sont désactivées et un message d’installation est affiché en FR/EN/TR/AR.
 ### Added
 - **feat(admin): impersonation SPA câblée sur POST /admin/impersonations (Closes #2518).** Le backend PA2-ADM-006 existait (PlatformImpersonationController : session Sanctum 30-120 min, motif obligatoire, audit) mais aucun bouton UI — la PR #2466 avait même retiré l'émetteur `@impersonate`. (1) `UsersView` recharge le détail via `GET /admin/users/{id}` (seule source du lien employé `company.employee_id`, décision #2519) ; (2) modal d'impersonation : motif obligatoire ≥ 5 caractères, POST `/admin/impersonations` {company_id, employee_id, reason}, affichage du jeton + expiration + copie, erreurs API ; (3) `UserDetailModal` affiche entreprise/employé lié depuis le payload `company` ; (4) i18n `users.impersonation.*` dans les 4 locales. Au passage (artefacts merge #2469 signalés par #2517) : doublons `import api` + `deleteUser` + handlers de modales morts (`handleUserCreated`/`handleUserUpdated`/`generateTemporaryPassword`) supprimés — lint 0 erreur, build vert.

--- a/front/admin-dashboard/src/views/companies/CompanyDetailView.vue
+++ b/front/admin-dashboard/src/views/companies/CompanyDetailView.vue
@@ -77,8 +77,8 @@
                 <div class="rounded-2xl bg-slate-50 p-4 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 transition-transform hover:scale-[1.02]">
                   <dt class="text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-400">Kiosk</dt>
                   <dd class="mt-2 flex items-center text-sm font-bold text-slate-900 dark:text-white">
-                    <div :class="['mr-2 h-2.5 w-2.5 rounded-full', health.adoption.kiosk.active ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' : 'bg-slate-300']"></div>
-                    {{ health.adoption.kiosk.active ? 'Actif' : 'Inactif' }}
+                    <div :class="['mr-2 h-2.5 w-2.5 rounded-full', health.adoption.kiosk?.active ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' : 'bg-slate-300']"></div>
+                    {{ health.adoption.kiosk ? (health.adoption.kiosk.active ? 'Actif' : 'Inactif') : 'Non disponible' }}
                   </dd>
                 </div>
               </div>


### PR DESCRIPTION
## #3034 — fiche entreprise blanche (P1)

`CompanyDetailView.vue` lisait `health.adoption.kiosk.active` sans garde : le payload `/admin/companies/{id}` de `PlatformCompanyHealthService` n'inclut jamais `kiosk` (adoption = health_score/risk_level/employees/attendance/onboarding/anomalies) → `Cannot read properties of undefined (reading 'active')` → fiche blanche.

Correctif : accès null-safe (`health.adoption.kiosk?.active`) + état honnête « Non disponible » quand le champ est absent (règle AGENTS.md : jamais de données fabriquées).

Closes #3034. ESLint OK. CHANGELOG mis à jour.