### PR TITLE
fix(api): token.refresh appliqué aux 16 groupes de routes modules (Closes #3889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **fix(api): token.refresh applique aux 16 groupes de routes modules (Closes #3889).** Le middleware `TokenAutoRefreshMiddleware` (refresh silencieux des tokens Sanctum expirants) etait applique au groupe principal + growth/sso/user, mais absent de absence, billing, cabinet, cameras, dashboard, expense, hr_app, hr_extended, integrations, marketing, payroll_engine, planning, rh, tracking, user et ai → les clients mobiles recevaient un 401 a l'expiration au lieu du refresh silencieux (deconnexions forcees).
+
 - **fix(admin): état réel du canal push — `pushUnavailable` défini dans le store (Closes #3932).** Référencé par `SystemAlertsOverlay` et `Header` mais jamais assigné, l'état était toujours falsy → la bannière rouge « Connexion temps réel perdue » s'affichait en permanence pour tout super-admin sans WS, l'état neutre « Push non configuré » (#3269) étant inatteignable. `pushUnavailable` est désormais un ref du store : réinitialisé à chaque `connect()`, passé à `true` sur `connect_error` et au grace timeout de 8 s (fallback polling PA2-COMM-013), repassé à `false` à la connexion. Spec : `docs/specifications/ISSUE_3932_PUSH_UNAVAILABLE.md`.
 - **fix(api): casts Eloquent manquants sur 3 modèles (Closes #3893).** `BiometricEnrollmentRequest` (booléens `requested_face_enabled`/`requested_fingerprint_enabled`, `submitted_at`/`approved_at`/`rejected_at`), `KioskAnnouncement` (`is_active`, `starts_at`, `expires_at`) et `ZktecoDevice` (`port`, capacités, `capabilities` JSON, `last_heartbeat_at`/`last_sync_at`) retournaient des chaînes au lieu de bool/Carbon/array → comparaisons silencieusement fausses côté API.
 

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -11,7 +11,7 @@ use App\Http\Middleware\AI\AITenantInjector;
 use App\Http\Middleware\AI\EnsureAIAnalyticsAccess;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'throttle:ai-sensitive', AIFeatureCheck::class, AITenantInjector::class, 'throttle:api-plan'])->prefix('ai')->group(function () {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'throttle:ai-sensitive', AIFeatureCheck::class, AITenantInjector::class, 'throttle:api-plan'])->prefix('ai')->group(function () {
 
     // Phase 1 — Chat IA
     Route::middleware([AIRateLimiter::class])->group(function () {

--- a/api/routes/modules/absence.php
+++ b/api/routes/modules/absence.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Route;
 | Full paths: /api/v1/absences/...
 */
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])
     ->prefix('absences')
     ->group(function (): void {
         Route::get('/', [AbsenceController::class, 'index']);

--- a/api/routes/modules/billing.php
+++ b/api/routes/modules/billing.php
@@ -16,7 +16,7 @@ use App\Modules\Onboarding\Interfaces\Api\V1\Controllers\OnboardingStepControlle
 use Illuminate\Support\Facades\Route;
 
 // ── Authenticated routes ──────────────────────────────────────────────────────
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // Onboarding Steps — tous les utilisateurs authentifiés du tenant
     // (l'app Employee complète son onboarding : T118 — plus de 403

--- a/api/routes/modules/cabinet.php
+++ b/api/routes/modules/cabinet.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/cabinet/shared/{token}', [CabinetShareController::class, 'accessByToken'])
     ->middleware('throttle:60,1');
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->prefix('cabinet')->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->prefix('cabinet')->group(function (): void {
 
     // ── Stats ────────────────────────────────────────────────────────────────
     Route::get('/stats', [CabinetShareController::class, 'stats']);

--- a/api/routes/modules/cameras.php
+++ b/api/routes/modules/cameras.php
@@ -21,7 +21,7 @@ use App\Modules\Cameras\Interfaces\Api\V1\Controllers\InternalCameraTokenControl
 use App\Modules\Cameras\Interfaces\Api\V1\Controllers\PublicCameraViewerController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'module.cameras'])
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'module.cameras'])
     ->prefix('cameras')
     ->group(function (): void {
         Route::get('/', [CameraController::class, 'index']);

--- a/api/routes/modules/dashboard.php
+++ b/api/routes/modules/dashboard.php
@@ -13,7 +13,7 @@ use App\Modules\Notification\Interfaces\Api\V1\Controllers\NotificationControlle
 use App\Modules\HR\Interfaces\Api\V1\Controllers\RoleAssignmentController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // Dashboard — managers only
     Route::middleware('api.manager')->group(function (): void {

--- a/api/routes/modules/expense.php
+++ b/api/routes/modules/expense.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Modules\Expense\Interfaces\Api\V1\Controllers\ExpenseClaimController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
     Route::get('/expense-claims', [ExpenseClaimController::class, 'index']);
     Route::post('/expense-claims', [ExpenseClaimController::class, 'store']);
     Route::get('/expense-claims/{expenseClaim}', [ExpenseClaimController::class, 'show']);

--- a/api/routes/modules/hr_app.php
+++ b/api/routes/modules/hr_app.php
@@ -20,7 +20,7 @@
 use App\Modules\HR\Interfaces\Api\V1\Controllers\HrController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'api.manager:rh,principal'])
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'api.manager:rh,principal'])
     ->prefix('hr')
     ->group(function (): void {
 

--- a/api/routes/modules/hr_extended.php
+++ b/api/routes/modules/hr_extended.php
@@ -32,7 +32,7 @@ use App\Modules\Recruitment\Interfaces\Api\V1\JobPostingActionController;
 use App\Modules\Recruitment\Interfaces\Api\V1\RecruitmentController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // ── Self-Service (all employees) ─────────────────────────────────────
     Route::get('/me/leave-balances', [LeavePolicyController::class, 'myBalances']);

--- a/api/routes/modules/integrations.php
+++ b/api/routes/modules/integrations.php
@@ -10,7 +10,7 @@ use App\Modules\Attendance\Interfaces\Api\V1\ZktecoController;
 use App\Modules\Notification\Interfaces\Api\V1\Controllers\DeviceTokenController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
     Route::post('/device-tokens', [DeviceTokenController::class, 'register']);
     Route::delete('/device-tokens', [DeviceTokenController::class, 'unregister']);
     Route::get('/device-tokens', [DeviceTokenController::class, 'index']);

--- a/api/routes/modules/marketing.php
+++ b/api/routes/modules/marketing.php
@@ -20,7 +20,7 @@ use App\Modules\Marketing\Interfaces\Api\V1\Controllers\SocialAccountController;
 use App\Modules\Marketing\Interfaces\Api\V1\Controllers\SocialPostController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'api.manager:marketing,principal'])
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'api.manager:marketing,principal'])
     ->prefix('marketing')
     ->group(function (): void {
         // ----------------------------------------------------------------

--- a/api/routes/modules/payroll_engine.php
+++ b/api/routes/modules/payroll_engine.php
@@ -31,7 +31,7 @@ use App\Modules\Payroll\Interfaces\Api\V1\SocialDeclarationController;
 use App\Modules\Payroll\Interfaces\Api\V1\TaxSlabController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'throttle:payroll-sensitive'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'throttle:payroll-sensitive'])->group(function (): void {
 
     // ── Self-service pay slips (all employees) ───────────────────────────
     Route::get('/me/pay-slips', [PaySlipController::class, 'myPaySlips']);

--- a/api/routes/modules/planning.php
+++ b/api/routes/modules/planning.php
@@ -3,7 +3,7 @@
 use App\Modules\Planning\Interfaces\Api\V1\PlanningController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'api.manager'])->prefix('planning')->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'api.manager'])->prefix('planning')->group(function (): void {
     Route::get('/weekly-optimization', [PlanningController::class, 'weeklyOptimization']);
     Route::get('/shift-rebalancing', [PlanningController::class, 'shiftRebalancing']);
 });

--- a/api/routes/modules/rh.php
+++ b/api/routes/modules/rh.php
@@ -38,7 +38,7 @@ use App\Modules\Planning\Interfaces\Api\V1\ScheduleController;
 use App\Modules\Planning\Interfaces\Api\V1\TaskController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
 
     // ── Employees ─────────────────────────────────────────────────────────────
     Route::get('/employees', [EmployeeController::class, 'index']);

--- a/api/routes/modules/tracking.php
+++ b/api/routes/modules/tracking.php
@@ -14,13 +14,13 @@ use Illuminate\Support\Facades\Route;
 //    pas manager (employé = son propre véhicule assigné uniquement)
 //  - GET /me/vehicles             → véhicules assignés à l'employé connecté
 //  (consommés par l'app mobile employé leopardo_employee)
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
     // Employee self-service (véhicule assigné uniquement)
     Route::get('/me/vehicles', [VehicleController::class, 'myVehicles']);
     Route::get('/vehicles/{id}/position', [VehicleController::class, 'position'])->whereNumber('id');
 });
 
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'api.manager'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'api.manager'])->group(function (): void {
     // Vehicles CRUD
     Route::get('/vehicles', [VehicleController::class, 'index']);
     Route::post('/vehicles', [VehicleController::class, 'store']);

--- a/api/routes/modules/user.php
+++ b/api/routes/modules/user.php
@@ -38,6 +38,6 @@ Route::middleware(['throttle:api', 'auth:user_api'])->prefix('user')->group(func
 // Manager: lier un utilisateur ordinaire a un employe
 // #3244 : groupe api.manager (défense en profondeur — famille #3150) — le
 // garde isManager() du contrôleur reste en second rideau.
-Route::middleware(['throttle:api', 'auth:sanctum', 'tenant', 'throttle:api-plan', 'api.manager'])->group(function (): void {
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan', 'api.manager'])->group(function (): void {
     Route::post('/employees/link-user', [UserEmployeeLinkController::class, 'linkByEmail']);
 });


### PR DESCRIPTION
## Problème
`token.refresh` (TokenAutoRefreshMiddleware — refresh silencieux des tokens Sanctum expirants) n'était appliqué qu'au groupe principal + growth/sso/user : 15 groupes modules + ai.php renvoyaient 401 à l'expiration au lieu du refresh → déconnexions forcées mobile.

## Correctif
`'token.refresh'` inséré après `'auth:sanctum'` dans les groupes authentifiés de : absence, billing, cabinet, cameras, dashboard, expense, hr_app, hr_extended, integrations, marketing, payroll_engine, planning, rh, tracking, user, ai (16 fichiers, 17 groupes).

## Validation
- Pas de changement de comportement hors ajout du middleware (déjà enregistré dans bootstrap/app.php)
- Contrat de routes inchangé (middleware uniquement)

Closes #3889