### PR TITLE
fix(api): durcissement sécurité — licence Edge fail-closed + SSO anti-SSRF + émission licence manager (Closes #3317, #3318, #3319)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -232,6 +232,9 @@ CAMERAS_TEST_RTSP_TIMEOUT=5
 CLOUD_API_URL=https://api.leopardo.app
 CLOUD_SYNC_INTERVAL_MINUTES=15
 EDGE_LICENSE_PRIVATE_KEY=
+# OBLIGATOIRE en production : sans clé publique, /api/v1/edge-node/validate-license
+# refuse tout token (fail-closed, issue #3317). Générer : openssl genrsa -out
+# edge_license_private.pem 2048 && openssl rsa -in edge_license_private.pem -pubout
 EDGE_LICENSE_PUBLIC_KEY=
 EDGE_LICENSE_VALIDITY_DAYS=30
 EDGE_NODE_ID=

--- a/api/app/Core/Auth/Interfaces/Api/V1/Requests/SsoConfigureRequest.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/Requests/SsoConfigureRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\Auth\Interfaces\Api\V1\Requests;
+
+use App\Rules\PublicEndpointUrl;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validation de la configuration SSO (SAML/OIDC).
+ *
+ * Issue #3318 : les URLs d'endpoints IdP sont vérifiées par le garde
+ * anti-SSRF PublicEndpointUrl (https uniquement, pas d'IP privée/locale).
+ * L'autorisation exige le manager principal (défense en profondeur : le
+ * middleware api.manager:principal et le contrôleur vérifient déjà).
+ */
+class SsoConfigureRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $actor = $this->user();
+
+        return $actor !== null
+            && method_exists($actor, 'hasManagerRole')
+            && $actor->hasManagerRole('principal');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $endpoint = ['nullable', 'string', 'max:2048', new PublicEndpointUrl()];
+
+        return [
+            'provider' => 'required|string|in:saml,oidc',
+            'entity_id' => 'nullable|string|max:2048',
+            'sso_url' => $endpoint,
+            'slo_url' => $endpoint,
+            'certificate' => 'nullable|string',
+            'client_id' => 'nullable|string',
+            'client_secret' => 'nullable|string',
+            // OpenID Connect (issue #2231) — champs du flux authorize/callback.
+            'issuer' => $endpoint,
+            'authorize_url' => $endpoint,
+            'token_url' => $endpoint,
+            'jwks_uri' => $endpoint,
+            'redirect_uri' => $endpoint,
+            'scopes' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
@@ -8,6 +8,7 @@ use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Auth\Infrastructure\Services\SSO\OidcFlowService;
 use App\Core\Auth\Infrastructure\Services\SSO\SSOService;
 use App\Core\Auth\Infrastructure\Services\SSO\SSOValidationNotImplementedException;
+use App\Core\Auth\Interfaces\Api\V1\Requests\SsoConfigureRequest;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -46,7 +47,7 @@ class SSOController extends Controller
         ]);
     }
 
-    public function configure(Request $request): JsonResponse
+    public function configure(SsoConfigureRequest $request): JsonResponse
     {
         /** @var Employee $actor */
         $actor = $request->user();
@@ -54,22 +55,7 @@ class SSOController extends Controller
             abort(403);
         }
 
-        $validated = $request->validate([
-            'provider' => 'required|string|in:saml,oidc',
-            'entity_id' => 'nullable|string|url',
-            'sso_url' => 'nullable|string|url',
-            'slo_url' => 'nullable|string|url',
-            'certificate' => 'nullable|string',
-            'client_id' => 'nullable|string',
-            'client_secret' => 'nullable|string',
-            // OpenID Connect (issue #2231) — champs du flux authorize/callback.
-            'issuer' => 'nullable|string|url',
-            'authorize_url' => 'nullable|string|url',
-            'token_url' => 'nullable|string|url',
-            'jwks_uri' => 'nullable|string|url',
-            'redirect_uri' => 'nullable|string|url',
-            'scopes' => 'nullable|string|max:255',
-        ]);
+        $validated = $request->validated();
 
         $config = $this->ssoService->configureSSO(
             $actor->company_id,

--- a/api/app/Modules/EdgeSync/Application/Services/EdgeLicenseService.php
+++ b/api/app/Modules/EdgeSync/Application/Services/EdgeLicenseService.php
@@ -111,6 +111,10 @@ class EdgeLicenseService
 
     /**
      * Decode and verify a JWT.
+     *
+     * Fail-closed : sans clé publique configurée, la vérification échoue
+     * (issue #3317). Le décodage sans vérification n'est toléré qu'en
+     * environnement local/testing (développement sans paire RSA).
      */
     protected function decode(string $token): array
     {
@@ -120,6 +124,12 @@ class EdgeLicenseService
             $decoded = \Firebase\JWT\JWT::decode($token, new \Firebase\JWT\Key($publicKey, 'RS256'));
 
             return (array) $decoded;
+        }
+
+        // Fail-closed : EDGE_LICENSE_PUBLIC_KEY absent en production → refuser
+        // (le défaut config/edge.php est null ; un token non signé serait accepté).
+        if (! app()->environment(['local', 'testing'])) {
+            throw new \RuntimeException('Edge license public key not configured');
         }
 
         // Dev/test fallback — decode without verification

--- a/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeNodeController.php
+++ b/api/app/Modules/EdgeSync/Interfaces/Api/V1/EdgeNodeController.php
@@ -14,6 +14,7 @@ use App\Modules\EdgeSync\Domain\Models\EdgeLicense;
 use App\Modules\EdgeSync\Domain\Models\EdgeNode;
 use App\Modules\EdgeSync\Domain\Models\SyncQueue;
 use App\Modules\EdgeSync\Interfaces\Api\V1\Requests\EdgeNodeActionRequest;
+use App\Modules\EdgeSync\Interfaces\Api\V1\Requests\IssueLicenseRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -96,12 +97,12 @@ class EdgeNodeController extends Controller
      * Issue or renew an Edge license.
      * POST /api/v1/edge/{nodeId}/license
      */
-    public function issueLicense(Request $request, string $nodeId): JsonResponse
+    public function issueLicense(IssueLicenseRequest $request, string $nodeId): JsonResponse
     {
         $node = EdgeNode::where('company_id', $request->user()->company_id)
             ->findOrFail($nodeId);
 
-        $days = (int) $request->input('valid_days', config('edge.license_validity_days', 30));
+        $days = $request->integer('valid_days', (int) config('edge.license_validity_days', 30));
         $license = $this->licenseService->issueLicense($node, $days);
 
         return response()->json(['data' => $license]);

--- a/api/app/Modules/EdgeSync/Interfaces/Api/V1/Requests/IssueLicenseRequest.php
+++ b/api/app/Modules/EdgeSync/Interfaces/Api/V1/Requests/IssueLicenseRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\EdgeSync\Interfaces\Api\V1\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validation de l'émission/renouvellement de licence Edge.
+ *
+ * Issue #3319 : la route POST /api/v1/edge/{nodeId}/license était ouverte à
+ * tout employé authentifié avec un valid_days non borné (auto-extension
+ * arbitraire de la validité). L'autorisation exige un manager (défense en
+ * profondeur : le middleware api.manager est aussi posé sur la route) et
+ * valid_days est borné à 1..3650 jours.
+ */
+class IssueLicenseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $actor = $this->user();
+
+        return $actor !== null && method_exists($actor, 'isManager') && $actor->isManager();
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'valid_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'valid_days.min' => 'The valid_days must be at least 1.',
+            'valid_days.max' => 'The valid_days must not exceed 3650.',
+        ];
+    }
+}

--- a/api/app/Modules/EdgeSync/routes/api.php
+++ b/api/app/Modules/EdgeSync/routes/api.php
@@ -51,7 +51,8 @@ Route::prefix('api/v1/edge')
         Route::post('/', [EdgeNodeController::class, 'store']);
         Route::get('/{nodeId}', [EdgeNodeController::class, 'show']);
         Route::post('/{nodeId}/sync', [EdgeNodeController::class, 'sync']);
-        Route::post('/{nodeId}/license', [EdgeNodeController::class, 'issueLicense']);
+        // #3319 : émission de licence réservée aux managers (api.manager).
+        Route::post('/{nodeId}/license', [EdgeNodeController::class, 'issueLicense'])->middleware('api.manager');
     });
 
 // ── Edge node machine routes ───────────────────────────────────────────────

--- a/api/app/Rules/PublicEndpointUrl.php
+++ b/api/app/Rules/PublicEndpointUrl.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Anti-SSRF guard for user-supplied SSO endpoint URLs (SAML/OIDC).
+ *
+ * Issue #3318 : la règle `|url` acceptait 169.254.169.254, localhost et les
+ * plages privées → le serveur faisait ensuite POST/GET vers ces cibles
+ * (OidcFlowService::token, OidcIdTokenValidator::jwks).
+ *
+ * Rejects:
+ *   - tout schéma autre que https://
+ *   - les hôtes locaux : localhost, *.localhost, *.local, *.internal
+ *   - les IP littérales privées/réservées (RFC1918, loopback, link-local,
+ *     CGNAT, TEST-NET, IPv6 ULA/link-local, 169.254.169.254…)
+ *   - les hostnames dont au moins un enregistrement DNS résout vers une IP
+ *     privée/réservée
+ *
+ * Tolère (best-effort, défense en profondeur comme NotPrivateUrl) les
+ * hostnames non résolubles au moment de la validation : on ne peut pas
+ * prouver qu'ils sont privés, et le rejet casserait les configurations
+ * d'IdP légitimes en cours de propagation DNS.
+ */
+class PublicEndpointUrl implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            $fail('validation.url')->translate();
+
+            return;
+        }
+
+        if (! str_starts_with(strtolower($value), 'https://')) {
+            $fail('SSO URL must use https://.');
+
+            return;
+        }
+
+        $host = parse_url($value, PHP_URL_HOST);
+        if (! is_string($host) || $host === '') {
+            $fail('SSO URL is invalid.');
+
+            return;
+        }
+
+        if (! self::isPublicHost($host)) {
+            $fail('SSO URL is not allowed (private, reserved, or local host).');
+        }
+    }
+
+    public static function isPublicHost(string $host): bool
+    {
+        $host = strtolower(trim($host, '[]'));
+
+        if ($host === 'localhost'
+            || str_ends_with($host, '.localhost')
+            || str_ends_with($host, '.local')
+            || str_ends_with($host, '.internal')) {
+            return false;
+        }
+
+        // Literal IP: validate directly.
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return self::isPublicIp($host);
+        }
+
+        // Hostname: resolve and reject if *any* record lands on a
+        // private/reserved range.
+        $records = array_filter([
+            ...(dns_get_record($host, DNS_A) ?: []),
+            ...(dns_get_record($host, DNS_AAAA) ?: []),
+        ]);
+
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+            if (! is_string($ip) || ! self::isPublicIp($ip)) {
+                return false;
+            }
+        }
+
+        // Unresolvable at validation time: tolerated (best-effort check).
+        return true;
+    }
+
+    private static function isPublicIp(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) !== false;
+    }
+}

--- a/api/routes/modules/sso.php
+++ b/api/routes/modules/sso.php
@@ -18,7 +18,8 @@ Route::get('/sso/oidc/{companyId}/callback', [SSOController::class, 'oidcCallbac
 
 // Authenticated: SSO management (manager principal only)
 // #2635 : aligné sur le groupe standard (token.refresh + throttle:api-plan).
-Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
+// #3318 : + api.manager:principal (défense en profondeur, pattern rh.php #3150).
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'api.manager:principal'])->group(function (): void {
     Route::get('/sso/status', [SSOController::class, 'status']);
     Route::post('/sso/configure', [SSOController::class, 'configure']);
     Route::delete('/sso/disable', [SSOController::class, 'disable']);

--- a/api/tests/Feature/Auth/SsoConfigureSsrfGuardTest.php
+++ b/api/tests/Feature/Auth/SsoConfigureSsrfGuardTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Auth\Domain\Models\Employee;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * Issue #3318 — SSRF via config SSO OIDC/SAML :
+ * les URLs d'endpoints IdP ne doivent pas pointer vers des IP privées/locales
+ * (169.254.169.254, loopback, RFC1918…), et la configuration reste réservée
+ * au manager principal.
+ */
+class SsoConfigureSsrfGuardTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    private Company $company;
+
+    private Employee $manager;
+
+    private Employee $employee;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+
+        $this->company = Company::factory()->create();
+
+        $this->manager = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'role' => 'manager',
+            'manager_role' => 'principal',
+        ]);
+
+        $this->employee = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'role' => 'employee',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public static function privateUrlPayloads(): iterable
+    {
+        yield 'metadata cloud AWS' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'token_url' => 'https://169.254.169.254/latest/meta-data/iam/security-credentials/'],
+        ];
+        yield 'loopback IPv4' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'jwks_uri' => 'https://127.0.0.1:8443/jwks'],
+        ];
+        yield 'RFC1918 10/8' => [
+            ['provider' => 'saml', 'sso_url' => 'https://10.0.0.5/sso'],
+        ];
+        yield 'RFC1918 192.168/16' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'authorize_url' => 'https://192.168.1.10/authorize'],
+        ];
+        yield 'localhost' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'token_url' => 'http://localhost:8080/token'],
+        ];
+        yield 'hostname .local' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'jwks_uri' => 'https://keycloak.local/jwks'],
+        ];
+        yield 'hostname .internal' => [
+            ['provider' => 'saml', 'slo_url' => 'https://idp.internal/slo'],
+        ];
+        yield 'scheme http' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'redirect_uri' => 'http://app.example.com/callback'],
+        ];
+        yield 'IPv6 loopback' => [
+            ['provider' => 'oidc', 'issuer' => 'https://issuer.example.com', 'token_url' => 'https://[::1]:8443/token'],
+        ];
+    }
+
+    /**
+     * @dataProvider privateUrlPayloads
+     */
+    public function test_configure_rejects_private_or_local_endpoints(array $payload): void
+    {
+        $response = $this->actingAs($this->manager, 'sanctum')
+            ->postJson('/api/v1/sso/configure', $payload);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_configure_accepts_public_https_endpoints(): void
+    {
+        $response = $this->actingAs($this->manager, 'sanctum')
+            ->postJson('/api/v1/sso/configure', [
+                'provider' => 'oidc',
+                'issuer' => 'https://issuer.example.com',
+                'authorize_url' => 'https://issuer.example.com/authorize',
+                'token_url' => 'https://issuer.example.com/token',
+                'jwks_uri' => 'https://issuer.example.com/jwks',
+                'client_id' => 'client-1',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.provider', 'oidc');
+    }
+
+    public function test_configure_by_plain_employee_is_forbidden(): void
+    {
+        $response = $this->actingAs($this->employee, 'sanctum')
+            ->postJson('/api/v1/sso/configure', [
+                'provider' => 'saml',
+                'entity_id' => 'https://idp.example.com/metadata',
+                'sso_url' => 'https://idp.example.com/sso',
+            ]);
+
+        $response->assertForbidden();
+    }
+}

--- a/api/tests/Feature/Edge/EdgeLicenseFailClosedTest.php
+++ b/api/tests/Feature/Edge/EdgeLicenseFailClosedTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Edge;
+
+use App\Modules\EdgeSync\Application\Services\EdgeLicenseService;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+/**
+ * Issue #3317 — Licence Edge fail-open : POST /api/v1/edge-node/validate-license
+ * acceptait tout payload non signé quand EDGE_LICENSE_PUBLIC_KEY était absent
+ * (défaut de config/edge.php).
+ *
+ * Vérifie que :
+ *   - En environnement production, sans clé publique → 422 (fail-closed).
+ *   - En production, un payload HS256 forgé (fallback dev) → 422.
+ *   - Avec une clé publique configurée, un token invalide → 422.
+ */
+class EdgeLicenseFailClosedTest extends TestCase
+{
+    public function test_validate_license_is_fail_closed_in_production_without_public_key(): void
+    {
+        app()->detectEnvironment(fn (): string => 'production');
+        Config::set('edge.license_public_key', null);
+
+        // Payload « valide » forgé à la main (aucune signature réelle).
+        $header = base64_encode(json_encode(['typ' => 'JWT', 'alg' => 'none']));
+        $body = base64_encode(json_encode([
+            'iss'          => 'https://attacker.example',
+            'edge_node_id' => '00000000-0000-0000-0000-000000000000',
+            'exp'          => now()->addDays(30)->timestamp,
+        ]));
+
+        $this->postJson('/api/v1/edge-node/validate-license', [
+            'signed_payload' => "$header.$body.",
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('valid', false);
+    }
+
+    public function test_validate_license_rejects_dev_fallback_token_in_production(): void
+    {
+        app()->detectEnvironment(fn (): string => 'production');
+        Config::set('edge.license_public_key', null);
+
+        // Token HS256 signé avec APP_KEY (fallback dev de sign()) : en
+        // production, sans clé publique, il doit être refusé.
+        $service = app(EdgeLicenseService::class);
+        $signed = $this->signWithAppKey(['exp' => now()->addDays(30)->timestamp]);
+
+        $response = $this->postJson('/api/v1/edge-node/validate-license', [
+            'signed_payload' => $signed,
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertNotTrue($response->json('valid'));
+    }
+
+    public function test_validate_license_rejects_garbage_in_production_with_public_key(): void
+    {
+        app()->detectEnvironment(fn (): string => 'production');
+        Config::set('edge.license_public_key', "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----");
+
+        $this->postJson('/api/v1/edge-node/validate-license', [
+            'signed_payload' => 'not-a-jwt',
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('valid', false);
+    }
+
+    private function signWithAppKey(array $payload): string
+    {
+        $header = base64url_encode(json_encode(['typ' => 'JWT', 'alg' => 'HS256']));
+        $body = base64url_encode(json_encode($payload));
+        $sig = base64url_encode(hash_hmac('sha256', "$header.$body", (string) config('app.key'), true));
+
+        return "$header.$body.$sig";
+    }
+}
+
+if (! function_exists('base64url_encode')) {
+    function base64url_encode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/api/tests/Feature/Edge/EdgeLicenseIssuanceGuardTest.php
+++ b/api/tests/Feature/Edge/EdgeLicenseIssuanceGuardTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Edge;
+
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Auth\Domain\Models\Employee;
+use App\Modules\EdgeSync\Domain\Models\EdgeNode;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\CreatesMvpSchema;
+use Tests\TestCase;
+
+/**
+ * Issue #3319 — Émission de licence Edge :
+ * POST /api/v1/edge/{nodeId}/license est réservé aux managers et
+ * valid_days est borné (1..3650).
+ */
+class EdgeLicenseIssuanceGuardTest extends TestCase
+{
+    use CreatesMvpSchema;
+
+    private Company $company;
+
+    private Employee $manager;
+
+    private Employee $employee;
+
+    private EdgeNode $node;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpMvpSchema();
+
+        $this->company = Company::factory()->create();
+
+        $this->manager = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'role' => 'manager',
+            'manager_role' => 'principal',
+        ]);
+
+        $this->employee = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'role' => 'employee',
+        ]);
+
+        $this->node = EdgeNode::create([
+            'company_id' => $this->company->id,
+            'name' => 'Site Test',
+            'slug' => 'site-test-'.substr((string) str()->uuid(), 0, 8),
+            'status' => 'active',
+            'mode' => 'hybrid',
+            'edge_version' => '1.0.0',
+            'capabilities' => ['features' => ['attendance'], 'max_employees' => 50],
+            'metadata' => [],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        DB::statement('DROP TABLE IF EXISTS public.edge_nodes CASCADE');
+        $this->tearDownMvpSchema();
+        parent::tearDown();
+    }
+
+    public function test_issue_license_by_plain_employee_is_forbidden(): void
+    {
+        $response = $this->actingAs($this->employee, 'sanctum')
+            ->postJson("/api/v1/edge/{$this->node->id}/license", [
+                'valid_days' => 30,
+            ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_issue_license_rejects_out_of_bounds_valid_days(): void
+    {
+        foreach ([0, -1, 999999] as $days) {
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->postJson("/api/v1/edge/{$this->node->id}/license", [
+                    'valid_days' => $days,
+                ]);
+
+            $response->assertStatus(422);
+        }
+    }
+
+    public function test_issue_license_by_manager_ok(): void
+    {
+        $response = $this->actingAs($this->manager, 'sanctum')
+            ->postJson("/api/v1/edge/{$this->node->id}/license", [
+                'valid_days' => 90,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.edge_node_id', $this->node->id);
+    }
+
+    public function test_issue_license_defaults_to_configured_validity(): void
+    {
+        config(['edge.license_validity_days' => 30]);
+
+        $response = $this->actingAs($this->manager, 'sanctum')
+            ->postJson("/api/v1/edge/{$this->node->id}/license", []);
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
Sécurité API, vague expert 5.

- **#3317 [P1]** : `EdgeLicenseService::decode()` fail-closed — sans `EDGE_LICENSE_PUBLIC_KEY` (défaut), `POST /api/v1/edge-node/validate-license` (public) refuse les tokens (422). Tolérance du décodage sans vérification limitée à local/testing. .env.example documenté. Test dédié.
- **#3318 [P2]** : `/sso/configure` → `SsoConfigureRequest` avec garde anti-SSRF `PublicEndpointUrl` (https uniquement, IP privées/locales refusées : 169.254.169.254, loopback, RFC1918, .local/.internal) + middleware `api.manager:principal` sur le groupe SSO (défense en profondeur). Tests SSRF.
- **#3319 [P2]** : `POST /api/v1/edge/{nodeId}/license` → middleware `api.manager` + `IssueLicenseRequest` (valid_days 1..3650). Tests 403/422.

CHANGELOG ajouté. Gates : PHPStan strict + tests ciblés (voir CI).