### PR TITLE
fix(web): imports vitest retirés des tests vitrine — CI Frontend débloquée

### DIFF
--- a/front/web/src/modules/vitrine/components/__tests__/footer-links.test.ts
+++ b/front/web/src/modules/vitrine/components/__tests__/footer-links.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import { getFooterHref } from '../Footer'
 
 describe('getFooterHref', () => {

--- a/front/web/src/modules/vitrine/components/__tests__/navbar-locale-url.test.ts
+++ b/front/web/src/modules/vitrine/components/__tests__/navbar-locale-url.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import { buildLocaleUrl } from '../Navbar'
 
 describe('buildLocaleUrl', () => {


### PR DESCRIPTION
## Problème (bloquant CI global)
`navbar-locale-url.test.ts` (#3785) et `footer-links.test.ts` (#3734) importent `from "vitest"` — vitest n’est **pas** dans package.json/package-lock → `TS2307` sur chaque `next build`/`tsc --noEmit` : la check « Frontend — ESLint + TypeScript » est rouge pour **toute** PR, main inclus.

## Correctif
Retrait de l’import `vitest` : `jest.config.ts` injecte déjà `describe/it/expect` en globals (les autres tests vitrine ne les importent pas).

## Validation
- `tsc --noEmit` : ✅ 0 erreur (avant : 2 × TS2307)
- `jest` sur les 2 suites : 5/5 ✅
- `npm run lint` : ✅

Débloque #3797/#3798/#3799 et toutes les PRs en cours.