### PR TITLE
docs(qa): session expert 7 2026-08-15 — spec kit, registre de constats, tasks

### DIFF
--- a/.specify/features/qa-expert7-session-2026-08-15/findings-registry.md
+++ b/.specify/features/qa-expert7-session-2026-08-15/findings-registry.md
@@ -1,0 +1,39 @@
+# Registre des manquements — Session QA Expert 7 2026-08-15
+
+> Session de test de la plateforme Leopardo RH (repo kitokoh/leopardo-hr).
+> Mission : tester la vitrine, le web, l'admin, les mobiles, les workflows, les APIs, les
+> logiques, l'onboarding et la cohérence — tout manquement → spec + tasks + issues (méthode
+> Spec Kit) puis implémentation. Anti-doublon (#2400) : constats déjà couverts par les vagues
+> QA existantes (#2600–#3434) exclus ou référencés ; une seule branche par issue.
+
+## A. Vérifications runtime effectuées (prod live)
+
+- [x] **Vitrine `leopardo-rh.com` → DOWN** : `getent hosts leopardo-rh.com` = NO DNS ;
+      Google DNS (`dns.google/resolve`) → **Status 3 NXDOMAIN** pour `leopardo-rh.com`,
+      `www.leopardo-rh.com` (A + NS). Aucun enregistrement DNS → la vitrine entière est
+      injoignable à son domaine canonique. (constat nouveau — cf. #2632 build Vercel failure,
+      #3251 divergence sitemap)
+- [x] API Render live (`gestionemployerbackend.onrender.com`, version **4.23.5**) :
+      `/api/v1/health` 200 · `/api/v1/health/live` 200 · `/api/v1/i18n/catalog/fr` **500** ·
+      `/api/v1/supported-countries` **404** · `/api/v1/trial/status` **404** ·
+      `/api/v1/api-explorer` **404** · `/api/v1/dashboard/kpi` 302 (auth) ·
+      POST `/api/v1/auth/login` demo → **401 INVALID_CREDENTIALS** (demo mode off, cf. #2646).
+      → déploiement Render obsolète vs main (#2627/#2632, déjà tracés — non dupliqué).
+- [x] Admin `leo-admin.pages.dev` : **200** (login servable).
+
+## B. Findings — Audit statique main (SHA au début de session : 4d66521c)
+
+| ID | Sév | Constat | Preuve | Statut |
+|----|-----|---------|--------|--------|
+| E7-01 | P1 | Vitrine DOWN : `leopardo-rh.com` NXDOMAIN (A/NS vides) — 0 visiteur possible | Google DNS Status 3 | Ouvert → issue |
+| E7-02 | P2 | `front/web/package.json` — dépendance `next` vs `react` versions incohérentes à vérifier au build | `npm run build` | À vérifier |
+| E7-03 | P3 | (réservé — complété au fil de l'audit) | — | — |
+
+## C. Actions session (branches/PRs)
+
+- [ ] Branche `docs/qa-expert7-session-2026-08-15` : spec + findings-registry + tasks → PR.
+- [ ] Issues implémentées : voir `tasks.md` (branches `fix/<issue>-*`).
+
+## D. Décisions & constats post-session
+
+_(complété en fin de session)_

--- a/.specify/features/qa-expert7-session-2026-08-15/spec.md
+++ b/.specify/features/qa-expert7-session-2026-08-15/spec.md
@@ -1,0 +1,53 @@
+# Feature Specification: Session QA Expert 7 2026-08-15 (live + audit main)
+
+**Feature Branch**: `docs/qa-expert7-session-2026-08-15` + branches par issue (`fix/<issue>-*`)
+
+**Created**: 2026-08-15 | **Status**: Draft → Implémentation en cours
+
+**Input**: Mission du propriétaire (session 2026-08-15) — en tant qu'expert, implémenter le max
+des tâches ouvertes, tester l'app dans tous les sens (vitrine, web, admin, mobiles, workflows,
+APIs, logiques, onboarding, cohérence) ; tout manquement → spec/tasks/issues selon la méthode
+Spec Kit ; implémenter les manquements en fin de test ; implémenter le max d'issues ouvertes ;
+merger le max de branches ; `main` doit rester VERT (plusieurs agents en parallèle).
+
+## User Stories & Testing
+
+### User Story 1 — La vitrine est de nouveau joignable (P1)
+
+Un visiteur peut atteindre la vitrine à son domaine canonique `leopardo-rh.com` (DNS résolu,
+HTTP 200, sitemap/robots cohérents).
+
+**Pourquoi P1** : constat live E7-01 — `leopardo-rh.com` est NXDOMAIN ; la totalité du funnel
+d'acquisition est inaccessible. Rien dans le code ne peut corriger le DNS, mais la détection
+doit être tracée (issue ops) et le code doit cesser de pointer des URLs mortes (#3251/#3190).
+
+**Acceptance Scenarios**:
+1. **Given** le domaine canonique, **When** `dns.google/resolve?name=leopardo-rh.com&type=A`,
+   **Then** un enregistrement existe (NXDOMAIN résolu) — action ops propriétaire.
+2. **Given** le code vitrine, **When** audit, **Then** aucune URL morte `leopardo-rh.com`
+   non-résolue n'est référencée dans sitemap/canonicals/robots.
+
+### User Story 2 — Les correctifs les plus petits et sûrs des issues ouvertes sont livrés (P1/P2)
+
+Les issues P1/P2 sans branche de lock (#2400) et à périmètre net sont implémentées, testées
+(CI verte) et mergées sans casser main.
+
+**Pourquoi P1** : backlog de 157 issues sans branche ; l'agent doit livrer le max de valeur
+sans entrer en collision avec les autres agents (lock par branche, `Closes #N` dans le body).
+
+**Acceptance Scenarios**:
+1. **Given** une issue sans branche, **When** implémentation, **Then** branche `fix/<issue>-<slug>`
+   poussée immédiatement (claim), PR avec `Closes #<issue>` dans le body + entrée CHANGELOG.
+2. **Given** la PR, **When** checks CI, **Then** PHPStan strict 0 erreur, lint front 0, tests verts.
+
+### User Story 3 — Les manquements trouvés en test deviennent des constats tracés (P2)
+
+Chaque manquement rencontré pendant les tests est consigné dans le registre (E7-*) et traduit
+en issue GitHub format `[QA][P#][surface]` (méthode Spec Kit), sans doublon des vagues
+précédentes.
+
+**Acceptance Scenarios**:
+1. **Given** un constat vérifié, **When** rédaction, **Then** issue avec preuve (fichier:ligne)
+   et référence aux issues existantes couvrant le même sujet.
+2. **Given** le registre, **When** fin de session, **Then** chaque constat a un statut
+   (issue ouverte / corrigé / référencé).

--- a/.specify/features/qa-expert7-session-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert7-session-2026-08-15/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Session QA Expert 7 2026-08-15
+
+**Input**: spec.md + findings-registry.md (`.specify/features/qa-expert7-session-2026-08-15/`)
+
+**Anti-duplication (#2400)** : avant chaque implémentation, vérifier branches + PRs ouvertes
+contenant le numéro d'issue ; une seule branche `fix/<issue>-*` par issue ; pousser la branche
+(claim) dès le self-assign ; `Closes #N` dans le body de la PR.
+
+## Phase 1 — Registre + session docs (branche docs)
+
+- [ ] T001 [P1] Issue vitrine DOWN (E7-01) : `[QA][P1][ops]` leopardo-rh.com NXDOMAIN — DNS
+      à restaurer + code à ne plus référencer d'URL mortes.
+- [ ] T002 [P3] PR `docs/qa-expert7-session-2026-08-15` (spec + findings-registry + tasks).
+
+## Phase 2 — Implémentation issues ouvertes sans lock (par priorité)
+
+- [ ] T010 [P1][admin] #3388 MarketingOAuthView — template string inline → composant jamais
+      rendu (build Vue runtime-only).
+- [ ] T011 [P2][web] #3434 Résidus « 30 jours » d'essai après arbitrage 14j (FAQ EN/TR +
+      TrialWelcomeMail 30 j).
+- [ ] T012 [P3][admin] #3393 KeyboardShortcutsModal annonce Alt+R → Recrutement retiré.
+- [ ] T013 [P3][admin] #3391 realtime store — « Tout marquer comme lu » POST → 405 (PUT).
+- [ ] T014 [P3][admin] #3394 GrowthDashboardView — affectation morte + fetch jamais consommé.
+- [ ] T015 [P3][admin] #3395 ExportsView — fetchHistory sans catch.
+- [ ] T016 [P3][admin] #3436 PayrollView — 3 exports CSV sans anti-injection de formule.
+- [ ] T017 [P3][admin] #3437 formatFeatureLabel 0/11 + CompanyDetailView 2/5 libellés bruts.
+- [ ] T018 [P3][tooling] #3414 openapi-coverage-allowlist.txt — 2 entrées mortes.
+- [ ] T019 [P3][tooling] #3416 front/web-offline — NEXT_PUBLIC_EDGE_API documenté nulle part.
+- [ ] T020 [P3][docs] #3412 RBAC_ROUTE_MATRIX.md — famille dupliquée 4× + F-10 journal 2×.
+- [ ] T021 [P3][docs] #3411 FRONTEND_API_CONTRACT_MATRIX.md — lignes orphelines + header dupliqué.
+- [ ] T022 [P3][docs] #3409 CHANGELOG.md — historique release dupliqué (lignes 1207-1656).
+- [ ] T023 [P3][api] #3366 RateLimiter trial-status enregistré DEUX fois.
+- [ ] T024 [P3][api] #3367 Limiteur kiosk-punch défini mais jamais appliqué.
+- [ ] T025 [P3][api] #3370 PasswordResetMail dupliqué (2 classes + 2 fichiers de test).
+- [ ] T026 [P3][api] #3429 SalaryAdvanceController::markPaid — TOCTOU double écriture.
+
+## Phase 3 — Tests approfondis (pendant implémentation)
+
+- [ ] T030 Vitrine : build `npm run build` + lint + jest ; vérifier sitemap/robots/i18n.
+- [ ] T031 Admin : build Vite + ESLint ; vérifier les composants touchés.
+- [ ] T032 API : PHPStan strict 0 erreur sur les modules touchés ; tests ciblés si possible.
+- [ ] T033 Vérification `main` vert : attendre fin des checks CI des derniers merges.
+
+## Convergence
+
+- [ ] T040 Mettre à jour CHANGELOG.md (entrées `## [Unreleased]` par PR).
+- [ ] T041 Merger les PRs vertes du backlog quand les checks le permettent (sans casser main).
+- [ ] T042 Mettre à jour registre + mémoire `.specify/memory/project-state.md` si pertinent.


### PR DESCRIPTION
## Session QA Expert 7 2026-08-15

Spec Kit : spec + findings-registry + tasks pour la session de test exhaustive
(vitrine, web, admin, mobiles, workflows, APIs, logiques, onboarding, cohérence).

- `.specify/features/qa-expert7-session-2026-08-15/spec.md`
- `.specify/features/qa-expert7-session-2026-08-15/findings-registry.md`
- `.specify/features/qa-expert7-session-2026-08-15/tasks.md`

Premier constat : vitrine `leopardo-rh.com` NXDOMAIN (issue séparée).

Session en cours — le registre sera complété au fil des tests.