### PR TITLE
fix(tooling): release-readiness.ps1 — variable morte retirée (Closes #3540)

### DIFF
--- a/dev-hub/tools/release-readiness.ps1
+++ b/dev-hub/tools/release-readiness.ps1
@@ -30,7 +30,6 @@ function Count-Files([string]$Path, [string]$Filter) {
 
 $backendTests = Count-Files "api/tests" "*.php"
 $adminE2e = Count-Files "front/admin-dashboard/e2e" "*.spec.js"
-$mobileTests = Count-Files "front/mobile/test" "*_test.dart"
 $mobileAppsTests = Count-Files "front/mobile_apps" "*_test.dart"
 $workflowCount = Count-Files ".github/workflows" "*.yml"
 


### PR DESCRIPTION
## Problème`release-readiness.ps1:33` comptait les tests de `front/mobile/test` (monolithe supprimé #754) ; la variable n'était utilisée par aucun Add-Check.## CorrectifLigne supprimée. grep mobileTests → 0.Closes #3540