### PR TITLE
fix(web): /case-studies/[slug] — metadata par page + sitemap (Closes #3435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): /case-studies/[slug] — metadata propres par page + sitemap (Closes #3435).** Les 12 études de cas héritaient du layout parent avec un canonical fixe `/case-studies` et aucun title/description propres → SEO dupliqué. Ajout de `generateMetadata` par slug (title/description/canonical via `getCaseStudy`, pattern blog `[slug]/layout.tsx`) + inclusion des 12 slugs dans `sitemap.ts`.
 ### Fixed
 - **fix(ci): main vert — PHPStan Strict/Modules (level 8/5), Module Structure Validator, I18N sync, AIGatewayAndAnalyticsTest.** (1) App : `AuthService::login` convertit `locked_until` en Carbon avant `isFuture()`/`AccountLockedException` (DateTimeInterface → Carbon) ; `AuthController::redirectToGoogle` type le provider Socialite (GoogleProvider) pour `with()` ; `KioskController::resolveAuthorizedKiosk` ne caste plus un `??` non nullable ; `EdgeNodeController::sync` refresh le nœud avant de lire `last_sync_at` (null-safe). (2) Tests : 29 fichiers réalignés PHPStan level 8 (collect(RouteCollection) → getRoutes()->getRoutes(), @var FQCN sur factory()->create(), Mockery typé, `assertExitCode` sur PendingCommand instancié, casts null-safe, dead props retirées, `@property company_id` ajouté à CalendarConnection). (3) `AIGatewayAndAnalyticsTest` attend 2 workflows (prepare_payroll, weekly_report) — le workflow fantôme `new_employee_onboarding` a été retiré (Closes #3118, #2808). Closes #1962 (préfixes migrations doublés) via #2969.
 

--- a/front/web/src/app/(landing)/case-studies/[slug]/layout.tsx
+++ b/front/web/src/app/(landing)/case-studies/[slug]/layout.tsx
@@ -1,0 +1,42 @@
+import { SITE_URL } from '@/lib/site-url';
+import { Metadata } from 'next';
+import { generateMetadata as generateSEOMetadata } from '@/modules/vitrine/lib/seo';
+import { getCaseStudy } from '@/modules/vitrine/lib/case-studies';
+
+interface CaseStudyLayoutProps {
+  params: Promise<{
+    slug: string;
+  }>;
+  children: React.ReactNode;
+}
+
+/**
+ * Issue #3435 : chaque page /case-studies/[slug] doit avoir ses propres
+ * title/description/canonical (avant : héritage du layout parent avec un
+ * canonical fixe /case-studies → title/description dupliqués sur 12 pages
+ * et canonical pointant vers la mauvaise URL).
+ */
+export async function generateMetadata({
+  params,
+}: CaseStudyLayoutProps): Promise<Metadata> {
+  const { slug } = await params;
+  const study = getCaseStudy(slug);
+
+  if (!study) {
+    return {
+      title: 'Cas client non trouvé',
+      description: "L'étude de cas que vous recherchez n'existe pas.",
+    };
+  }
+
+  return generateSEOMetadata({
+    title: study.title,
+    description: study.description,
+    ogType: 'website',
+    canonical: `${SITE_URL}/case-studies/${study.slug}`,
+  });
+}
+
+export default function CaseStudyLayout({ children }: CaseStudyLayoutProps) {
+  return children;
+}

--- a/front/web/src/app/sitemap.ts
+++ b/front/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next';
 import { getBlogPosts, type BlogPost } from '@/modules/vitrine/data/blog';
+import { getAllCaseStudies } from '@/modules/vitrine/lib/case-studies';
 import { getEnvConfig } from '@/modules/vitrine/lib/env';
 import { getSiteUrl } from '@/lib/site';
 
@@ -96,5 +97,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
     return [...staticPages, ...blogPages];
   }
 
-  return staticPages;
+  // Issue #3435 : les 12 études de cas dynamiques (/case-studies/[slug]) sont
+  // indexées individuellement (avant : seule la page /case-studies l'était).
+  const caseStudies: MetadataRoute.Sitemap = getAllCaseStudies().map((study) => ({
+    url: `${siteUrl}/case-studies/${study.slug}`,
+    lastModified: today,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+    alternates: localizedAlternates(`/case-studies/${study.slug}`),
+  }));
+
+  return [...staticPages, ...caseStudies];
 }


### PR DESCRIPTION
## Problème

Les 12 pages `/case-studies/[slug]` héritaient du layout parent (canonical fixe `/case-studies`, title/description partagés) → SEO dupliqué et canonical erroné. Seule `/case-studies` était dans le sitemap.

## Correctif

- `[slug]/layout.tsx` : `generateMetadata` par slug (title/description/canonical via `getCaseStudy`, pattern blog `[slug]/layout.tsx`).
- `sitemap.ts` : les 12 slugs indexés individuellement via `getAllCaseStudies()`.
- Build Next.js ✅, tsc ✅, ESLint 0 erreur.

Closes #3435