### PR TITLE
fix(mobile): DateTime.parse résiduels → tryParse dans 3 modèles core (Closes #3433)

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/models/attendance_log.dart
+++ b/front/mobile_apps/leopardo_core/lib/models/attendance_log.dart
@@ -63,18 +63,17 @@ class AttendanceLog {
             (json['employee_id'] ?? json['employeeId'])?.toString() ?? '',
           ) ??
           0,
-      date: DateTime.parse(
-        (json['date'] ?? DateTime.now().toIso8601String()) as String,
-      ),
+      // #3433 : date nullable/malformée → tryParse avec repli sur maintenant.
+      date: DateTime.tryParse((json['date'] ?? '').toString()) ?? DateTime.now(),
       sessionNumber:
           int.tryParse(
             (json['session_number'] ?? json['sessionNumber'])?.toString() ?? '',
           ) ??
           1,
       checkIn:
-          json['check_in'] != null ? DateTime.parse(json['check_in']) : null,
+          json['check_in'] != null ? DateTime.tryParse(json['check_in'] as String? ?? '') : null,
       checkOut:
-          json['check_out'] != null ? DateTime.parse(json['check_out']) : null,
+          json['check_out'] != null ? DateTime.tryParse(json['check_out'] as String? ?? '') : null,
       status: (json['status'] ?? 'incomplete') as String,
       workType: (json['work_type'] ?? json['workType'] ?? 'normal').toString(),
       punchNote: json['punch_note']?.toString(),

--- a/front/mobile_apps/leopardo_core/lib/models/payroll.dart
+++ b/front/mobile_apps/leopardo_core/lib/models/payroll.dart
@@ -100,7 +100,7 @@ class Payroll {
       status: json['status'] as String,
       pdfPath: json['pdf_path'] as String?,
       validatedAt: json['validated_at'] != null
-          ? DateTime.parse(json['validated_at'] as String)
+          ? DateTime.tryParse(json['validated_at'] as String? ?? '')
           : null,
       compliance: complianceJson is Map<String, dynamic>
           ? PayrollCompliance.fromJson(complianceJson)

--- a/front/mobile_apps/leopardo_core/lib/models/project_task.dart
+++ b/front/mobile_apps/leopardo_core/lib/models/project_task.dart
@@ -24,11 +24,11 @@ class Project {
       description: json['description'] as String?,
       startDate:
           json['start_date'] != null
-              ? DateTime.parse(json['start_date'] as String)
+              ? DateTime.tryParse(json['start_date'] as String? ?? '')
               : null,
       endDate:
           json['end_date'] != null
-              ? DateTime.parse(json['end_date'] as String)
+              ? DateTime.tryParse(json['end_date'] as String? ?? '')
               : null,
       status: json['status'] as String,
       memberIds:
@@ -82,7 +82,7 @@ class Task {
       projectId: json['project_id'] as int?,
       dueDate:
           json['due_date'] != null
-              ? DateTime.parse(json['due_date'] as String)
+              ? DateTime.tryParse(json['due_date'] as String? ?? '')
               : null,
       priority: json['priority'] as String,
       status: json['status'] as String,


### PR DESCRIPTION
## ProblèmeFormatException sur données malformées (classe de crash #2767/#3054) : DateTime.parse dans attendance_log (date/check_in/check_out), payroll (validated_at), project_task (start_date/end_date/due_date).## CorrectifDateTime.tryParse avec repli null-safe dans les 3 modèles (core partagé).Closes #3433