### PR TITLE
fix(test): PasswordResetTest + MobilePayloadContractTest réalignés sur les contrats courants

### DIFF
--- a/api/tests/Feature/Auth/PasswordResetTest.php
+++ b/api/tests/Feature/Auth/PasswordResetTest.php
@@ -4,7 +4,7 @@ namespace Tests\Feature\Auth;
 
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
-use App\Mail\PasswordResetMail;
+use App\Core\Auth\Infrastructure\Mail\PasswordResetMail;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -64,13 +64,12 @@ class PasswordResetTest extends TestCase
         ]);
 
         $response->assertStatus(200)
-            ->assertJson(['success' => true, 'message' => 'PASSWORD_RESET_SENT']);
+            ->assertJson(['message' => 'Si un compte existe pour cet email, un lien de réinitialisation a été envoyé.']);
 
         Mail::assertSent(PasswordResetMail::class);
 
         $this->assertDatabaseHas('password_reset_tokens', [
             'email' => 'reset.me@example.com',
-            'company_id' => $this->company->id,
         ]);
     }
 
@@ -83,7 +82,7 @@ class PasswordResetTest extends TestCase
         ]);
 
         $response->assertStatus(200)
-            ->assertJson(['success' => true, 'message' => 'PASSWORD_RESET_SENT']);
+            ->assertJson(['message' => 'Si un compte existe pour cet email, un lien de réinitialisation a été envoyé.']);
 
         Mail::assertNothingSent();
     }
@@ -94,12 +93,9 @@ class PasswordResetTest extends TestCase
 
         DB::table('password_reset_tokens')->insert([
             'email' => 'reset.me@example.com',
-            'company_id' => $this->company->id,
-            'employee_id' => $this->employee->id,
             'token_hash' => hash('sha256', $token),
             'expires_at' => now()->addMinutes(60),
             'created_at' => now(),
-            'updated_at' => now(),
         ]);
 
         $this->employee->createToken('legacy-device');
@@ -112,7 +108,7 @@ class PasswordResetTest extends TestCase
         ]);
 
         $response->assertStatus(200)
-            ->assertJson(['success' => true, 'message' => 'PASSWORD_RESET_DONE']);
+            ->assertJson(['message' => 'Mot de passe réinitialisé. Connectez-vous avec votre nouveau mot de passe.']);
 
         $this->employee->refresh();
         $this->assertTrue(Hash::check('new-password-123', (string) $this->employee->password_hash));
@@ -130,13 +126,10 @@ class PasswordResetTest extends TestCase
 
         DB::table('password_reset_tokens')->insert([
             'email' => 'reset.me@example.com',
-            'company_id' => $this->company->id,
-            'employee_id' => $this->employee->id,
             'token_hash' => hash('sha256', $token),
             'expires_at' => now()->addMinutes(60),
             'used_at' => now(),
             'created_at' => now(),
-            'updated_at' => now(),
         ]);
 
         $this->postJson('/api/v1/auth/reset-password', [

--- a/api/tests/Feature/Contracts/MobilePayloadContractTest.php
+++ b/api/tests/Feature/Contracts/MobilePayloadContractTest.php
@@ -107,7 +107,9 @@ class MobilePayloadContractTest extends TestCase
         $response->assertJsonPath('data.role', 'employee');
         $response->assertJsonPath('data.company.name', 'Company A');
         $response->assertJsonPath('data.features.rh', true);
-        $response->assertJsonPath('data.mobile_experience.stage', 'regular');
+        // Employée fraîchement créée sans pointage/absence → stage 'new'
+        // (MobileExperienceService::stageFor — signaux réels d'activité).
+        $response->assertJsonPath('data.mobile_experience.stage', 'new');
         $modules = $response->json('data.mobile_experience.modules');
         $quickActions = $response->json('data.mobile_experience.quick_actions');
 


### PR DESCRIPTION
## Drift test ↔ contrat courant (détecté via suite locale)

Le rework password-reset (swarm) a changé : (1) réponse générique anti-énumération (`message` seul, plus de PASSWORD_RESET_SENT/DONE), (2) table `password_reset_tokens` sans colonnes company_id/employee_id/updated_at (migration 2026_08_15_000004), (3) mailable déplacé en `App\Core\Auth\Infrastructure\Mail\PasswordResetMail`. Le test n'avait pas suivi → 4 échecs. Réaligné, vérifié localement 4/4.