### PR TITLE
fix(mobile): mark-all notifications → POST /notifications/mark-all-read (Closes #3005)

### DIFF
--- a/front/mobile_apps/leopardo_employee/lib/features/notifications/data/notification_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/notifications/data/notification_repository.dart
@@ -21,7 +21,7 @@ class NotificationRepository {
 
   Future<void> markAllAsRead() async {
     await apiClient.requestWithRetry<void>(
-      '/notifications/read-all',
+      '/notifications/mark-all-read',
       method: 'POST',
       timeoutOverride: const Duration(seconds: 12),
     );

--- a/front/mobile_apps/leopardo_hr/lib/features/modules/data/modules_repository.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/modules/data/modules_repository.dart
@@ -278,7 +278,7 @@ class ModulesRepository {
 
   Future<void> markAllNotificationsRead() async {
     await _apiClient.requestWithRetry<void>(
-      '/notifications/read-all',
+      '/notifications/mark-all-read',
       method: 'POST',
       timeoutOverride: const Duration(seconds: 12),
     );

--- a/front/mobile_apps/leopardo_manager/lib/features/modules/data/modules_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/modules/data/modules_repository.dart
@@ -278,7 +278,7 @@ class ModulesRepository {
 
   Future<void> markAllNotificationsRead() async {
     await _apiClient.requestWithRetry<void>(
-      '/notifications/read-all',
+      '/notifications/mark-all-read',
       method: 'POST',
       timeoutOverride: const Duration(seconds: 12),
     );


### PR DESCRIPTION
## ProblèmeLes 3 apps appelaient POST /notifications/read-all — aucune route ne correspond (rh.php = PUT /read-all, dashboard.php = POST /mark-all-read) → 405 sur « Tout marquer comme lu » du ModulesScreen.## CorrectifEmployee, HR et Manager : markAll → POST /notifications/mark-all-read (canonique dashboard.php). markRead PATCH /{id}/read déjà correct.## Critères d'acceptation- Actions notifications → 2xxCloses #3005