### PR TITLE
fix(mobile): Contract.fromJson — start_date nullable gardé (Closes #3432)

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/models/contract.dart
+++ b/front/mobile_apps/leopardo_core/lib/models/contract.dart
@@ -27,7 +27,8 @@ class Contract {
       employeeId: json['employee_id'] as int,
       reference: json['reference'] as String? ?? '',
       type: json['type'] as String? ?? 'cdi',
-      startDate: json['start_date'] as String,
+      // #3432 : start_date est nullable côté API (ContractResource) — cast gardé.
+      startDate: json['start_date'] as String? ?? '',
       endDate: json['end_date'] as String?,
       baseSalary: (json['base_salary'] as num?)?.toDouble() ?? 0,
       currency: json['currency'] as String? ?? 'DZD',


### PR DESCRIPTION
## ProblèmeContractResource renvoie start_date nullable (toDateString) ; le cast « as String » non gardé provoquait un TypeError au parsing → crash liste contrats (3 apps).## Correctifjson['start_date'] as String? ?? '' (comme endDate).Closes #3432