### PR TITLE
fix(web): route pricing CTAs to canonical plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **refactor(payroll): SocialDeclarationService — agrégation paie + gardes dédupliquées (Closes #3149).** Les 3 méthodes JSON (CNAS DZ, CNSS MA, DSN FR) consomment désormais `SocialDeclarationService` (activeEmployees/quarterMonths/quarterPayrollData/monthPayrollData) au lieu de réimplémenter l'extraction pay_slips/payroll_runs ; les 7 déclarations par run partagent le helper `assertPayrollRunAccess` (404 tenant → 403 RBAC → 422 pays → audit). Controller : 556 → 503 lignes, comportement identique (tests Feature existants).
 
 - **refactor(mobile-hr): 9 routes GoRouter mortes retirées (Closes #3284).** `/notifications`, `/evaluations`, `/history`, `/modules/rh`, `/training`, `/expenses`, `/ai-chat`, `/ai-voice`, `/vehicle-map` n'avaient aucune entrée UI (`push`/`go`) ni manifest backend — surface de navigation morte + écrans orphelins (`ModulesScreen` inaccessible). Retrait des routes + imports dans `app.dart` (motif aligné sur le chantier manager #3285).
+- **fix(web): CTA pricing alignés sur les clés checkout canoniques (Closes #3718).** Les plans Starter et Business ne retombent plus sur `free` : ils routent respectivement vers `pilot` et `operations`, tandis qu’Enterprise reste `enterprise`.
 
 - **fix(admin/api): UsersView utilise le contrat super-admin pour le détail et l’impersonation (Closes #3268).** `/platform/users` expose la liaison société/employé par email canonique et le dashboard n’interroge plus `/admin/users` avec un ID `super_admins`.
 

--- a/docs/specifications/ISSUE_3718.md
+++ b/docs/specifications/ISSUE_3718.md
@@ -1,0 +1,24 @@
+# Mini-spec — Issue #3718
+
+## Intention
+Empêcher les CTA de la homepage pricing de rediriger silencieusement les plans Starter et Business vers le checkout gratuit.
+
+## Contrat de routage
+Les noms affichés sont normalisés vers les clés checkout canoniques : `Starter → pilot`, `Business → operations`, `Enterprise → enterprise`. Les alias historiques `Pilot`, `Operations` et `Scale` restent acceptés. Le plan `pilot` conserve son parcours d’essai sans carte via `/signup?source=home_pilot`.
+
+## Implémentation
+La fonction `planNameToCheckoutKey()` centralise le mapping dans `PricingSection.tsx`. Le CTA utilise cette fonction au lieu de branches incompatibles avec les noms actuels fournis par `pricing.ts`.
+
+## Critères d’acceptation
+
+| Plan affiché | Destination attendue |
+|---|---|
+| Starter | `/signup?source=home_pilot` |
+| Business | `/checkout?plan=operations&billing=...` |
+| Enterprise | `/checkout?plan=enterprise&billing=...` |
+
+Les tokens de facturation mensuelle/annuelle et la branche Enterprise « sur devis » restent inchangés. Le test Jest couvre les noms actuels et les alias historiques.
+
+## Validation
+
+Le test Jest ciblé passe avec 7 assertions et `npx tsc --noEmit` passe sans erreur.

--- a/front/web/src/modules/vitrine/components/PricingSection.tsx
+++ b/front/web/src/modules/vitrine/components/PricingSection.tsx
@@ -11,20 +11,24 @@ function showsCurrency(price: string) {
   return !['Sur devis', 'Custom', 'Teklif', 'حسب العرض'].includes(price)
 }
 
+export function planNameToCheckoutKey(planName?: string): 'free' | 'pilot' | 'operations' | 'enterprise' {
+  const name = (planName ?? '').trim().toLowerCase()
+  if (name.includes('pilot') || name.includes('starter')) return 'pilot'
+  if (name.includes('operations') || name.includes('business')) return 'operations'
+  if (name.includes('scale') || name.includes('enterprise')) return 'enterprise'
+  if (name.includes('free')) return 'free'
+  return 'free'
+}
+
 function getPlanCtaHref(price: string, planName?: string, isAnnual?: boolean) {
   if (!showsCurrency(price)) return '/contact?topic=enterprise'
   const billing = isAnnual ? 'annual' : 'monthly'
   // #2907 : mappe le NOM de plan affiché vers la clé canonique du checkout.
   // Avant, tout plan non-Operations tombait sur 'starter' (Pilot payant) :
   // le CTA « Start for free » du plan Free menait au paywall 24€/mois.
-  const name = (planName ?? '').toLowerCase()
-  // #3329 : « Lancer un pilote gratuit » doit mener au parcours d'essai sans
-  // carte (/signup), comme /pricing — pas au checkout payant Pilot.
-  if (name.includes('pilot')) return `/signup?source=home_pilot`
-  const planKey = name.includes('free') ? 'free'
-    : name.includes('operations') ? 'business'
-    : name.includes('scale') || name.includes('enterprise') ? 'enterprise'
-    : 'free'
+  // #3329 : le plan pilote gratuit doit mener au parcours d'essai sans carte.
+  if (planNameToCheckoutKey(planName) === 'pilot') return `/signup?source=home_pilot`
+  const planKey = planNameToCheckoutKey(planName)
   return `/checkout?plan=${planKey}&billing=${billing}`
 }
 

--- a/front/web/src/modules/vitrine/components/__tests__/pricing-plan-routing.test.ts
+++ b/front/web/src/modules/vitrine/components/__tests__/pricing-plan-routing.test.ts
@@ -1,0 +1,20 @@
+import { planNameToCheckoutKey } from '../PricingSection'
+
+describe('planNameToCheckoutKey', () => {
+  it.each([
+    ['Starter', 'pilot'],
+    ['Business', 'operations'],
+    ['Enterprise', 'enterprise'],
+    ['Pilot', 'pilot'],
+    ['Operations', 'operations'],
+    ['Scale', 'enterprise'],
+  ])('maps %s to %s', (name, expected) => {
+    expect(planNameToCheckoutKey(name)).toBe(expected)
+  })
+
+  it('keeps unknown and free names on the free fallback', () => {
+    expect(planNameToCheckoutKey('Free')).toBe('free')
+    expect(planNameToCheckoutKey('')).toBe('free')
+    expect(planNameToCheckoutKey(undefined)).toBe('free')
+  })
+})


### PR DESCRIPTION
## Summary

- closes #3718
- maps the displayed Starter/Business/Enterprise names to checkout keys `pilot`/`operations`/`enterprise`
- preserves the free pilot signup path and Enterprise contact path
- adds focused Jest coverage plus the Spec Kit mini-spec and changelog entry

## Validation

- `npm test -- --runInBand src/modules/vitrine/components/__tests__/pricing-plan-routing.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
