### PR TITLE
fix(api): config/queue.php sans app() — CI backend réparée (régression #3693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **fix(api): config/queue.php ne doit pas appeler app() — composer install / package:discover réparés (régression #3693).** `'default' => env('QUEUE_CONNECTION', app()->environment('production') ? ...)` cassait TOUTE la CI backend : pendant le chargement des configs, le conteneur n'a pas encore de binding `env` → `Target class [env] does not exist` → post-autoload-dump en échec → Backend Coverage + PHPStan rouges sur chaque PR (même UI-only). Remplacement par `env('APP_ENV', 'production') === 'production'` (lecture directe de la variable, pas du conteneur). Vérifié : `php artisan package:discover` exit 0.
+
 - **refactor(mobile-manager): 11 routes GoRoute dupliquées supprimées (Closes #3746).** `/tasks`, `/salary-advances`, `/payrolls`, `/notifications`, `/modules`, `/me/monthly`, `/history`, `/evaluations`, `/attendance`, `/absences`, `/team` étaient déclarés 2× dans le même ShellRoute (artefact #3223/#3205 après #2801) — GoRouter n'utilisait que la 1ʳᵉ. Second bloc retiré, routes `/manager/*` et `/smart-attendance/*` conservées, aucun import mort.
 
 - **fix(admin): lint à 0 warning — imports et helpers inutilisés retirés (Closes #3751).** 9 warnings `no-unused-vars` sur main, dont 2 introduits par les merges #3699 (InformationCircleIcon dans SystemView) et #3701 (StatusBadge dans WebhooksView) : 5 icônes mortes dans CommandPalette, helpers morts formatDuration (EdgeNodesView) et formatDate (TaxRatesView). `npm run lint` → 0 warning, `npm run build` → vert.

--- a/api/config/queue.php
+++ b/api/config/queue.php
@@ -17,7 +17,7 @@ return [
     // retomber sur 'sync' (jobs lourds exécutés dans la requête web) — le
     // worker redis est déployé (render.yaml leopardo-queue-worker). En
     // dev/test, le défaut reste 'sync' pour la simplicité locale.
-    'default' => env('QUEUE_CONNECTION', app()->environment('production') ? 'redis' : 'sync'),
+    'default' => env('QUEUE_CONNECTION', env('APP_ENV', 'production') === 'production' ? 'redis' : 'sync'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Problème — P1 CI globale

Le merge #3693 a introduit `app()->environment()` dans `config/queue.php`. Pendant le chargement des configs (LoadConfiguration), le conteneur na pas encore le binding `env` → `Target class [env] does not exist` → `composer install` échoue au post-autoload-dump (`package:discover`) → **Backend Coverage + PHPStan rouges sur TOUTES les PRs** (vérifié sur #3715, #3720, #3721, #3723, #3761 — y compris UI-only).

## Correctif

`env(QUEUE_CONNECTION, env(APP_ENV, production) === production ? redis : sync)` — lecture directe de la variable denvironnement au lieu du conteneur. Comportement #3562 préservé (prod sans QUEUE_CONNECTION → redis).

## Preuves

- `php artisan package:discover` : exit 0 (reproduit localement avant/après).
- Seule occurrence de `app()` dans les configs (scramble/sentry utilisent `config()`, sans risque).

Closes #3562 (correctif du correctif)