### PR TITLE
fix(ci): deduplicate mobile main builds

### DIFF
--- a/.github/workflows/mobile-distribute.yml
+++ b/.github/workflows/mobile-distribute.yml
@@ -1,17 +1,12 @@
 name: Mobile - Build and Firebase Distribution
 
 on:
+  # Main pushes are handled exclusively by mobile-distribute-main.yml.
+  # Keep tag releases here so staging/prod tag distribution remains available.
   push:
-    branches:
-      - main
     tags:
       - "v*-staging"
       - "v*-prod"
-    paths:
-      - "front/mobile_apps/**"
-      - "dev-hub/tools/install-mobile-firebase-configs.ps1"
-      - ".github/workflows/mobile-distribute.yml"
-      - "docs/validation/MOBILE_FIREBASE_DISTRIBUTION.md"
   workflow_dispatch:
     inputs:
       environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - **fix(admin): lint à 0 warning — imports et helpers inutilisés retirés (Closes #3751).** 9 warnings `no-unused-vars` sur main, dont 2 introduits par les merges #3699 (InformationCircleIcon dans SystemView) et #3701 (StatusBadge dans WebhooksView) : 5 icônes mortes dans CommandPalette, helpers morts formatDuration (EdgeNodesView) et formatDate (TaxRatesView). `npm run lint` → 0 warning, `npm run build` → vert.
 - **fix(ci): garde de protection de branche sans faux 403 horaires (Closes #3742).** Le cron utilisant `GITHUB_TOKEN` est retiré ; la vérification devient manuelle/PR et utilise uniquement `BRANCH_PROTECTION_TOKEN` lorsqu’un token admin `administration:read` est configuré, avec une notice explicite sinon.
+- **fix(ci): builds mobiles main dédupliqués (Closes #3743).** `mobile-distribute-main.yml` est désormais l’unique workflow sur push `main` ; `mobile-distribute.yml` reste réservé aux tags staging/prod et aux déclenchements manuels.
 
 - **docs(spec-kit): audit 360° 2026-08-15 — registre, spec, tasks et 23 issues (T001–T023, #3724–#3746).** Couverture API (OAuth auto-provision, erreurs brutes, race import CSV, scope fail-open), vitrine (e2e no-op, SW pages authentifiées, /mobile, OG guides, a11y FAQ, seo-metadata mort, footer, sync ?lang=), admin (notifications 405, palette, titre onglet, FleetView), mobile/kiosk/edge/CI (App ID HR, Caddyfile.edge, garde branch-protection 403, routes GoRouter dupliquées, builds doublés, perms kiosk.db, bornes bridge). Artifacts : `.specify/features/qa-360-audit-expert-2026-08-15/`.
 

--- a/docs/specifications/ISSUE_3743.md
+++ b/docs/specifications/ISSUE_3743.md
@@ -1,0 +1,17 @@
+# Mini-spec — Issue #3743
+
+## Intention
+Éviter que chaque push sur `main` déclenche deux matrices de builds mobiles staging pour les mêmes quatre applications.
+
+## Décision
+`mobile-distribute-main.yml` est le workflow maître des pushes sur `main`, avec son checkout de `github.sha` protégé. `mobile-distribute.yml` conserve uniquement les distributions déclenchées par tags `v*-staging`/`v*-prod` et les lancements manuels. Ses builds ne sont donc plus concurrents sur un push `main`.
+
+## Critères d’acceptation
+
+| Déclencheur | Workflow responsable |
+|---|---|
+| Push `main` avec changements mobiles | `mobile-distribute-main.yml` uniquement |
+| Tag `v*-staging` ou `v*-prod` | `mobile-distribute.yml` |
+| Lancement manuel | `mobile-distribute.yml` ou `mobile-distribute-main.yml` selon le besoin |
+
+Le diff ne modifie ni les matrices, ni les secrets Firebase, ni les étapes de build et de distribution.


### PR DESCRIPTION
## Summary

- closes #3743
- removes the overlapping `push: main` trigger from `mobile-distribute.yml`
- keeps tag-based staging/prod releases and manual dispatches
- makes `mobile-distribute-main.yml` the sole main-push distributor
- adds the Spec Kit mini-spec and changelog entry

## Validation

- `git diff --check`
