### PR TITLE
fix(api): « Envoyer les bulletins » déclenche une vraie notification push (Closes #3946)

### DIFF
--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PaySlipController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PaySlipController.php
@@ -4,19 +4,24 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Interfaces\Api\V1;
 
-use App\Http\Controllers\Controller;
-use App\Http\Resources\Api\V1\PaySlipResource;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Auth\Infrastructure\Services\DataAccessAuditLogger;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\PaySlipResource;
 use App\Modules\Cabinet\Domain\Models\CabinetDocument;
+use App\Modules\Notification\Infrastructure\Services\PushNotificationService;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use App\Modules\Payroll\Infrastructure\Services\PaySlipPdfGenerator;
+use App\Support\I18nCatalog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
 
 class PaySlipController extends Controller
 {
@@ -228,25 +233,60 @@ class PaySlipController extends Controller
         }
 
         $slips = $payrollRun->paySlips()
-            ->with('employee:id,first_name,last_name,email')
+            ->with('employee:id,first_name,last_name,email,preferred_language')
             ->whereIn('status', ['calculated', 'validated'])
             ->get();
 
+        /** @var PushNotificationService $pushService */
+        $pushService = app(PushNotificationService::class);
+
         $sent = 0;
+        $notified = 0;
         foreach ($slips as $slip) {
-            if (! empty($slip->employee->email)) {
-                $slip->update(['status' => 'sent']);
-                $sent++;
+            $employee = $slip->employee;
+            if ($employee === null || empty($employee->email)) {
+                continue;
+            }
+
+            $slip->update(['status' => 'sent']);
+            $sent++;
+
+            // Issue #3946 — « Envoyer les bulletins » était un no-op : seul le
+            // statut passait à `sent`, aucun mail/push n'était déclenché.
+            // On notifie l'employé via le canal push existant (PA2-COMM-006,
+            // même clés i18n que GeneratePaySlipPdfJob), dans sa propre locale.
+            try {
+                $previousLocale = App::getLocale();
+                App::setLocale(I18nCatalog::normalizeLocale($employee->preferred_language));
+
+                $pushService->sendToEmployee(
+                    $employee,
+                    (string) trans('notifications.payroll_ready_title'),
+                    (string) trans('notifications.payroll_ready_body_with_period', [
+                        'period' => $payrollRun->period_end->format('M Y'),
+                    ]),
+                    [
+                        'type' => 'pay_slip_sent',
+                        'payroll_run_id' => $payrollRun->id,
+                        'pay_slip_id' => $slip->id,
+                    ],
+                );
+
+                App::setLocale($previousLocale);
+                $notified++;
+            } catch (Throwable $e) {
+                App::setLocale(App::getFallbackLocale());
+                Log::warning("PaySlipController::sendSlips — push notification failed for slip #{$slip->id}: {$e->getMessage()}");
             }
         }
 
         return response()->json([
-            'message' => "{$sent} bulletin(s) marqué(s) comme envoyé(s).",
+            'message' => "{$sent} bulletin(s) envoyé(s), {$notified} notification(s) push déclenchée(s).",
             'sent_count' => $sent,
+            'notified_count' => $notified,
             'total_slips' => $slips->count(),
         ]);
     }
-
 
     /**
      * Issue #1817 — téléchargement sécurisé du bulletin archivé dans le

--- a/api/tests/Feature/PaySlipControllerTest.php
+++ b/api/tests/Feature/PaySlipControllerTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature;
 
-use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Notification\Infrastructure\Services\PushNotificationService;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use App\Modules\Payroll\Domain\Models\PaySlipLine;
@@ -355,5 +356,82 @@ class PaySlipControllerTest extends TestCase
 
         return [$run, $slip];
     }
-}
 
+    /**
+     * Issue #3946 — « Envoyer les bulletins » était un no-op : seul le statut
+     * passait à `sent`. Depuis le fix, une notification push réelle est
+     * déclenchée par employé (même canal que GeneratePaySlipPdfJob).
+     */
+    public function test_send_slips_marks_sent_and_dispatches_push_notification(): void
+    {
+        [$company, $manager, $employee] = $this->payrollActor();
+        [$run, $slipA] = $this->payrollSlip($company, $employee, [
+            'run_status' => 'validated',
+            'status' => 'calculated',
+        ]);
+        $employeeB = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => fake()->unique()->safeEmail(),
+            'preferred_language' => 'ar',
+        ]);
+        $this->payrollSlip($company, $employeeB, [
+            'run' => $run,
+            'status' => 'validated',
+        ]);
+
+        $push = $this->mock(PushNotificationService::class);
+        $push->shouldReceive('sendToEmployee')
+            ->twice()
+            ->withArgs(function (Employee $target, string $title, string $body, array $data): bool {
+                return $data['type'] === 'pay_slip_sent'
+                    && $data['pay_slip_id'] > 0
+                    && $title !== ''
+                    && $body !== '';
+            })
+            ->andReturn(1);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/send-slips")
+            ->assertOk()
+            ->assertJsonPath('sent_count', 2)
+            ->assertJsonPath('notified_count', 2)
+            ->assertJsonPath('total_slips', 2);
+
+        $this->assertSame('sent', $slipA->fresh()->status);
+    }
+
+    public function test_send_slips_forbidden_for_non_manager(): void
+    {
+        [$company, , $employee] = $this->payrollActor();
+        [$run] = $this->payrollSlip($company, $employee, ['run_status' => 'validated', 'status' => 'calculated']);
+
+        Sanctum::actingAs($employee);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/send-slips")
+            ->assertForbidden();
+    }
+
+    public function test_send_slips_returns_404_for_foreign_tenant_run(): void
+    {
+        [$companyA, $managerA] = $this->payrollActor();
+        [$companyB, , $employeeB] = $this->payrollActor();
+        [$runB] = $this->payrollSlip($companyB, $employeeB, ['run_status' => 'validated', 'status' => 'calculated']);
+
+        Sanctum::actingAs($managerA);
+
+        $this->postJson("/api/v1/payroll-runs/{$runB->id}/send-slips")
+            ->assertNotFound();
+    }
+
+    public function test_send_slips_rejects_unvalidated_run(): void
+    {
+        [$company, $manager, $employee] = $this->payrollActor();
+        [$run] = $this->payrollSlip($company, $employee, ['run_status' => 'calculated', 'status' => 'calculated']);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/send-slips")
+            ->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Problème (issue #3946)

`PaySlipController::sendSlips` était un no-op : il passait le statut des bulletins à `sent` sans déclencher **aucune** notification. Les managers voyaient « N bulletin(s) marqué(s) comme envoyé(s) » et les employés ne recevaient rien — le statut `sent` corrompant en plus le flux `myPaySlips` (qui ne liste que `validated, sent`).

## Changements

- `PaySlipController::sendSlips` : chaque bulletin marqué `sent` déclenche désormais une vraie notification push via `PushNotificationService::sendToEmployee` :
  - mêmes clés i18n que `GeneratePaySlipPdfJob` (`notifications.payroll_ready_title` / `payroll_ready_body_with_period`)
  - locale de l'employé via `I18nCatalog::normalizeLocale` (comme le job)
  - `data.type = pay_slip_sent` + `payroll_run_id` + `pay_slip_id`
  - try/catch par bulletin : un échec push est loggé, la requête reste 200 (aucun employé bloquant les autres)
- Réponse enrichie : `sent_count` + `notified_count`
- CHANGELOG : entrée sous `## [Unreleased]`

## Validation locale (PHP 8.4 + PostgreSQL 16)

- `php artisan test --filter=PaySlipControllerTest` → **20 passed (69 assertions)** dont 4 nouveaux tests (mock push réel, 403 non-manager, 404 cross-tenant, 422 run non validé)
- `vendor/bin/pint` appliqué ✅
- `vendor/bin/phpstan analyse --configuration phpstan-strict.neon` → `[OK] No errors` ✅

Closes #3946
