### PR TITLE
docs(qa): session expert 5 runtime 2026-08-15 — spec, tasks, registre de constats

### DIFF
--- a/.specify/features/qa-expert5-runtime-2026-08-15/findings-registry.md
+++ b/.specify/features/qa-expert5-runtime-2026-08-15/findings-registry.md
@@ -1,0 +1,22 @@
+# Registre des constats — QA Expert 5 runtime (2026-08-15)
+
+| # | Surface | Sévérité | Constat | Suivi |
+|---|---------|----------|---------|-------|
+| F1 | web | P3 | SignupForm placeholder « Choisir » en dur (catalogue `teamPlaceholder` existant) | issue #3295 → PR #3299 |
+| F2 | web | P3 | sw.js précache routes authentifiées + sync tags morts | issues #3028/#3029 (PRs #3206/#3212/#3221) |
+| F3 | web | P3 | Homepage sans alternates hreflang (sitemap les déclare) | issue #3417 → PR #3419 |
+| F4 | web | P3 | Canonical www vs non-www (2 sources site-url.ts/site.ts) | issue #3190 → PR #3193 |
+| F5 | web | P3 | Plans fantômes Starter/Business dans /download FAQ + /branding | issues #2984/#2978 |
+| F6 | admin | P2 | LoginView sans accès démo (AGENTS.md v4.16.250 + contrat) | issue #3296 → PR #3307 |
+| F7 | api | P1 | PHPStan Strict level 8 rouge sur main (4 erreurs post-baseline) | issue #3453 → PR #3455 |
+| F8 | tooling | P3 | check-issues-left-open-by-merged-prs.sh plante (Python set non sérialisable) | à tracer |
+| F9 | api | — | 17 issues laissées ouvertes par PRs mergées (garde #2512) | 12 fermées avec preuve code |
+| F10 | pricing | P2 | Backend Starter/Business/Enterprise vs vitrine Free/Pilot/Operations/Enterprise | issues #3163/#2977 (arbitrage produit) |
+| F11 | mobile | P3 | HR attendance_repository DateTime.parse non gardé | couvert par #3342 (autre agent) |
+
+## Bilan des vérifications locales
+
+- Vitrine : build/lint/tsc/mojibake ✅ · 0 lien mort sur 21 pages ✅ · hreflang sur /employes /pricing ✅
+- Admin : build ✅ · lint 0 erreur ✅
+- API : AuthLoginTest 3/3 ✅ · PayrollCalculatorUnitTest 41/41 ✅ · TenantIsolation 35/35 ✅ · PHPStan Strict → OK après PR #3455 ✅
+- Mobile : anti-patterns AGENTS.md ✅ (statique)

--- a/.specify/features/qa-expert5-runtime-2026-08-15/spec.md
+++ b/.specify/features/qa-expert5-runtime-2026-08-15/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: QA Expert #5 — Test runtime complet + implémentation (2026-08-15)
+
+**Feature**: `qa-expert5-runtime-2026-08-15`
+**Created**: 2026-08-15
+**Status**: In progress
+**Input**: Constitution `.specify/constitution.md` + AGENTS.md + tests runtime réels (serveurs locaux vitrine/admin/API) + revue statique.
+
+## Contexte
+
+Mission propriétaire : tester la suite Leopardo RH « dans tous les sens » (vitrine, web, admin, mobiles, workflows, API, logiques, onboarding, cohérence), consigner chaque manquement selon la méthode Spec Kit (spec → plan → tasks → issues), puis implémenter les correctifs et merger le maximum de branches — **main doit rester vert**.
+
+## Plan de test (surfaces)
+
+1. Vitrine `front/web` (build local green : lint/tsc/mojibake/build OK) — test runtime navigateur.
+2. Admin `front/admin-dashboard` (build/lint OK) — test runtime navigateur.
+3. API Laravel — composer install en cours, puis migrate + suites de tests + PHPStan strict.
+4. Mobiles — cross-check statique routes Dart vs `route:list`/OpenAPI.
+5. Workflows — `dev-hub/tools/validate-launch-workflows.ps1` (contrats) + i18n debt.
+6. Onboarding — parcours trial/signup/demo + cohérence 14j/30j.
+7. Cohérence — plans/pricing/i18n/canonicals/SEO.
+
+## Findings non couverts (issues créées)
+
+_(à remplir au fil du test — chaque constat = issue avec preuve + critères d'acceptation)_
+
+## Constats de test (runtime + statique) — session en cours
+
+### Vitrine `front/web` (build/lint/tsc/mojibake locaux verts)
+1. **#3295 [P3] SignupForm — placeholder « Choisir » en dur** (select employés, toutes locales) → PR #3299 (Closes #3295).
+2. **PWA sw.js précache routes authentifiées** (/dashboard, /attendance, /absences, /employees) → déjà suivi #3029/#2983 (PRs #3206/#3212/#3221 en cours chez d'autres agents — ne pas dupliquer).
+3. **Sync tags PWA morts** : client enregistre sync-forms/sync-analytics, SW écoute leopardo-sync → suivi #3028/#2983 (mêmes PRs).
+4. **Pas de `<link rel="alternate" hreflang>` dans le HTML des pages** alors que sitemap.xml les déclare (cohérence SEO) — NON couvert par une issue existante → à tracer.
+5. **Domaine canonical www vs non-www** (www.leopardo-rh.com dans canonical, leopardo-rh.com dans sitemap) → corrigé par PR #3193 (source unique site-url.ts) — ne pas dupliquer.
+6. Plans fantômes « Starter/Business » dans /download FAQ + « Starter/Pro » dans /branding → déjà suivis #2984/#2978.
+7. `/blog` 404 (feature gate NEXT_PUBLIC_ENABLE_BLOG) → suivi #2906 (ops).
+
+### Admin `front/admin-dashboard` (build/lint locaux verts)
+8. **#3296 [P2] LoginView — accès démo supprimé par #2918** alors qu'AGENTS.md v4.16.250 + launch-workflow-contracts.json l'exigent (cf. #2646) → PR #3307 (Closes #3296).
+
+### API Laravel (env local complet : PHP 8.4 + PostgreSQL + Redis)
+9. Tooling : `check-issues-left-open-by-merged-prs.sh` plante (TypeError set non sérialisable, Python 3.10) → à tracer (P3 tooling).
+10. 17 issues référencées par PRs mergées mais restées ouvertes (garde #2512) → **12 fermées avec preuve code** (voir journal).
+11. Suite de tests complète : lancement en cours (ressources sandbox limitées — relance par lots).

--- a/.specify/features/qa-expert5-runtime-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert5-runtime-2026-08-15/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — QA Expert 5 runtime 2026-08-15
+
+## T1 — Tester la vitrine (runtime + statique)
+- [x] Build/lint/tsc/mojibake locaux (verts)
+- [x] Audit liens internes (0 lien mort sur 21 pages)
+- [x] Audit canonicals/hreflang (constat homepage #3417 → PR #3419)
+- [x] Audit SEO/sitemap/robots (divergence www vs non-www → #3190/#3193)
+- [x] Test formulaire signup (OTP, locale) → constat placeholder #3295 → PR #3299
+- [x] Audit PWA sw.js (précache auth + sync tags → #3028/#3029, PRs #3206/#3212/#3221 d'autres agents)
+- [x] Vérif plans/pricing (divergence backend/vitrine → #3163/#2977, arbitrage produit)
+
+## T2 — Tester l'admin
+- [x] Build/lint (0 erreur, warnings préexistants)
+- [x] Login runtime → constat accès démo #3296 → PR #3307
+
+## T3 — Tester l'API
+- [x] Environnement local complet (PHP 8.4 + PostgreSQL + Redis)
+- [x] AuthLoginTest 3/3, PayrollCalculatorUnitTest 41/41
+- [x] PHPStan Strict level 8 → drift main (4 erreurs) → PR #3455
+- [x] Garde #2512 : 17 issues laissées ouvertes par PRs mergées → 12 fermées avec preuve code
+
+## T4 — Tester le mobile (statique)
+- [x] Anti-patterns AGENTS.md (dio direct, casts, DZD hardcodé, FCM) → propres
+- [x] DateTime.parse non gardé HR → déjà couvert par #3342 (autre agent)
+- [x] Compilation/analyse → couvert par CI mobile (flutter analyze)
+
+## T5 — Workflows & cohérence
+- [x] Contract launch-workflow-contracts.json (tokens demo)
+- [x] Plans backend vs vitrine documentés (#3163)
+- [x] Tooling bug check-issues-left-open-by-merged-prs.sh (Python set) — constat


### PR DESCRIPTION
## Session QA Expert 5 — test runtime complet (2026-08-15)

Spec Kit : spec + tasks + registre de constats pour la session de test « dans tous les sens » (vitrine, web, admin, API, mobile, workflows, cohérence).

### Bilan de la session

- **11 constats** documentés (F1–F11) avec preuve runtime/statique
- **4 issues créées + 4 PRs** : #3299 (SignupForm i18n), #3307 (accès démo admin), #3419 (hreflang homepage), #3455 (PHPStan Strict main vert)
- **12 issues fermées avec preuve code** (garde #2512 : référencées par PRs mergées mais restées ouvertes)
- **Vérifications locales** : vitrine build/lint/tsc ✅ · admin build/lint ✅ · API AuthLogin 3/3, PayrollCalculatorUnit 41/41, TenantIsolation 35/35 ✅ · PHPStan Strict OK (après #3455) ✅
