### PR TITLE
fix(api): eager-load session.course on training enrollments (Closes #3598)

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/TrainingController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/TrainingController.php
@@ -145,7 +145,7 @@ class TrainingController extends Controller
         $actor = $request->user();
 
         $query = TrainingEnrollment::query()
-            ->with(['employee:id,first_name,last_name', 'session:id,training_course_id,start_date,status'])
+            ->with(['employee:id,first_name,last_name', 'session:id,training_course_id,start_date,status', 'session.course:id,title'])
             ->where('company_id', $actor->company_id);
 
         if ($request->filled('status')) {

--- a/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformAdminTrainingController.php
+++ b/api/app/Modules/Platform/Interfaces/Api/V1/Controllers/PlatformAdminTrainingController.php
@@ -62,7 +62,7 @@ class PlatformAdminTrainingController extends Controller
     public function indexEnrollments(Request $request): JsonResponse
     {
         $query = TrainingEnrollment::query()
-            ->with(['employee:id,first_name,last_name', 'session:id,training_course_id,start_date,status'])
+            ->with(['employee:id,first_name,last_name', 'session:id,training_course_id,start_date,status', 'session.course:id,title'])
             ->leftJoin('companies', 'companies.id', '=', 'training_enrollments.company_id')
             ->select('training_enrollments.*', 'companies.name as company_name');
 


### PR DESCRIPTION
## Fix #3598

N+1 query on GET /v1/training/enrollments and /v1/admin/training/enrollments.

**Root cause**: Controllers eager-load `session:id,training_course_id,start_date,status` but `TrainingEnrollmentResource` reads `$this->session?->course?->title`, triggering 1 query per row (up to +100 queries/page).

**Fix**: Add `session.course:id,title` to the `->with()` in both controllers.

Closes #3598