### PR TITLE
fix(web): preuve sociale honnête (Closes #3246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **fix(web): preuve sociale honnête — témoignages/cas marqués « exemples », chiffres invérifiables retirés (Closes #3246).** `TESTIMONIALS_ARE_DEMO` est enfin consommé : TestimonialCard et TestimonialHighlight affichent un badge « Exemple illustratif » (fr/en/tr/ar) et suffixent l'attribution « (exemple) » — plus aucune citation présentée comme réelle. /about : les stats « 50K+ utilisateurs », « 99,9 % » remplacées par les métriques vérifiables de SocialProofMetrics (6 pays de paie, 4 locales, 7 surfaces, 1200+ tests backend) ; MiniCaseStudies : badge sur chaque profil type et métriques inventées (-40 %/+60 %/-35 %) retirées ; /videos : « Témoignage client : Atlas Digital » rewordé en « Démonstration produit » sans revendication client.
+
 - **fix(admin): raccourcis clavier — source unique + Alt+R implémenté (Closes #3275).** `KEYBOARD_SHORTCUTS` exporté depuis le composable ; Alt+R → /recruitment (annoncé mais jamais implémenté) ; plus de drift entre deux listes.
 - **fix(admin): route morte /users/:id supprimée (Closes #3280).** UserDetailView (prop `:show` inexistante, « Impersonner » inerte) jamais liée — code mort retiré du bundle.
 - **fix(admin): notifications temps réel — id de repli déterministe (Closes #3191).** `stores/realtime.js` : `socket-<timestamp>-<compteur>` au lieu de `Date.now()+Math.random()` (id non persistant, non corrélable).

--- a/front/web/src/app/(landing)/about/page.tsx
+++ b/front/web/src/app/(landing)/about/page.tsx
@@ -66,11 +66,16 @@ export default function AboutPage() {
     },
   ];
 
+  // #3246 — preuve sociale honnête : mêmes métriques vérifiables que
+  // SocialProofMetrics (PA2-MKT-006). Aucune donnée client inventée
+  // (PILOTAGE.md « Clients payants | 0 ») : règles de paie par pays,
+  // locales produit, surfaces produit et taille de la suite de tests
+  // backend — tout est vérifiable dans le dépôt public.
   const stats = [
-    { value: '50K+', label: 'Utilisateurs Actifs' },
-    { value: '99.9%', label: 'Précision' },
-    { value: '3x', label: 'Plus Rapide' },
-    { value: '24/7', label: 'Support' },
+    { value: '6', label: 'Pays avec règles de paie dédiées' },
+    { value: '4', label: 'Langues produit (FR/EN/TR/AR)' },
+    { value: '7', label: 'Surfaces produit (web, mobile, kiosk)' },
+    { value: '1200+', label: 'Tests automatisés backend' },
   ];
 
   return (
@@ -272,7 +277,7 @@ export default function AboutPage() {
               Chiffres Clés
             </div>
             <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
-              Notre Impact
+              Leopardo en Chiffres
             </h2>
           </motion.div>
 
@@ -297,7 +302,8 @@ export default function AboutPage() {
           </div>
 
           <p className="mt-8 text-center text-slate-400 dark:text-slate-500 text-xs">
-            Chiffres de démonstration — données fictives à titre d&apos;illustration.
+            Métriques vérifiables dans le dépôt public du produit — aucun chiffre client
+            (Leopardo n&apos;a pas encore de client payant, cf. PILOTAGE.md).
           </p>
         </div>
       </section>

--- a/front/web/src/app/(landing)/videos/page.tsx
+++ b/front/web/src/app/(landing)/videos/page.tsx
@@ -33,9 +33,9 @@ const upcomingVideos = [
     category: 'Intégration',
   },
   {
-    title: 'Témoignage client : Atlas Digital',
-    description: 'Comment Atlas Digital gère 350 employés sur 3 pays avec Leopardo RH.',
-    category: 'Témoignage',
+    title: 'Démonstration produit : paie multi-pays',
+    description: 'Parcours illustratif — gestion de la paie et des présences pour une entreprise type de 350 employés répartis sur 3 pays.',
+    category: 'Démonstration',
   },
 ];
 

--- a/front/web/src/modules/vitrine/components/sections/MiniCaseStudies.tsx
+++ b/front/web/src/modules/vitrine/components/sections/MiniCaseStudies.tsx
@@ -1,13 +1,21 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Building2, MapPin, Users, ArrowRight } from 'lucide-react';
+import { MapPin, Users, ArrowRight } from 'lucide-react';
 import type { AppLocale } from '@/lib/i18n';
+import { getIllustrativeExampleLabel } from '@/modules/vitrine/lib/vitrine-locale';
 
+/**
+ * #3246 — preuve sociale honnête. Aucun client payant à ce jour
+ * (PILOTAGE.md « Clients payants | 0 ») : ces cas ne décrivent PAS des
+ * clients réels mais des profils types illustratifs. Chaque carte porte un
+ * badge « Exemple illustratif » et les métriques chiffrées inventées
+ * (-40 % temps admin, +60 % remplissage, -35 % absentéisme) ont été
+ * retirées des résultats — seuls les scénarios d'usage restent décrits.
+ */
 type MiniCase = {
   company: string;
   country: string;
-  sector: string;
   employees: string;
   challenge: string;
   result: string;
@@ -17,136 +25,124 @@ type MiniCase = {
 const casesByLocale: Record<AppLocale, { badge: string; title: string; titleHighlight: string; cases: MiniCase[] }> = {
   fr: {
     badge: 'Profils types',
-    title: 'Des resultats',
-    titleHighlight: 'concrets',
+    title: 'Des cas d\'usage',
+    titleHighlight: 'typiques',
     cases: [
       {
-        company: 'IT & Services · 350 emp.',
+        company: 'IT & Services — profil type',
         country: 'Algerie',
-        sector: 'IT & Services',
         employees: '350',
         challenge: 'Pointage papier sur 3 sites, paie manuelle multi-bureaux',
-        result: 'Paie automatisee, pointage biometrique ZKTeco, -40% temps admin',
+        result: 'Paie automatisee, pointage biometrique ZKTeco',
         flag: '🇩🇿',
       },
       {
-        company: 'Marketing Digital · 120 emp.',
+        company: 'Marketing Digital — profil type',
         country: 'Maroc',
-        sector: 'Marketing digital',
         employees: '120',
         challenge: 'Recrutement eparpille, pas de suivi integre',
-        result: 'Pipeline kanban, onboarding automatise, +60% remplissage postes',
+        result: 'Pipeline kanban, onboarding automatise',
         flag: '🇲🇦',
       },
       {
-        company: 'Transport & Logistique · 200 emp.',
+        company: 'Transport & Logistique — profil type',
         country: 'Senegal',
-        sector: 'Transport & Logistique',
         employees: '200',
         challenge: 'Equipes terrain sans visibilite, pointage impossible hors connexion',
-        result: 'Mode offline mobile, synchro auto, -35% absenteisme',
+        result: 'Mode offline mobile, synchro auto',
         flag: '🇸🇳',
       },
     ],
   },
   en: {
     badge: 'Use cases',
-    title: 'Real',
-    titleHighlight: 'results',
+    title: 'Typical',
+    titleHighlight: 'use cases',
     cases: [
       {
-        company: 'IT & Services · 350 emp.',
+        company: 'IT & Services — example profile',
         country: 'Algeria',
-        sector: 'IT & Services',
         employees: '350',
         challenge: 'Paper-based attendance across 3 sites, manual multi-office payroll',
-        result: 'Automated payroll, ZKTeco biometric, -40% admin time',
+        result: 'Automated payroll, ZKTeco biometric attendance',
         flag: '🇩🇿',
       },
       {
-        company: 'Digital Marketing · 120 emp.',
+        company: 'Digital Marketing — example profile',
         country: 'Morocco',
-        sector: 'Digital marketing',
         employees: '120',
         challenge: 'Scattered recruitment, no integrated tracking',
-        result: 'Kanban pipeline, automated onboarding, +60% position fill rate',
+        result: 'Kanban pipeline, automated onboarding',
         flag: '🇲🇦',
       },
       {
-        company: 'Transport & Logistics · 200 emp.',
+        company: 'Transport & Logistics — example profile',
         country: 'Senegal',
-        sector: 'Transport & Logistics',
         employees: '200',
         challenge: 'Field teams with no visibility, impossible offline attendance',
-        result: 'Offline mobile mode, auto sync, -35% absenteeism',
+        result: 'Offline mobile mode, auto sync',
         flag: '🇸🇳',
       },
     ],
   },
   tr: {
     badge: 'Kullanım senaryoları',
-    title: 'Gercek',
-    titleHighlight: 'sonuclar',
+    title: 'Ornek',
+    titleHighlight: 'kullanim senaryolari',
     cases: [
       {
-        company: 'BT Hizmetleri · 350 çal.',
+        company: 'BT Hizmetleri — ornek profil',
         country: 'Cezayir',
-        sector: 'BT ve Hizmetler',
         employees: '350',
         challenge: '3 sahada kagit devam takibi, manuel bordro',
-        result: 'Otomatik bordro, ZKTeco biyometrik, -%40 yonetim suresi',
+        result: 'Otomatik bordro, ZKTeco biyometrik devam takibi',
         flag: '🇩🇿',
       },
       {
-        company: 'Dijital Pazarlama · 120 çal.',
+        company: 'Dijital Pazarlama — ornek profil',
         country: 'Fas',
-        sector: 'Dijital pazarlama',
         employees: '120',
         challenge: 'Daginis ise alim, entegre takip yok',
-        result: 'Kanban boru hatti, otomatik ise alim, +%60 pozisyon doldurma',
+        result: 'Kanban boru hatti, otomatik ise alim',
         flag: '🇲🇦',
       },
       {
-        company: 'Taşımacılık · 200 çal.',
+        company: 'Tasimacilik — ornek profil',
         country: 'Senegal',
-        sector: 'Ulasim ve Lojistik',
         employees: '200',
         challenge: 'Saha ekipleri gorunurluk yok, cevrimdisi devam imkansiz',
-        result: 'Cevrimdisi mobil, otomatik esitleme, -%35 devamsizlik',
+        result: 'Cevrimdisi mobil mod, otomatik esitleme',
         flag: '🇸🇳',
       },
     ],
   },
   ar: {
     badge: 'سيناريوهات الاستخدام',
-    title: 'نتائج',
-    titleHighlight: 'ملموسة',
+    title: 'حالات استخدام',
+    titleHighlight: 'نموذجية',
     cases: [
       {
-        company: 'تكنولوجيا المعلومات · 350 موظف',
+        company: 'تكنولوجيا المعلومات — نموذج توضيحي',
         country: 'الجزائر',
-        sector: 'تكنولوجيا المعلومات',
         employees: '350',
         challenge: 'حضور ورقي عبر 3 مواقع، رواتب يدوية',
-        result: 'رواتب آلية، بصمة ZKTeco، -40% وقت إداري',
+        result: 'رواتب آلية، حضور بيومتري عبر ZKTeco',
         flag: '🇩🇿',
       },
       {
-        company: 'التسويق الرقمي · 120 موظف',
+        company: 'التسويق الرقمي — نموذج توضيحي',
         country: 'المغرب',
-        sector: 'تسويق رقمي',
         employees: '120',
         challenge: 'توظيف مبعثر، بدون تتبع متكامل',
-        result: 'لوحة كانبان، تأهيل آلي، +60% ملء المناصب',
+        result: 'لوحة كانبان، تأهيل آلي',
         flag: '🇲🇦',
       },
       {
-        company: 'النقل واللوجستيك · 200 موظف',
+        company: 'النقل واللوجستيك — نموذج توضيحي',
         country: 'السنغال',
-        sector: 'نقل ولوجستيك',
         employees: '200',
         challenge: 'فرق ميدانية بدون رؤية، حضور مستحيل بدون اتصال',
-        result: 'وضع دون اتصال، مزامنة تلقائية، -35% تغيب',
+        result: 'وضع دون اتصال، مزامنة تلقائية',
         flag: '🇸🇳',
       },
     ],
@@ -159,6 +155,7 @@ export interface MiniCaseStudiesProps {
 
 export function MiniCaseStudies({ locale = 'fr' }: MiniCaseStudiesProps) {
   const data = casesByLocale[locale] ?? casesByLocale.fr;
+  const exampleLabel = getIllustrativeExampleLabel(locale);
 
   return (
     <section className="relative py-24 overflow-hidden">
@@ -194,11 +191,14 @@ export function MiniCaseStudies({ locale = 'fr' }: MiniCaseStudiesProps) {
               transition={{ duration: 0.6, delay: index * 0.15 }}
               className="group relative bg-white dark:bg-slate-900/80 rounded-2xl border border-slate-200/80 dark:border-slate-800/80 p-6 hover:shadow-lg hover:border-blue-200/50 dark:hover:border-blue-800/50 transition-all duration-300"
             >
+              <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-amber-100/70 dark:bg-amber-500/10 border border-amber-300/50 dark:border-amber-500/30 text-amber-700 dark:text-amber-400 text-[11px] font-semibold tracking-wide uppercase mb-3">
+                {exampleLabel}
+              </span>
+
               <div className="flex items-center gap-3 mb-4">
                 <span className="text-2xl">{miniCase.flag}</span>
                 <div>
                   <div className="text-base font-bold text-slate-900 dark:text-white">{miniCase.company}</div>
-                  <div className="text-xs text-slate-500 dark:text-slate-400">{miniCase.sector}</div>
                 </div>
               </div>
 

--- a/front/web/src/modules/vitrine/components/sections/TestimonialCard.tsx
+++ b/front/web/src/modules/vitrine/components/sections/TestimonialCard.tsx
@@ -3,6 +3,12 @@
 import { motion } from 'framer-motion';
 import { Star } from 'lucide-react';
 import Image from 'next/image';
+import { TESTIMONIALS_ARE_DEMO } from '@/modules/vitrine/data/testimonials';
+import {
+  useVitrineLocale,
+  getIllustrativeExampleLabel,
+  getIllustrativeExampleSuffix,
+} from '@/modules/vitrine/lib/vitrine-locale';
 
 export interface TestimonialCardProps {
   quote: string;
@@ -20,6 +26,14 @@ export interface TestimonialCardProps {
   avatar?: string;
   rating: number;
   index?: number;
+  /**
+   * #3246 — preuve sociale honnête : quand la vitrine ne contient que des
+   * témoignages de démo (TESTIMONIALS_ARE_DEMO), la carte affiche un badge
+   * « Exemple illustratif » et l'attribution est suffixée « (exemple) ».
+   * Par défaut, suit le flag global — aucun client payant à ce jour
+   * (PILOTAGE.md), donc tout témoignage non marqué serait trompeur.
+   */
+  demo?: boolean;
 }
 
 function getInitials(name: string): string {
@@ -39,7 +53,12 @@ export function TestimonialCard({
   avatar,
   rating,
   index = 0,
+  demo = TESTIMONIALS_ARE_DEMO,
 }: TestimonialCardProps) {
+  const { locale } = useVitrineLocale();
+  const exampleLabel = getIllustrativeExampleLabel(locale);
+  const exampleSuffix = getIllustrativeExampleSuffix(locale);
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 40 }}
@@ -53,6 +72,12 @@ export function TestimonialCard({
       <div className="absolute -inset-px rounded-3xl bg-gradient-to-r from-emerald-500 to-cyan-500 opacity-0 group-hover:opacity-10 blur-xl transition-opacity duration-500" />
 
       <div className="relative bg-white dark:bg-slate-900/80 backdrop-blur-sm rounded-3xl border border-slate-200/80 dark:border-slate-800/80 p-8 transition-all duration-300 group-hover:border-emerald-200/50 dark:group-hover:border-emerald-800/50 group-hover:shadow-xl">
+        {demo && (
+          <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-amber-100/70 dark:bg-amber-500/10 border border-amber-300/50 dark:border-amber-500/30 text-amber-700 dark:text-amber-400 text-[11px] font-semibold tracking-wide uppercase mb-5">
+            {exampleLabel}
+          </span>
+        )}
+
         {/* Rating */}
         <div className="flex gap-1 mb-6">
           {Array.from({ length: 5 }).map((_, i) => (
@@ -89,7 +114,14 @@ export function TestimonialCard({
             </div>
           )}
           <div>
-            <div className="font-bold text-slate-900 dark:text-white">{author}</div>
+            <div className="font-bold text-slate-900 dark:text-white">
+              {author}
+              {demo && (
+                <span className="ml-1.5 font-normal text-slate-500 dark:text-slate-400">
+                  {exampleSuffix}
+                </span>
+              )}
+            </div>
             <div className="text-sm text-slate-500 dark:text-slate-400">
               {role} at {company}
             </div>

--- a/front/web/src/modules/vitrine/components/sections/TestimonialHighlight.tsx
+++ b/front/web/src/modules/vitrine/components/sections/TestimonialHighlight.tsx
@@ -3,6 +3,11 @@
 import { motion } from 'framer-motion';
 import { Quote, Star } from 'lucide-react';
 import type { AppLocale } from '@/lib/i18n';
+import { TESTIMONIALS_ARE_DEMO } from '@/modules/vitrine/data/testimonials';
+import {
+  getIllustrativeExampleLabel,
+  getIllustrativeExampleSuffix,
+} from '@/modules/vitrine/lib/vitrine-locale';
 
 type HighlightTestimonial = {
   quote: string;
@@ -10,8 +15,6 @@ type HighlightTestimonial = {
   role: string;
   company: string;
   avatar: string;
-  metric: string;
-  metricLabel: string;
 };
 
 const highlightByLocale: Record<AppLocale, HighlightTestimonial> = {
@@ -21,8 +24,6 @@ const highlightByLocale: Record<AppLocale, HighlightTestimonial> = {
     role: 'Directrice des Ressources Humaines',
     company: 'Entreprise IT · 350 employés, 3 pays',
     avatar: 'AD',
-    metric: '-40%',
-    metricLabel: 'temps admin RH',
   },
   en: {
     quote: "Since adopting Leopardo RH, we cut HR admin time by 40%. Multi-country payroll and biometric attendance transformed our day-to-day operations across three offices.",
@@ -30,8 +31,6 @@ const highlightByLocale: Record<AppLocale, HighlightTestimonial> = {
     role: 'HR Director',
     company: 'IT Company · 350 employees, 3 countries',
     avatar: 'AD',
-    metric: '-40%',
-    metricLabel: 'HR admin time',
   },
   tr: {
     quote: "Leopardo RH'yi kullanmaya basladigimizdan beri IK yonetim surelerimizi %40 azalttik. Cok ulkeli bordro ve biyometrik devam takibi operasyonlarimizi donusturdu.",
@@ -39,8 +38,6 @@ const highlightByLocale: Record<AppLocale, HighlightTestimonial> = {
     role: 'IK Direktoru',
     company: 'BT Şirketi · 350 çalışan, 3 ülke',
     avatar: 'AD',
-    metric: '-40%',
-    metricLabel: 'IK yonetim suresi',
   },
   ar: {
     quote: "منذ اعتمادنا Leopardo RH، خفضنا وقت إدارة الموارد البشرية بنسبة 40%. الرواتب متعددة البلدان والحضور البيومتري غيّرا عملياتنا اليومية.",
@@ -48,8 +45,6 @@ const highlightByLocale: Record<AppLocale, HighlightTestimonial> = {
     role: 'مديرة الموارد البشرية',
     company: 'شركة تقنية · 350 موظف، 3 دول',
     avatar: 'AD',
-    metric: '-40%',
-    metricLabel: 'وقت إدارة الموارد البشرية',
   },
 };
 
@@ -72,6 +67,12 @@ export function TestimonialHighlight({ locale = 'fr' }: TestimonialHighlightProp
           transition={{ duration: 0.7 }}
           className="relative bg-white dark:bg-slate-900 rounded-3xl border border-slate-200/80 dark:border-slate-800/80 p-10 md:p-14 shadow-xl"
         >
+          {TESTIMONIALS_ARE_DEMO && (
+            <span className="inline-flex items-center px-3 py-1 rounded-full bg-amber-100/70 dark:bg-amber-500/10 border border-amber-300/50 dark:border-amber-500/30 text-amber-700 dark:text-amber-400 text-xs font-semibold tracking-wide uppercase mb-6">
+              {getIllustrativeExampleLabel(locale)}
+            </span>
+          )}
+
           <Quote className="w-12 h-12 text-emerald-200 dark:text-emerald-900/50 mb-6" />
 
           <div className="flex gap-1 mb-6">
@@ -90,18 +91,16 @@ export function TestimonialHighlight({ locale = 'fr' }: TestimonialHighlightProp
                 {testimonial.avatar}
               </div>
               <div>
-                <div className="text-base font-bold text-slate-900 dark:text-white">{testimonial.name}</div>
+                <div className="text-base font-bold text-slate-900 dark:text-white">
+                  {testimonial.name}
+                  {TESTIMONIALS_ARE_DEMO && (
+                    <span className="ml-1.5 font-normal text-slate-500 dark:text-slate-400">
+                      {getIllustrativeExampleSuffix(locale)}
+                    </span>
+                  )}
+                </div>
                 <div className="text-sm text-slate-500 dark:text-slate-400">{testimonial.role}</div>
                 <div className="text-sm text-slate-400 dark:text-slate-500">{testimonial.company}</div>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3 px-6 py-4 bg-emerald-50 dark:bg-emerald-900/20 rounded-2xl border border-emerald-100 dark:border-emerald-800/30">
-              <div className="text-3xl font-black text-emerald-600 dark:text-emerald-400">
-                {testimonial.metric}
-              </div>
-              <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium">
-                {testimonial.metricLabel}
               </div>
             </div>
           </div>

--- a/front/web/src/modules/vitrine/lib/vitrine-locale.ts
+++ b/front/web/src/modules/vitrine/lib/vitrine-locale.ts
@@ -760,6 +760,33 @@ export function setVitrineLocale(locale: AppLocale): void {
   broadcastLocaleChange()
 }
 
+// #3246 — preuve sociale honnête. Aucun client payant à ce jour
+// (PILOTAGE.md « Clients payants | 0 ») : tout contenu « client » de la
+// vitrine est illustratif. Ces libellés sont consommés par TestimonialCard,
+// TestimonialHighlight et MiniCaseStudies pour marquer explicitement les
+// citations/cas comme des exemples (voir TESTIMONIALS_ARE_DEMO).
+export const ILLUSTRATIVE_EXAMPLE_LABEL: Record<AppLocale, string> = {
+  fr: 'Exemple illustratif',
+  en: 'Illustrative example',
+  tr: 'Temsili örnek',
+  ar: 'مثال توضيحي',
+}
+
+export const ILLUSTRATIVE_EXAMPLE_SUFFIX: Record<AppLocale, string> = {
+  fr: '(exemple)',
+  en: '(example)',
+  tr: '(örnek)',
+  ar: '(مثال)',
+}
+
+export function getIllustrativeExampleLabel(locale: AppLocale): string {
+  return ILLUSTRATIVE_EXAMPLE_LABEL[locale] ?? ILLUSTRATIVE_EXAMPLE_LABEL.fr
+}
+
+export function getIllustrativeExampleSuffix(locale: AppLocale): string {
+  return ILLUSTRATIVE_EXAMPLE_SUFFIX[locale] ?? ILLUSTRATIVE_EXAMPLE_SUFFIX.fr
+}
+
 export function useVitrineLocale() {
   const [locale, setLocaleState] = useState<AppLocale>(() => getCurrentLocale())
 


### PR DESCRIPTION
## Contexte

#3246 — la vitrine présentait de la preuve sociale fabriquée (0 client payant selon PILOTAGE.md) sur 4 surfaces. Les témoignages/cas sont désormais explicitement marqués comme exemples, et les chiffres invérifiables sont retirés.

## Changements

1. **Témoignages démo enfin marqués** — `TESTIMONIALS_ARE_DEMO` (testimonials.ts) est désormais consommé : `TestimonialCard` et `TestimonialHighlight` affichent un badge « Exemple illustratif » (fr/en/tr/ar via `useVitrineLocale` + nouveaux libellés dans `vitrine-locale.ts`) et suffixent l'attribution « (exemple) ». La carte `TestimonialCard` suit le flag par défaut (`demo = TESTIMONIALS_ARE_DEMO`), donc toutes les surfaces qui l'utilisent (home, pages modules) sont couvertes.
2. **/about** — les stats « 50K+ utilisateurs », « 99,9 % précision », « 3x », « 24/7 » remplacées par les métriques vérifiables de `SocialProofMetrics` (6 pays avec règles de paie dédiées, 4 locales produit, 7 surfaces, 1200+ tests backend automatisés — vérifiable dans le dépôt). Disclaimer « données fictives » remplacé par la mention de vérifiabilité.
3. **MiniCaseStudies** — les 3 cas inventés (IT & Services 350 emp., -40 % temps admin, +60 % remplissage, -35 % absentéisme) sont badgés « Exemple illustratif », renommés « profil type / example profile » et les métriques inventées sont retirées des résultats. Titres réalignés (« Real results » → « Typical use cases », etc.).
4. **/videos** — « Témoignage client : Atlas Digital, 350 employés sur 3 pays » rewordé en « Démonstration produit : paie multi-pays » (parcours illustratif, aucune revendication client).

Aucun nouveau chiffre inventé nulle part. `TestimonialHighlight` perd aussi le bloc métrique « -40 % temps admin RH » (même classe de fabrication).

## Note (hors scope #3246)

`front/web/src/modules/vitrine/lib/content.ts` (pages modules /employes, /comptabilite, /marketing, /documents) contient encore des témoignages/études de cas fictifs (ex. « Satisfaction 98% », « 500+ employés gérés ») — désormais couverts par le badge « Exemple illustratif » via le défaut de `TestimonialCard`, mais les chiffres des études de cas y restent ; à traiter dans un ticket dédié si souhaité.

Closes #3246