### PR TITLE
fix(mobile): employee notifications — /read-all canonique (garde production proof)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ## [Unreleased]
 
-- **fix(mobile): employee — notifications « tout marquer lu » aligné sur l'endpoint canonique `/notifications/read-all` (garde validate-mobile-notification-production-proof.ps1).** L'app employé appelait l'alias `/notifications/mark-all-read` (issue #3005) pendant que manager + garde CI utilisent `/read-all` (route POST canonique `rh.php`) — les deux routes restent servies, l'app employé est désormais conforme au contrat de production.
-
 - **fix(api): config/queue.php ne doit pas appeler app() — composer install / package:discover réparés (régression #3693).** `'default' => env('QUEUE_CONNECTION', app()->environment('production') ? ...)` cassait TOUTE la CI backend : pendant le chargement des configs, le conteneur n'a pas encore de binding `env` → `Target class [env] does not exist` → post-autoload-dump en échec → Backend Coverage + PHPStan rouges sur chaque PR (même UI-only). Remplacement par `env('APP_ENV', 'production') === 'production'` (lecture directe de la variable, pas du conteneur). Vérifié : `php artisan package:discover` exit 0.
 
 - **refactor(mobile-manager): 11 routes GoRoute dupliquées supprimées (Closes #3746).** `/tasks`, `/salary-advances`, `/payrolls`, `/notifications`, `/modules`, `/me/monthly`, `/history`, `/evaluations`, `/attendance`, `/absences`, `/team` étaient déclarés 2× dans le même ShellRoute (artefact #3223/#3205 après #2801) — GoRouter n'utilisait que la 1ʳᵉ. Second bloc retiré, routes `/manager/*` et `/smart-attendance/*` conservées, aucun import mort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **fix(mobile): employee — notifications « tout marquer lu » aligné sur l'endpoint canonique `/notifications/read-all` (garde validate-mobile-notification-production-proof.ps1).** L'app employé appelait l'alias `/notifications/mark-all-read` (issue #3005) pendant que manager + garde CI utilisent `/read-all` (route POST canonique `rh.php`) — les deux routes restent servies, l'app employé est désormais conforme au contrat de production.
+
 - **fix(api): config/queue.php ne doit pas appeler app() — composer install / package:discover réparés (régression #3693).** `'default' => env('QUEUE_CONNECTION', app()->environment('production') ? ...)` cassait TOUTE la CI backend : pendant le chargement des configs, le conteneur n'a pas encore de binding `env` → `Target class [env] does not exist` → post-autoload-dump en échec → Backend Coverage + PHPStan rouges sur chaque PR (même UI-only). Remplacement par `env('APP_ENV', 'production') === 'production'` (lecture directe de la variable, pas du conteneur). Vérifié : `php artisan package:discover` exit 0.
 
 - **refactor(mobile-manager): 11 routes GoRoute dupliquées supprimées (Closes #3746).** `/tasks`, `/salary-advances`, `/payrolls`, `/notifications`, `/modules`, `/me/monthly`, `/history`, `/evaluations`, `/attendance`, `/absences`, `/team` étaient déclarés 2× dans le même ShellRoute (artefact #3223/#3205 après #2801) — GoRouter n'utilisait que la 1ʳᵉ. Second bloc retiré, routes `/manager/*` et `/smart-attendance/*` conservées, aucun import mort.

--- a/front/mobile_apps/leopardo_employee/lib/features/notifications/data/notification_repository.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/notifications/data/notification_repository.dart
@@ -21,7 +21,7 @@ class NotificationRepository {
 
   Future<void> markAllAsRead() async {
     await apiClient.requestWithRetry<void>(
-      '/notifications/mark-all-read',
+      '/notifications/read-all',
       method: 'POST',
       timeoutOverride: const Duration(seconds: 12),
     );


### PR DESCRIPTION
## Problème

La garde `validate-mobile-notification-production-proof.ps1` échoue sur main et toutes les PRs mobiles : « employee notifications read all is missing required marker: /notifications/read-all ». Le commit #3005 a basculé l'app employé sur l'alias `/notifications/mark-all-read` sans mettre à jour la garde ; l'app manager et la garde CI utilisent `/notifications/read-all` (route POST canonique `api/routes/modules/rh.php`).

## Correctif

- `notification_repository.dart` (employee) : `markAllAsRead()` → `POST /notifications/read-all` (même contrat que manager, les deux routes restent servies côté API).

## Validation

- `pwsh dev-hub/tools/validate-mobile-notification-production-proof.ps1` : passe.
- Aucun changement de contrat API.