### PR TITLE
fix(ci): deploy-admin-dashboard — YAML parse error (VITE_WEBSOCKET_URL collé à run: |)

### DIFF
--- a/.github/workflows/deploy-admin-dashboard.yml
+++ b/.github/workflows/deploy-admin-dashboard.yml
@@ -68,7 +68,8 @@ jobs:
           # régression de fallback et garde le contrat avec la doc.
           VITE_API_URL: https://gestionemployerbackend.onrender.com/api/v1
           # Serveur push Socket.IO (optionnel) — sinon le client dérive wss://<hôte API> (#3392).
-          VITE_WEBSOCKET_URL: ${{ secrets.VITE_WEBSOCKET_URL }}        run: |
+          VITE_WEBSOCKET_URL: ${{ secrets.VITE_WEBSOCKET_URL }}
+        run: |
           npm ci
           npm run build
 


### PR DESCRIPTION
Régression introduite par le merge de la vague QA expert 5 (PR #3552) : l'ajout de `VITE_WEBSOCKET_URL` dans le job Build a collé la ligne à `run: |` (newline manquante) → **YAML parse error → tous les runs `deploy-admin-dashboard.yml` échouent sur main** (0 job, conclusion failure immédiate).

Correctif : newline rétablie, YAML revalidé (`yaml.safe_load` OK).