### PR TITLE
fix(mobile): use extractDataMap() in settings repositories (Closes #3595)

### DIFF
--- a/front/mobile_apps/leopardo_employee/lib/features/settings/data/settings_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/settings/data/settings_repository.dart
@@ -110,8 +110,7 @@ class SettingsRepository {
     );
 
     return NotificationPreferences.fromJson(
-      ((response.data ?? const <String, dynamic>{})['data'] as Map)
-          .cast<String, dynamic>(),
+      extractDataMap(response.data),
     );
   }
 
@@ -126,8 +125,7 @@ class SettingsRepository {
     );
 
     return NotificationPreferences.fromJson(
-      ((response.data ?? const <String, dynamic>{})['data'] as Map)
-          .cast<String, dynamic>(),
+      extractDataMap(response.data),
     );
   }
 

--- a/front/mobile_apps/leopardo_hr/lib/features/settings/data/settings_repository.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/settings/data/settings_repository.dart
@@ -63,8 +63,7 @@ class SettingsRepository {
     );
 
     return NotificationPreferences.fromJson(
-      ((response.data ?? const <String, dynamic>{})['data'] as Map)
-          .cast<String, dynamic>(),
+      extractDataMap(response.data),
     );
   }
 
@@ -79,8 +78,7 @@ class SettingsRepository {
     );
 
     return NotificationPreferences.fromJson(
-      ((response.data ?? const <String, dynamic>{})['data'] as Map)
-          .cast<String, dynamic>(),
+      extractDataMap(response.data),
     );
   }
 

--- a/front/mobile_apps/leopardo_manager/lib/features/settings/data/settings_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/settings/data/settings_repository.dart
@@ -110,8 +110,7 @@ class SettingsRepository {
     );
 
     return NotificationPreferences.fromJson(
-      ((response.data ?? const <String, dynamic>{})['data'] as Map)
-          .cast<String, dynamic>(),
+      extractDataMap(response.data),
     );
   }
 
@@ -126,8 +125,7 @@ class SettingsRepository {
     );
 
     return NotificationPreferences.fromJson(
-      ((response.data ?? const <String, dynamic>{})['data'] as Map)
-          .cast<String, dynamic>(),
+      extractDataMap(response.data),
     );
   }
 


### PR DESCRIPTION
## Fix #3595

Settings repositories in 3 Flutter apps (employee, manager, hr) used raw `['data'] as Map` casts instead of `extractDataMap()`, crashing when the API returns a non-wrapped payload.

**Fix**: Replace all 6 sites with `extractDataMap(response.data)`.

Closes #3595