### PR TITLE
fix(test): factories newModel() protected→public — fatal PHP résiduel (complète #3695)

### DIFF
--- a/api/database/factories/EmployeeFactory.php
+++ b/api/database/factories/EmployeeFactory.php
@@ -31,7 +31,7 @@ class EmployeeFactory extends Factory
      * (forceFill) pour préserver les états de test (manager, archived, ...)
      * sans affaiblir la protection applicative.
      */
-    protected function newModel(array $attributes)
+    public function newModel(array $attributes = [])
     {
         $model = new $this->model();
         $model->forceFill($attributes);

--- a/api/database/factories/SalaryAdvanceFactory.php
+++ b/api/database/factories/SalaryAdvanceFactory.php
@@ -16,7 +16,7 @@ class SalaryAdvanceFactory extends Factory
      * (forceFill) pour préserver les états de test (manager, archived, ...)
      * sans affaiblir la protection applicative.
      */
-    protected function newModel(array $attributes)
+    public function newModel(array $attributes = [])
     {
         $model = new $this->model();
         $model->forceFill($attributes);

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -20,7 +20,7 @@ class UserFactory extends Factory
      * (forceFill) pour préserver les états de test (manager, archived, ...)
      * sans affaiblir la protection applicative.
      */
-    protected function newModel(array $attributes)
+    public function newModel(array $attributes = [])
     {
         $model = new $this->model();
         $model->forceFill($attributes);


### PR DESCRIPTION
Suite à #3695 : le commit mergé n'embarquait que le retrait du test doublon — les 3 overrides de factory (Employee/User/SalaryAdvance) étaient restés non stagés dans mon worktree (erreur de staging de mon côté, détectée en re-vérifiant `git show`). La suite Feature restait fatale : `Access level to ...newModel() must be public`.

Cette PR contient **uniquement** les 3 changements de visibilité vérifiés par `git show` cette fois. Vérif locale : PasswordResetTest 6/6 verts.