### PR TITLE
fix(mobile): leopardo_core — sync_models_example.dart déplacé lib/ → example/ (Closes #3565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+
+- **fix(mobile): leopardo_core — sync_models_example.dart déplacé de `lib/` vers `example/` (Closes #3565).** Fichier de démonstration (0 import dans les apps) retiré de la surface publique du package — ses 12 `print()` ne partent plus en log production et le bundle allège. Imports convertis en `package:leopardo_core/...` (convention Dart example/).
 ### Fixed
 - **fix(ci): main vert round 3 — 29 erreurs PHPStan reintroduites par les merges swarm corrigées.** KioskController (bug runtime `undefined $kiosk` dans doRoster, `$deviceCode` non câblé dans doAnnouncements, @param validated ×4), `@property company` sur AttendanceKiosk, `@property Carbon|null` subscription_start/end sur Company + TrialWelcomeMail null-safe, GenerateBankExportJob (3e argument redondant retiré), tests réalignés (GrowthModuleTest doublon country, OnboardingStepWriteGuardTest, TrackingSyncTripsDateRangeTest, VehicleControllerTest, CreatesCameraFixtures, TestRtspSsidGuardTest).
 - **fix(mobile): onboarding HR compile KO, route cabinet manager dédupliquée, verbes notifications (Closes #3003, #3004, #3005).** `onboarding_screen.dart` HR passait un int à `completeStep(String)` (2 erreurs de typage = compile KO) ; route `/cabinet/folder/:folderId` déclarée 2× dans manager `app.dart` (la 1re `int.parse` non gardée gagnait → crash sur deep-link non numérique) ; `modules_repository` (hr/manager) : `PUT /notifications/{id}/read` et `/read-all` → `PATCH`/`POST` (contrat rh.php).

--- a/front/mobile_apps/leopardo_core/example/sync_models_example.dart
+++ b/front/mobile_apps/leopardo_core/example/sync_models_example.dart
@@ -1,11 +1,11 @@
 // Exemple d'utilisation des nouvelles classes de synchronisation
 // Ce fichier démontre comment utiliser Feature, FeatureManifest, FormSchema, ListSchema, et DetailSchema
 
-import 'feature.dart';
-import 'feature_manifest.dart';
-import 'form_schema.dart';
-import 'list_schema.dart';
-import 'detail_schema.dart';
+import 'package:leopardo_core/models/feature.dart';
+import 'package:leopardo_core/models/feature_manifest.dart';
+import 'package:leopardo_core/models/form_schema.dart';
+import 'package:leopardo_core/models/list_schema.dart';
+import 'package:leopardo_core/models/detail_schema.dart';
 
 /// Exemple de création et utilisation des modèles de synchronisation
 class SyncModelsExample {


### PR DESCRIPTION
## Constat

`leopardo_core/lib/models/sync_models_example.dart` : fichier de démonstration compilé dans la surface publique du package partagé, avec 12 `print()` de debug. **Zéro référence** dans les 4 apps ni les tests (vérifié par grep global).

## Changement

- Déplacé vers `front/mobile_apps/leopardo_core/example/sync_models_example.dart` (convention Dart : `example/` hors bundle).
- Imports relatifs → `package:leopardo_core/models/...`.
- `print()` conservés tel quel : idiomatiques dans un `example/`, désormais hors `lib/` donc jamais compilés dans les apps.

Closes #3565

## Réf spec

`.specify/features/qa-expert9-session-2026-08-15/` (E9-03)