### PR TITLE
fix(ci): mobile-distribute-main — App ID Firebase correct pour hr (Closes #3740)

### DIFF
--- a/.github/workflows/mobile-distribute-main.yml
+++ b/.github/workflows/mobile-distribute-main.yml
@@ -103,7 +103,7 @@ jobs:
         # actions/excessive-secrets-exposure: static ternary — only one literal
         # `secrets.NAME` reference is evaluated per matrix entry. No dynamic indexing.
         env:
-          FIREBASE_APP_ID: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID }}
+          FIREBASE_APP_ID: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || matrix.app.name == 'platform_admin' && secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID || secrets.FIREBASE_APP_ID }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_APP_ID_SECRET_NAME: ${{ matrix.app.firebase_secret }}
           PROJECT_PATH: ${{ matrix.app.project_path }}
@@ -177,7 +177,7 @@ jobs:
         if: env.MOBILE_DISTRIBUTE_READY == 'true'
         uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
         with:
-          appId: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID }}
+          appId: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || matrix.app.name == 'platform_admin' && secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID || secrets.FIREBASE_APP_ID }}
           token: ${{ secrets.FIREBASE_TOKEN }}
           groups: testeurs-internes
           file: ${{ matrix.app.project_path }}/build/app/outputs/flutter-apk/app-release.apk
@@ -192,7 +192,7 @@ jobs:
         if: env.MOBILE_DISTRIBUTE_READY == 'true'
         shell: bash
         env:
-          FIREBASE_APP_ID: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID }}
+          FIREBASE_APP_ID: ${{ matrix.app.name == 'employee' && secrets.FIREBASE_EMPLOYEE_ANDROID_APP_ID || matrix.app.name == 'manager' && secrets.FIREBASE_MANAGER_ANDROID_APP_ID || matrix.app.name == 'platform_admin' && secrets.FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID || secrets.FIREBASE_APP_ID }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           FIREBASE_READBACK_REQUIRED: ${{ secrets.FIREBASE_READBACK_REQUIRED }}


### PR DESCRIPTION
Issue T017 (#3740) — audit 360° 2026-08-15 (M-01).

Le ternaire Firebase App ID ne couvrait que employee/manager → hr et platform_admin tombaient sur FIREBASE_PLATFORM_ADMIN_ANDROID_APP_ID → validation node exit 1 → distribution staging HR KO à chaque push main. Fix : branche explicite platform_admin + fallback || secrets.FIREBASE_APP_ID (miroir mobile-distribute.yml:152) sur les 3 occurrences.

Vérification : yaml.safe_load OK. Closes #3740