### PR TITLE
docs(qa): session merge 2026-08-15 — déblocage CI global + leçons

### DIFF
--- a/docs/qa/SESSION_MERGE_2026-08-15.md
+++ b/docs/qa/SESSION_MERGE_2026-08-15.md
@@ -1,0 +1,47 @@
+# Session merge/QA — 2026-08-15 (après-midi)
+
+> Bilan de la session « main vert » : déblocage CI global, merges, et
+> correctifs racine. Agents concernés : expert5/8/10/11/12 + agents merge.
+
+## 1. Déblocage CI global (main était rouge pour TOUTES les PRs)
+
+| Bloqueur | Cause racine | Correctif | PR |
+|---|---|---|---|
+| composer `package:discover` KO | `config/queue.php` appelait `app()->environment()` (régression #3693) | `env('APP_ENV','production')==='production'` | #3778 ✅ |
+| Governance Gates (mojibake) | `CHANGELOG.md` ligne 500 : `Ã©` résiduel | ré-encodage UTF-8 | #3782 ✅ |
+| PHPStan strict + Modules Arch. (53+31 erreurs) | drift #3158 : morts de code `PlatformAdminDashboardController` (fallbacks après `reportDashboardFailure`, spec #3001), `CompanyRequestController` ($user mort après return), `issueDemoAccess` jamais appelé, docblocks Department/Camera (company_id uuid→string), UserInvitation (employee_id int), generics factories manquants, `@param $q` vs `$query`, mojibake triple-encodé | fix racine 27 fichiers | #3791 |
+| Frontend ESLint+TS (TS2307 vitest) | tests mergés #3734/#3735 importent `vitest` alors que le projet configure **jest** | imports vitest retirés | #3802 |
+| I18N validate-and-sync | checksum `versions.json` stale après merges | régénération checksum | #3815 |
+| OpenAPI route coverage | `GET /edge/download/Caddyfile.edge` (#3741) non documenté | openapi.yaml | #3815 |
+
+## 2. Merges réalisés (sélection)
+
+- #3778 queue config, #3782 mojibake, #3783 notifications read-all mobile,
+  #3761 admin lint, #3713 gardes dev-hub, #3773/#3781 docs sessions,
+  #3760 SW protégé, #3733 seo mort, #3734 footer, #3735 locale URL,
+  #3716 canonical domains, #3725 exception leak, #3720 payroll service,
+  #3722/#3748/#3754/#3755/#3757/#3752/#3758/#3759 merges précédents.
+
+## 3. Protocoles respectés
+
+- Anti-doublon #2400 : #3779 fermé (doublon #3768 + fix déjà mergé #3778) ;
+  commentaire de renvoi sur #3731 (deux branches de claim, canonique =
+  `fix/3731-guides-og`).
+- Branches mergées supprimées ; branches orphelines mergées nettoyées.
+
+## 4. Leçons pour les prochains agents
+
+1. **`config/queue.php` ne doit JAMAIS appeler `app()`** — les configs sont
+   chargées avant le conteneur ; utiliser `env()` (régression #3693, garde
+   Governance Gates).
+2. **Ne pas mélanger jest et vitest** dans `front/web` — le projet est 100%
+   jest (`package.json test` + `jest.config.ts`).
+3. **`company_id` est un UUID (string) partout** (même `departments`,
+   `cameras.*`) — les docblocks `int` sont faux et cassent PHPStan strict.
+4. **`Employee::factory()` / `Company::factory()`** doivent garder leur
+   `@extends Factory<...>` — sans lui, `->id` retombe sur `Model` et les
+   tests échouent PHPStan.
+5. **Vérifier la mojibake AVANT de merger** : `rg 'Ã|â€|Â' CHANGELOG.md`.
+6. **Un merge de PR ne suffit pas** : vérifier `gh pr checks` APRÈS le merge
+   (les gardes non requises — E2E, validate-and-sync, openapi — peuvent être
+   rouges sur main et bloquer les PRs suivantes).


### PR DESCRIPTION
Bilan de la session « main vert » : les 6 bloqueurs CI partagés (queue.php #3693, mojibake CHANGELOG, drift PHPStan #3158, vitest TS2307, checksum i18n, openapi coverage), les merges réalisés, et les leçons pour les prochains agents (company_id uuid, factories generics, jest vs vitest, etc.).

- `docs/qa/SESSION_MERGE_2026-08-15.md`

Closes #3158