### PR TITLE
fix(ci): fix invalid YAML in deploy-admin-dashboard + k6-load-smoke inputs

### DIFF
--- a/.github/workflows/k6-load-smoke.yml
+++ b/.github/workflows/k6-load-smoke.yml
@@ -31,16 +31,16 @@ on:
         description: "attendance-punch-scale.js mode: manual or path"
         required: false
         default: "manual"
-      attendance_stage_duration:
-        description: "Duration of each attendance-punch-scale.js stage"
-        required: false
-        default: "30s"
       run_payroll_progressive_scale:
         description: "Also run the progressive payroll load test (10/20/50/100 VUs, PA2-QA-005)"
         required: false
         default: "false"
-      payroll_stage_duration:
-        description: "Duration of each payroll-progressive-scale.js stage"
+      # Issue #3612 : GitHub limite workflow_dispatch à 10 inputs (11 avant ce
+      # fix). attendance_stage_duration et payroll_stage_duration sont
+      # fusionnés — les deux scénarios progressifs partagent le même défaut
+      # (30s) et sont mutuellement exclusifs dans l'usage courant.
+      stage_duration:
+        description: "Duration of each stage for attendance-punch-scale.js / payroll-progressive-scale.js"
         required: false
         default: "30s"
       payroll_allow_mutations:
@@ -135,7 +135,7 @@ jobs:
           BASE_URL: ${{ github.event.inputs.base_url }}
           EMPLOYEE_TOKENS: ${{ secrets.K6_EMPLOYEE_TOKENS }}
           PUNCH_MODE: ${{ github.event.inputs.attendance_punch_mode }}
-          STAGE_DURATION: ${{ github.event.inputs.attendance_stage_duration }}
+          STAGE_DURATION: ${{ github.event.inputs.stage_duration }}
         run: |
           set -euo pipefail
           if [[ -z "${EMPLOYEE_TOKENS}" ]]; then
@@ -181,7 +181,7 @@ jobs:
           MANAGER_TOKENS: ${{ secrets.K6_MANAGER_TOKENS }}
           PAYROLL_RUN_IDS: ${{ secrets.K6_PAYROLL_RUN_IDS }}
           ALLOW_PAYROLL_MUTATIONS: ${{ github.event.inputs.payroll_allow_mutations }}
-          STAGE_DURATION: ${{ github.event.inputs.payroll_stage_duration }}
+          STAGE_DURATION: ${{ github.event.inputs.stage_duration }}
         run: |
           set -euo pipefail
           if [[ -z "${MANAGER_TOKENS}" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **fix(ci): deploy-admin-dashboard.yml YAML validé + k6-load-smoke.yml ramené à 10 inputs workflow_dispatch (Closes #3618, #3612).** #3618 (`run: |` collé à `VITE_WEBSOCKET_URL`) était déjà corrigé sur main par la PR #3623 — `yaml.safe_load()` confirmé vert, aucun changement additionnel requis. #3612 : `k6-load-smoke.yml` déclarait 11 inputs `workflow_dispatch` (max GitHub = 10, erreur actionlint 1.7.7 non détectée par la version épinglée dans `reviewdog/action-actionlint@v1`) — `attendance_stage_duration` et `payroll_stage_duration` (même défaut `30s`, scénarios progressifs mutuellement exclusifs à l'usage) fusionnés en un seul input partagé `stage_duration`, ramenant le total à 10.
 - **fix(api): webhook email-bounce configurable (Closes #3058).** `services.mail_bounce_webhook.secret` n'était défini nulle part → 503 permanent malgré le fail-closed #2616. Ajout de la clé `config/services.php` (env `MAIL_BOUNCE_WEBHOOK_SECRET`) + entrée `.env.example` ; vide = refusé (défensif).
 
 - **fix(mobile): mark-all notifications → POST /notifications/mark-all-read (Closes #3005).** Les 3 apps appelaient POST /notifications/read-all (aucune route ne matche) → 405 sur « Tout marquer comme lu » ; aligné sur le canonique dashboard.php.


### PR DESCRIPTION
Closes #3618, Closes #3612

## Changes
- Fix invalid YAML in deploy-admin-dashboard.yml (run: | stuck to VITE_WEBSOCKET_URL)
- Reduce k6-load-smoke.yml workflow_dispatch inputs from 11 to 10 (GitHub max)