### PR TITLE
fix(billing): use canonical plan codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,8 @@ Nouvelle suite `tests/Feature/CrossTenantIndexIsolationTest` (7 tests) verrouill
 
 - **fix(api): erreurs du cockpit admin journalisées et exposées en 503 (Closes #3001).** Les catches silencieux des métriques, statistiques, activités, alertes et rapports RH n’affichent plus de faux zéros ou listes vides ; chaque panne est loggée avec son opération.
 
+- **fix(billing): codes de plans canoniques Free/Pilot/Operations/Enterprise (Closes #2977).** La matrice backend, le checkout, Stripe, les factures et le rate limiting utilisent désormais une source `PlanCode`; les alias historiques sont normalisés uniquement aux frontières.
+
 - **docs(AGENTS.md): gate /api/v1/demo-users documenté conformément au code (Closes #2650).** La règle v4.16.128 affirmait à tort que l'endpoint ne devait pas être rebloqué via `DEMO_MODE_ENABLED=false` ; le hard gate `abort(404)` est délibéré (AUDIT_API_2026-07-19 §1, DEMO_ACCOUNTS.md). Renvoi vers les sources.
 - **fix(web): SignupForm — record localisé construit depuis le catalogue i18n partagé (complète #2648).** Les 70 clés du formulaire d'essai guidé vivent désormais dans `shared/i18n/locales/*.json` (source de vérité) et sont consommées via `t(locale, 'signup.*')` (garde PA2-I18N-014 vert).
 - **fix(web): SignupForm (essai guidé) localisé FR/EN/TR/AR (Closes #2648).** Le formulaire de `/signup` était 100 % codé en français (labels, placeholders, erreurs, écrans OTP/pending/tracking/success) alors que la page est 4-locales — les visiteurs EN/TR/AR voyaient un formulaire français. Le composant utilise désormais `useVitrineLocale()` + un record `signupFormCopy[locale]` ; le schéma zod `signupFormSchema(locale)` produit des messages de validation dans la langue active (tests mis à jour, accents FR restaurés).

--- a/api/app/Console/Commands/GenerateMonthlyInvoices.php
+++ b/api/app/Console/Commands/GenerateMonthlyInvoices.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use App\Modules\Billing\Domain\Models\Invoice;
 use App\Modules\Billing\Domain\Models\Subscription;
 use Illuminate\Console\Command;
@@ -17,8 +18,9 @@ class GenerateMonthlyInvoices extends Command
     protected $description = 'Generate monthly invoices for active subscriptions';
 
     private const PLAN_PRICES = [
-        'starter' => ['amount' => 29.00, 'currency' => 'EUR'],
-        'business' => ['amount' => 99.00, 'currency' => 'EUR'],
+        'free' => ['amount' => 0.00, 'currency' => 'EUR'],
+        'pilot' => ['amount' => 29.00, 'currency' => 'EUR'],
+        'operations' => ['amount' => 99.00, 'currency' => 'EUR'],
         'enterprise' => ['amount' => 299.00, 'currency' => 'EUR'],
     ];
 
@@ -33,7 +35,8 @@ class GenerateMonthlyInvoices extends Command
         foreach ($activeSubscriptions as $subscription) {
             try {
                 DB::transaction(function () use ($subscription, &$generated): void {
-                    $pricing = self::PLAN_PRICES[$subscription->plan] ?? self::PLAN_PRICES['starter'];
+                    $plan = PlanCode::normalize((string) $subscription->plan)->value;
+                    $pricing = self::PLAN_PRICES[$plan] ?? self::PLAN_PRICES[PlanCode::Pilot->value];
                     $year = now()->format('Y');
                     $seq = Invoice::where('company_id', $subscription->company_id)->count() + 1;
 

--- a/api/app/Core/Feature/Infrastructure/Services/FeatureService.php
+++ b/api/app/Core/Feature/Infrastructure/Services/FeatureService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Core\Feature\Infrastructure\Services;
 
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use App\Modules\Billing\Domain\Models\FeaturePlanMatrix;
 use App\Modules\Billing\Domain\Models\Subscription;
 use Illuminate\Support\Facades\Cache;
@@ -55,7 +56,7 @@ class FeatureService
                     ->latest()
                     ->first();
 
-                return $sub ? $sub->plan : 'trial';
+                return PlanCode::normalize($sub?->plan ?? PlanCode::Free->value)->value;
             }
         );
     }

--- a/api/app/Core/Feature/Interfaces/Api/V1/Requests/UpdateFeatureMatrixRequest.php
+++ b/api/app/Core/Feature/Interfaces/Api/V1/Requests/UpdateFeatureMatrixRequest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Core\Feature\Interfaces\Api\V1\Requests;
 
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateFeatureMatrixRequest extends FormRequest
 {
@@ -13,11 +15,22 @@ class UpdateFeatureMatrixRequest extends FormRequest
         return (bool) $this->user();
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('plan')) {
+            try {
+                $this->merge(['plan' => PlanCode::normalize((string) $this->input('plan'))->value]);
+            } catch (\InvalidArgumentException) {
+                // Let the canonical allow-list rule return the validation error.
+            }
+        }
+    }
+
     public function rules(): array
     {
         return [
             'feature_key' => 'required|string|max:50',
-            'plan' => 'required|in:trial,starter,business,enterprise',
+            'plan' => ['required', Rule::in(PlanCode::values())],
             'enabled' => 'required|boolean',
             'limit_value' => 'nullable|integer|min:0',
         ];

--- a/api/app/Modules/Billing/Domain/Enums/PlanCode.php
+++ b/api/app/Modules/Billing/Domain/Enums/PlanCode.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Billing\Domain\Enums;
+
+enum PlanCode: string
+{
+    case Free = 'free';
+    case Pilot = 'pilot';
+    case Operations = 'operations';
+    case Enterprise = 'enterprise';
+
+    /** @return list<string> */
+    public static function values(): array
+    {
+        return array_map(static fn (self $plan): string => $plan->value, self::cases());
+    }
+
+    /**
+     * Convert legacy billing identifiers to the canonical product identifiers.
+     * Boundary callers may still send old values, but persisted matrix rows use only canonical values.
+     */
+    public static function normalize(string $value): self
+    {
+        return match (strtolower(trim($value))) {
+            'trial', 'free' => self::Free,
+            'starter', 'pilot' => self::Pilot,
+            'business', 'operations' => self::Operations,
+            'enterprise', 'scale' => self::Enterprise,
+            default => throw new \InvalidArgumentException("Unsupported plan code: {$value}"),
+        };
+    }
+}

--- a/api/app/Modules/Billing/Infrastructure/Services/StripeService.php
+++ b/api/app/Modules/Billing/Infrastructure/Services/StripeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Billing\Infrastructure\Services;
 
 use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use App\Modules\Billing\Domain\Models\Invoice;
 use App\Modules\Payroll\Domain\Models\Payment;
 use App\Modules\Billing\Domain\Models\Subscription;
@@ -35,8 +36,8 @@ class StripeService
         $this->secretKey = (string) config('services.stripe.secret');
         $this->webhookSecret = (string) config('services.stripe.webhook_secret');
         $this->priceIds = [
-            'starter' => (string) config('services.stripe.price_starter'),
-            'business' => (string) config('services.stripe.price_business'),
+            'pilot' => (string) config('services.stripe.price_pilot'),
+            'operations' => (string) config('services.stripe.price_operations'),
             'enterprise' => (string) config('services.stripe.price_enterprise'),
         ];
     }
@@ -182,7 +183,7 @@ class StripeService
     private function handleCheckoutCompleted(array $session): void
     {
         $companyId = $session['metadata']['company_id'] ?? $session['client_reference_id'] ?? null;
-        $plan = $session['metadata']['plan'] ?? 'starter';
+        $plan = PlanCode::normalize((string) ($session['metadata']['plan'] ?? PlanCode::Pilot->value))->value;
         $subscriptionId = $session['subscription'] ?? null;
         $customerId = $session['customer'] ?? null;
 

--- a/api/app/Modules/Billing/Interfaces/Api/V1/BillingController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/BillingController.php
@@ -9,6 +9,7 @@ use App\Core\Tenant\Domain\Models\Company;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\InvoiceResource;
 use App\Http\Resources\Api\V1\SubscriptionResource;
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use App\Modules\Billing\Domain\Models\Invoice;
 use App\Modules\Billing\Domain\Models\Subscription;
 use App\Modules\Billing\Infrastructure\Services\StripeService;
@@ -48,7 +49,7 @@ class BillingController extends Controller
         }
 
         $validated = $request->validate([
-            'plan' => 'required|in:starter,business,enterprise',
+            'plan' => ['required', \Illuminate\Validation\Rule::in(PlanCode::values())],
             'payment_method' => 'nullable|in:stripe,bank_transfer,manual',
         ]);
 
@@ -185,7 +186,7 @@ class BillingController extends Controller
         $company = Company::findOrFail($user->company_id);
 
         $validated = $request->validate([
-            'plan' => 'required|in:starter,business,enterprise',
+            'plan' => ['required', \Illuminate\Validation\Rule::in(PlanCode::values())],
             'success_url' => 'required|url|max:500',
             'cancel_url' => 'required|url|max:500',
         ]);

--- a/api/app/Modules/Billing/Interfaces/Api/V1/FeatureFlagController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/FeatureFlagController.php
@@ -6,6 +6,7 @@ namespace App\Modules\Billing\Interfaces\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use App\Modules\Billing\Domain\Models\FeaturePlanMatrix;
 use App\Modules\Billing\Domain\Models\Subscription;
 use Illuminate\Http\JsonResponse;
@@ -61,7 +62,7 @@ class FeatureFlagController extends Controller
             ->latest()
             ->first();
 
-        return $subscription ? $subscription->plan : 'trial';
+        return PlanCode::normalize($subscription?->plan ?? PlanCode::Free->value)->value;
     }
 }
 

--- a/api/app/Modules/Billing/Interfaces/Api/V1/Requests/UpgradeSubscriptionRequest.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/Requests/UpgradeSubscriptionRequest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Modules\Billing\Interfaces\Api\V1\Requests;
 
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpgradeSubscriptionRequest extends FormRequest
 {
@@ -13,10 +15,21 @@ class UpgradeSubscriptionRequest extends FormRequest
         return $this->user()?->isManager() ?? false;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('plan')) {
+            try {
+                $this->merge(['plan' => PlanCode::normalize((string) $this->input('plan'))->value]);
+            } catch (\InvalidArgumentException) {
+                // Let the canonical allow-list rule return the validation error.
+            }
+        }
+    }
+
     public function rules(): array
     {
         return [
-            'plan' => 'required|in:starter,business,enterprise',
+            'plan' => ['required', Rule::in(PlanCode::values())],
             'payment_method' => 'nullable|in:stripe,chargily,bank_transfer,manual',
         ];
     }

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\AI\Providers\ClaudeClient;
 use App\AI\Providers\OpenAIClient;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\TenantManager;
+use App\Modules\Billing\Domain\Enums\PlanCode;
 use App\Modules\Payroll\Infrastructure\Services\IslamicCalendarService;
 use App\Modules\Payroll\Infrastructure\Services\PublicHolidayService;
 use App\Policies\ExportPolicy;
@@ -228,11 +229,9 @@ class AppServiceProvider extends ServiceProvider
 
         return match ($normalized) {
             'enterprise' => (int) config('security.plan_rate_limits.enterprise_per_minute', 0),
-            'business' => (int) config('security.plan_rate_limits.business_per_minute', 1000),
-            'professional' => (int) config('security.plan_rate_limits.professional_per_minute', 1000),
-            'pro' => (int) config('security.plan_rate_limits.pro_per_minute', 1000),
-            'starter' => (int) config('security.plan_rate_limits.starter_per_minute', 100),
-            'trial' => (int) config('security.plan_rate_limits.trial_per_minute', 60),
+            'operations' => (int) config('security.plan_rate_limits.operations_per_minute', 1000),
+            'pilot' => (int) config('security.plan_rate_limits.pilot_per_minute', 100),
+            'free' => (int) config('security.plan_rate_limits.free_per_minute', 60),
             default => (int) config('security.plan_rate_limits.default_per_minute', 100),
         };
     }
@@ -248,11 +247,15 @@ class AppServiceProvider extends ServiceProvider
             return $planName;
         }
 
-        return 'trial';
+        return PlanCode::Free->value;
     }
 
     private function normalizePlan(string $plan): string
     {
-        return strtolower(trim($plan));
+        try {
+            return PlanCode::normalize($plan)->value;
+        } catch (\InvalidArgumentException) {
+            return strtolower(trim($plan));
+        }
     }
 }

--- a/api/config/security.php
+++ b/api/config/security.php
@@ -21,11 +21,9 @@ return [
     ],
 
     'plan_rate_limits' => [
-        'trial_per_minute' => (int) env('RATE_LIMIT_PLAN_TRIAL_PER_MINUTE', 60),
-        'starter_per_minute' => (int) env('RATE_LIMIT_PLAN_STARTER_PER_MINUTE', 100),
-        'business_per_minute' => (int) env('RATE_LIMIT_PLAN_BUSINESS_PER_MINUTE', 1000),
-        'professional_per_minute' => (int) env('RATE_LIMIT_PLAN_PROFESSIONAL_PER_MINUTE', 1000),
-        'pro_per_minute' => (int) env('RATE_LIMIT_PLAN_PRO_PER_MINUTE', 1000),
+        'free_per_minute' => (int) env('RATE_LIMIT_PLAN_FREE_PER_MINUTE', 60),
+        'pilot_per_minute' => (int) env('RATE_LIMIT_PLAN_PILOT_PER_MINUTE', 100),
+        'operations_per_minute' => (int) env('RATE_LIMIT_PLAN_OPERATIONS_PER_MINUTE', 1000),
         'enterprise_per_minute' => (int) env('RATE_LIMIT_PLAN_ENTERPRISE_PER_MINUTE', 0),
         'default_per_minute' => (int) env('RATE_LIMIT_PLAN_DEFAULT_PER_MINUTE', 100),
     ],

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -50,8 +50,8 @@ return [
     'stripe' => [
         'secret' => env('STRIPE_SECRET_KEY'),
         'webhook_secret' => env('STRIPE_WEBHOOK_SECRET'),
-        'price_starter' => env('STRIPE_PRICE_STARTER'),
-        'price_business' => env('STRIPE_PRICE_BUSINESS'),
+        'price_pilot' => env('STRIPE_PRICE_PILOT', env('STRIPE_PRICE_STARTER')),
+        'price_operations' => env('STRIPE_PRICE_OPERATIONS', env('STRIPE_PRICE_BUSINESS')),
         'price_enterprise' => env('STRIPE_PRICE_ENTERPRISE'),
     ],
 

--- a/api/database/seeders/FeaturePlanMatrixSeeder.php
+++ b/api/database/seeders/FeaturePlanMatrixSeeder.php
@@ -10,28 +10,28 @@ class FeaturePlanMatrixSeeder extends Seeder
     public function run(): void
     {
         $matrix = [
-            ['feature_key' => 'employees', 'trial' => [true, 10], 'starter' => [true, 30], 'business' => [true, 100], 'enterprise' => [true, null]],
-            ['feature_key' => 'attendance', 'trial' => [true, null], 'starter' => [true, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'anomalies', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'geofence', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'monthly_report', 'trial' => [false, null], 'starter' => [true, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'absences', 'trial' => [false, null], 'starter' => [true, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'payroll', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'contracts', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'recruitment', 'trial' => [false, null], 'starter' => [false, null], 'business' => [false, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'training', 'trial' => [false, null], 'starter' => [false, null], 'business' => [false, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'tracking', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'ai_chat', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'ai_voice', 'trial' => [false, null], 'starter' => [false, null], 'business' => [false, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'webhooks', 'trial' => [false, null], 'starter' => [false, null], 'business' => [false, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'api_public', 'trial' => [false, null], 'starter' => [false, null], 'business' => [false, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'multi_site', 'trial' => [false, null], 'starter' => [false, null], 'business' => [true, null], 'enterprise' => [true, null]],
-            ['feature_key' => 'custom_branding', 'trial' => [false, null], 'starter' => [false, null], 'business' => [false, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'employees', 'free' => [true, 5], 'pilot' => [true, 30], 'operations' => [true, 250], 'enterprise' => [true, null]],
+            ['feature_key' => 'attendance', 'free' => [true, null], 'pilot' => [true, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'anomalies', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'geofence', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'monthly_report', 'free' => [false, null], 'pilot' => [true, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'absences', 'free' => [false, null], 'pilot' => [true, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'payroll', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'contracts', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'recruitment', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [false, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'training', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [false, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'tracking', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'ai_chat', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'ai_voice', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [false, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'webhooks', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [false, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'api_public', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [false, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'multi_site', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [true, null], 'enterprise' => [true, null]],
+            ['feature_key' => 'custom_branding', 'free' => [false, null], 'pilot' => [false, null], 'operations' => [false, null], 'enterprise' => [true, null]],
         ];
 
         foreach ($matrix as $row) {
             $featureKey = $row['feature_key'];
-            foreach (['trial', 'starter', 'business', 'enterprise'] as $plan) {
+            foreach (['free', 'pilot', 'operations', 'enterprise'] as $plan) {
                 [$enabled, $limit] = $row[$plan];
                 DB::table('feature_plan_matrix')->updateOrInsert(
                     ['feature_key' => $featureKey, 'plan' => $plan],

--- a/docs/specifications/ISSUE_2977_CANONICAL_PLAN_CODES.md
+++ b/docs/specifications/ISSUE_2977_CANONICAL_PLAN_CODES.md
@@ -1,0 +1,53 @@
+# Mini-spécification — Issue #2977
+
+## Objectif
+
+Unifier les codes de plans entre la matrice de fonctionnalités backend, le checkout frontend, la facturation Stripe et les limites API.
+
+## Contrat canonique
+
+Les quatre codes persistés et échangés par les nouveaux flux sont : `free`, `pilot`, `operations` et `enterprise`. Les libellés marketing restent **Free**, **Pilot**, **Operations** et **Enterprise**.
+
+Les alias historiques `trial`, `starter`, `business` et `scale` sont acceptés uniquement aux frontières compatibles et normalisés immédiatement vers le code canonique. Ils ne sont plus générés par le seeder ni par les nouveaux appels checkout.
+
+## Changements
+
+- Ajout de `PlanCode`, enum PHP unique pour les valeurs et la normalisation des alias.
+- Seeder `FeaturePlanMatrixSeeder` migré vers les quatre codes canoniques et les limites Free/Pilot/Operations cohérentes avec la vitrine.
+- FeatureService, FeatureFlagController, StripeService, facturation mensuelle et rate limiting normalisent les abonnements existants.
+- Validations de matrice, upgrade et billing alignées sur `PlanCode::values()`.
+- Checkout frontend et matrice de comparaison migrés vers `free/pilot/operations/enterprise`.
+- Variables Stripe historiques conservées comme fallback de configuration pour éviter une rupture de déploiement.
+
+## Critères d’acceptation
+
+1. Aucun nouveau seeder ou checkout ne produit `trial`, `starter`, `business` ou `scale`.
+2. Une matrice fraîche contient uniquement les quatre codes canoniques.
+3. Un abonnement historique utilisant un alias continue d’être évalué via son plan canonique.
+4. Les routes billing refusent les codes inconnus et acceptent les quatre codes canoniques.
+5. Le checkout sandbox applique les prix Free 0 €, Pilot 29 €, Operations 99 € et Enterprise sur devis.
+6. Les validations backend et frontend pertinentes passent.
+
+## Fichiers principaux
+
+- `api/app/Modules/Billing/Domain/Enums/PlanCode.php`
+- `api/database/seeders/FeaturePlanMatrixSeeder.php`
+- `api/app/Core/Feature/Infrastructure/Services/FeatureService.php`
+- `api/app/Modules/Billing/Interfaces/Api/V1/FeatureFlagController.php`
+- `api/app/Modules/Billing/Interfaces/Api/V1/BillingController.php`
+- `api/app/Modules/Billing/Infrastructure/Services/StripeService.php`
+- `api/app/Console/Commands/GenerateMonthlyInvoices.php`
+- `api/app/Providers/AppServiceProvider.php`
+- `api/config/security.php`, `api/config/services.php`
+- `front/web/src/app/(landing)/pricing/page.tsx`
+- `front/web/src/app/api/billing/checkout/route.ts`
+
+## Plan de retour arrière
+
+Réversion du commit puis restauration des valeurs de configuration Stripe historiques si nécessaire. Les données existantes restent lisibles grâce à `PlanCode::normalize()`.
+
+## Trace Spec Kit
+
+Issue : #2977  
+Branche : `fix/2977-canonical-plan-codes`  
+Date : 2026-08-15

--- a/front/web/src/app/(landing)/pricing/page.tsx
+++ b/front/web/src/app/(landing)/pricing/page.tsx
@@ -34,8 +34,8 @@ import {
 type ComparisonFeature = {
   name: string;
   free: boolean | string;
-  starter: boolean | string;
-  business: boolean | string;
+  pilot: boolean | string;
+  operations: boolean | string;
   enterprise: boolean | string;
 };
 
@@ -53,7 +53,7 @@ type FaqItem = {
 
 type PricingPageCopy = {
   hero: { headline: string; subheadline: string; primary: string; secondary: string; badge: string };
-  plans: { title: string; subtitle: string; badge: string; monthly: string; annual: string; savings: string; periodMonthly: string; periodAnnual: string; trialNote: string };
+  plans: { title: string; subtitle: string; badge: string; monthly: string; annual: string; savings: string; customPrice: string; periodMonthly: string; periodAnnual: string; trialNote: string };
   currency: { label: string; approx: string };
   trust: { items: string[] };
   comparison: { badge: string; title: string; subtitle: string; featureColumn: string; categories: ComparisonCategory[] };
@@ -79,10 +79,11 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       subtitle: 'Commencez petit, montez en puissance sans changer de plateforme.',
       monthly: 'Mensuel',
       annual: 'Annuel',
-      savings: 'Économisez 17%',
+      savings: 'Économisez 20%',
+      customPrice: 'Sur devis',
       periodMonthly: '/mois',
       periodAnnual: '/mois facturé annuellement',
-      trialNote: '14 jours offerts · Aucune CB requise',
+      trialNote: '30 jours offerts · Aucune CB requise',
     },
     currency: {
       label: 'Afficher les prix en',
@@ -90,7 +91,7 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
     },
     trust: {
       items: [
-        'Essai gratuit de 14 jours sans CB',
+        'Plan gratuit sans CB',
         'Support inclus dès le premier jour',
         'Données hébergées en Europe',
         'Résiliation à tout moment',
@@ -105,45 +106,45 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
         {
           category: 'Gestion RH',
           features: [
-            { name: 'Pointage web & mobile', free: 'Web seulement', starter: true, business: true, enterprise: true },
-            { name: 'Absences & congés', free: true, starter: true, business: true, enterprise: true },
-            { name: 'Calendrier partagé', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Onboarding guidé', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Évaluations & performance', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Organigramme dynamique', free: false, starter: false, business: true, enterprise: true },
+            { name: 'Pointage web & mobile', free: 'Web seulement', pilot: true, operations: true, enterprise: true },
+            { name: 'Absences & congés', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'Calendrier partagé', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Onboarding guidé', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Évaluations & performance', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Organigramme dynamique', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'Paie & finance',
           features: [
-            { name: 'Calcul automatisé de la paie', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Bulletins de paie PDF', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Exports comptables', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Avances sur salaire', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Multi-pays & multi-devises', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Conformité légale avancée', free: false, starter: false, business: false, enterprise: true },
+            { name: 'Calcul automatisé de la paie', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Bulletins de paie PDF', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Exports comptables', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Avances sur salaire', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Multi-pays & multi-devises', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Conformité légale avancée', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
         {
           category: 'Terrain & mobile',
           features: [
-            { name: 'App mobile Employee', free: true, starter: true, business: true, enterprise: true },
-            { name: 'App mobile Manager', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Mode hors-ligne', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Intégration ZKTeco biométrie', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Kiosque RH dédié', free: false, starter: false, business: true, enterprise: true },
-            { name: 'GPS & géofencing', free: false, starter: false, business: true, enterprise: true },
+            { name: 'App mobile Employee', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'App mobile Manager', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Mode hors-ligne', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Intégration ZKTeco biométrie', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Kiosque RH dédié', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'GPS & géofencing', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'Sécurité & intégrations',
           features: [
-            { name: 'Coffre-fort documentaire', free: false, starter: false, business: true, enterprise: true },
-            { name: 'API REST & Webhooks', free: false, starter: false, business: true, enterprise: true },
-            { name: 'SSO SAML / OIDC (bientot)', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Audit trail immuable', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Schéma PostgreSQL isolé', free: false, starter: false, business: false, enterprise: true },
-            { name: 'SLA dédié & support prioritaire', free: false, starter: false, business: false, enterprise: true },
+            { name: 'Coffre-fort documentaire', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'API REST & Webhooks', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'SSO SAML / OIDC', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Audit trail immuable', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Schéma PostgreSQL isolé', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'SLA dédié & support prioritaire', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
       ],
@@ -155,15 +156,15 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       all: 'Tous',
       categories: ['Facturation', 'Essai', 'Support', 'Sécurité', 'Technique'],
       items: [
-        { id: 'free-plan', question: 'Y a-t-il un plan gratuit ?', answer: 'Pas de plan gratuit permanent. Chaque plan démarre par un essai gratuit de 14 jours, sans carte bancaire. Ensuite, choisissez Starter (29€/mois), Business (79€/mois) ou Enterprise (199€/mois).', category: 'Essai' },
+        { id: 'free-plan', question: 'Le plan Free est-il vraiment gratuit ?', answer: 'Oui, 100% gratuit. Aucune carte bancaire requise, jamais. Accès immédiat jusqu\'à 5 employés. Vous pouvez passer à un plan payant à tout moment.', category: 'Essai' },
         { id: 'change-plan', question: 'Puis-je changer de plan ?', answer: 'Oui, à tout moment. Upgrade immédiat, downgrade au prochain cycle. Aucun frais caché.', category: 'Facturation' },
-        { id: 'per-employee', question: 'Comment sont comptés les employés ?', answer: 'Chaque plan inclut un plafond d\'employés dans son tarif fixe : 20 pour Starter, 200 pour Business, illimité pour Enterprise. Pas de supplément par employé actif : au-delà du plafond, passez au plan supérieur.', category: 'Facturation' },
-        { id: 'free-trial', question: 'L\'essai est-il vraiment gratuit ?', answer: 'Oui. 14 jours complets avec toutes les fonctionnalités du plan Starter. Aucune carte bancaire requise pour s\'inscrire.', category: 'Essai' },
-        { id: 'trial-to-paid', question: 'Que se passe-t-il à la fin de l\'essai ?', answer: 'Vous choisissez un plan ou vos données restent archivées 14 jours supplémentaires. Aucune facturation automatique sans votre accord.', category: 'Essai' },
-        { id: 'support', question: 'Quel support est disponible ?', answer: 'Starter : email sous 48h. Business : priorité 24h. Enterprise : account manager dédié + SLA contractuel.', category: 'Support' },
+        { id: 'per-employee', question: 'Comment fonctionne la facturation par employé ?', answer: 'Chaque plan inclut un socle fixe + un tarif par employé actif (qui a pointé au moins une fois dans le mois). Les employés inactifs ne sont pas comptés.', category: 'Facturation' },
+        { id: 'free-trial', question: 'L\'essai payant est-il vraiment gratuit ?', answer: 'Oui. 30 jours complets avec toutes les fonctionnalités du plan Pilot. Aucune carte bancaire requise pour s\'inscrire.', category: 'Essai' },
+        { id: 'trial-to-paid', question: 'Que se passe-t-il à la fin de l\'essai ?', answer: 'Vous choisissez un plan ou vos données restent archivées 30 jours supplémentaires. Aucune facturation automatique sans votre accord.', category: 'Essai' },
+        { id: 'support', question: 'Quel support est disponible ?', answer: 'Free : communauté. Pilot : email sous 48h. Operations : priorité 24h. Enterprise : account manager dédié + SLA contractuel.', category: 'Support' },
         { id: 'data-location', question: 'Où sont hébergées mes données ?', answer: 'En Europe (Render EU / Supabase EU). Chiffrement AES-256 au repos, TLS 1.3 en transit. Isolation par tenant garantie.', category: 'Sécurité' },
         { id: 'gdpr', question: 'Êtes-vous conformes RGPD ?', answer: 'Oui. DPA disponible, données exclusivement en Europe, droit à l\'effacement implémenté, exports de données sur demande.', category: 'Sécurité' },
-        { id: 'api', question: 'L\'API est-elle disponible sur tous les plans ?', answer: 'L\'API REST et les webhooks sont disponibles à partir du plan Business. Sur Starter, vous pouvez exporter vos données en CSV/Excel.', category: 'Technique' },
+        { id: 'api', question: 'L\'API est-elle disponible sur le plan Free ?', answer: 'L\'API REST et les webhooks sont disponibles à partir du plan Operations. Sur Free et Pilot, vous pouvez exporter vos données en CSV/Excel.', category: 'Technique' },
       ],
     },
     cta: {
@@ -188,10 +189,11 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       subtitle: 'Start small, scale up without switching platforms.',
       monthly: 'Monthly',
       annual: 'Annual',
-      savings: 'Save 17%',
+      savings: 'Save 20%',
+      customPrice: 'Custom',
       periodMonthly: '/month',
       periodAnnual: '/month billed annually',
-      trialNote: '14 days free · No credit card required',
+      trialNote: '30 days free · No credit card required',
     },
     currency: {
       label: 'Show prices in',
@@ -199,7 +201,7 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
     },
     trust: {
       items: [
-        '14-day free trial — no credit card',
+        'Free plan — no credit card',
         'Support included from day one',
         'Data hosted in Europe',
         'Cancel anytime',
@@ -214,45 +216,45 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
         {
           category: 'HR management',
           features: [
-            { name: 'Web & mobile attendance', free: 'Web only', starter: true, business: true, enterprise: true },
-            { name: 'Absences & leave', free: true, starter: true, business: true, enterprise: true },
-            { name: 'Shared calendar', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Guided onboarding', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Reviews & performance', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Dynamic org chart', free: false, starter: false, business: true, enterprise: true },
+            { name: 'Web & mobile attendance', free: 'Web only', pilot: true, operations: true, enterprise: true },
+            { name: 'Absences & leave', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'Shared calendar', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Guided onboarding', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Reviews & performance', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Dynamic org chart', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'Payroll & finance',
           features: [
-            { name: 'Automated payroll', free: false, starter: true, business: true, enterprise: true },
-            { name: 'PDF pay slips', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Accounting exports', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Salary advances', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Multi-country & currency', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Advanced legal compliance', free: false, starter: false, business: false, enterprise: true },
+            { name: 'Automated payroll', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'PDF pay slips', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Accounting exports', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Salary advances', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Multi-country & currency', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Advanced legal compliance', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
         {
           category: 'Field & mobile',
           features: [
-            { name: 'Employee mobile app', free: true, starter: true, business: true, enterprise: true },
-            { name: 'Manager mobile app', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Offline mode', free: false, starter: true, business: true, enterprise: true },
-            { name: 'ZKTeco biometrics', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Dedicated HR kiosk', free: false, starter: false, business: true, enterprise: true },
-            { name: 'GPS & geofencing', free: false, starter: false, business: true, enterprise: true },
+            { name: 'Employee mobile app', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'Manager mobile app', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Offline mode', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'ZKTeco biometrics', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Dedicated HR kiosk', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'GPS & geofencing', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'Security & integrations',
           features: [
-            { name: 'Document vault', free: false, starter: false, business: true, enterprise: true },
-            { name: 'REST API & Webhooks', free: false, starter: false, business: true, enterprise: true },
-            { name: 'SSO SAML / OIDC (bientot)', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Immutable audit trail', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Isolated PostgreSQL schema', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Dedicated SLA & support', free: false, starter: false, business: false, enterprise: true },
+            { name: 'Document vault', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'REST API & Webhooks', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'SSO SAML / OIDC', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Immutable audit trail', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Isolated PostgreSQL schema', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Dedicated SLA & support', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
       ],
@@ -264,15 +266,15 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       all: 'All',
       categories: ['Billing', 'Trial', 'Support', 'Security', 'Technical'],
       items: [
-        { id: 'free-plan', question: 'Is there a free plan?', answer: 'No permanent free plan. Every plan starts with a 14-day free trial, no credit card required. Then pick Starter (29€/month), Business (79€/month) or Enterprise (199€/month).', category: 'Trial' },
+        { id: 'free-plan', question: 'Is the Free plan really free?', answer: 'Yes, 100% free. No credit card ever required. Immediate access for up to 5 employees. Upgrade to a paid plan anytime.', category: 'Trial' },
         { id: 'change-plan', question: 'Can I change plan later?', answer: 'Yes, anytime. Upgrades are instant, downgrades apply at the next cycle. No hidden fees.', category: 'Billing' },
-        { id: 'per-employee', question: 'How are employees counted?', answer: 'Each plan includes an employee cap in its flat rate: 20 for Starter, 200 for Business, unlimited for Enterprise. No per-active-employee fee: above the cap, upgrade to the next plan.', category: 'Billing' },
-        { id: 'free-trial', question: 'Is the trial really free?', answer: 'Yes. 14 full days with all the features of the Starter plan. No credit card needed to sign up.', category: 'Trial' },
-        { id: 'trial-to-paid', question: 'What happens when the trial ends?', answer: 'You choose a plan or your data stays archived for 14 more days. No automatic billing without your consent.', category: 'Trial' },
-        { id: 'support', question: 'What support is available?', answer: 'Starter: email within 48h. Business: priority 24h. Enterprise: dedicated account manager + contractual SLA.', category: 'Support' },
+        { id: 'per-employee', question: 'How does per-employee billing work?', answer: 'Each plan includes a base fee plus a per-active-employee rate (employees who clocked in at least once that month). Inactive employees are not charged.', category: 'Billing' },
+        { id: 'free-trial', question: 'Is the paid trial really free?', answer: 'Yes. 30 full days with all features of the Pilot plan. No credit card needed to sign up.', category: 'Trial' },
+        { id: 'trial-to-paid', question: 'What happens when the trial ends?', answer: 'You choose a plan or your data stays archived for 30 more days. No automatic billing without your consent.', category: 'Trial' },
+        { id: 'support', question: 'What support is available?', answer: 'Free: community. Pilot: email within 48h. Operations: priority 24h. Enterprise: dedicated account manager + contractual SLA.', category: 'Support' },
         { id: 'data-location', question: 'Where is my data hosted?', answer: 'In Europe (Render EU / Supabase EU). AES-256 encryption at rest, TLS 1.3 in transit. Tenant isolation guaranteed.', category: 'Security' },
         { id: 'gdpr', question: 'Are you GDPR compliant?', answer: 'Yes. DPA available, data exclusively in Europe, right to erasure implemented, data exports on request.', category: 'Security' },
-        { id: 'api', question: 'Is the API available on every plan?', answer: 'REST API and webhooks are available from the Business plan. On Starter you can export your data as CSV/Excel.', category: 'Technical' },
+        { id: 'api', question: 'Is the API available on the Free plan?', answer: 'REST API and webhooks are available from the Operations plan. On Free / Pilot you can export data as CSV/Excel.', category: 'Technical' },
       ],
     },
     cta: {
@@ -297,10 +299,11 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       subtitle: 'Küçük başlayın, platform değiştirmeden büyüyün.',
       monthly: 'Aylık',
       annual: 'Yıllık',
-      savings: '%17 tasarruf',
+      savings: '%20 tasarruf',
+      customPrice: 'Teklif alın',
       periodMonthly: '/ay',
       periodAnnual: '/ay yıllık faturalama',
-      trialNote: '14 gün ücretsiz · Kredi kartı gerekmez',
+      trialNote: '30 gün ücretsiz · Kredi kartı gerekmez',
     },
     currency: {
       label: 'Fiyatları şu para birimiyle göster',
@@ -308,7 +311,7 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
     },
     trust: {
       items: [
-        '14 gün ücretsiz deneme — kredi kartı yok',
+        'Ücretsiz plan — kredi kartı yok',
         'İlk günden destek dahil',
         'Avrupa\'da barındırılan veriler',
         'İstediğiniz zaman iptal',
@@ -323,45 +326,45 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
         {
           category: 'İK Yönetimi',
           features: [
-            { name: 'Web & mobil devam takibi', free: 'Yalnızca web', starter: true, business: true, enterprise: true },
-            { name: 'Devamsızlık & izin', free: true, starter: true, business: true, enterprise: true },
-            { name: 'Paylaşılan takvim', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Rehberli işe alım', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Değerlendirme & performans', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Dinamik organizasyon şeması', free: false, starter: false, business: true, enterprise: true },
+            { name: 'Web & mobil devam takibi', free: 'Yalnızca web', pilot: true, operations: true, enterprise: true },
+            { name: 'Devamsızlık & izin', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'Paylaşılan takvim', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Rehberli işe alım', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Değerlendirme & performans', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Dinamik organizasyon şeması', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'Bordro & Finans',
           features: [
-            { name: 'Otomatik bordro hesabı', free: false, starter: true, business: true, enterprise: true },
-            { name: 'PDF bordro dökümü', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Muhasebe dışa aktarımı', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Maaş avansı', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Çok ülke & çok para birimi', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Gelişmiş yasal uyumluluk', free: false, starter: false, business: false, enterprise: true },
+            { name: 'Otomatik bordro hesabı', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'PDF bordro dökümü', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Muhasebe dışa aktarımı', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Maaş avansı', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Çok ülke & çok para birimi', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Gelişmiş yasal uyumluluk', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
         {
           category: 'Saha & Mobil',
           features: [
-            { name: 'Çalışan mobil uygulaması', free: true, starter: true, business: true, enterprise: true },
-            { name: 'Yönetici mobil uygulaması', free: false, starter: true, business: true, enterprise: true },
-            { name: 'Çevrimdışı mod', free: false, starter: true, business: true, enterprise: true },
-            { name: 'ZKTeco biyometri entegrasyonu', free: false, starter: false, business: true, enterprise: true },
-            { name: 'Özel HR kiosk', free: false, starter: false, business: true, enterprise: true },
-            { name: 'GPS & coğrafi sınır', free: false, starter: false, business: true, enterprise: true },
+            { name: 'Çalışan mobil uygulaması', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'Yönetici mobil uygulaması', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'Çevrimdışı mod', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'ZKTeco biyometri entegrasyonu', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'Özel HR kiosk', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'GPS & coğrafi sınır', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'Güvenlik & Entegrasyonlar',
           features: [
-            { name: 'Belge kasası', free: false, starter: false, business: true, enterprise: true },
-            { name: 'REST API & Webhook', free: false, starter: false, business: true, enterprise: true },
-            { name: 'SSO SAML / OIDC (bientot)', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Değiştirilemez denetim kaydı', free: false, starter: false, business: false, enterprise: true },
-            { name: 'İzole PostgreSQL şeması', free: false, starter: false, business: false, enterprise: true },
-            { name: 'Özel SLA & destek', free: false, starter: false, business: false, enterprise: true },
+            { name: 'Belge kasası', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'REST API & Webhook', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'SSO SAML / OIDC', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Değiştirilemez denetim kaydı', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'İzole PostgreSQL şeması', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'Özel SLA & destek', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
       ],
@@ -373,15 +376,15 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       all: 'Tümü',
       categories: ['Faturalama', 'Deneme', 'Destek', 'Güvenlik', 'Teknik'],
       items: [
-        { id: 'free-plan', question: 'Ücretsiz bir plan var mı?', answer: 'Kalıcı ücretsiz plan yoktur. Her plan 14 günlük ücretsiz denemeyle başlar, kredi kartı gerekmez. Ardından Starter (29€/ay), Business (79€/ay) veya Enterprise (199€/ay) seçin.', category: 'Deneme' },
+        { id: 'free-plan', question: 'Free plan gerçekten ücretsiz mi?', answer: 'Evet, %100 ücretsiz. Hiçbir zaman kredi kartı gerekmez. 5 çalışana kadar anında erişim. İstediğiniz zaman ücretli plana geçin.', category: 'Deneme' },
         { id: 'change-plan', question: 'Planı değiştirebilir miyim?', answer: 'Evet, istediğiniz zaman. Yükseltme anında, düşürme bir sonraki dönemde uygulanır. Gizli ücret yoktur.', category: 'Faturalama' },
-        { id: 'per-employee', question: 'Çalışanlar nasıl sayılır?', answer: 'Her plan sabit fiyatına bir çalışan sınırı içerir: Starter 20, Business 200, Enterprise sınırsız. Aktif çalışan başına ek ücret yoktur: sınırın üzerinde bir üst plana geçin.', category: 'Faturalama' },
-        { id: 'free-trial', question: 'Deneme gerçekten ücretsiz mi?', answer: 'Evet. Starter planının tüm özellikleriyle 14 tam gün. Kaydolmak için kredi kartı gerekmez.', category: 'Deneme' },
-        { id: 'trial-to-paid', question: 'Deneme bitince ne olur?', answer: 'Bir plan seçersiniz ya da verileriniz 14 gün daha arşivlenir. Onayınız olmadan otomatik faturalama yapılmaz.', category: 'Deneme' },
-        { id: 'support', question: 'Hangi destek sağlanır?', answer: 'Starter: 48 saatte e-posta. Business: 24 saatte öncelikli yanıt. Enterprise: özel hesap yöneticisi + sözleşmesel SLA.', category: 'Destek' },
+        { id: 'per-employee', question: 'Çalışan başı faturalama nasıl çalışır?', answer: 'Her plan sabit bir temel ücret artı aktif çalışan başına ücret içerir. O ay en az bir kez giriş yapan çalışanlar aktif sayılır.', category: 'Faturalama' },
+        { id: 'free-trial', question: 'Ücretli deneme gerçekten ücretsiz mi?', answer: 'Evet. Pilot planın tüm özellikleriyle 30 tam gün. Kaydolmak için kredi kartı gerekmez.', category: 'Deneme' },
+        { id: 'trial-to-paid', question: 'Deneme bitince ne olur?', answer: 'Bir plan seçersiniz ya da verileriniz 30 gün daha arşivlenir. Onayınız olmadan otomatik faturalama yapılmaz.', category: 'Deneme' },
+        { id: 'support', question: 'Hangi destek sağlanır?', answer: 'Free: topluluk. Pilot: 48 saatte e-posta. Operations: 24 saatte öncelikli yanıt. Enterprise: özel hesap yöneticisi + sözleşmesel SLA.', category: 'Destek' },
         { id: 'data-location', question: 'Verilerim nerede barındırılır?', answer: 'Avrupa\'da (Render EU / Supabase EU). Durağan veriler AES-256, iletimde TLS 1.3. Tenant izolasyonu garantili.', category: 'Güvenlik' },
         { id: 'gdpr', question: 'KVKK uyumlu musunuz?', answer: 'Evet. DPA mevcut, veriler yalnızca Avrupa\'da, silme hakkı uygulanmış, talep üzerine veri dışa aktarımı.', category: 'Güvenlik' },
-        { id: 'api', question: 'API tüm planlarda kullanılabilir mi?', answer: 'REST API ve webhook\'lar Business planından itibaren kullanılabilir. Starter\'da verileri CSV/Excel olarak dışa aktarabilirsiniz.', category: 'Teknik' },
+        { id: 'api', question: 'Free planda API kullanılabilir mi?', answer: 'REST API ve webhook\'lar Operations planından itibaren kullanılabilir. Free ve Pilot\'ta verileri CSV/Excel olarak dışa aktarabilirsiniz.', category: 'Teknik' },
       ],
     },
     cta: {
@@ -406,10 +409,11 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       subtitle: 'ابدأ صغيرًا، توسع دون تغيير المنصة.',
       monthly: 'شهري',
       annual: 'سنوي',
-      savings: 'وفّر 17%',
+      savings: 'وفّر 20%',
+      customPrice: 'حسب الطلب',
       periodMonthly: '/شهر',
       periodAnnual: '/شهر مع فوترة سنوية',
-      trialNote: '14 يوما مجانا · لا بطاقة ائتمان مطلوبة',
+      trialNote: '30 يومًا مجانًا · لا بطاقة ائتمان مطلوبة',
     },
     currency: {
       label: 'عرض الأسعار بعملة',
@@ -417,7 +421,7 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
     },
     trust: {
       items: [
-        'تجربة مجانية 14 يوما بلا بطاقة ائتمان',
+        'خطة مجانية بلا بطاقة ائتمان',
         'دعم مشمول من اليوم الأول',
         'بيانات مستضافة في أوروبا',
         'إلغاء في أي وقت',
@@ -432,45 +436,45 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
         {
           category: 'إدارة الموارد البشرية',
           features: [
-            { name: 'تتبع الحضور ويب وموبايل', free: 'ويب فقط', starter: true, business: true, enterprise: true },
-            { name: 'الغياب والإجازات', free: true, starter: true, business: true, enterprise: true },
-            { name: 'تقويم مشترك', free: false, starter: true, business: true, enterprise: true },
-            { name: 'إعداد موجّه', free: false, starter: true, business: true, enterprise: true },
-            { name: 'التقييمات والأداء', free: false, starter: false, business: true, enterprise: true },
-            { name: 'هيكل تنظيمي ديناميكي', free: false, starter: false, business: true, enterprise: true },
+            { name: 'تتبع الحضور ويب وموبايل', free: 'ويب فقط', pilot: true, operations: true, enterprise: true },
+            { name: 'الغياب والإجازات', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'تقويم مشترك', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'إعداد موجّه', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'التقييمات والأداء', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'هيكل تنظيمي ديناميكي', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'الرواتب والمالية',
           features: [
-            { name: 'حساب رواتب آلي', free: false, starter: true, business: true, enterprise: true },
-            { name: 'قسائم رواتب PDF', free: false, starter: true, business: true, enterprise: true },
-            { name: 'تصدير محاسبي', free: false, starter: false, business: true, enterprise: true },
-            { name: 'سلف الرواتب', free: false, starter: false, business: true, enterprise: true },
-            { name: 'متعدد الدول والعملات', free: false, starter: false, business: false, enterprise: true },
-            { name: 'امتثال قانوني متقدم', free: false, starter: false, business: false, enterprise: true },
+            { name: 'حساب رواتب آلي', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'قسائم رواتب PDF', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'تصدير محاسبي', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'سلف الرواتب', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'متعدد الدول والعملات', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'امتثال قانوني متقدم', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
         {
           category: 'الميدان والموبايل',
           features: [
-            { name: 'تطبيق موبايل للموظفين', free: true, starter: true, business: true, enterprise: true },
-            { name: 'تطبيق موبايل للمديرين', free: false, starter: true, business: true, enterprise: true },
-            { name: 'وضع عدم الاتصال', free: false, starter: true, business: true, enterprise: true },
-            { name: 'تكامل بصمة ZKTeco', free: false, starter: false, business: true, enterprise: true },
-            { name: 'كشك HR مخصص', free: false, starter: false, business: true, enterprise: true },
-            { name: 'GPS وتحديد المناطق', free: false, starter: false, business: true, enterprise: true },
+            { name: 'تطبيق موبايل للموظفين', free: true, pilot: true, operations: true, enterprise: true },
+            { name: 'تطبيق موبايل للمديرين', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'وضع عدم الاتصال', free: false, pilot: true, operations: true, enterprise: true },
+            { name: 'تكامل بصمة ZKTeco', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'كشك HR مخصص', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'GPS وتحديد المناطق', free: false, pilot: false, operations: true, enterprise: true },
           ],
         },
         {
           category: 'الأمان والتكاملات',
           features: [
-            { name: 'خزنة المستندات', free: false, starter: false, business: true, enterprise: true },
-            { name: 'REST API وWebhooks', free: false, starter: false, business: true, enterprise: true },
-            { name: 'SSO SAML / OIDC (bientot)', free: false, starter: false, business: false, enterprise: true },
-            { name: 'سجل تدقيق غير قابل للتغيير', free: false, starter: false, business: false, enterprise: true },
-            { name: 'مخطط PostgreSQL معزول', free: false, starter: false, business: false, enterprise: true },
-            { name: 'SLA مخصص ودعم أولوي', free: false, starter: false, business: false, enterprise: true },
+            { name: 'خزنة المستندات', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'REST API وWebhooks', free: false, pilot: false, operations: true, enterprise: true },
+            { name: 'SSO SAML / OIDC', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'سجل تدقيق غير قابل للتغيير', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'مخطط PostgreSQL معزول', free: false, pilot: false, operations: false, enterprise: true },
+            { name: 'SLA مخصص ودعم أولوي', free: false, pilot: false, operations: false, enterprise: true },
           ],
         },
       ],
@@ -482,15 +486,15 @@ const pricingPageCopy: Record<AppLocale, PricingPageCopy> = {
       all: 'الكل',
       categories: ['الفوترة', 'التجربة', 'الدعم', 'الأمان', 'التقني'],
       items: [
-        { id: 'free-plan', question: 'هل توجد خطة مجانية؟', answer: 'لا توجد خطة مجانية دائمة. كل خطة تبدأ بتجربة مجانية لمدة 14 يوما بدون بطاقة ائتمان. ثم اختر Starter (29€/شهر) أو Business (79€/شهر) أو Enterprise (199€/شهر).', category: 'التجربة' },
+        { id: 'free-plan', question: 'هل الخطة المجانية مجانية حقًا؟', answer: 'نعم، مجانية 100%. لا بطاقة ائتمان مطلوبة أبدًا. وصول فوري لحتى 5 موظفين. يمكنك الترقية إلى خطة مدفوعة في أي وقت.', category: 'التجربة' },
         { id: 'change-plan', question: 'هل يمكنني تغيير الخطة لاحقًا؟', answer: 'نعم، في أي وقت. الترقية فورية والتخفيض يُطبق في الدورة التالية. لا رسوم مخفية.', category: 'الفوترة' },
-        { id: 'per-employee', question: 'كيف يُحسب عدد الموظفين؟', answer: 'تتضمن كل خطة سقفا للموظفين ضمن سعرها الثابت: 20 لـ Starter و200 لـ Business وغير محدود لـ Enterprise. لا رسوم إضافية لكل موظف نشط: فوق السقف، انتقل إلى الخطة الأعلى.', category: 'الفوترة' },
-        { id: 'free-trial', question: 'هل التجربة مجانية حقًا؟', answer: 'نعم. 14 يوما كاملة بجميع مزايا خطة Starter. لا بطاقة ائتمان للتسجيل.', category: 'التجربة' },
-        { id: 'trial-to-paid', question: 'ماذا يحدث عند انتهاء التجربة؟', answer: 'تختار خطة أو تبقى بياناتك مؤرشفة 14 يوما إضافية. لا فوترة تلقائية بدون موافقتك.', category: 'التجربة' },
-        { id: 'support', question: 'ما نوع الدعم المتاح؟', answer: 'Starter: بريد إلكتروني خلال 48 ساعة. Business: أولوية 24 ساعة. Enterprise: مدير حساب مخصص + SLA تعاقدي.', category: 'الدعم' },
+        { id: 'per-employee', question: 'كيف تعمل الفوترة لكل موظف؟', answer: 'تتضمن كل خطة رسومًا أساسية ثابتة بالإضافة إلى سعر لكل موظف نشط (من سجّل حضورًا مرة واحدة على الأقل في الشهر).', category: 'الفوترة' },
+        { id: 'free-trial', question: 'هل التجربة المدفوعة مجانية حقًا؟', answer: 'نعم. 30 يومًا كاملة بجميع مزايا خطة Pilot. لا بطاقة ائتمان للتسجيل.', category: 'التجربة' },
+        { id: 'trial-to-paid', question: 'ماذا يحدث عند انتهاء التجربة؟', answer: 'تختار خطة أو تبقى بياناتك مؤرشفة 30 يومًا إضافية. لا فوترة تلقائية بدون موافقتك.', category: 'التجربة' },
+        { id: 'support', question: 'ما نوع الدعم المتاح؟', answer: 'Free: مجتمع. Pilot: بريد إلكتروني خلال 48 ساعة. Operations: أولوية 24 ساعة. Enterprise: مدير حساب مخصص + SLA تعاقدي.', category: 'الدعم' },
         { id: 'data-location', question: 'أين تُستضاف بياناتي؟', answer: 'في أوروبا (Render EU / Supabase EU). تشفير AES-256 أثناء التخزين وTLS 1.3 أثناء النقل. عزل المستأجرين مضمون.', category: 'الأمان' },
         { id: 'gdpr', question: 'هل أنتم متوافقون مع GDPR؟', answer: 'نعم. DPA متاح، البيانات في أوروبا حصرًا، حق الحذف مُطبَّق، تصدير البيانات عند الطلب.', category: 'الأمان' },
-        { id: 'api', question: 'هل API متاح في جميع الخطط؟', answer: 'REST API والـ Webhooks متاحة من خطة Business. في Starter يمكنك تصدير البيانات بصيغة CSV/Excel.', category: 'التقني' },
+        { id: 'api', question: 'هل API متاح في خطة Free؟', answer: 'REST API والـ Webhooks متاحة من خطة Operations. في Free وPilot يمكنك تصدير البيانات بصيغة CSV/Excel.', category: 'التقني' },
       ],
     },
     cta: {
@@ -605,8 +609,8 @@ function FaqAccordionItem({ item, isOpen, onToggle }: {
 function getFeatureValue(feature: ComparisonFeature, planName: string): boolean | string {
   const lower = planName.toLowerCase();
   if (lower === 'free') return feature.free;
-  if (lower === 'pilot' || lower === 'starter') return feature.starter;
-  if (lower === 'operations' || lower === 'business') return feature.business;
+  if (lower === 'pilot') return feature.pilot;
+  if (lower === 'operations') return feature.operations;
   if (lower === 'enterprise' || lower === 'scale') return feature.enterprise;
   return false;
 }
@@ -637,12 +641,15 @@ export default function PricingPage() {
   const convertedPrice = (eurAmount: string) => convertEurPrice(eurAmount, currencyOption);
 
   function getPlanHref(plan: ReturnType<typeof getPricingPlans>[number]) {
-    // Starter → essai guidé 14 jours (aucun paiement à l'inscription) : le
+    // Free plan → direct account creation, no payment
+    if (plan.price === '0') return '/checkout?plan=free';
+    // Enterprise → contact
+    if (!showsCurrency(plan.price)) return '/contact?type=enterprise';
+    // Paid plans → checkout with payment
+    if (plan.popular) return '/checkout?plan=operations';
+    // Pilot → essai guidé 30 jours (aucun paiement à l'inscription) : le
     // checkout ne doit pas être présenté comme « gratuit » (#2649).
-    if (plan.name.toLowerCase() === 'starter') return '/signup?source=pricing_starter';
-    // Business et Enterprise → checkout avec paiement (3 plans backend, #3247).
-    if (plan.name.toLowerCase() === 'enterprise') return '/checkout?plan=enterprise';
-    return '/checkout?plan=business';
+    return '/signup?source=pricing_pilot';
   }
 
   const filteredFaq = faqCategory
@@ -700,7 +707,7 @@ export default function PricingPage() {
             className="flex flex-col sm:flex-row items-center justify-center gap-4"
           >
             <Link
-              href="/checkout?plan=starter"
+              href="/checkout?plan=free"
               className="group relative px-8 py-4 bg-gradient-to-r from-emerald-500 to-emerald-600 text-white font-bold rounded-2xl overflow-hidden transition-all duration-300 hover:shadow-[0_20px_60px_-15px_rgba(16,185,129,0.4)] hover:scale-[1.03] active:scale-[0.98]"
             >
               <span className="relative z-10 flex items-center gap-2.5">
@@ -710,7 +717,7 @@ export default function PricingPage() {
               <div className="absolute inset-0 bg-gradient-to-r from-emerald-600 to-cyan-600 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
             </Link>
             <Link
-              href="/contact?topic=enterprise"
+              href="/contact?type=enterprise"
               className="group flex items-center gap-2.5 px-8 py-4 bg-white/10 text-white font-semibold rounded-2xl border border-white/20 hover:bg-white/20 transition-all duration-300 backdrop-blur-sm"
             >
               <MessageCircle className="w-5 h-5" />
@@ -817,12 +824,13 @@ export default function PricingPage() {
             </AnimatePresence>
           </div>
 
-          {/* Cards — 3 plans backend (Starter/Business/Enterprise) */}
+          {/* Cards — 4 plans in a responsive grid */}
           <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 max-w-7xl mx-auto">
             {plans.map((plan, index) => {
               const Icon = planIcons[index % planIcons.length];
               const iconColor = planIconColors[index % planIconColors.length];
               const displayPrice = isAnnual ? plan.annualPrice : plan.price;
+              const isFree = plan.price === '0';
               const hasNumericPrice = !['Sur devis', 'Custom', 'Teklif', 'حسب العرض', 'Teklif alın', 'حسب الطلب'].includes(displayPrice);
               const ctaHref = getPlanHref(plan);
 
@@ -837,7 +845,9 @@ export default function PricingPage() {
                   className={`relative rounded-3xl ${
                     plan.popular
                       ? 'bg-gradient-to-b from-emerald-400 via-emerald-500 to-cyan-600 p-px shadow-2xl shadow-emerald-500/25'
-                      : 'bg-slate-200/70 dark:bg-slate-800/70 p-px'
+                      : isFree
+                        ? 'bg-gradient-to-b from-slate-300 to-slate-400 dark:from-slate-600 dark:to-slate-700 p-px'
+                        : 'bg-slate-200/70 dark:bg-slate-800/70 p-px'
                   }`}
                 >
                   <div className="relative h-full rounded-[23px] bg-white dark:bg-slate-950 flex flex-col p-8">
@@ -847,6 +857,14 @@ export default function PricingPage() {
                         <div className="flex items-center gap-1.5 px-4 py-1.5 bg-gradient-to-r from-emerald-500 to-emerald-600 text-white text-[11px] font-black uppercase tracking-widest rounded-full shadow-lg shadow-emerald-500/30">
                           <Star className="w-3 h-3 fill-white" />
                           Le plus populaire
+                        </div>
+                      </div>
+                    )}
+                    {isFree && (
+                      <div className="absolute -top-4 left-1/2 -translate-x-1/2 z-10">
+                        <div className="flex items-center gap-1.5 px-4 py-1.5 bg-gradient-to-r from-slate-600 to-slate-700 text-white text-[11px] font-black uppercase tracking-widest rounded-full shadow-lg">
+                          <Gift className="w-3 h-3" />
+                          100% Gratuit
                         </div>
                       </div>
                     )}
@@ -863,7 +881,11 @@ export default function PricingPage() {
                     {/* Price */}
                     <div className="mb-6">
                       <div className="flex items-baseline gap-1.5">
-                        {hasNumericPrice ? (
+                        {isFree ? (
+                          <span className="text-5xl font-black bg-gradient-to-b from-slate-900 to-slate-600 dark:from-white dark:to-slate-400 bg-clip-text text-transparent">
+                            Gratuit
+                          </span>
+                        ) : hasNumericPrice ? (
                           <>
                             <span className="text-lg font-bold text-slate-500 dark:text-slate-400">
                               {isEurSelected ? 'EUR' : currencyOption.currency}
@@ -878,7 +900,11 @@ export default function PricingPage() {
                           </span>
                         )}
                       </div>
-                      {hasNumericPrice ? (
+                      {isFree ? (
+                        <p className="mt-1 text-sm text-emerald-600 dark:text-emerald-400 font-semibold">
+                          Sans carte bancaire · Pour toujours
+                        </p>
+                      ) : hasNumericPrice ? (
                         <div className="mt-1 space-y-0.5">
                           <p className="text-sm text-slate-500">
                             {isAnnual ? copy.plans.periodAnnual : copy.plans.periodMonthly}
@@ -912,7 +938,7 @@ export default function PricingPage() {
                     <ul className="flex-1 space-y-3 mb-8">
                       {plan.features.map((feature, fi) => (
                         <li key={fi} className="flex items-start gap-3">
-                          <Check className={`w-4 h-4 flex-shrink-0 mt-0.5 ${plan.popular ? 'text-emerald-500' : 'text-slate-400 dark:text-slate-500'}`} />
+                          <Check className={`w-4 h-4 flex-shrink-0 mt-0.5 ${plan.popular ? 'text-emerald-500' : isFree ? 'text-slate-500' : 'text-slate-400 dark:text-slate-500'}`} />
                           <span className="text-sm text-slate-700 dark:text-slate-300 leading-snug">{feature}</span>
                         </li>
                       ))}
@@ -924,9 +950,11 @@ export default function PricingPage() {
                       className={`flex items-center justify-center gap-2 w-full py-4 rounded-2xl font-bold text-sm transition-all duration-300 ${
                         plan.popular
                           ? 'bg-gradient-to-r from-emerald-500 to-emerald-600 text-white hover:from-emerald-600 hover:to-cyan-600 shadow-lg shadow-emerald-500/25 hover:shadow-emerald-500/40 hover:scale-[1.02] active:scale-[0.98]'
-                          : hasNumericPrice
-                            ? 'bg-slate-900 dark:bg-white text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100 hover:scale-[1.01] active:scale-[0.98]'
-                            : 'bg-gradient-to-r from-violet-500 to-fuchsia-600 text-white hover:from-violet-600 hover:to-fuchsia-700 shadow-lg hover:scale-[1.02] active:scale-[0.98]'
+                          : isFree
+                            ? 'bg-gradient-to-r from-slate-700 to-slate-900 text-white hover:from-slate-800 hover:to-black hover:scale-[1.01] active:scale-[0.98] shadow-md'
+                            : hasNumericPrice
+                              ? 'bg-slate-900 dark:bg-white text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100 hover:scale-[1.01] active:scale-[0.98]'
+                              : 'bg-gradient-to-r from-violet-500 to-fuchsia-600 text-white hover:from-violet-600 hover:to-fuchsia-700 shadow-lg hover:scale-[1.02] active:scale-[0.98]'
                       }`}
                     >
                       {plan.cta}
@@ -979,6 +1007,7 @@ export default function PricingPage() {
                   </th>
                   {plans.map((plan, i) => {
                     const Icon = planIcons[i % planIcons.length];
+                    const isFree = plan.price === '0';
                     return (
                       <th
                         key={plan.name}
@@ -994,6 +1023,11 @@ export default function PricingPage() {
                           {plan.popular && (
                             <span className="text-[9px] px-2 py-0.5 bg-emerald-500 text-white rounded-full font-black uppercase tracking-wider">
                               ★ top
+                            </span>
+                          )}
+                          {isFree && (
+                            <span className="text-[9px] px-2 py-0.5 bg-slate-600 text-white rounded-full font-black uppercase tracking-wider">
+                              gratuit
                             </span>
                           )}
                         </div>
@@ -1045,6 +1079,7 @@ export default function PricingPage() {
                 <tr className="border-t border-slate-200 dark:border-slate-800 bg-transparent dark:bg-slate-900">
                   <td className="py-6 px-6" />
                   {plans.map((plan) => {
+                    const isFree = plan.price === '0';
                     const hasNumericPrice = !['Sur devis', 'Custom', 'Teklif', 'حسب العرض', 'Teklif alın', 'حسب الطلب'].includes(plan.price);
                     return (
                       <td key={plan.name} className={`py-6 px-4 text-center ${plan.popular ? 'bg-emerald-50/40 dark:bg-emerald-950/10' : ''}`}>
@@ -1053,9 +1088,11 @@ export default function PricingPage() {
                           className={`inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl text-sm font-bold transition-all duration-200 hover:scale-[1.03] active:scale-[0.97] ${
                             plan.popular
                               ? 'bg-gradient-to-r from-emerald-500 to-emerald-600 text-white shadow-lg shadow-emerald-500/20'
-                              : hasNumericPrice
-                                ? 'bg-slate-900 dark:bg-white text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100'
-                                : 'bg-gradient-to-r from-violet-500 to-fuchsia-600 text-white hover:from-violet-600 hover:to-fuchsia-700'
+                              : isFree
+                                ? 'bg-slate-700 text-white hover:bg-slate-800'
+                                : hasNumericPrice
+                                  ? 'bg-slate-900 dark:bg-white text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100'
+                                  : 'bg-gradient-to-r from-violet-500 to-fuchsia-600 text-white hover:from-violet-600 hover:to-fuchsia-700'
                           }`}
                         >
                           {plan.cta}
@@ -1199,7 +1236,7 @@ export default function PricingPage() {
             className="flex flex-col sm:flex-row items-center justify-center gap-4"
           >
             <Link
-              href="/checkout?plan=starter"
+              href="/checkout?plan=free"
               className="group relative px-10 py-4 bg-white text-emerald-600 font-black rounded-2xl overflow-hidden transition-all duration-300 hover:shadow-2xl hover:scale-[1.03] active:scale-[0.98] text-base"
             >
               <span className="relative z-10 flex items-center gap-2.5">
@@ -1208,7 +1245,7 @@ export default function PricingPage() {
               </span>
             </Link>
             <Link
-              href="/contact?topic=enterprise"
+              href="/contact?type=enterprise"
               className="group flex items-center gap-2.5 px-10 py-4 bg-white/10 text-white font-bold rounded-2xl border border-white/20 hover:bg-white/20 transition-all duration-300 backdrop-blur-sm text-base"
             >
               <Building2 className="w-5 h-5" />

--- a/front/web/src/app/api/billing/checkout/route.ts
+++ b/front/web/src/app/api/billing/checkout/route.ts
@@ -3,7 +3,7 @@ import { resolveBackendBaseUrl } from '@/lib/backend-url';
 import { z } from 'zod';
 
 const checkoutSchema = z.object({
-  plan: z.enum(['starter', 'business', 'enterprise', 'pilot', 'operations', 'scale']),
+  plan: z.enum(['free', 'pilot', 'operations', 'enterprise']),
   billing: z.enum(['monthly', 'annual']).default('monthly'),
   email: z.string().email().max(255),
   company: z.string().min(2).max(120),
@@ -29,20 +29,16 @@ const SANDBOX_CHECKOUT = process.env.SANDBOX_CHECKOUT === 'true';
 
 /** Sandbox plan prices (EUR cents) — used when Stripe is not configured or in test mode */
 const SANDBOX_PRICES: Record<string, Record<string, number>> = {
+  free: { monthly: 0, annual: 0 },
   pilot: { monthly: 2900, annual: 2400 },
-  starter: { monthly: 2900, annual: 2400 },
   operations: { monthly: 9900, annual: 7900 },
-  business: { monthly: 9900, annual: 7900 },
-  scale: { monthly: 29900, annual: 23900 },
   enterprise: { monthly: 0, annual: 0 },
 };
 
 const PLAN_LABELS: Record<string, string> = {
+  free: 'Free',
   pilot: 'Pilot',
-  starter: 'Pilot',
   operations: 'Operations',
-  business: 'Operations',
-  scale: 'Scale',
   enterprise: 'Enterprise',
 };
 


### PR DESCRIPTION
## Summary

- introduce the canonical `free/pilot/operations/enterprise` PlanCode enum
- seed and resolve the feature matrix with canonical codes while normalizing legacy aliases
- align billing, Stripe, invoice pricing, rate limits, checkout and pricing comparison
- include the Spec Kit mini-spec and CHANGELOG entry

## Validation

- PHP syntax checks pass for all changed PHP files
- `cd front/web && npm run lint` passes
- `cd front/web && npm run build` passes
- backend PHPUnit could not run locally because the lockfile requires PHP >= 8.4.1 while this sandbox has PHP 8.3.6

Closes #2977