### PR TITLE
fix(seeder): align canonical pricing plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,8 @@ Nouvelle suite `tests/Feature/CrossTenantIndexIsolationTest` (7 tests) verrouill
 
 - **fix(billing): codes de plans canoniques Free/Pilot/Operations/Enterprise (Closes #2977).** La matrice backend, le checkout, Stripe, les factures et le rate limiting utilisent désormais une source `PlanCode`; les alias historiques sont normalisés uniquement aux frontières.
 
+- **fix(seeder): grille de plans backend alignée sur Free/Pilot/Operations/Enterprise (Closes #3163).** PlanSeeder migre Starter/Business, conserve les références d’entreprises et applique les montants, limites et essais canoniques.
+
 - **docs(AGENTS.md): gate /api/v1/demo-users documenté conformément au code (Closes #2650).** La règle v4.16.128 affirmait à tort que l'endpoint ne devait pas être rebloqué via `DEMO_MODE_ENABLED=false` ; le hard gate `abort(404)` est délibéré (AUDIT_API_2026-07-19 §1, DEMO_ACCOUNTS.md). Renvoi vers les sources.
 - **fix(web): SignupForm — record localisé construit depuis le catalogue i18n partagé (complète #2648).** Les 70 clés du formulaire d'essai guidé vivent désormais dans `shared/i18n/locales/*.json` (source de vérité) et sont consommées via `t(locale, 'signup.*')` (garde PA2-I18N-014 vert).
 - **fix(web): SignupForm (essai guidé) localisé FR/EN/TR/AR (Closes #2648).** Le formulaire de `/signup` était 100 % codé en français (labels, placeholders, erreurs, écrans OTP/pending/tracking/success) alors que la page est 4-locales — les visiteurs EN/TR/AR voyaient un formulaire français. Le composant utilise désormais `useVitrineLocale()` + un record `signupFormCopy[locale]` ; le schéma zod `signupFormSchema(locale)` produit des messages de validation dans la langue active (tests mis à jour, accents FR restaurés).

--- a/api/database/seeders/PlanSeeder.php
+++ b/api/database/seeders/PlanSeeder.php
@@ -6,34 +6,75 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 /**
- * PlanSeeder — Crée les 3 plans tarifaires
+ * PlanSeeder — source de vérité des plans tarifaires publics.
  *
- * Source de vérité : docs/dossierdeConception/03_modele_economique/03_MODELE_ECONOMIQUE.md
- *
- * DÉCISIONS :
- * - excel_export = true pour Starter (corrigé v3.1 — était false)
- * - evaluations + schema_isolation inclus dans tous les plans
- * - Trial est géré via companies.status='trial', pas un plan séparé
+ * Les codes métier sont consommés par le checkout et la matrice de
+ * fonctionnalités ; les noms affichés restent Free/Pilot/Operations/Enterprise.
  */
 class PlanSeeder extends Seeder
 {
+    /** @var array<string, string> */
+    private const LEGACY_NAMES = [
+        'Starter' => 'Pilot',
+        'Business' => 'Operations',
+    ];
+
     public function run(): void
     {
         DB::statement('SET search_path TO public');
+        DB::transaction(function (): void {
+            $this->migrateLegacyPlanNames();
 
-        $plans = [
+            foreach ($this->plans() as $plan) {
+                DB::table('plans')->updateOrInsert(
+                    ['name' => $plan['name']],
+                    $plan,
+                );
+            }
+        });
+
+        $this->command->info('Plans créés : Free (0€/5emp), Pilot (29€/30emp), Operations (99€/250emp), Enterprise (sur devis).');
+    }
+
+    /**
+     * Preserve existing plan IDs when the old seed has already run. If both
+     * names exist, move company references before removing the duplicate.
+     */
+    private function migrateLegacyPlanNames(): void
+    {
+        foreach (self::LEGACY_NAMES as $legacyName => $canonicalName) {
+            $legacyId = DB::table('plans')->where('name', $legacyName)->value('id');
+            if ($legacyId === null) {
+                continue;
+            }
+
+            $canonicalId = DB::table('plans')->where('name', $canonicalName)->value('id');
+            if ($canonicalId === null) {
+                DB::table('plans')->where('id', $legacyId)->update(['name' => $canonicalName]);
+                continue;
+            }
+
+            DB::table('companies')->where('plan_id', $legacyId)->update(['plan_id' => $canonicalId]);
+            DB::table('plans')->where('id', $legacyId)->delete();
+        }
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function plans(): array
+    {
+        return [
             [
-                'name' => 'Starter',
-                'price_monthly' => 29.00,
-                'price_yearly' => 290.00,     // -17% vs mensuel
-                'max_employees' => 20,
-                'trial_days' => (int) config('billing.trial_days'),
+                'name' => 'Free',
+                'price_monthly' => 0.00,
+                'price_yearly' => 0.00,
+                'max_employees' => 5,
+                'trial_days' => 30,
                 'is_active' => true,
                 'features' => json_encode([
                     'biometric' => false,
                     'tasks' => false,
                     'advanced_reports' => false,
-                    'excel_export' => true,   // ✅ CORRECTION v3.1 — était false
+                    'excel_export' => false,
                     'bank_export' => false,
                     'billing_auto' => false,
                     'multi_managers' => false,
@@ -41,14 +82,35 @@ class PlanSeeder extends Seeder
                     'api_public' => false,
                     'evaluations' => false,
                     'schema_isolation' => false,
-                ]),
+                ], JSON_THROW_ON_ERROR),
             ],
             [
-                'name' => 'Business',
-                'price_monthly' => 79.00,
-                'price_yearly' => 790.00,
-                'max_employees' => 200,
-                'trial_days' => (int) config('billing.trial_days'),
+                'name' => 'Pilot',
+                'price_monthly' => 29.00,
+                'price_yearly' => 290.00,
+                'max_employees' => 30,
+                'trial_days' => 30,
+                'is_active' => true,
+                'features' => json_encode([
+                    'biometric' => false,
+                    'tasks' => false,
+                    'advanced_reports' => false,
+                    'excel_export' => true,
+                    'bank_export' => false,
+                    'billing_auto' => false,
+                    'multi_managers' => false,
+                    'photo_attendance' => false,
+                    'api_public' => false,
+                    'evaluations' => false,
+                    'schema_isolation' => false,
+                ], JSON_THROW_ON_ERROR),
+            ],
+            [
+                'name' => 'Operations',
+                'price_monthly' => 99.00,
+                'price_yearly' => 948.00,
+                'max_employees' => 250,
+                'trial_days' => 30,
                 'is_active' => true,
                 'features' => json_encode([
                     'biometric' => true,
@@ -61,15 +123,15 @@ class PlanSeeder extends Seeder
                     'photo_attendance' => true,
                     'api_public' => false,
                     'evaluations' => true,
-                    'schema_isolation' => false,  // Schéma partagé (shared_tenants)
-                ]),
+                    'schema_isolation' => false,
+                ], JSON_THROW_ON_ERROR),
             ],
             [
                 'name' => 'Enterprise',
-                'price_monthly' => 199.00,
-                'price_yearly' => 1990.00,
-                'max_employees' => null,         // NULL = illimité
-                'trial_days' => (int) config('billing.trial_days'),           // Trial plus long pour Enterprise
+                'price_monthly' => 0.00,
+                'price_yearly' => 0.00,
+                'max_employees' => null,
+                'trial_days' => 30,
                 'is_active' => true,
                 'features' => json_encode([
                     'biometric' => true,
@@ -82,18 +144,9 @@ class PlanSeeder extends Seeder
                     'photo_attendance' => true,
                     'api_public' => true,
                     'evaluations' => true,
-                    'schema_isolation' => true,   // Schéma PostgreSQL dédié
-                ]),
+                    'schema_isolation' => true,
+                ], JSON_THROW_ON_ERROR),
             ],
         ];
-
-        foreach ($plans as $plan) {
-            DB::table('plans')->updateOrInsert(
-                ['name' => $plan['name']],
-                $plan
-            );
-        }
-
-        $this->command->info('✅ Plans créés : Starter (29€/20emp), Business (79€/200emp), Enterprise (199€/illimité)');
     }
 }

--- a/docs/specifications/ISSUE_3163_PLAN_SEEDER_ALIGNMENT.md
+++ b/docs/specifications/ISSUE_3163_PLAN_SEEDER_ALIGNMENT.md
@@ -1,0 +1,37 @@
+# Mini-spécification — Issue #3163
+
+## Objectif
+
+Aligner le seeder des plans publics backend sur la grille canonique de la vitrine : **Free**, **Pilot**, **Operations**, **Enterprise**.
+
+## Contrat canonique
+
+| Plan | Mensuel | Annuel | Employés inclus | Essai |
+|---|---:|---:|---:|---:|
+| Free | 0 € | 0 € | 5 | 30 jours |
+| Pilot | 29 € | 290 € | 30 | 30 jours |
+| Operations | 99 € | 948 € | 250 | 30 jours |
+| Enterprise | Sur devis | Sur devis | Illimité | 30 jours |
+
+## Migration
+
+Le seeder reste idempotent. Lorsqu’il rencontre un plan historique Starter ou Business, il le renomme en Pilot ou Operations si le plan canonique n’existe pas encore. Si les deux lignes existent, les entreprises référencées sont déplacées vers le plan canonique puis le doublon historique est supprimé. Les IDs canoniques existants sont ainsi conservés.
+
+## Critères d’acceptation
+
+1. Une exécution sur base vide crée exactement les quatre noms canoniques.
+2. Starter et Business ne sont plus générés.
+3. Les montants et limites correspondent à la vitrine actuelle.
+4. Une seconde exécution ne crée aucun doublon.
+5. Les références `companies.plan_id` historiques restent valides après migration.
+6. Le seeder passe la syntaxe PHP et respecte `git diff --check`.
+
+## Plan de retour arrière
+
+Réversion du commit et restauration des anciennes lignes uniquement si la migration n’a pas encore été appliquée en production. Les références d’entreprises sont migrées transactionnellement.
+
+## Trace Spec Kit
+
+Issue : #3163  
+Branche : `fix/3163-plan-seeder-alignment`  
+Date : 2026-08-15


### PR DESCRIPTION
## Summary

- seed Free, Pilot, Operations and Enterprise with canonical prices and employee limits
- migrate Starter/Business rows while preserving company plan references
- make the seeder idempotent and document the Spec Kit contract

## Validation

- `php -l api/database/seeders/PlanSeeder.php` passes
- canonical names and limits verified by a targeted grep
- `git diff --check` passes

Closes #3163