### PR TITLE
fix(web): accept base62 trial provisioning tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - **refactor(mobile-hr): 9 routes GoRouter mortes retirées (Closes #3284).** `/notifications`, `/evaluations`, `/history`, `/modules/rh`, `/training`, `/expenses`, `/ai-chat`, `/ai-voice`, `/vehicle-map` n'avaient aucune entrée UI (`push`/`go`) ni manifest backend — surface de navigation morte + écrans orphelins (`ModulesScreen` inaccessible). Retrait des routes + imports dans `app.dart` (motif aligné sur le chantier manager #3285).
 - **fix(web): CTA pricing alignés sur les clés checkout canoniques (Closes #3718).** Les plans Starter et Business ne retombent plus sur `free` : ils routent respectivement vers `pilot` et `operations`, tandis qu’Enterprise reste `enterprise`.
+- **fix(web): trial-status accepte les provisioning tokens base62 (Closes #3717).** La route Next.js n’attend plus un token hexadécimal minuscule impossible à produire avec Laravel `Str::random(64)` ; la validation accepte exactement `A-Za-z0-9` sur 64 caractères et reste rejetée pour toute longueur ou caractère invalide.
 
 - **fix(admin/api): UsersView utilise le contrat super-admin pour le détail et l’impersonation (Closes #3268).** `/platform/users` expose la liaison société/employé par email canonique et le dashboard n’interroge plus `/admin/users` avec un ID `super_admins`.
 

--- a/docs/specifications/ISSUE_3717.md
+++ b/docs/specifications/ISSUE_3717.md
@@ -1,0 +1,24 @@
+# Mini-spec — Issue #3717
+
+## Intention
+Rétablir le polling du guided trial en acceptant les `provisioning_token` réellement émis par Laravel `Str::random(64)`.
+
+## Contrat
+Le token est une chaîne de **64 caractères base62 sensibles à la casse** : `A-Z`, `a-z` et `0-9`. Les valeurs vides, de longueur différente ou contenant un caractère hors alphabet sont rejetées avant tout appel backend.
+
+## Implémentation
+La validation est centralisée dans `src/app/api/forms/_lib/provisioning-token.ts` et utilisée par la route same-origin `src/app/api/forms/trial-status/route.ts`. Le regex hexadécimal minuscule qui rejetait presque tous les tokens réels est supprimé.
+
+## Critères d’acceptation
+
+| Scénario | Résultat attendu |
+|---|---|
+| Token base62 de 64 caractères | Accepté et transmis au backend |
+| Token de 63 ou 65 caractères | Rejeté avec le contrat `PROVISIONING_TOKEN_INVALID` |
+| Token contenant `-`, espace ou autre caractère non base62 | Rejeté |
+| Token vide | Rejeté |
+| Réponse backend | Contrat et comportement de proxy inchangés |
+
+## Validation
+
+Le test Jest dédié passe avec 3 scénarios et `npx tsc --noEmit` passe sans erreur.

--- a/front/web/src/app/api/forms/_lib/__tests__/provisioning-token.test.ts
+++ b/front/web/src/app/api/forms/_lib/__tests__/provisioning-token.test.ts
@@ -1,0 +1,17 @@
+import { isValidProvisioningToken } from '../provisioning-token';
+
+describe('isValidProvisioningToken', () => {
+  it('accepts a Laravel Str::random-style base62 token', () => {
+    expect(isValidProvisioningToken('Aa09Zz'.repeat(10) + 'Aa09')).toBe(true);
+  });
+
+  it('rejects tokens with the wrong length', () => {
+    expect(isValidProvisioningToken('a'.repeat(63))).toBe(false);
+    expect(isValidProvisioningToken('a'.repeat(65))).toBe(false);
+  });
+
+  it('rejects characters outside the base62 alphabet', () => {
+    expect(isValidProvisioningToken('a'.repeat(63) + '-')).toBe(false);
+    expect(isValidProvisioningToken('a'.repeat(63) + ' ')).toBe(false);
+  });
+});

--- a/front/web/src/app/api/forms/_lib/provisioning-token.ts
+++ b/front/web/src/app/api/forms/_lib/provisioning-token.ts
@@ -1,0 +1,6 @@
+/** Laravel Str::random(64) uses a case-sensitive base62 alphabet. */
+export const PROVISIONING_TOKEN_LENGTH = 64;
+
+export function isValidProvisioningToken(token: string): boolean {
+  return new RegExp(`^[A-Za-z0-9]{${PROVISIONING_TOKEN_LENGTH}}$`).test(token);
+}

--- a/front/web/src/app/api/forms/trial-status/route.ts
+++ b/front/web/src/app/api/forms/trial-status/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { resolveBackendBaseUrl } from '@/lib/backend-url';
 import { areFormsEnabled, formsDisabledResponse, getClientIp } from '../_lib/lead-capture';
 import { RateLimiter } from '@/modules/vitrine/lib/validation';
+import { isValidProvisioningToken } from '../_lib/provisioning-token';
 
 /**
  * GET /api/forms/trial-status?token=<provisioning_token>
@@ -22,8 +23,6 @@ const LEOPARDO_API_URL =
 // Polling ~5 s côté client → 12 req/min max par prospect. Marge à 30/min.
 const rateLimiter = new RateLimiter(30, 60 * 1000);
 
-const TOKEN_RE = /^[a-f0-9]{64}$/;
-
 export async function GET(request: NextRequest) {
   if (!areFormsEnabled()) {
     return formsDisabledResponse();
@@ -31,7 +30,7 @@ export async function GET(request: NextRequest) {
 
   const token = request.nextUrl.searchParams.get('token') ?? '';
 
-  if (!TOKEN_RE.test(token)) {
+  if (!isValidProvisioningToken(token)) {
     return NextResponse.json(
       {
         success: false,


### PR DESCRIPTION
## Summary

- closes #3717
- accepts the exact base62 alphabet emitted by Laravel `Str::random(64)` in the trial-status proxy
- keeps the 64-character length guard and rejects empty, malformed, or non-alphanumeric tokens
- adds a focused Jest unit test and the required Spec Kit mini-spec/changelog entry

## Validation

- `npm test -- --runInBand src/app/api/forms/_lib/__tests__/provisioning-token.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
