### PR TITLE
fix(api): RateLimiter trial-status dédupliqué + per_page borné 8 endpoints (Closes #3320, #3321)

### DIFF
--- a/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
@@ -258,7 +258,7 @@ class WebhookController extends Controller
             $webhookEndpoint->deliveries()
                 ->deadLettered()
                 ->orderByDesc('delivered_at')
-                ->paginate((int) $request->integer('per_page', 20))
+                ->paginate(min(100, (int) $request->integer('per_page', 20)))
         );
     }
 

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/SelfServiceController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/SelfServiceController.php
@@ -71,7 +71,7 @@ class SelfServiceController extends Controller
             ->where('company_id', $user->company_id)
             ->with(['session.course:id,title,category,type,duration_hours'])
             ->orderByDesc('created_at')
-            ->paginate($request->integer('per_page', 20));
+            ->paginate(min(100, $request->integer('per_page', 20)));
 
         return TrainingEnrollmentResource::collection($enrollments)->response();
     }
@@ -110,7 +110,7 @@ class SelfServiceController extends Controller
             ->where('company_id', $user->company_id)
             ->withCount('repayments')
             ->orderByDesc('created_at')
-            ->paginate($request->integer('per_page', 20));
+            ->paginate(min(100, $request->integer('per_page', 20)));
 
         return LoanResource::collection($loans)->response();
     }

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/TrainingController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/TrainingController.php
@@ -30,7 +30,7 @@ class TrainingController extends Controller
             $query->where('category', $request->input('category'));
         }
 
-        return TrainingCourseResource::collection($query->orderBy('title')->paginate($request->integer('per_page', 15)))
+        return TrainingCourseResource::collection($query->orderBy('title')->paginate(min(100, $request->integer('per_page', 15))))
             ->response();
     }
 
@@ -118,7 +118,7 @@ class TrainingController extends Controller
             ->where('company_id', $user->company_id)
             ->with(['course:id,title', 'trainer:id,first_name,last_name'])
             ->orderByDesc('start_date')
-            ->paginate($request->integer('per_page', 20));
+            ->paginate(min(100, $request->integer('per_page', 20)));
 
         return TrainingSessionResource::collection($sessions)->response();
     }
@@ -156,7 +156,7 @@ class TrainingController extends Controller
         }
 
         return TrainingSessionResource::collection(
-            $query->orderByDesc('start_date')->paginate($request->integer('per_page', 15))
+            $query->orderByDesc('start_date')->paginate(min(100, $request->integer('per_page', 15)))
         )->response();
     }
 
@@ -182,7 +182,7 @@ class TrainingController extends Controller
         }
 
         return TrainingEnrollmentResource::collection(
-            $query->orderByDesc('created_at')->paginate($request->integer('per_page', 15))
+            $query->orderByDesc('created_at')->paginate(min(100, $request->integer('per_page', 15)))
         )->response();
     }
 

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/EmployeeLoanController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/EmployeeLoanController.php
@@ -43,7 +43,7 @@ class EmployeeLoanController extends Controller
         }
 
         return LoanResource::collection(
-            $query->orderByDesc('created_at')->paginate($request->integer('per_page', 15))
+            $query->orderByDesc('created_at')->paginate(min(100, $request->integer('per_page', 15)))
         )->response();
     }
 

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -220,12 +220,6 @@ class AppServiceProvider extends ServiceProvider
                 ->by('public-careers:'.$request->ip());
         });
 
-        // Issue #2621 : GET /trial/status est POLLÉ par la vitrine (~1 req /
-        // 5 s pendant 60 s) — un limit 5/15 min le 429ait systématiquement.
-        // Limiteur dédié 60/min/IP (statut non sensible, pas de mutation).
-        RateLimiter::for('trial-status', function (Request $request) {
-            return Limit::perMinute(60)->by('trial-status:'.$request->ip());
-        });
     }
 
     private function resolvePlanLimit(string $plan): int


### PR DESCRIPTION
Closes #3320 : le RateLimiter trial-status était défini 2x (AppServiceProvider) — l\u2019anti-scraping token+IP de #2621 était du code mort. Closes #3321 : per_page non borné sur 8 endpoints (Training x4, SelfService x2, EmployeeLoan, Webhook dead-letters) — min(100, ...). PHPStan strict local vert.