### PR TITLE
fix(admin): DashboardView champs réels (Closes #3036, #3037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+### Fixed
+- **fix(admin): DashboardView — champs alignés sur les payloads réels (Closes #3036, #3037).** « Priorités Portefeuille » lisait item.name/slug/mrr_eur (absents) → noms vides, MRR 0€, lien /companies/undefined ; corrigé sur item.company.* + item.subscription.mrr/currency. « Inscriptions en attente » lisait request.name/manager_email (absents) → titres vides ; corrigé sur company_name + user.name || email.
 - **fix(kiosk): état non configuré localisé quand apiBaseUrl ou deviceCode manque (Closes #2911).** La borne n’essaie plus d’appeler une URL `/api/v1/kiosks/` invalide : les actions distantes sont désactivées et un message d’installation est affiché en FR/EN/TR/AR.
 ### Added
 - **feat(admin): impersonation SPA câblée sur POST /admin/impersonations (Closes #2518).** Le backend PA2-ADM-006 existait (PlatformImpersonationController : session Sanctum 30-120 min, motif obligatoire, audit) mais aucun bouton UI — la PR #2466 avait même retiré l'émetteur `@impersonate`. (1) `UsersView` recharge le détail via `GET /admin/users/{id}` (seule source du lien employé `company.employee_id`, décision #2519) ; (2) modal d'impersonation : motif obligatoire ≥ 5 caractères, POST `/admin/impersonations` {company_id, employee_id, reason}, affichage du jeton + expiration + copie, erreurs API ; (3) `UserDetailModal` affiche entreprise/employé lié depuis le payload `company` ; (4) i18n `users.impersonation.*` dans les 4 locales. Au passage (artefacts merge #2469 signalés par #2517) : doublons `import api` + `deleteUser` + handlers de modales morts (`handleUserCreated`/`handleUserUpdated`/`generateTemporaryPassword`) supprimés — lint 0 erreur, build vert.

--- a/front/admin-dashboard/src/views/DashboardView.vue
+++ b/front/admin-dashboard/src/views/DashboardView.vue
@@ -85,8 +85,8 @@
                       <BuildingOfficeIcon class="h-full w-full text-slate-400" />
                     </div>
                     <div class="ml-4">
-                      <div class="text-sm font-bold text-slate-900 dark:text-white">{{ item.name }}</div>
-                      <div class="text-[10px] font-medium text-slate-400 uppercase tracking-widest">{{ item.slug }}</div>
+                      <div class="text-sm font-bold text-slate-900 dark:text-white">{{ item.company?.name }}</div>
+                      <div class="text-[10px] font-medium text-slate-400 uppercase tracking-widest">{{ item.company?.slug }}</div>
                     </div>
                   </div>
                 </td>
@@ -106,10 +106,10 @@
                   <span :class="riskClass(item.risk_level)">{{ riskLabel(item.risk_level) }}</span>
                 </td>
                 <td class="whitespace-nowrap px-6 py-4 text-sm font-black text-slate-950 dark:text-white">
-                  {{ formatCurrency(item.mrr_eur, 'EUR') }}
+                  {{ formatCurrency(item.subscription?.mrr, item.subscription?.currency || 'EUR') }}
                 </td>
                 <td class="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
-                  <router-link :to="`/companies/${item.id}`" class="text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 font-bold">
+                  <router-link :to="`/companies/${item.company?.id}`" class="text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 font-bold">
                     Détails
                   </router-link>
                 </td>
@@ -130,8 +130,8 @@
           <div v-for="request in pendingCompanyRequests" :key="request.id" class="p-6 transition-colors hover:bg-white/5 dark:hover:bg-slate-900/5">
             <div class="flex items-start justify-between">
               <div class="space-y-1">
-                <h3 class="text-sm font-bold text-slate-950 dark:text-white uppercase tracking-tight">{{ request.name }}</h3>
-                <p class="text-xs font-medium text-slate-500 dark:text-slate-400">{{ request.manager_email }}</p>
+                <h3 class="text-sm font-bold text-slate-950 dark:text-white uppercase tracking-tight">{{ request.company_name }}</h3>
+                <p class="text-xs font-medium text-slate-500 dark:text-slate-400">{{ request.user?.name || request.email }}</p>
                 <div class="pt-1 flex items-center text-[10px] font-black uppercase tracking-widest text-slate-400">
                   <GlobeAltIcon class="mr-1.5 h-3 w-3" />
                   {{ request.city }}, {{ request.country }}


### PR DESCRIPTION
## DashboardView — champs alignés sur les payloads backend

### #3036 — Priorités Portefeuille
Le template lisait `item.name/slug/mrr_eur` mais `/platform/companies/health` renvoie `company.{id,name,slug}` + `subscription.{mrr,currency}` → noms vides, MRR 0 €, lien `/companies/undefined`. Corrigé.

### #3037 — Inscriptions en attente
Le template lisait `request.name/manager_email` mais `PlatformCompanyRequestController@index` renvoie `company_name` + `user.{name,email}` → titres vides. Corrigé (repli user.name || email).

ESLint OK. CHANGELOG mis à jour.