### PR TITLE
fix(mobile): providers orphelins retirés des 3 core_providers.dart (régression #3855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(mobile): providers orphelins retirés des 3 `core_providers.dart` (régression #3855).** Le merge #3855 supprimait les repos/écrans orphelins (issue #3812) mais laissait 8 registrations `core_providers.dart` (hr: expense/aiChat/vehiclePosition/approval, employee: aiChat/vehiclePosition, manager: contract/expense) référencer des classes supprimées → `flutter analyze` cassé ×3 apps. Suppression des registrations mortes ; les providers des features conservées (manager ai_chat/vehicle_position/approvals, hr contracts/organigramme) sont inchangés.
 
 - **fix(web): a11y FAQ + Navbar (Closes #3732).** Input de recherche /faq avec `<label>` sr-only + `aria-label` localisés (4 locales), accordéons avec `aria-expanded`/`aria-controls` + `role=region`, tiroir mobile Navbar : `aria-label` localisé (`copy.nav.menuLabel`) et toggle avec `aria-expanded`/`aria-controls` (parité desktop).
 - **fix(api): matrice PHP standardisée sur 8.4.1 (Closes #3819).** `composer.json` et `composer.lock` (platform) déclaraient `^8.2` alors que le lock verrouille des composants Symfony 8.x exigeant PHP >= 8.4.1 → `composer install` échouait sur PHP 8.3 documenté. Alignés sur 8.4.1 (déjà utilisé par CI, Dockerfile.prod et README) + `DEVELOPMENT.md` à jour.

--- a/front/mobile_apps/leopardo_employee/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_employee/lib/core/providers/core_providers.dart
@@ -165,17 +165,9 @@ final userAuthRepositoryProvider = Provider<UserAuthRepository>((ref) {
   return UserAuthRepository(apiClient, storage, preferences);
 });
 
-final aiChatRepositoryProvider = Provider<AiChatRepository>((ref) {
-  final apiClient = ref.watch(apiClientProvider);
-  return AiChatRepository(apiClient);
-});
 
-final vehiclePositionRepositoryProvider = Provider<VehiclePositionRepository>((
-  ref,
-) {
-  final apiClient = ref.watch(apiClientProvider);
-  return VehiclePositionRepository(apiClient);
-});
+
+
 
 final onboardingRepositoryProvider = Provider<OnboardingRepository>((ref) {
   final apiClient = ref.watch(apiClientProvider);

--- a/front/mobile_apps/leopardo_hr/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_hr/lib/core/providers/core_providers.dart
@@ -129,27 +129,13 @@ final contractRepositoryProvider = Provider<ContractRepository>((ref) {
   return ContractRepository(apiClient);
 });
 
-final expenseRepositoryProvider = Provider<ExpenseRepository>((ref) {
-  final apiClient = ref.watch(apiClientProvider);
-  return ExpenseRepository(apiClient);
-});
 
-final aiChatRepositoryProvider = Provider<AiChatRepository>((ref) {
-  final apiClient = ref.watch(apiClientProvider);
-  return AiChatRepository(apiClient);
-});
 
-final vehiclePositionRepositoryProvider = Provider<VehiclePositionRepository>((
-  ref,
-) {
-  final apiClient = ref.watch(apiClientProvider);
-  return VehiclePositionRepository(apiClient);
-});
 
-final approvalRepositoryProvider = Provider<ApprovalRepository>((ref) {
-  final apiClient = ref.watch(apiClientProvider);
-  return ApprovalRepository(apiClient);
-});
+
+
+
+
 
 final onboardingRepositoryProvider = Provider<OnboardingRepository>((ref) {
   final apiClient = ref.watch(apiClientProvider);

--- a/front/mobile_apps/leopardo_manager/lib/core/providers/core_providers.dart
+++ b/front/mobile_apps/leopardo_manager/lib/core/providers/core_providers.dart
@@ -126,15 +126,9 @@ final userAuthRepositoryProvider = Provider<UserAuthRepository>((ref) {
   return UserAuthRepository(apiClient, storage, preferences);
 });
 
-final contractRepositoryProvider = Provider<ContractRepository>((ref) {
-  final apiClient = ref.watch(apiClientProvider);
-  return ContractRepository(apiClient);
-});
 
-final expenseRepositoryProvider = Provider<ExpenseRepository>((ref) {
-  final apiClient = ref.watch(apiClientProvider);
-  return ExpenseRepository(apiClient);
-});
+
+
 
 final aiChatRepositoryProvider = Provider<AiChatRepository>((ref) {
   final apiClient = ref.watch(apiClientProvider);


### PR DESCRIPTION
## Problème

Le merge #3855 (issue #3812) supprimait les repos/écrans orphelins mais laissait 8 registrations `core_providers.dart` référencer des classes supprimées → `flutter analyze` cassé sur les 3 apps mobile (main rouge).

| App | Registrations mortes retirées |
|---|---|
| leopardo_hr | expense, aiChat, vehiclePosition, approval |
| leopardo_employee | aiChat, vehiclePosition |
| leopardo_manager | contract, expense |

## Correctif

Suppression des blocs de providers référençant des classes supprimées. Providers des features conservées (manager ai_chat/vehicle_position/approvals, hr contracts/organigramme) inchangés.

## Validation

- `grep` global : 0 référence restante vers les classes supprimées
- Les fichiers conservés existent bien sur la branche
- CI : attendre Backend/Frontend/Mobile checks