### PR TITLE
fix(web): CTA « Lancer un pilote gratuit » → essai guidé /signup (Closes #3329)

### DIFF
--- a/front/web/src/modules/vitrine/components/PricingSection.tsx
+++ b/front/web/src/modules/vitrine/components/PricingSection.tsx
@@ -18,8 +18,11 @@ function getPlanCtaHref(price: string, planName?: string, isAnnual?: boolean) {
   // Avant, tout plan non-Operations tombait sur 'starter' (Pilot payant) :
   // le CTA « Start for free » du plan Free menait au paywall 24€/mois.
   const name = (planName ?? '').toLowerCase()
+  // #3329 : le CTA « Lancer un pilote gratuit » ne doit pas mener à un
+  // checkout avec carte — le parcours Pilot passe par l'essai guidé /signup
+  // (cohérent avec /pricing, source=pricing_pilot → home_pilot ici).
+  if (name.includes('pilot')) return '/signup?source=home_pilot'
   const planKey = name.includes('free') ? 'free'
-    : name.includes('pilot') ? 'starter'
     : name.includes('operations') ? 'business'
     : name.includes('scale') || name.includes('enterprise') ? 'enterprise'
     : 'starter'


### PR DESCRIPTION
## Problème
Le CTA home « Lancer un pilote gratuit » (plan Pilot) pointait vers /checkout?plan=starter — un checkout payant avec carte — alors que /pricing envoie le Pilot vers l'essai guidé /signup sans carte (résiduel #3013).

## Correctif
PricingSection.tsx : le plan Pilot redirige désormais vers /signup?source=home_pilot (essai guidé, cohérent avec /pricing). Les plans Free/Operations/Enterprise conservent leur destination actuelle.

## Validation
- npx tsc --noEmit : OK
- npm run lint : 0 erreur
- Funnel : home → CTA Pilot → /signup (aucune carte)

Closes #3329