### PR TITLE
fix(api): POST /employees/link-user sous api.manager (Closes #3244)

### DIFF
--- a/api/routes/modules/user.php
+++ b/api/routes/modules/user.php
@@ -36,6 +36,8 @@ Route::middleware(['throttle:api', 'auth:user_api'])->prefix('user')->group(func
 });
 
 // Manager: lier un utilisateur ordinaire a un employe
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+// #3244 : groupe api.manager (défense en profondeur — famille #3150) — le
+// garde isManager() du contrôleur reste en second rideau.
+Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'api.manager'])->group(function (): void {
     Route::post('/employees/link-user', [UserEmployeeLinkController::class, 'linkByEmail']);
 });


### PR DESCRIPTION
## ProblèmeRoute protégée uniquement par isManager() dans le contrôleur (famille #3150).## CorrectifMiddleware api.manager ajouté (défense en profondeur) ; le garde contrôleur reste en second rideau.Closes #3244