### PR TITLE
fix(web): improve FAQ and mobile nav accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## [Unreleased]
 
+- **fix(web/a11y): FAQ et Navbar mobile accessibles (#3732).** Ajout des labels de recherche, `aria-expanded`/`aria-controls` sur les accordéons et sous-menus, panneau FAQ nommé, et label du drawer localisé.
+
+- **chore(web): supprimer le module `seo-metadata.ts` mort et divergent (#3733).** `seo.ts` reste la source active unique ; aucune référence runtime ne subsiste dans `front/web/src`.
+
+- **fix(web): Footer sans fallback `#` silencieux (#3734).** Les routes inconnues ne sont plus rendues comme des liens morts ; les chemins canoniques existants et la désactivation du Blog restent inchangés.
+
 - **refactor(mobile-manager): 11 routes GoRoute dupliquées supprimées (Closes #3746).** `/tasks`, `/salary-advances`, `/payrolls`, `/notifications`, `/modules`, `/me/monthly`, `/history`, `/evaluations`, `/attendance`, `/absences`, `/team` étaient déclarés 2× dans le même ShellRoute (artefact #3223/#3205 après #2801) — GoRouter n'utilisait que la 1ʳᵉ. Second bloc retiré, routes `/manager/*` et `/smart-attendance/*` conservées, aucun import mort.
 
 - **fix(admin): lint à 0 warning — imports et helpers inutilisés retirés (Closes #3751).** 9 warnings `no-unused-vars` sur main, dont 2 introduits par les merges #3699 (InformationCircleIcon dans SystemView) et #3701 (StatusBadge dans WebhooksView) : 5 icônes mortes dans CommandPalette, helpers morts formatDuration (EdgeNodesView) et formatDate (TaxRatesView). `npm run lint` → 0 warning, `npm run build` → vert.

--- a/docs/specifications/ISSUE_3732.md
+++ b/docs/specifications/ISSUE_3732.md
@@ -1,0 +1,19 @@
+# Mini-spec — Issue #3732
+
+## Contrat d’accessibilité
+
+| Surface | Exigence |
+|---|---|
+| Recherche FAQ | label programmatique `faq-search` et icône décorative masquée |
+| Accordéon FAQ | chaque déclencheur expose `aria-expanded` et `aria-controls` |
+| Réponse FAQ | panneau ouvert expose `role=region` et `aria-labelledby` |
+| Drawer mobile | label issu de `copy.nav.menuLabel`, jamais une chaîne FR en dur |
+| Sous-menus mobile | chaque bouton expose `aria-expanded` |
+
+## Locales et RTL
+
+Les attributs sont indépendants de la langue affichée ; le texte de label vient du catalogue de copie existant et le comportement RTL arabe est conservé.
+
+## Validation
+
+Le diff est validé par `git diff --check`. Les tests frontend complets sont exécutés par la CI avec les dépendances verrouillées du projet.

--- a/front/web/src/app/(landing)/faq/page.tsx
+++ b/front/web/src/app/(landing)/faq/page.tsx
@@ -103,8 +103,10 @@ export default function FaqPage() {
       <section className="py-24">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="relative mb-8">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
+            <label htmlFor="faq-search" className="sr-only">Rechercher une question</label>
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" aria-hidden="true" />
             <input
+              id="faq-search"
               type="text"
               placeholder="Rechercher une question..."
               value={search}
@@ -136,7 +138,10 @@ export default function FaqPage() {
                 className="border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden"
               >
                 <button
+                  id={`faq-trigger-${index}`}
                   onClick={() => setOpenIndex(openIndex === index ? null : index)}
+                  aria-expanded={openIndex === index}
+                  aria-controls={`faq-panel-${index}`}
                   className="w-full flex items-center justify-between p-5 text-left hover:bg-transparent dark:hover:bg-slate-800/50 transition-colors"
                 >
                   <span className="font-semibold text-slate-900 dark:text-white pr-4">{item.question}</span>
@@ -145,6 +150,9 @@ export default function FaqPage() {
                 <AnimatePresence>
                   {openIndex === index && (
                     <motion.div
+                      id={`faq-panel-${index}`}
+                      role="region"
+                      aria-labelledby={`faq-trigger-${index}`}
                       initial={{ height: 0, opacity: 0 }}
                       animate={{ height: 'auto', opacity: 1 }}
                       exit={{ height: 0, opacity: 0 }}

--- a/front/web/src/modules/vitrine/components/Navbar.tsx
+++ b/front/web/src/modules/vitrine/components/Navbar.tsx
@@ -376,7 +376,7 @@ export function Navbar({ isDark, onToggleDark }: Props) {
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
-            aria-label="Menu mobile"
+            aria-label={copy.nav.menuLabel}
             className="lg:hidden bg-white/95 dark:bg-slate-950/95 backdrop-blur-2xl border-t border-slate-200/50 dark:border-slate-800/50 max-h-[80vh] overflow-y-auto"
           >
             <div className="px-6 py-6 space-y-1">
@@ -405,6 +405,7 @@ export function Navbar({ isDark, onToggleDark }: Props) {
                       transition={{ delay: index * 0.05 }}
                       className="w-full flex items-center justify-between px-4 py-3 text-lg font-semibold text-slate-900 dark:text-white rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
                       onClick={() => setOpenDropdown(openDropdown === entry.label ? null : entry.label)}
+                      aria-expanded={openDropdown === entry.label}
                     >
                       {entry.label}
                       <ChevronDown className={`w-4 h-4 transition-transform ${openDropdown === entry.label ? 'rotate-180' : ''}`} />


### PR DESCRIPTION
## Summary

- closes #3732
- adds accessible search and FAQ accordion relationships
- localizes the mobile drawer label and exposes mobile submenu state
- includes Spec Kit mini-spec and changelog entry

## Validation

- `git diff --check`
