### PR TITLE
fix(web): imports vitest retirés des tests vitrine — Frontend ESLint+TS vert (régression #3734/#3735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **fix(web): tests unitaires vitrine — imports `vitest` retirés (globals jest, TS2307).** Les tests ajoutés par #3734/#3735 (`footer-links`, `navbar-locale-url`) importaient `vitest` alors que le projet configure jest — le check « Frontend — ESLint + TypeScript » échouait sur main et toutes les PRs web (TS2307: Cannot find module).
+
 - **fix(ci): gardes dev-hub câblées en CI — job hygiene-guards (Closes #3708).** `architecture-check.yml` exécute désormais sur PR et push main : `check-app-version-sync.sh` (anti-drift APP_VERSION, #3528), `check-env-example-parity.sh` (#1487), `check-migration-basename-collisions.sh` (#1962) et `check-country-catalog.sh` (#2600). Ces gardes bash-pures n'étaient appelées par aucun workflow — la régression APP_VERSION 4.23.5 (b0630dd5) et la dérive des 6 clés .env.example sont passées inaperçues sur main.
 - **docs: CHANGELOG.md — séquences mojibake résiduelles ré-encodées (issues #1589/#1612).** Deux occurrences mojibake ré-encodées en « Aucune évaluation » (ligne hygiène mobile #2738) ; garde Governance Gates repassée au vert pour les PRs API.
 - **fix(api): plus aucun message d'exception brut dans les réponses d'erreur (Closes #3725).** `EmployeeImportController`, `BulkPaymentController`, `WebhookController` (test), `AuthController` (callback Google + échange de jeton) renvoyaient `$e->getMessage()` (SQL/PDO/Redis/Socialite) vers les tenants — remplacé par des codes d'erreur stables (`EMPLOYEE_IMPORT_FAILED`, `BULK_PAYMENT_STATUS_UNAVAILABLE`, `WEBHOOK_DELIVERY_FAILED`, `GOOGLE_AUTH_FAILED`, `GOOGLE_TOKEN_INVALID`) + message générique, détails loggés serveur (pattern `PartnerDashboardController`). Spec : `docs/specifications/ISSUE_3725_EXCEPTION_LEAK.md`.

--- a/front/web/src/modules/vitrine/components/__tests__/footer-links.test.ts
+++ b/front/web/src/modules/vitrine/components/__tests__/footer-links.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import { getFooterHref } from '../Footer'
 
 describe('getFooterHref', () => {

--- a/front/web/src/modules/vitrine/components/__tests__/navbar-locale-url.test.ts
+++ b/front/web/src/modules/vitrine/components/__tests__/navbar-locale-url.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import { buildLocaleUrl } from '../Navbar'
 
 describe('buildLocaleUrl', () => {


### PR DESCRIPTION
## Problème

Les tests ajoutés par #3734 (footer) et #3735 (locale URL) importent `describe/expect/it` depuis `vitest`, mais le projet configure **jest** (`package.json` test script, `jest.config.ts`) — `vitest` n'est pas dans les devDependencies. Résultat : TS2307 `Cannot find module 'vitest'` → le check requis « Frontend — ESLint + TypeScript » échoue sur main et sur TOUTES les PRs web.

## Correctif

- `footer-links.test.ts` / `navbar-locale-url.test.ts` : import `vitest` supprimé (globals jest, cohérent avec les autres tests `src/**/__tests__`).
- `pricing-plan-routing.test.ts` : aucun import (déjà propre).

Closes #3734
Closes #3735