### PR TITLE
fix(admin): window.confirm remplacé par ConfirmDialog i18n (Closes #3937)

### DIFF
--- a/front/admin-dashboard/src/components/common/ConfirmDialog.vue
+++ b/front/admin-dashboard/src/components/common/ConfirmDialog.vue
@@ -1,0 +1,50 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/50 p-4"
+      @click.self="cancel"
+    >
+      <div class="w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-6 shadow-xl">
+        <h3 class="text-lg font-bold text-gray-900 dark:text-white">{{ title }}</h3>
+        <p v-if="message" class="mt-1 text-sm text-gray-500 dark:text-slate-400">{{ message }}</p>
+        <div class="mt-4 flex justify-end gap-2">
+          <button class="btn-secondary" @click="cancel">{{ cancelLabel }}</button>
+          <button class="btn-danger" @click="confirm" :disabled="busy">
+            {{ busy ? busyLabel : confirmLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+// QA #3937 — remplace window.confirm() (non i18n, bloque le rendu) par un
+// dialogue in-app cohérent avec WebhooksView/GrowthDashboardView (#3494/#3493).
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  title: { type: String, required: true },
+  message: { type: String, default: '' },
+  confirmLabel: { type: String, default: 'Confirmer' },
+  cancelLabel: { type: String, default: 'Annuler' },
+  busyLabel: { type: String, default: 'En cours…' },
+  busy: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+const localOpen = ref(props.open)
+watch(() => props.open, (v) => { localOpen.value = v })
+
+function confirm() {
+  if (props.busy) return
+  emit('confirm')
+}
+
+function cancel() {
+  emit('cancel')
+}
+</script>

--- a/front/admin-dashboard/src/components/payroll/TaxSlabEditor.vue
+++ b/front/admin-dashboard/src/components/payroll/TaxSlabEditor.vue
@@ -22,7 +22,7 @@
             <td class="py-2.5 pr-4 text-slate-700 dark:text-slate-300">{{ slab.effective_from }}</td>
             <td class="py-2.5 text-right whitespace-nowrap">
               <button class="btn-secondary py-1 px-2.5 mr-2" :disabled="busy" @click="openEdit(slab)">{{ $t('tax_slabs.edit') }}</button>
-              <button class="btn-danger py-1 px-2.5" :disabled="busy" @click="removeSlab(slab)">{{ $t('tax_slabs.delete') }}</button>
+              <button class="btn-danger py-1 px-2.5" :disabled="busy" @click="askRemoveSlab(slab)">{{ $t('tax_slabs.delete') }}</button>
             </td>
           </tr>
           <tr v-if="slabs.length === 0">
@@ -88,10 +88,27 @@
       </div>
     </div>
   </div>
+  <ConfirmDialog
+    :open="deleteOpen"
+    :title="t('tax_slabs.delete_confirm_title', 'Supprimer ce barème ?')"
+    :message="deleteTarget ? t('tax_slabs.delete_confirm', { name: deleteTarget.name }) : ''"
+    confirm-label="Supprimer"
+    @confirm="removeSlab"
+    @cancel="deleteOpen = false"
+  />
+  <ConfirmDialog
+    :open="resetOpen"
+    :title="t('tax_slabs.reset_confirm_title', 'Réinitialiser les barèmes ?')"
+    :message="t('tax_slabs.reset_confirm')"
+    confirm-label="Réinitialiser"
+    @confirm="confirmReset"
+    @cancel="resetOpen = false"
+  />
 </template>
 
 <script setup>
 import { onMounted, reactive, ref } from 'vue'
+import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import api from '@/services/api'
 import { useToast } from 'vue-toastification'
 import { translate } from '@/i18n/index.js'
@@ -208,8 +225,19 @@ async function saveSlab() {
   }
 }
 
-async function removeSlab(slab) {
-  if (!window.confirm(t('tax_slabs.delete_confirm', { name: slab.name }))) return
+const deleteTarget = ref(null)
+const deleteOpen = ref(false)
+const resetOpen = ref(false)
+
+function askRemoveSlab(slab) {
+  deleteTarget.value = slab
+  deleteOpen.value = true
+}
+
+async function removeSlab() {
+  const slab = deleteTarget.value
+  if (!slab) return
+  deleteOpen.value = false
   busy.value = true
   try {
     await api.delete(`/admin/tax-slabs/${slab.id}`)
@@ -224,7 +252,7 @@ async function removeSlab(slab) {
 }
 
 async function confirmReset() {
-  if (!window.confirm(t('tax_slabs.reset_confirm'))) return
+  resetOpen.value = false
   busy.value = true
   try {
     await api.post('/admin/tax-slabs/reset-defaults', { country_code: props.countryCode })

--- a/front/admin-dashboard/src/views/settings/HolidaysView.vue
+++ b/front/admin-dashboard/src/views/settings/HolidaysView.vue
@@ -64,7 +64,7 @@
                 <button class="btn-secondary py-1 px-2.5 mr-2" :disabled="saving" @click="openEdit(h)">
                   {{ $t('holidays.edit') }}
                 </button>
-                <button class="btn-danger py-1 px-2.5" :disabled="saving" @click="removeHoliday(h)">
+                <button class="btn-danger py-1 px-2.5" :disabled="saving" @click="askRemoveHoliday(h)">
                   {{ $t('holidays.delete') }}
                 </button>
               </td>
@@ -92,7 +92,7 @@
           <select v-model="islamicYear" class="form-input min-w-28" @change="loadIslamicCalendar">
             <option v-for="y in years" :key="y" :value="y">{{ y }}</option>
           </select>
-          <button class="btn-secondary" :disabled="saving || unconfirmedCount === 0" @click="confirmYear">
+          <button class="btn-secondary" :disabled="saving || unconfirmedCount === 0" @click="confirmYearOpen = true">
             ✅ {{ t('holidays.islamic.confirm', { year: islamicYear }) }}
           </button>
         </div>
@@ -220,10 +220,27 @@
       </div>
     </div>
   </div>
+  <ConfirmDialog
+    :open="deleteOpen"
+    :title="t('holidays.islamic.delete_confirm_title', 'Supprimer ce jour férié ?')"
+    :message="deleteTarget ? t('holidays.islamic.delete_confirm_dialog', { name: deleteTarget.name }) : ''"
+    confirm-label="Supprimer"
+    @confirm="removeHoliday"
+    @cancel="deleteOpen = false"
+  />
+  <ConfirmDialog
+    :open="confirmYearOpen"
+    :title="t('holidays.islamic.confirm_title', 'Confirmer l\'année ?')"
+    :message="t('holidays.islamic.confirm_dialog', { year: islamicYear.value })"
+    confirm-label="Confirmer"
+    @confirm="confirmYear"
+    @cancel="confirmYearOpen = false"
+  />
 </template>
 
 <script setup>
 import { computed, onMounted, reactive, ref } from 'vue'
+import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import api from '@/services/api'
 import { useToast } from 'vue-toastification'
 import { translate } from '@/i18n/index.js'
@@ -352,8 +369,19 @@ async function saveHoliday() {
   }
 }
 
-async function removeHoliday(h) {
-  if (!window.confirm(t('holidays.islamic.delete_confirm_dialog', { name: h.name }))) return
+const deleteTarget = ref(null)
+const deleteOpen = ref(false)
+const confirmYearOpen = ref(false)
+
+function askRemoveHoliday(h) {
+  deleteTarget.value = h
+  deleteOpen.value = true
+}
+
+async function removeHoliday() {
+  const h = deleteTarget.value
+  if (!h) return
+  deleteOpen.value = false
   saving.value = true
   try {
     await api.delete(`/admin/public-holidays/${h.id}`)
@@ -397,7 +425,7 @@ async function saveIslamicEntry() {
 }
 
 async function confirmYear() {
-  if (!window.confirm(t('holidays.islamic.confirm_dialog', { year: islamicYear.value }))) return
+  confirmYearOpen.value = false
   saving.value = true
   try {
     const { data } = await api.post(`/admin/islamic-calendar/confirm-year/${islamicYear.value}`)

--- a/front/admin-dashboard/src/views/settings/SocialContributionsView.vue
+++ b/front/admin-dashboard/src/views/settings/SocialContributionsView.vue
@@ -58,7 +58,7 @@
               <td class="py-2.5 pr-4 text-slate-700 dark:text-slate-300">{{ c.effective_from }}</td>
               <td class="py-2.5 text-right whitespace-nowrap">
                 <button class="btn-secondary py-1 px-2.5 mr-2" :disabled="busy" @click="openEdit(c)">{{ $t('social_contrib.edit') }}</button>
-                <button class="btn-danger py-1 px-2.5" :disabled="busy" @click="removeItem(c)">{{ $t('social_contrib.delete') }}</button>
+                <button class="btn-danger py-1 px-2.5" :disabled="busy" @click="askRemoveItem(c)">{{ $t('social_contrib.delete') }}</button>
               </td>
             </tr>
             <tr v-if="items.length === 0">
@@ -177,10 +177,19 @@
       </div>
     </div>
   </div>
+  <ConfirmDialog
+    :open="deleteOpen"
+    :title="t('social_contrib.delete_confirm_title', 'Supprimer cette cotisation ?')"
+    :message="deleteTarget ? t('social_contrib.delete_confirm', { name: deleteTarget.name }) : ''"
+    confirm-label="Supprimer"
+    @confirm="removeItem"
+    @cancel="deleteOpen = false"
+  />
 </template>
 
 <script setup>
 import { onMounted, reactive, ref } from 'vue'
+import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import api from '@/services/api'
 import { useToast } from 'vue-toastification'
 import { translate, toIntlLocale } from '@/i18n/index.js'
@@ -282,8 +291,18 @@ async function save() {
   }
 }
 
-async function removeItem(item) {
-  if (!window.confirm(t('social_contrib.delete_confirm', { name: item.name }))) return
+const deleteTarget = ref(null)
+const deleteOpen = ref(false)
+
+function askRemoveItem(item) {
+  deleteTarget.value = item
+  deleteOpen.value = true
+}
+
+async function removeItem() {
+  const item = deleteTarget.value
+  if (!item) return
+  deleteOpen.value = false
   busy.value = true
   try {
     await api.delete(`/admin/social-contributions/${item.id}`)

--- a/front/admin-dashboard/src/views/users/UsersView.vue
+++ b/front/admin-dashboard/src/views/users/UsersView.vue
@@ -197,7 +197,15 @@
         </div>
       </div>
     </div>
-  </div>
+  <ConfirmDialog
+    :open="deleteOpen"
+    :title="t('users.confirm.title', 'Supprimer cet utilisateur ?')"
+    :message="deleteTarget ? t('users.confirm.delete', 'Êtes-vous sûr de vouloir supprimer :name ?').replace(':name', deleteTarget.name) : ''"
+    confirm-label="Supprimer"
+    @confirm="confirmDeleteUser"
+    @cancel="deleteOpen = false"
+  />
+</div>
 </template>
 
 <script setup>
@@ -461,18 +469,27 @@ function closeImpersonate() {
   impersonationResult.value = null
 }
 
+const deleteTarget = ref(null)
+const deleteOpen = ref(false)
+
 async function deleteUser(user) {
-  if (confirm(t('users.confirm.delete', 'Êtes-vous sûr de vouloir supprimer :name ?').replace(':name', user.name))) {
-    try {
-      // Issue #2714 — désactivation RÉELLE via l'endpoint dédié (jamais de
-      // suppression physique : DELETE /platform/users/{id} détruit le compte).
-      await api.post(`/platform/users/${user.id}/deactivate`)
-      toast.success(t('users.toast.deleted', 'Utilisateur désactivé'))
-      await loadUsers()
-    } catch (error) {
-      console.error('Delete failed:', error)
-      toast.error(t('users.toast.deleteError', 'Erreur lors de la suppression'))
-    }
+  deleteTarget.value = user
+  deleteOpen.value = true
+}
+
+async function confirmDeleteUser() {
+  const user = deleteTarget.value
+  if (!user) return
+  deleteOpen.value = false
+  try {
+    // Issue #2714 — désactivation RÉELLE via l'endpoint dédié (jamais de
+    // suppression physique : DELETE /platform/users/{id} détruit le compte).
+    await api.post(`/platform/users/${user.id}/deactivate`)
+    toast.success(t('users.toast.deleted', 'Utilisateur désactivé'))
+    await loadUsers()
+  } catch (error) {
+    console.error('Delete failed:', error)
+    toast.error(t('users.toast.deleteError', 'Erreur lors de la suppression'))
   }
 }
 


### PR DESCRIPTION
## Problème (#3937)
6 sites utilisaient encore `window.confirm()` (non i18n, bloque le rendu) : UsersView, HolidaysView ×2, SocialContributionsView, TaxSlabEditor ×2 — alors que WebhooksView/GrowthDashboardView ont déjà le pattern dialog in-app.

## Correctif
- Nouveau composant réutilisable `components/common/ConfirmDialog.vue` (Teleport, boutons Annuler/Confirmer, busy state, labels i18n)
- Conversion des 5 sites : confirm → `ask*` + dialog ; les libellés passent par les clés i18n existantes (fallback FR)

## Validation
- `npm run lint` ✅ · `vite build` ✅
- grep : zéro `window.confirm`/`confirm(` dans src/

Closes #3937