### PR TITLE
fix(admin): cluster UX — export groupé respecte la sélection, exports tenant honnêtes, Ctrl+K single-binding (Closes #3865)

### DIFF
--- a/docs/specifications/ISSUE_3865_ADMIN_UX_CLUSTER.md
+++ b/docs/specifications/ISSUE_3865_ADMIN_UX_CLUSTER.md
@@ -1,0 +1,24 @@
+# Mini-spécification — Issue #3865
+
+## Objectif
+
+Corriger trois défauts UX de la console admin super-admin : export groupé qui ignore la sélection, vue Exports mélangeant contrats tenant (401) et admin, double-binding Ctrl+K.
+
+## Correction
+
+1. **UsersView** : `exportUsers(rows = null)` accepte une liste cible ; `exportSelectedUsers()` filtre `users` par `selectedUsers` avant export. Le bouton haut de page exporte toute la page courante (inchangé), le bouton du panneau groupé exporte la sélection.
+2. **ExportsView** : les 6 types d'export (`/v1/export/*`) sont marqués `clientSpace: true` — cartes désactivées avec mention « Disponible dans l'espace client » (via `t()`). `fetchHistory` : 401 → message honnête « Historique disponible dans l'espace client ». Le générateur `/admin/hr-reports` (vrai contrat super-admin) reste actif.
+3. **Ctrl+K** : `case 'k'` retiré de `useKeyboardShortcuts.js` — `CommandPalette` (toujours montée dans DashboardLayout) possède le toggle.
+
+## Critères d'acceptation
+
+1. Export groupé = sélection uniquement (CSV).
+2. Aucune carte d'export tenant actionnable dans le cockpit super-admin ; mention « espace client » visible.
+3. Ctrl+K ouvre/ferme la palette une seule fois par frappe.
+4. Lint, build Vite et `check-i18n-diff.js` verts.
+
+## Trace Spec Kit
+
+Issue : #3865
+Branche : `fix/3865-admin-ux-cluster`
+Date : 2026-08-15

--- a/front/admin-dashboard/src/composables/useKeyboardShortcuts.js
+++ b/front/admin-dashboard/src/composables/useKeyboardShortcuts.js
@@ -20,11 +20,9 @@ export function useKeyboardShortcuts() {
           e.preventDefault()
           themeStore.toggle()
           break
-        case 'k':
-          e.preventDefault()
-          // Focus search bar
-          document.getElementById('search')?.focus()
-          break
+        // #3865 : Ctrl+K est possédé par CommandPalette (toggle palette) —
+        // le double-binding précédent (focus #search ici) ouvrait la palette
+        // ET focusait la recherche en même temps.
       }
       return
     }

--- a/front/admin-dashboard/src/views/exports/ExportsView.vue
+++ b/front/admin-dashboard/src/views/exports/ExportsView.vue
@@ -15,19 +15,27 @@
             <p class="mt-1 text-xs text-gray-500">{{ report.description }}</p>
           </div>
         </div>
-        <div class="mt-4 flex items-center gap-2">
-          <select v-model="report.format" class="rounded-md border-gray-300 text-xs focus:border-indigo-500 focus:ring-indigo-500">
-            <option value="csv">CSV</option>
-            <option value="json">JSON</option>
-            <option value="xlsx" v-if="report.supportsXlsx">Excel</option>
-          </select>
-          <button
-            class="flex-1 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
-            :disabled="report.downloading"
-            @click="downloadReport(report)"
+        <div class="mt-4">
+          <div
+            v-if="report.clientSpace"
+            class="rounded-md bg-slate-100 px-3 py-2 text-xs text-slate-600 ring-1 ring-slate-200"
           >
-            {{ report.downloading ? 'Telechargement...' : 'Telecharger' }}
-          </button>
+            {{ $t('exports.clientSpaceNote', "Disponible dans l'espace client") }}
+          </div>
+          <div v-else class="flex items-center gap-2">
+            <select v-model="report.format" class="rounded-md border-gray-300 text-xs focus:border-indigo-500 focus:ring-indigo-500">
+              <option value="csv">CSV</option>
+              <option value="json">JSON</option>
+              <option value="xlsx" v-if="report.supportsXlsx">Excel</option>
+            </select>
+            <button
+              class="flex-1 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              :disabled="report.downloading"
+              @click="downloadReport(report)"
+            >
+              {{ report.downloading ? 'Telechargement...' : 'Telecharger' }}
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -125,8 +133,15 @@ import {
 } from '@heroicons/vue/24/outline'
 import api, { downloadApiFile } from '@/services/api'
 import { useToast } from 'vue-toastification'
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale.js'
 
 const toast = useToast()
+const localeStore = useLocaleStore()
+
+function t(key, fallback = '') {
+  return translate(localeStore.current, key, fallback)
+}
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 
@@ -144,12 +159,16 @@ const hrReport = reactive({
 })
 
 const reportTypes = reactive([
-  { key: 'employees', title: 'Employes', description: 'Liste complete avec postes, contrats, departements.', icon: UsersIcon, format: 'csv', supportsXlsx: true, downloading: false, endpoint: '/v1/export/employees' },
-  { key: 'attendance', title: 'Pointage', description: 'Registre de presence avec heures et anomalies.', icon: ClipboardDocumentListIcon, format: 'csv', supportsXlsx: true, downloading: false, endpoint: '/v1/export/attendance' },
-  { key: 'payslips', title: 'Bulletins de paie', description: 'Export mensuel bulletins avec details salaire.', icon: CurrencyEuroIcon, format: 'csv', supportsXlsx: false, downloading: false, endpoint: '/v1/export/pay-slips' },
-  { key: 'absences', title: 'Absences & conges', description: 'Historique demandes et soldes par employe.', icon: DocumentTextIcon, format: 'csv', supportsXlsx: true, downloading: false, endpoint: '/v1/export/absences' },
-  { key: 'training', title: 'Formations', description: 'Catalogue, sessions, inscriptions et progression.', icon: AcademicCapIcon, format: 'csv', supportsXlsx: false, downloading: false, endpoint: '/v1/export/training' },
-  { key: 'vehicles', title: 'Vehicules', description: 'Flotte, kilometrage, maintenances.', icon: TruckIcon, format: 'csv', supportsXlsx: false, downloading: false, endpoint: '/v1/export/vehicles' },
+  // #3865 : ces exports appellent des endpoints TENANT (/v1/export/*, auth
+  // employee/manager) — le super-admin n'a pas de contrat equivalent dans le
+  // cockpit (/admin/*). Marques `clientSpace` : la carte affiche un etat
+  // honnete au lieu d'un bouton qui echoue en 401.
+  { key: 'employees', title: 'Employes', description: 'Liste complete avec postes, contrats, departements.', icon: UsersIcon, format: 'csv', supportsXlsx: true, downloading: false, endpoint: '/v1/export/employees', clientSpace: true },
+  { key: 'attendance', title: 'Pointage', description: 'Registre de presence avec heures et anomalies.', icon: ClipboardDocumentListIcon, format: 'csv', supportsXlsx: true, downloading: false, endpoint: '/v1/export/attendance', clientSpace: true },
+  { key: 'payslips', title: 'Bulletins de paie', description: 'Export mensuel bulletins avec details salaire.', icon: CurrencyEuroIcon, format: 'csv', supportsXlsx: false, downloading: false, endpoint: '/v1/export/pay-slips', clientSpace: true },
+  { key: 'absences', title: 'Absences & conges', description: 'Historique demandes et soldes par employe.', icon: DocumentTextIcon, format: 'csv', supportsXlsx: true, downloading: false, endpoint: '/v1/export/absences', clientSpace: true },
+  { key: 'training', title: 'Formations', description: 'Catalogue, sessions, inscriptions et progression.', icon: AcademicCapIcon, format: 'csv', supportsXlsx: false, downloading: false, endpoint: '/v1/export/training', clientSpace: true },
+  { key: 'vehicles', title: 'Vehicules', description: 'Flotte, kilometrage, maintenances.', icon: TruckIcon, format: 'csv', supportsXlsx: false, downloading: false, endpoint: '/v1/export/vehicles', clientSpace: true },
 ])
 
 const historyColumns = [
@@ -203,7 +222,13 @@ async function fetchHistory() {
     exportHistory.value = res.data.data || res.data || []
   } catch (err) {
     // #3395 : état d'erreur visible + retry au lieu d'une liste vide trompeuse.
-    historyError.value = err?.response?.data?.message || 'Impossible de charger l\'historique des exports.'
+    // #3865 : l'historique des exports est un contrat TENANT (/v1/export/history)
+    // — pour le super-admin, afficher un etat honnete au lieu d'une erreur generique.
+    if (err?.response?.status === 401) {
+      historyError.value = t('exports.historyClientOnly', "Historique des exports disponible dans l'espace client")
+    } else {
+      historyError.value = err?.response?.data?.message || t('exports.historyError', "Impossible de charger l'historique des exports.")
+    }
   } finally {
     historyLoading.value = false
   }

--- a/front/admin-dashboard/src/views/users/UsersView.vue
+++ b/front/admin-dashboard/src/views/users/UsersView.vue
@@ -255,7 +255,10 @@ const filteredUsers = computed(() => users.value)
 // #2481 : export groupé = export client CSV de la page courante (aucun
 // endpoint d'export groupé côté API).
 function exportSelectedUsers() {
-  exportUsers()
+  // #3865 : l'export groupé respecte la sélection (avant : exportait toute
+  // la page courante, sélection ignorée).
+  const selected = users.value.filter(u => selectedUsers.value.includes(u.id))
+  exportUsers(selected)
 }
 const usersSummary = computed(() => {
   return t('users.page.summary', ':count utilisateur(s) plateforme')
@@ -475,12 +478,14 @@ async function deleteUser(user) {
 
 // Génère un mot de passe temporaire sûr (16 caractères) pour la création
 // d'un utilisateur plateforme (exigence API : ≥ 12 caractères).
-async function exportUsers() {
+async function exportUsers(rows = null) {
   try {
     // Export honnête de la page courante (pas de mock) — CSV côté client.
     // Issue #2700 — exporte les champs MAPÉS (createdAt/lastLoginAt, sinon les
     // colonnes dates étaient toujours vides) + échappement anti-injection de
     // formule (cellules commençant par = + - @).
+    // #3865 : `rows` optionnel — l'export groupé passe la sélection courante.
+    const exportRows = rows !== null ? rows : users.value
     const escapeCell = (value) => {
       const str = value === null || value === undefined ? '' : String(value)
       if (/^[=+\-@]/.test(str)) return `'${str}`
@@ -491,7 +496,7 @@ async function exportUsers() {
       : ''
     const csvContent = "data:text/csv;charset=utf-8," +
       "Nom,Email,Statut,Entreprise,Inscription,Dernière connexion\n" +
-      users.value.map(user =>
+      exportRows.map(user =>
         [user.name, user.email, user.status, user.company?.name || '', formatDate(user.createdAt), formatDate(user.lastLoginAt)]
           .map(escapeCell).join(',')
       ).join('\n')


### PR DESCRIPTION
## Problème (issue #3865 — audit QA 360°)
Trois défauts UX de la console admin super-admin :
1. **UsersView** — l'export groupé du panneau de sélection appelle `exportUsers()` qui exporte **toute la page courante** ; la sélection est ignorée.
2. **ExportsView** — les 6 exports métier (`/v1/export/*`) et l'historique (`/v1/export/history`) sont des contrats **tenant** (auth employee/manager) → **401 systématique** pour le super-admin ; seuls `Rapports RH` (`/admin/hr-reports`) est un vrai contrat cockpit.
3. **Ctrl+K** — double-binding : `CommandPalette` (toggle) **et** `useKeyboardShortcuts` (focus `#search`) réagissent tous deux.

## Correctif
1. `exportUsers(rows = null)` — l'export groupé filtre la sélection, l'export haut de page garde la page courante.
2. Cartes d'export tenant → état honnête « Disponible dans l'espace client » (désactivées) ; historique 401 → message honnête ; Rapports RH fonctionnels.
3. `case 'k'` retiré de `useKeyboardShortcuts` — CommandPalette (toujours montée) possède le toggle.

## Validation locale
- ESLint 0 erreur · `npm run build` ✓ · `check-i18n-diff.js` ✅ (toutes les nouvelles chaînes passent par `t()`)

Closes #3865
