### PR TITLE
fix(api): races Growth — candidature unique, payout sous verrou, erreurs génériques (Closes #2999)

### DIFF
--- a/api/app/Modules/Billing/Infrastructure/Services/PartnerService.php
+++ b/api/app/Modules/Billing/Infrastructure/Services/PartnerService.php
@@ -10,6 +10,8 @@ use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\Billing\Domain\Models\Partner;
 use App\Modules\Billing\Domain\Models\PartnerAuditLog;
 use App\Modules\Payroll\Domain\Models\Payment;
+use App\Exceptions\DomainException;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -17,6 +19,10 @@ class PartnerService
 {
     /**
      * Soumet une candidature de partenaire.
+     *
+     * Anti-doublon #2999 : la contrainte unique partners_user_id_unique
+     * (migration 2026_08_15_000006) est le verrou définitif — deux
+     * candidatures simultanées ne peuvent pas créer deux partenaires.
      */
     public function apply(int $userId, array $details): Partner
     {
@@ -25,14 +31,23 @@ class PartnerService
             ? $encryptor->encrypt($details['payment_details'])
             : null;
 
-        return Partner::create([
-            'user_id' => $userId,
-            'referral_code' => strtoupper(\Illuminate\Support\Str::random(10)),
-            'application_status' => 'pending',
-            'status' => 'suspended', // Suspended until approved
-            'type' => $details['type'] ?? 'individual',
-            'payment_details' => $encryptedDetails,
-        ]);
+        try {
+            return Partner::create([
+                'user_id' => $userId,
+                'referral_code' => strtoupper(\Illuminate\Support\Str::random(10)),
+                'application_status' => 'pending',
+                'status' => 'suspended', // Suspended until approved
+                'type' => $details['type'] ?? 'individual',
+                'payment_details' => $encryptedDetails,
+            ]);
+        } catch (QueryException $e) {
+            // 23505 = violation de contrainte unique (race gagnée par l'autre requête).
+            if ($e->getCode() === '23505' || str_contains($e->getMessage(), 'partners_user_id_unique')) {
+                throw new DomainException('Déjà partenaire.', 400, 'ALREADY_EXISTS');
+            }
+
+            throw $e;
+        }
     }
 
     /**
@@ -140,31 +155,42 @@ class PartnerService
 
     /**
      * Demander un paiement (Payout).
+     *
+     * #2999 : transaction + lockForUpdate sur le partenaire — les demandes
+     * concurrentes se sérialisent et ne peuvent pas dépasser le solde.
      */
     public function requestPayout(Partner $partner, int $amountCents, string $currency): \App\Modules\Billing\Domain\Models\PartnerPayoutRequest
     {
-        // Calcul du solde disponible
-        $totalEarned = $partner->commissions()->where('status', 'approved')->sum('amount');
-        $totalRequested = \App\Modules\Billing\Domain\Models\PartnerPayoutRequest::where('partner_id', $partner->id)
-            ->whereIn('status', ['pending', 'approved', 'paid'])
-            ->sum('amount');
+        return DB::transaction(function () use ($partner, $amountCents, $currency) {
+            // Verrou pessimiste : sérialise les demandes concurrentes.
+            $lockedPartner = Partner::query()
+                ->whereKey($partner->id)
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        $available = $totalEarned - $totalRequested;
+            // Calcul du solde disponible (recalculé sous verrou).
+            $totalEarned = $lockedPartner->commissions()->where('status', 'approved')->sum('amount');
+            $totalRequested = \App\Modules\Billing\Domain\Models\PartnerPayoutRequest::where('partner_id', $lockedPartner->id)
+                ->whereIn('status', ['pending', 'approved', 'paid'])
+                ->sum('amount');
 
-        if ($amountCents > $available) {
-            throw new \App\Exceptions\DomainException("Solde insuffisant.", 422, "INSUFFICIENT_BALANCE");
-        }
+            $available = $totalEarned - $totalRequested;
 
-        if ($amountCents < $partner->payout_threshold) {
-            throw new \App\Exceptions\DomainException("Montant sous le seuil.", 422, "BELOW_PAYOUT_THRESHOLD");
-        }
+            if ($amountCents > $available) {
+                throw new \App\Exceptions\DomainException("Solde insuffisant.", 422, "INSUFFICIENT_BALANCE");
+            }
 
-        return \App\Modules\Billing\Domain\Models\PartnerPayoutRequest::create([
-            'partner_id' => $partner->id,
-            'amount' => $amountCents,
-            'currency' => $currency,
-            'status' => 'pending',
-        ]);
+            if ($amountCents < $lockedPartner->payout_threshold) {
+                throw new \App\Exceptions\DomainException("Montant sous le seuil.", 422, "BELOW_PAYOUT_THRESHOLD");
+            }
+
+            return \App\Modules\Billing\Domain\Models\PartnerPayoutRequest::create([
+                'partner_id' => $lockedPartner->id,
+                'amount' => $amountCents,
+                'currency' => $currency,
+                'status' => 'pending',
+            ]);
+        });
     }
 
     /**

--- a/api/app/Modules/Growth/Interfaces/Api/V1/Controllers/PartnerDashboardController.php
+++ b/api/app/Modules/Growth/Interfaces/Api/V1/Controllers/PartnerDashboardController.php
@@ -56,7 +56,15 @@ class PartnerDashboardController extends Controller
             'payment_details' => 'nullable|string',
         ]);
 
-        $partner = $this->partnerService->apply($globalUser->id, $validated);
+        try {
+            $partner = $this->partnerService->apply($globalUser->id, $validated);
+        } catch (\App\Exceptions\DomainException $e) {
+            return new JsonResponse([
+                'error' => $e->errorCode(),
+                'message' => 'Candidature deja soumise.',
+                'localized_message' => 'Candidature deja soumise.',
+            ], 400);
+        }
 
         return new JsonResponse(['data' => $partner], 201);
     }
@@ -81,8 +89,24 @@ class PartnerDashboardController extends Controller
         try {
             $payout = $this->partnerService->requestPayout($partner, $validated['amount'], $validated['currency']);
             return new JsonResponse(['data' => $payout], 201);
-        } catch (\Exception $e) {
-            return new JsonResponse(['error' => $e->getMessage()], 422);
+        } catch (\App\Exceptions\DomainException $e) {
+            // Erreur métier propre : code d'erreur générique, jamais de message brut.
+            return new JsonResponse([
+                'error' => $e->errorCode(),
+                'message' => 'Demande de paiement refusee.',
+                'localized_message' => 'Demande de paiement refusee.',
+            ], $e->statusCode());
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\Log::error('partner.payout.request_failed', [
+                'partner_id' => $partner->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new JsonResponse([
+                'error' => 'PAYOUT_REQUEST_FAILED',
+                'message' => 'Une erreur est survenue lors de la demande de paiement.',
+                'localized_message' => 'Une erreur est survenue lors de la demande de paiement.',
+            ], 500);
         }
     }
 

--- a/api/database/migrations/public/2026_08_15_000006_add_unique_user_id_to_partners.php
+++ b/api/database/migrations/public/2026_08_15_000006_add_unique_user_id_to_partners.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * QA expert5 #2999 — anti-doublon partenaire : un même user_id ne peut pas
+ * candidater deux fois. La garde applicative (exists() puis create) laisse
+ * une fenêtre de course ; la contrainte unique est le verrou définitif.
+ * PostgreSQL-only (comme le reste du projet).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('partners')) {
+            return;
+        }
+
+        $index = 'partners_user_id_unique';
+        if ($this->uniqueIndexExists($index)) {
+            return;
+        }
+
+        Schema::table('partners', function (Blueprint $table) use ($index): void {
+            $table->unique('user_id', $index);
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('partners')) {
+            return;
+        }
+
+        Schema::table('partners', function (Blueprint $table): void {
+            $table->dropUnique('partners_user_id_unique');
+        });
+    }
+
+    private function uniqueIndexExists(string $index): bool
+    {
+        return DB::table('pg_indexes')
+            ->where('schemaname', 'public')
+            ->where('tablename', 'partners')
+            ->where('indexname', $index)
+            ->exists();
+    }
+};

--- a/api/tests/Feature/Growth/GrowthPartnerRaceTest.php
+++ b/api/tests/Feature/Growth/GrowthPartnerRaceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Growth;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Billing\Domain\Models\Partner;
+use App\Modules\Billing\Domain\Models\PartnerPayoutRequest;
+use App\Modules\Payroll\Domain\Models\Commission;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * QA expert5 #2999 — races Growth :
+ * - double candidature partenaire → 1 seul partner (contrainte unique + 400 propre) ;
+ * - demandes de payout concurrentes ne dépassent pas le solde (lock transaction) ;
+ * - jamais de message d'exception brut exposé au client.
+ */
+class GrowthPartnerRaceTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Company $company;
+
+    private Employee $employee;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->company = Company::factory()->create(['country' => 'DZ', 'currency' => 'DZD']);
+        $this->employee = Employee::factory()->manager()->create(['company_id' => $this->company->id]);
+        Sanctum::actingAs($this->employee);
+    }
+
+    public function test_double_apply_is_blocked_with_clean_400(): void
+    {
+        $payload = ['type' => 'individual'];
+
+        $first = $this->postJson('/api/v1/growth/partner/apply', $payload);
+        $first->assertCreated();
+
+        // Seconde candidature (même user) → 400 ALREADY_EXISTS, pas 201, pas de doublon.
+        $second = $this->postJson('/api/v1/growth/partner/apply', $payload);
+        $second->assertStatus(400)
+            ->assertJsonPath('error', 'ALREADY_EXISTS');
+
+        $this->assertSame(1, Partner::where('user_id', $this->employee->id)->count());
+    }
+
+    public function test_payout_does_not_expose_raw_exception_message(): void
+    {
+        $partner = $this->createApprovedPartner(10000); // 100,00 de commissions approuvées
+
+        $response = $this->postJson('/api/v1/growth/partner/payout', [
+            'amount' => 999999,
+            'currency' => 'DZD',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error', 'INSUFFICIENT_BALANCE')
+            ->assertJsonMissing(['message' => 'Solde insuffisant.']);
+    }
+
+    public function test_consecutive_payouts_cannot_overdraw_balance(): void
+    {
+        $partner = $this->createApprovedPartner(10000); // solde disponible 100,00
+
+        $first = $this->postJson('/api/v1/growth/partner/payout', [
+            'amount' => 8000,
+            'currency' => 'DZD',
+        ]);
+        $first->assertCreated();
+
+        // Solde restant 20,00 → une seconde demande de 50,00 doit être refusée.
+        $second = $this->postJson('/api/v1/growth/partner/payout', [
+            'amount' => 5000,
+            'currency' => 'DZD',
+        ]);
+        $second->assertStatus(422)
+            ->assertJsonPath('error', 'INSUFFICIENT_BALANCE');
+
+        $this->assertSame(1, PartnerPayoutRequest::where('partner_id', $partner->id)->count());
+    }
+
+    public function test_service_apply_is_idempotent_under_unique_constraint(): void
+    {
+        $service = app(\App\Modules\Billing\Infrastructure\Services\PartnerService::class);
+
+        $first = $service->apply((int) $this->employee->id, ['type' => 'individual']);
+        $this->assertInstanceOf(Partner::class, $first);
+
+        $this->expectException(\App\Exceptions\DomainException::class);
+        $this->expectExceptionMessage('Déjà partenaire.');
+        $service->apply((int) $this->employee->id, ['type' => 'individual']);
+    }
+
+    private function createApprovedPartner(int $commissionsCents): Partner
+    {
+        $partner = Partner::create([
+            'user_id' => $this->employee->id,
+            'referral_code' => 'QA-'.strtoupper(substr(uniqid(), -6)),
+            'application_status' => 'approved',
+            'status' => 'active',
+            'type' => 'individual',
+            'payout_threshold' => 0,
+        ]);
+
+        Commission::create([
+            'partner_id' => $partner->id,
+            'company_id' => $this->company->id,
+            'payment_id' => 1,
+            'amount' => $commissionsCents,
+            'currency' => 'DZD',
+            'applied_rate' => 1000,
+            'status' => 'approved',
+            'approved_at' => now(),
+        ]);
+
+        return $partner;
+    }
+}


### PR DESCRIPTION
## Résumé
QA expert5 2026-08-15 — #2999 (trois volets) :
1. **Doublons candidature** : `exists()` puis `create` sur `partners` sans contrainte unique → 2 requêtes simultanées créent 2 partenaires. Ajout de la contrainte unique `partners_user_id_unique` (migration public `2026_08_15_000006`) + `PartnerService::apply` traduit la violation 23505 en `DomainException(ALREADY_EXISTS)` → le contrôleur répond 400 propre.
2. **Overdraft payout** : `requestPayout` calculait le solde puis créait sans verrou → les demandes concurrentes dépassaient le solde. Désormais `DB::transaction` + `lockForUpdate()` sur le partenaire (recalcul sous verrou).
3. **Message d'erreur brut** : le contrôleur renvoyait `$e->getMessage()` (422) → `DomainException` mappée sur `errorCode` (`INSUFFICIENT_BALANCE`/`BELOW_PAYOUT_THRESHOLD`), toute autre exception → message générique + `Log::error`.

Closes #2999

## Tests
`api/tests/Feature/Growth/GrowthPartnerRaceTest.php` (RefreshTenantDatabase, 4 cas) : double apply → 1 partner + 400 ; payout > solde → 422 INSUFFICIENT_BALANCE sans message brut ; 2 payout successifs → overdraft refusé ; idempotence service.

## Validation
- CI backend requis (tests + PHPStan + couverture)
- CHANGELOG sous [Unreleased]