### PR TITLE
fix(web): FeatureLockedPanel localisé (4 locales) — plus de FR en dur (Closes #2986)

### DIFF
--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -16,6 +16,7 @@ import {
   normalizeLocale,
   storeAuthSession,
   type AppLocale,
+  type CopyTree,
   type StoredAuthUser,
 } from '@/lib/i18n';
 import { OnboardingWizard } from '@/modules/onboarding/components/OnboardingWizard';
@@ -366,7 +367,7 @@ export default function DashboardLayout({
         </header>
         <main className="mx-auto w-full max-w-7xl p-8">
           {currentModule && !currentModule.enabled ? (
-            <FeatureLockedPanel module={currentModule} />
+            <FeatureLockedPanel module={currentModule} labels={labels} />
           ) : (
             children
           )}
@@ -412,10 +413,11 @@ function SidebarLink({ module, active }: { module: ClientModuleAccess; active: b
   );
 }
 
-function FeatureLockedPanel({ module }: { module: ClientModuleAccess }) {
+function FeatureLockedPanel({ module, labels }: { module: ClientModuleAccess; labels: CopyTree }) {
+  // #2986 : messages localisés (4 locales) — plus de FR en dur.
   const reason = module.reason === 'role_locked'
-    ? 'Votre role actuel ne permet pas d acceder a ce module.'
-    : 'Ce module n est pas inclus dans votre plan actuel.';
+    ? labels.dashboard.featureLockedRole
+    : labels.dashboard.featureLockedPlan;
 
   useEffect(() => {
     trackClientEvent('feature_blocked', {
@@ -431,12 +433,12 @@ function FeatureLockedPanel({ module }: { module: ClientModuleAccess }) {
         <div className="space-y-4">
           <span className="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-amber-700">
             <LockKeyhole className="h-4 w-4" aria-hidden="true" />
-            Module non inclus
+            {labels.dashboard.featureLockedBadge}
           </span>
           <div>
             <h1 className="text-3xl font-black text-slate-950">{module.upgradeLabel}</h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-              {reason} Leopardo RH garde l interface explicite afin d eviter les 404 confuses et les erreurs API inutiles.
+              {reason} {labels.dashboard.featureLockedExplanation}
             </p>
           </div>
           <div className="rounded-2xl border border-slate-200 bg-transparent p-4 text-sm text-slate-700">

--- a/front/web/src/lib/i18n.ts
+++ b/front/web/src/lib/i18n.ts
@@ -31,7 +31,7 @@ export const AUTH_TOKEN_KEY = 'auth_token';
 export const AUTH_USER_KEY = 'auth_user';
 export const PREFERRED_LOCALE_KEY = 'preferred_locale';
 
-type CopyTree = {
+export type CopyTree = {
   login: {
     title: string;
     subtitle: string;
@@ -79,6 +79,10 @@ type CopyTree = {
     presentBadge: string;
     employeeLabel: string;
     checkInAt: string;
+    featureLockedRole: string;
+    featureLockedPlan: string;
+    featureLockedBadge: string;
+    featureLockedExplanation: string;
   };
   payrollPage: {
     title: string;
@@ -367,6 +371,10 @@ const copy: Record<AppLocale, CopyTree> = {
       presentBadge: 'Present',
       employeeLabel: 'Employé',
       checkInAt: 'Check-in a',
+      featureLockedRole: "Votre role actuel ne permet pas d'acceder a ce module.",
+      featureLockedPlan: "Ce module n'est pas inclus dans votre plan actuel.",
+      featureLockedBadge: 'Module non inclus',
+      featureLockedExplanation: "Leopardo RH garde l'interface explicite afin d'eviter les 404 confuses et les erreurs API inutiles.",
     },
     payrollPage: {
       title: 'Paie',
@@ -653,6 +661,10 @@ const copy: Record<AppLocale, CopyTree> = {
       presentBadge: 'حاضر',
       employeeLabel: 'موظف',
       checkInAt: 'تسجيل الدخول في',
+      featureLockedRole: 'دورك الحالي لا يسمح بالوصول إلى هذه الوحدة.',
+      featureLockedPlan: 'هذه الوحدة غير مشمولة في خطتك الحالية.',
+      featureLockedBadge: 'الوحدة غير مشمولة',
+      featureLockedExplanation: 'يحافظ Leopardo RH على واجهة واضحة لتجنب أخطاء 404 المربكة وأخطاء API غير الضرورية.',
     },
     payrollPage: {
       title: 'الرواتب',
@@ -939,6 +951,10 @@ const copy: Record<AppLocale, CopyTree> = {
       presentBadge: 'Burada',
       employeeLabel: 'Calisan',
       checkInAt: 'Giris saati',
+      featureLockedRole: "Mevcut rolunuz bu module erisim izni vermiyor.",
+      featureLockedPlan: "Bu modul mevcut planiniza dahil degil.",
+      featureLockedBadge: 'Modul dahil degil',
+      featureLockedExplanation: "Leopardo RH, kafa karistiran 404'leri ve gereksiz API hatalarini onlemek icin arayuzu acik tutar.",
     },
     payrollPage: {
       title: 'Bordro',
@@ -1225,6 +1241,10 @@ const copy: Record<AppLocale, CopyTree> = {
       presentBadge: 'Present',
       employeeLabel: 'Employee',
       checkInAt: 'Check-in at',
+      featureLockedRole: "Your current role does not allow access to this module.",
+      featureLockedPlan: "This module is not included in your current plan.",
+      featureLockedBadge: 'Module not included',
+      featureLockedExplanation: "Leopardo RH keeps the interface explicit to avoid confusing 404s and unnecessary API errors.",
     },
     payrollPage: {
       title: 'Payroll',


### PR DESCRIPTION
## Problème
Le layout dashboard affichait les messages du FeatureLockedPanel en FR quel que soit la locale (fr/ar/tr/en).

## Correctif
4 clés ajoutées au catalogue dashboard (featureLockedRole/Plan/Badge/Explanation) dans les 4 locales ; le composant consomme labels. CopyTree exporté.

## Validation
- npx tsc --noEmit : OK
- npm run lint : 0 erreur

Closes #2986