### PR TITLE
fix(ci): wire hygiene guards into architecture checks

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -226,6 +226,24 @@ jobs:
 
           dev-hub/tools/check-phpstan-baseline-delta.sh "${base_sha}" "${head_sha}" api
 
+  hygiene-guards:
+    name: Hygiene guards — versions, env et domaines
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
+
+      - name: Check APP_VERSION synchronisation
+        run: bash dev-hub/tools/check-app-version-sync.sh api
+
+      - name: Check .env.example parity
+        run: bash dev-hub/tools/check-env-example-parity.sh api
+
+      - name: Check canonical first-party domains
+        run: bash dev-hub/tools/check-canonical-domains.sh
+
   frontend-lint:
     name: Frontend — ESLint + TypeScript
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **fix(ci): gardes d’hygiène câblées dans architecture-check (Closes #3708).** Ajout du job bloquant `hygiene-guards` sur pull requests, `main` et merge queue : synchronisation `APP_VERSION`, parité `config/` ↔ `.env.example` et contrôle des domaines first-party enregistrés. Toute dérive échoue désormais explicitement en CI.
+
 - **fix(mobile): Smart Attendance utilise des query parameters et un décodage paginé sûr (Closes #3291).** Les apps manager et HR ne castent plus directement `data` en liste.
 
 - **docs(AGENTS.md): gate /api/v1/demo-users documenté conformément au code (Closes #2650).** La règle v4.16.128 affirmait à tort que l'endpoint ne devait pas être rebloqué via `DEMO_MODE_ENABLED=false` ; le hard gate `abort(404)` est délibéré (AUDIT_API_2026-07-19 §1, DEMO_ACCOUNTS.md). Renvoi vers les sources.

--- a/dev-hub/tools/check-canonical-domains.sh
+++ b/dev-hub/tools/check-canonical-domains.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# check-canonical-domains.sh — détecte les domaines first-party inconnus.
+# Les domaines autorisés sont centralisés ici jusqu'à la canonicalisation infra.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+allowed_hosts=(
+  "gestionemployerbackend.onrender.com"
+  "gestionemployer-backend.vercel.app"
+  "api.leopardo-rh.com"
+  "api-staging.leopardo-rh.com"
+  "app.leopardo-rh.com"
+  "admin.leopardo-rh.com"
+  "client-a.leopardo-rh.com"
+  "demo.leopardo-rh.com"
+  "docs.leopardo-rh.com"
+  "proxy.leopardo-rh.com"
+  "www.leopardo-rh.com"
+  "leopardo-rh.com"
+  "demo.leopardo.app"
+  "api.leopardo.app"
+  "leopardo-api.onrender.com"
+  "leopardo-hr.vercel.app"
+)
+
+allowlist="$(printf '%s\n' "${allowed_hosts[@]}" | sort -u)"
+# Inspect tracked text files only; external SaaS domains are intentionally ignored.
+files=$(git ls-files | grep -E '\.(md|mdx|json|ya?ml|ya?ml\.example|env|ts|tsx|js|jsx|dart|py|php|sh)$' || true)
+unknown=""
+while IFS= read -r host; do
+  [[ -z "${host}" ]] && continue
+  [[ "${host}" == "your-app.onrender.com" ]] && continue
+  if ! grep -qxF "${host}" <<< "${allowlist}"; then
+    unknown+="${host}\n"
+  fi
+done < <(grep -rhoE '([A-Za-z0-9-]+\.)+(leopardo-rh\.com|leopardo\.app|onrender\.com|vercel\.app)' ${files} 2>/dev/null | sort -u || true)
+
+if [[ -n "${unknown}" ]]; then
+  echo "::error::Domaine first-party hors registre canonique :"
+  printf '::error::  - %s' "${unknown}"
+  exit 1
+fi
+
+echo "✓ Domaines first-party présents dans le registre canonique."

--- a/docs/specifications/ISSUE_3708.md
+++ b/docs/specifications/ISSUE_3708.md
@@ -1,0 +1,28 @@
+# Mini-spec — Issue #3708
+
+## Intention
+Rendre les gardes d’hygiène du dépôt réellement bloquantes dans GitHub Actions afin d’empêcher les dérives silencieuses de version, de variables d’environnement et de domaines first-party.
+
+## Périmètre
+La solution ajoute `dev-hub/tools/check-canonical-domains.sh`, conserve les gardes existantes `check-app-version-sync.sh` et `check-env-example-parity.sh`, puis les exécute dans le job indépendant `hygiene-guards` du workflow `.github/workflows/architecture-check.yml`. Le workflow est déjà déclenché sur les pull requests, les pushes sur `main` et les merge groups.
+
+La garde de domaines inspecte uniquement les fichiers texte suivis par Git et les hôtes first-party du registre explicite. Elle échoue avec une erreur GitHub Actions lorsqu’un nouvel hôte appartenant aux suffixes Leopardo, Render ou Vercel apparaît sans être enregistré. Les domaines SaaS tiers ne sont pas concernés.
+
+## Critères d’acceptation
+
+| Critère | Vérification |
+|---|---|
+| APP_VERSION synchronisée | `bash dev-hub/tools/check-app-version-sync.sh api` retourne 0 |
+| Parité `.env.example` | `bash dev-hub/tools/check-env-example-parity.sh api` retourne 0 |
+| Domaines contrôlés | `bash dev-hub/tools/check-canonical-domains.sh` retourne 0 sur l’arbre actuel |
+| CI bloquante | Le job `hygiene-guards` n’utilise pas `continue-on-error` |
+| Déclencheurs | Le job hérite des déclencheurs PR, push `main` et `merge_group` du workflow |
+| Robustesse shell | Les scripts passent `bash -n` et utilisent `set -euo pipefail` |
+
+## Validation
+
+Les trois gardes et la validation syntaxique Bash ont été exécutées localement avec succès. La parité actuelle rapporte 273 clés documentées et aucune clé manquante.
+
+## Hors périmètre
+
+La décision et la mise en production du domaine API canonique restent couvertes par l’issue d’infrastructure dédiée. Cette issue installe uniquement la barrière CI contre la réapparition de domaines first-party non enregistrés.


### PR DESCRIPTION
## Summary

- closes #3708
- wires APP_VERSION and `.env.example` parity guards into a blocking `hygiene-guards` job
- adds the canonical first-party domain guard
- adds `docs/specifications/ISSUE_3708.md` and updates `CHANGELOG.md`

## Spec Kit

The implementation follows the mini-spec in `docs/specifications/ISSUE_3708.md` and the merged audit artefacts in `.specify/features/qa-expert11-2026-08-15/`.

## Validation

- `bash -n dev-hub/tools/check-app-version-sync.sh dev-hub/tools/check-env-example-parity.sh dev-hub/tools/check-canonical-domains.sh`
- `bash dev-hub/tools/check-app-version-sync.sh api`
- `bash dev-hub/tools/check-env-example-parity.sh api`
- `bash dev-hub/tools/check-canonical-domains.sh`
- `git diff --check`
