### PR TITLE
fix(admin): pushUnavailable défini dans le store realtime (Closes #3932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+
+- **fix(admin): état réel du canal push — `pushUnavailable` défini dans le store (Closes #3932).** Référencé par `SystemAlertsOverlay` et `Header` mais jamais assigné, l'état était toujours falsy → la bannière rouge « Connexion temps réel perdue » s'affichait en permanence pour tout super-admin sans WS, l'état neutre « Push non configuré » (#3269) étant inatteignable. `pushUnavailable` est désormais un ref du store : réinitialisé à chaque `connect()`, passé à `true` sur `connect_error` et au grace timeout de 8 s (fallback polling PA2-COMM-013), repassé à `false` à la connexion. Spec : `docs/specifications/ISSUE_3932_PUSH_UNAVAILABLE.md`.
 - **fix(api): casts Eloquent manquants sur 3 modèles (Closes #3893).** `BiometricEnrollmentRequest` (booléens `requested_face_enabled`/`requested_fingerprint_enabled`, `submitted_at`/`approved_at`/`rejected_at`), `KioskAnnouncement` (`is_active`, `starts_at`, `expires_at`) et `ZktecoDevice` (`port`, capacités, `capabilities` JSON, `last_heartbeat_at`/`last_sync_at`) retournaient des chaînes au lieu de bool/Carbon/array → comparaisons silencieusement fausses côté API.
 
 - **fix(api): ATS — index unique (job_posting_id, email) + garde 409 ALREADY_APPLIED (Closes #3860).** `applicants` n'avait aucune contrainte d'unicité → candidatures en double illimitées (double-clic, spam, retry). Migration tenant additive : dédoublonnage (garde la plus ancienne) puis `CREATE UNIQUE INDEX applicants_job_posting_email_unique`. Portail public (`CandidateApplicationController`) et ajout manager (`RecruitmentController`) : check préalable + catch 23505 → 409 `ALREADY_APPLIED`. 2 tests ajoutés (doublon refusé, multi-poste autorisé).

--- a/docs/specifications/ISSUE_3932_PUSH_UNAVAILABLE.md
+++ b/docs/specifications/ISSUE_3932_PUSH_UNAVAILABLE.md
@@ -1,0 +1,34 @@
+# Mini-spec — Issue #3932
+
+## Problème
+
+`realtimeStore.pushUnavailable` est référencé dans 3 templates
+(`SystemAlertsOverlay.vue:45`, `Header.vue:41,45`) mais **jamais défini** dans
+`stores/realtime.js` (grep : zéro affectation) → toujours `undefined`/falsy.
+Résultat : l'état neutre « push non configuré » (gris, #3269) est
+inatteignable ; dès que `isConnected=false` (cas par défaut d'un super-admin
+sans serveur WS), la bannière rouge « Connexion temps réel perdue » s'affiche
+en permanence alors que le fallback polling (PA2-COMM-013) fonctionne.
+
+## Contrat
+
+| Vérification | Résultat attendu |
+|---|---|
+| `connect_error` (WS injoignable) | `pushUnavailable=true` → état neutre gris, pas de fausse alerte |
+| Grace timeout 8 s sans connexion | `pushUnavailable=true` + polling de secours |
+| Connexion WS établie | `pushUnavailable=false`, `isConnected=true` |
+| Nouvel essai de connexion | `pushUnavailable` réinitialisé (state unknown) |
+| lint + build admin | 0 erreur |
+
+## Correctif
+
+`realtime.js` : nouvel état `pushUnavailable` (ref false), réinitialisé à
+chaque `connect()`, passé à `true` sur `connect_error` et sur le grace timeout,
+repasé à `false` à la connexion ; exporté dans le store. Templates inchangés.
+
+## Validation
+
+`npm run lint` + `npm run build` verts (admin-dashboard). Comportement WS
+réel : vérification manuelle en runtime (pas de serveur WS dans la sandbox).
+
+Closes #3932

--- a/front/admin-dashboard/src/stores/realtime.js
+++ b/front/admin-dashboard/src/stores/realtime.js
@@ -19,6 +19,9 @@ export const useRealtimeStore = defineStore('realtime', () => {
   const socket = ref(null)
   const isConnected = ref(false)
   const isPolling = ref(false)
+  // #3932 : canal push déterminé indisponible (connect_error ou grace timeout)
+  // → état neutre « Push non configuré » au lieu d'une fausse alerte rouge.
+  const pushUnavailable = ref(false)
   const notifications = ref([])
   const onlineUsers = ref([])
   const globePoints = ref([])
@@ -77,12 +80,17 @@ export const useRealtimeStore = defineStore('realtime', () => {
     // If the push channel hasn't connected within the grace period, assume
     // it is unavailable (blocked websocket, server down, ...) and fall back
     // to REST polling so the inbox keeps updating regardless.
+    // Nouvel essai de connexion : l'état « push indisponible » est réinitialisé
+    // jusqu'à preuve du contraire (connect_error / grace timeout).
+    pushUnavailable.value = false
+
     schedulePushGraceTimer()
 
     // Événements de connexion
     socket.value.on('connect', () => {
       // console.log removed (audit 2026-08-15) — WebSocket connecté
       isConnected.value = true
+      pushUnavailable.value = false
       clearPushGraceTimer()
       stopPolling()
       toast.success('Connexion temps réel établie')
@@ -100,6 +108,9 @@ export const useRealtimeStore = defineStore('realtime', () => {
     socket.value.on('connect_error', (error) => {
       console.error('Erreur de connexion WebSocket:', error)
       isConnected.value = false
+      // Le canal push est indisponible (serveur WS injoignable/bloqué) :
+      // état neutre, pas une panne de la plateforme (#3269/#3932).
+      pushUnavailable.value = true
       startPolling()
     })
 
@@ -111,6 +122,9 @@ export const useRealtimeStore = defineStore('realtime', () => {
     clearPushGraceTimer()
     pushGraceTimer = setTimeout(() => {
       if (!isConnected.value) {
+        // Aucune connexion push dans le délai de grâce : le canal est
+        // considéré indisponible → état neutre (gris), polling de secours.
+        pushUnavailable.value = true
         startPolling()
       }
     }, PUSH_CONNECT_GRACE_MS)
@@ -393,6 +407,7 @@ export const useRealtimeStore = defineStore('realtime', () => {
     socket,
     isConnected,
     isPolling,
+    pushUnavailable,
     notifications,
     onlineUsers,
     globePoints,


### PR DESCRIPTION
## Problème
`realtimeStore.pushUnavailable` référencé dans 3 templates mais jamais défini → toujours falsy → bannière rouge « Connexion temps réel perdue » permanente pour tout super-admin sans WS, état neutre #3269 inatteignable.

## Correctif
Nouvel état `pushUnavailable` dans `stores/realtime.js` : réinitialisé à chaque `connect()`, `true` sur `connect_error` et au grace timeout (8 s), `false` à la connexion. Templates inchangés.

## Validation
`npm run lint` + `npm run build` verts. Spec : `docs/specifications/ISSUE_3932_PUSH_UNAVAILABLE.md`.

Closes #3932