### PR TITLE
fix(ci): deploy-main — déduplication par SHA réellement active (Closes #3904)

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -16,14 +16,20 @@ env:
   DEFAULT_API_BASE_URL: https://gestionemployerbackend.onrender.com/api/v1
   DEFAULT_API_HEALTHCHECK_URL: https://gestionemployerbackend.onrender.com/api/v1/health
 
-# Issue #1835 : déduplication par SHA — deux parents (Tests + Web CI)
+# Issue #1835 + #3904 : déduplication par SHA — deux parents (Tests + Web CI)
 # complètent chacun pour le même SHA ; le 2e run annule le 1er (qui évalue
 # le même SHA, donc même décision) au lieu d'empiler 2 déploiements + 2 E2E
 # + 2 OWASP. Deux SHA différents restent indépendants (pas d'annulation
 # croisée) : le gate anti-stale de deploy-main tranche seul.
+# #3904 : `github.event_name == 'pull_request'` n'était JAMAIS vrai ici
+# (événements workflow_run / workflow_dispatch) → cancel-in-progress restait
+# false et le même SHA s'exécutait en série à chaque run parent (observé :
+# 4× sur un SHA en 11 min). Le groupe est déjà par-SHA ; on active donc
+# l'annulation inconditionnelle. `github.sha` couvre le workflow_dispatch
+# (pas de workflow_run.head_sha) et garde un groupe unique par SHA manuel.
 concurrency:
-  group: deploy-main-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: deploy-main-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   prepare:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(ci): deploy-main — déduplication par SHA réellement active (Closes #3904).** `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` n'était jamais vrai (événements `workflow_run`/`workflow_dispatch`) → le même SHA s'exécutait en série à chaque run parent (observé 4× en 11 min, doublant E2E + OWASP et saturant la file CI). Groupe par-SHA conservé (`head_sha`, fallback `github.sha` pour le dispatch manuel) + `cancel-in-progress: true` : le 2e run du même SHA annule le 1er, deux SHA différents restent indépendants.
 
 - **fix(api): token.refresh applique aux 16 groupes de routes modules (Closes #3889).** Le middleware `TokenAutoRefreshMiddleware` (refresh silencieux des tokens Sanctum expirants) etait applique au groupe principal + growth/sso/user, mais absent de absence, billing, cabinet, cameras, dashboard, expense, hr_app, hr_extended, integrations, marketing, payroll_engine, planning, rh, tracking, user et ai → les clients mobiles recevaient un 401 a l'expiration au lieu du refresh silencieux (deconnexions forcees).
 


### PR DESCRIPTION
## Résumé

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` n'était **jamais vrai** sur ce workflow (déclenché par `workflow_run`/`workflow_dispatch`) : le même SHA s'exécutait en série à chaque run parent — observé 4× en 11 min pour un SHA, avec E2E-staging et OWASP ZAP doublés (contribue à la famine CI #3545).

## Changements

- `concurrency.group` : par SHA via `github.event.workflow_run.head_sha`, fallback `github.sha` pour le dispatch manuel.
- `cancel-in-progress: true` : le 2e run du même SHA annule le 1er (même décision évaluée). Deux SHA différents restent indépendants.
- YAML validé (parse OK). Entrée `CHANGELOG.md [Unreleased]`.

Closes #3904