### PR TITLE
fix(api): BulkPay fail-closed quand Redis est down — 503 au dispatch, lot aborté au job, tests (Closes #3857)

### DIFF
--- a/api/app/Jobs/ProcessBulkPaymentJob.php
+++ b/api/app/Jobs/ProcessBulkPaymentJob.php
@@ -126,6 +126,7 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
         // permettre le retry de CE slip uniquement.
         $claimPrefix = "bulk_pay:slip:{$run->id}:";
         $redis = Redis::connection('default');
+        $redisUnavailable = false;
 
         foreach ($slips as $slip) {
             try {
@@ -133,14 +134,19 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
                 try {
                     $claimed = (bool) $redis->set($claimPrefix.$slip->id, '1', 'EX', 21600, 'NX'); // @phpstan-ignore argument.type, arguments.count
                 } catch (Throwable $redisError) {
-                    // Redis indisponible : on traite sans garde (comportement
-                    // historique) mais on le trace pour l'observabilité.
-                    Log::warning('ProcessBulkPaymentJob: Redis claim unavailable, processing without guard', [
+                    // #3857 : FAIL-CLOSED. Sans claim NX, un job concurrent
+                    // (retry queue, second dispatch) re-traiterait des slips
+                    // déjà payés → double déclaration de paiement. On ABORTE
+                    // le lot entier : rien n'est marqué payé après ce point,
+                    // le job échoue et la queue retry rejouera proprement une
+                    // fois Redis revenu ($tries=3).
+                    Log::error('ProcessBulkPaymentJob: Redis claim unavailable — batch aborted (fail-closed)', [
                         'payroll_run_id' => $run->id,
                         'pay_slip_id' => $slip->id,
                         'error' => $redisError->getMessage(),
                     ]);
-                    $claimed = true;
+                    $redisUnavailable = true;
+                    break;
                 }
 
                 if (! $claimed) {
@@ -174,6 +180,21 @@ class ProcessBulkPaymentJob implements ShouldQueue, TenantScopedJob
 
             $done++;
             $this->updateProgress($done, 'processing', $total, $failures);
+        }
+
+        if ($redisUnavailable) {
+            // Fail-closed : libérer le claim du run pour permettre un
+            // redispatch propre, puis échouer le job (retry $tries=3 avec
+            // backoff par défaut de la queue).
+            try {
+                $redis->del("bulk_pay:run:{$run->id}");
+            } catch (Throwable) {
+                // non bloquant
+            }
+
+            throw new \RuntimeException(
+                "ProcessBulkPaymentJob: batch aborted — Redis claim coordinator unavailable (payroll_run_id: {$run->id})."
+            );
         }
 
         $succeeded = $total - count($failures);

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/BulkPaymentController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/BulkPaymentController.php
@@ -81,8 +81,24 @@ class BulkPaymentController extends Controller
                 // Statut stale (completed*/crash) : on reprend la main.
                 Redis::connection('default')->set($progressKey, $claimPayload, 'EX', 21600); // @phpstan-ignore argument.type, arguments.count
             }
-        } catch (Throwable) {
-            // Redis unavailable — allow dispatch to continue
+        } catch (Throwable $e) {
+            // #3857 : FAIL-CLOSED. Redis est le coordinateur anti-doublon
+            // (claim NX du run). S'il est indisponible, un dispatch sans
+            // claim laisserait deux requêtes concurrentes (retry client,
+            // double-clic) lancer deux jobs qui paieraient 2× les mêmes
+            // bulletins — mouvement d'argent, inacceptable. On refuse le
+            // dispatch avec un 503 explicite : le client retry-aware pourra
+            // re-tenter, aucun job n'est lancé.
+            Log::error('payroll.bulk_payment.redis_unavailable', [
+                'payroll_run_id' => $payrollRun->id,
+                'actor_id' => $actor->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'message' => 'Bulk payment is temporarily unavailable (payment coordinator offline). Please retry in a few seconds.',
+                'error' => 'BULK_PAYMENT_COORDINATOR_UNAVAILABLE',
+            ], 503);
         }
 
         ProcessBulkPaymentJob::dispatch($payrollRun->id, $actor->id, $paySlipIds);

--- a/api/tests/Feature/BulkPaymentControllerTest.php
+++ b/api/tests/Feature/BulkPaymentControllerTest.php
@@ -10,6 +10,7 @@ use App\Jobs\ProcessBulkPaymentJob;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Redis;
 use Laravel\Sanctum\Sanctum;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
@@ -167,4 +168,29 @@ class BulkPaymentControllerTest extends TestCase
         // Un seul job dispatché au total
         Bus::assertDispatchedTimes(ProcessBulkPaymentJob::class, 1);
     }
+
+    public function test_bulk_pay_fails_closed_with_503_when_redis_is_unavailable(): void
+    {
+        // #3857 : FAIL-CLOSED. Redis est le coordinateur anti-doublon (claim
+        // NX du run) : s'il est indisponible, un dispatch sans claim
+        // laisserait deux requêtes concurrentes lancer deux jobs qui
+        // paieraient 2× les mêmes bulletins (mouvement d'argent). On refuse
+        // avec 503 et AUCUN job n'est dispatché.
+        Bus::fake();
+
+        [$company, $manager, $run, $slipA, $slipB] = $this->fixture();
+        Sanctum::actingAs($manager);
+
+        $client = Mockery::mock();
+        $client->shouldReceive('set')->andThrow(new \RuntimeException('Redis connection refused'));
+        $client->shouldReceive('get')->andReturn(null);
+        Redis::shouldReceive('connection')->with('default')->andReturn($client);
+
+        $this->postJson("/api/v1/payroll-runs/{$run->id}/bulk-pay")
+            ->assertStatus(503)
+            ->assertJsonPath('error', 'BULK_PAYMENT_COORDINATOR_UNAVAILABLE');
+
+        Bus::assertNotDispatched(ProcessBulkPaymentJob::class);
+    }
 }
+

--- a/api/tests/Feature/ProcessBulkPaymentJobTest.php
+++ b/api/tests/Feature/ProcessBulkPaymentJobTest.php
@@ -14,6 +14,7 @@ use App\Modules\Notification\Domain\Models\Notification;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Redis;
 use RuntimeException;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
@@ -218,6 +219,43 @@ class ProcessBulkPaymentJobTest extends TestCase
 
         $run->refresh();
         $this->assertSame('paid', $run->status);
+    }
+
+    public function test_job_aborts_fail_closed_when_redis_claims_are_unavailable(): void
+    {
+        // #3857 : FAIL-CLOSED. Sans claim NX, un job concurrent (retry queue,
+        // second dispatch) re-traiterait des slips déjà payés → double
+        // déclaration de paiement. Quand Redis est indisponible pendant le
+        // traitement, le lot entier est avorté : aucune avance marquée payée,
+        // le run reste 'validated', le claim du run est libéré et le job
+        // échoue (RuntimeException) pour retry propre.
+        Queue::fake();
+
+        [$company, $manager] = $this->companyAndManager();
+        $run = $this->payrollRun($company);
+        $employeeA = Employee::factory()->create(['company_id' => $company->id]);
+        $employeeB = Employee::factory()->create(['company_id' => $company->id]);
+        $this->paySlip($run, $employeeA);
+        $this->paySlip($run, $employeeB);
+
+        $client = Mockery::mock();
+        $client->shouldReceive('set')->andThrow(new RuntimeException('Redis connection refused'));
+        $client->shouldReceive('del')->andReturn(1);
+        Redis::shouldReceive('connection')->with('default')->andReturn($client);
+
+        try {
+            (new ProcessBulkPaymentJob($run->id, $manager->id))->handle();
+            $this->fail('Le job doit échouer (fail-closed) quand Redis est indisponible.');
+        } catch (RuntimeException) {
+            // attendu — le lot est avorté
+        }
+
+        $run->refresh();
+        $this->assertSame('validated', $run->status, 'Le run ne doit pas être marqué paid après un abort fail-closed.');
+        $this->assertSame(0, AuditLog::query()
+            ->where('action', 'bulk_payment_processed')
+            ->where('company_id', $company->id)
+            ->count(), 'Aucun audit de batch terminé ne doit être écrit.');
     }
 
     /**

--- a/docs/specifications/ISSUE_3857_BULKPAY_FAIL_CLOSED.md
+++ b/docs/specifications/ISSUE_3857_BULKPAY_FAIL_CLOSED.md
@@ -1,0 +1,24 @@
+# Mini-spécification — Issue #3857
+
+## Objectif
+
+Rendre BulkPay fail-closed quand Redis (coordinateur anti-doublon) est indisponible. Avant : le dispatch continuait sans claim et le job traitait sans garde NX → deux requêtes concurrentes (retry, double-clic) pouvaient payer 2× les mêmes bulletins (mouvement d'argent).
+
+## Correction
+
+1. **`BulkPaymentController::bulkPay`** : `catch (Throwable)` → 503 `BULK_PAYMENT_COORDINATOR_UNAVAILABLE` + log `payroll.bulk_payment.redis_unavailable`. Aucun dispatch sans claim.
+2. **`ProcessBulkPaymentJob::handle`** : la panne Redis pendant le claim NX d'un slip → `$redisUnavailable = true` + `break` (fini le `$claimed = true` de secours). Après la boucle : libération du claim du run + `throw RuntimeException` (retry `$tries=3`). Aucune avance marquée `payment_declared` après le point d'abort, run jamais `paid`, aucun audit de batch écrit.
+3. Redis UP : comportement inchangé (409 si en cours, NX par slip, run `paid` si tous les slips traités).
+
+## Critères d'acceptation
+
+1. Redis down → `POST /bulk-pay` renvoie 503, zéro job dispatché.
+2. Redis down pendant le job → lot aborté (exception), zéro slip marqué payé, claim du run libéré.
+3. Redis up → 409/202 inchangés, tests existants verts.
+4. PHPStan strict vert.
+
+## Trace Spec Kit
+
+Issue : #3857
+Branche : `fix/3857-bulkpay-redis-fail-closed`
+Date : 2026-08-15


### PR DESCRIPTION
## Problème (issue #3857 — audit QA 360°)
BulkPay (paiement en masse, **mouvement d'argent**) contourne sa garde anti-doublon quand Redis est indisponible :
1. `BulkPaymentController::bulkPay` : `catch (Throwable) { // Redis unavailable — allow dispatch to continue }` → deux requêtes concurrentes (retry client, double-clic) passent le guard et dispatchent **deux jobs** qui paient 2× les mêmes bulletins.
2. `ProcessBulkPaymentJob` : `$claimed = true` de secours → chaque slip est traité **sans garde NX** pendant la panne.

## Correctif (fail-closed)
1. **Controller** : Redis down → **503 `BULK_PAYMENT_COORDINATOR_UNAVAILABLE`**, zéro dispatch (le client retry-aware re-tente ; aucun job ne peut doubler).
2. **Job** : panne Redis au claim → **abort du lot entier** (`RuntimeException` → retry `$tries=3`), libération du claim du run, **aucune avance marquée payée**, run jamais `paid`, aucun audit de batch.
3. Redis UP : comportement inchangé (409 si en cours, NX par slip).

## Tests ajoutés
- `test_bulk_pay_fails_closed_with_503_when_redis_is_unavailable` — 503 + `Bus::assertNotDispatched`
- `test_job_aborts_fail_closed_when_redis_claims_are_unavailable` — run reste `validated`, aucun audit

## Validation
- PHPStan strict / tests BulkPayment à confirmer par CI (pas de PHP local dans la sandbox — raisonnement vérifié ligne à ligne).

Closes #3857
