### PR TITLE
docs(spec-kit): session audit qa-expert11 2026-08-15 (issues #3706 #3707 #3708)

### DIFF
--- a/.specify/features/qa-expert11-2026-08-15/plan.md
+++ b/.specify/features/qa-expert11-2026-08-15/plan.md
@@ -1,0 +1,36 @@
+# Plan: Domaines canoniques, régression .env.example, gardes de hygiène
+
+**Input**: spec.md (qa-expert11-2026-08-15)
+
+## Phase A — Réparer la régression b0630dd5 (US2) — PR courte, prioritaire
+
+1. Restaurer `APP_VERSION=4.24.0` dans `api/.env.example` (fix #3528 re-cassé).
+2. Restaurer la ligne `MAIL_BOUNCE_WEBHOOK_SECRET=` (avec commentaire #3058).
+3. Restaurer le commentaire `EDGE_LICENSE_PUBLIC_KEY` (génération openssl, #3317).
+4. Vérifier localement : `bash dev-hub/tools/check-app-version-sync.sh` → OK.
+5. PR `fix/3528-3058-3317-env-example-regression` (Closes les issues dédiées), CHANGELOG.
+
+## Phase B — Registre des domaines canoniques (US1)
+
+1. Créer `docs/ops/DOMAINS.md` — source de vérité : tableau domaine → usage → statut DNS
+   (vérifié via `getent hosts` / curl /health), + procédure de mise à jour.
+2. Aligner `api/.env.example` (APP_URL/FRONTEND_URL/CLOUD_API_URL) sur le registre.
+3. Aligner les defaults web : `front/web/src/lib/backend-url.ts`, `front/web/next.config.ts`,
+   `front/web/.env.local.example`, `front/web/README.md`, `front/web/vercel.json` (CSP connect-src).
+4. Aligner les workflows : `deploy-main.yml`, `mobile-distribute-main.yml`
+   (DEFAULT_API_BASE_URL / DEFAULT_API_HEALTHCHECK_URL) sur le registre.
+5. Aligner les docs/outils : READMEs mobile, `front/mobile_apps/leopardo_platform_admin/README.md`,
+   `front/zkteco-kiosk/config.example.json`, `postman/leopardo_hr.postman_collection.json`,
+   `scripts/agent-smoke-api.sh`, `docs/edge-sync/ARCHITECTURE.md`.
+6. Ajouter le garde `dev-hub/tools/check-canonical-domains.sh` + allowlist.
+
+## Phase C — Câbler les gardes en CI (US3)
+
+1. Nouveau job `hygiene-guards` dans `architecture-check.yml` : exécute
+   `check-app-version-sync.sh`, `check-env-example-parity.sh`, `check-canonical-domains.sh`.
+2. Tests locaux avant push (bash), puis PR + CHANGELOG.
+
+## Phase D — Clôture
+
+- Issues fermées avec preuve code (commentaire + état closed).
+- Entrée CHANGELOG + session docs (`docs/qa-expert11-session-2026-08-15.md`).

--- a/.specify/features/qa-expert11-2026-08-15/spec.md
+++ b/.specify/features/qa-expert11-2026-08-15/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Domaines canoniques, régression .env.example, gardes de hygiène (qa-expert11)
+
+**Created**: 2026-08-15
+
+**Status**: Draft
+
+**Wave**: qa-expert11-2026-08-15 (audit 360° — surfaces live, configs, CI, onboarding)
+
+**Input**: Audit 2026-08-15 — vérification DNS live de tous les domaines documentés, revue des defaults de build/déploiement, revue des gardes dev-hub vs CI, vérification des régressions sur main.
+
+## Résumé des constats (vérifiés en live)
+
+### US1 — Domaine API canonique introuvable : seuls les defaults « legacy » sont vivants (P1)
+Vérification DNS/HTTP en live (2026-08-15) :
+
+| Domaine documenté | DNS | HTTP |
+|---|---|---|
+| `gestionemployerbackend.onrender.com` (defaults code/builds) | ✅ 216.24.57.7 | ✅ 200 — API v4.23.5, `queue: sync` |
+| `api.leopardo-rh.com` (api/.env.example `APP_URL`) | ❌ NXDOMAIN | ❌ 000 |
+| `app.leopardo-rh.com` (api/.env.example `FRONTEND_URL`) | ❌ NXDOMAIN | ❌ 000 |
+| `leopardo-rh.com` / `www.leopardo-rh.com` (vitrine) | ❌ NXDOMAIN | ❌ 000 (cf. #3452) |
+| `api.leopardo.app` (api/.env.example `CLOUD_API_URL`, docs edge) | ❌ NXDOMAIN | ❌ 000 |
+
+Conséquence : le seul backend joignable porte un nom de domaine legacy ; toute doc,
+template d'env, collection Postman ou README qui référence `*.leopardo-rh.com` /
+`*.leopardo.app` pointe vers du néant. Chaque nouvel installateur qui suit les docs
+obtient un backend mort, et la confusion sur « quel est le vrai domaine prod » persiste.
+Le nom canonique devra être tranché par le propriétaire (issue #3452 = infra DNS) ;
+ce spec couvre la **canonicalisation côté code/docs** : une seule source de vérité,
+tous les fichiers alignés, garde CI anti-réapparition.
+
+Fichiers impactés (constatés) :
+- `api/.env.example` (APP_URL, FRONTEND_URL, CLOUD_API_URL)
+- `.github/workflows/deploy-main.yml` + `.github/workflows/mobile-distribute-main.yml` (`DEFAULT_API_BASE_URL` / `DEFAULT_API_HEALTHCHECK_URL`)
+- `front/web/src/lib/backend-url.ts` (DEFAULT_BACKEND_API_URL)
+- `front/web/next.config.ts` (fallback NEXT_PUBLIC_API_URL)
+- `front/web/.env.local.example`, `front/web/README.md`
+- `front/web/vercel.json` (CSP connect-src)
+- `front/mobile_apps/*/README.md` (colonne Staging), `front/mobile_apps/leopardo_platform_admin/README.md` (commandes run/build)
+- `front/zkteco-kiosk/config.example.json` (apiBaseUrl)
+- `postman/leopardo_hr.postman_collection.json`
+- `scripts/agent-smoke-api.sh` (STAGING_API par défaut)
+- `docs/edge-sync/ARCHITECTURE.md`
+
+### US2 — Régression sur main : commit b0630dd5 (fix/3058-mail-bounce-secret) (P1)
+Le commit `b0630dd5` (mergé sur main) a régressé trois choses dans `api/.env.example` :
+1. `APP_VERSION` repassé de `4.24.0` → `4.23.5` — annule le fix #3528 ; la garde
+   `dev-hub/tools/check-app-version-sync.sh` (issue #3528) échoue sur main.
+2. Suppression de la ligne `MAIL_BOUNCE_WEBHOOK_SECRET=` alors que
+   `api/config/services.php` lit toujours `env('MAIL_BOUNCE_WEBHOOK_SECRET')` et que
+   `EmailBounceWebhookController` est fail-closed (503) sans le secret (#3058) —
+   rupture de parité .env.example, nouveau déploiement = webhook bounce mort en silence.
+3. Suppression du commentaire `EDGE_LICENSE_PUBLIC_KEY` (fail-closed #3317) — la
+   doc de génération de clé disparaît du template.
+
+Vérifié : `bash dev-hub/tools/check-env-example-parity.sh` échoue aussi sur main
+(6 clés config/ absentes de .env.example — RATE_LIMIT_PLAN_*, STRIPE_PRICE_*, TRIAL_DAYS,
+couvertes par PR #3690 ; le retour de MAIL_BOUNCE_WEBHOOK_SECRET doit s'y ajouter).
+
+### US3 — Gardes dev-hub non câblées en CI (P2)
+`check-app-version-sync.sh` et `check-env-example-parity.sh` ne sont appelés par
+aucun workflow : la dérive US2 est passée inaperçue. Câbler un job de garde
+« hygiene » dans `architecture-check.yml` (ou workflow dédié) pour que toute
+régression de ce type fasse échouer la PR.
+
+**Acceptance Scenarios**:
+1. **Given** main, **When** `bash dev-hub/tools/check-app-version-sync.sh` et
+   `bash dev-hub/tools/check-env-example-parity.sh` sont exécutés, **Then** les deux passent (0 erreur).
+2. **Given** un fichier de config/docs qui référence un domaine hors registre,
+   **When** la garde CI « domaines canoniques » tourne, **Then** la PR échoue avec le chemin fautif listé.
+3. **Given** la CI PR, **When** un commit modifie `api/.env.example`,
+   **Then** les gardes de parité/version s'exécutent (pas de drift silencieux).

--- a/.specify/features/qa-expert11-2026-08-15/tasks.md
+++ b/.specify/features/qa-expert11-2026-08-15/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Domaines canoniques, régression .env.example, gardes de hygiène (qa-expert11)
+
+**Input**: spec.md + plan.md — 3 US vérifiées en live (2026-08-15).
+
+## US1 — Domaine API canonique (P1)
+- [ ] T001 Créer `docs/ops/DOMAINS.md` — registre canonique (domaine → usage → statut DNS vérifié) + procédure de mise à jour
+- [ ] T002 Aligner `api/.env.example` (APP_URL, FRONTEND_URL, CLOUD_API_URL) sur le registre
+- [ ] T003 Aligner les defaults web : `front/web/src/lib/backend-url.ts`, `next.config.ts`, `.env.local.example`, `README.md`, `vercel.json` (CSP connect-src)
+- [ ] T004 Aligner les workflows : `deploy-main.yml` + `mobile-distribute-main.yml` (DEFAULT_API_BASE_URL / DEFAULT_API_HEALTHCHECK_URL)
+- [ ] T005 Aligner docs/outils : READMEs mobile, `leopardo_platform_admin/README.md`, `zkteco-kiosk/config.example.json`, collection Postman, `scripts/agent-smoke-api.sh`, `docs/edge-sync/ARCHITECTURE.md`
+- [ ] T006 Ajouter la garde `dev-hub/tools/check-canonical-domains.sh` + allowlist
+
+## US2 — Régression b0630dd5 sur main (P1)
+- [ ] T007 Restaurer `APP_VERSION=4.24.0`, `MAIL_BOUNCE_WEBHOOK_SECRET=` (commentaire #3058) et le commentaire `EDGE_LICENSE_PUBLIC_KEY` (#3317) dans `api/.env.example` ; `check-app-version-sync.sh` → OK
+
+## US3 — Gardes de hygiène en CI (P2)
+- [ ] T008 Job `hygiene-guards` dans `architecture-check.yml` : `check-app-version-sync.sh`, `check-env-example-parity.sh`, `check-canonical-domains.sh`
+
+## Clôture
+- [ ] T009 CHANGELOG + `docs/qa-expert11-session-2026-08-15.md` + PR(s) `Closes #...` ; issues fermées avec preuve code


### PR DESCRIPTION
Session audit 360° qa-expert11 (2026-08-15) — artefacts spec-kit.

- **#3706** [P1][ops] Domaine API canonique introuvable — NXDOMAIN partout sauf defaults legacy
- **#3707** [P1][ops] Régression b0630dd5 sur main — APP_VERSION, MAIL_BOUNCE_WEBHOOK_SECRET, EDGE_LICENSE_PUBLIC_KEY
- **#3708** [P2][CI] Gardes dev-hub mortes (app-version-sync / env-example-parity jamais câblées)

Livrable : `.specify/features/qa-expert11-2026-08-15/` (spec.md + plan.md + tasks.md).
Les implémentations suivront dans des PR dédiées (Phase 3).