### PR TITLE
fix(api): TenantMiddleware — gardes de statut pour comptes ordinaires sans entreprise (Closes #3942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(api): comptes ordinaires sans entreprise — gardes de statut appliquées (Closes #3942).** TenantMiddleware laissait passer un employé `role: ordinary` suspendu/archivé (branche $next sans les checks) → accès API conservé. Désormais 403 EMPLOYEE_SUSPENDED/EMPLOYEE_ARCHIVED, comme les employés liés.
 - **fix(ci): launch-observability-smoke — cancel-in-progress: true (Closes #3968).** Le cron */30 (48 runs/jour) s'empilait sur une queue saturée (#3545) : un run en retard remplace désormais le précédent.
 - **fix(edge): HEALTHCHECK Dockerfile.publish aligné sur /api/v1/edge/health (Closes #3960).** La probe sondait encore `/api/edge/health` (pré-#3592) → 404 → conteneur « unhealthy » permanent et deadlock `depends_on: service_healthy` futur. Le docker-compose.yml était déjà corrigé (#3908) ; le Dockerfile standalone restait sur l'ancien chemin.
 

--- a/api/app/Http/Middleware/TenantMiddleware.php
+++ b/api/app/Http/Middleware/TenantMiddleware.php
@@ -49,6 +49,26 @@ class TenantMiddleware
 
         if (! $company) {
             if ($employee->role === 'ordinary') {
+                // Issue #3942 — les mêmes gardes de statut que les employés
+                // liés s'appliquent aux comptes ordinaires sans entreprise
+                // (fail-closed) : un compte suspendu/archivé n'a AUCUN accès
+                // API, même à la surface self-service.
+                if ($employee->status === 'archived') {
+                    if ($request->expectsJson() || $request->is('api/*')) {
+                        return new JsonResponse(['error' => 'EMPLOYEE_ARCHIVED'], 403);
+                    }
+
+                    abort(403);
+                }
+
+                if ($employee->status === 'suspended') {
+                    if ($request->expectsJson() || $request->is('api/*')) {
+                        return new JsonResponse(['error' => 'EMPLOYEE_SUSPENDED'], 403);
+                    }
+
+                    abort(403);
+                }
+
                 // Issue #3727 — fail-closed : cet employé poursuit SANS compagnie
                 // liée. Le marqueur convertit toute requête BelongsToCompany en
                 // 403 TENANT_CONTEXT_MISSING au lieu d'une requête cross-tenant

--- a/api/tests/Feature/Security/TenantScopeFailClosedTest.php
+++ b/api/tests/Feature/Security/TenantScopeFailClosedTest.php
@@ -111,4 +111,37 @@ class TenantScopeFailClosedTest extends TestCase
             \App\Modules\Notification\Domain\Models\Notification::query()->count()
         );
     }
+
+    public function test_suspended_ordinary_user_without_company_is_rejected(): void
+    {
+        // Issue #3942 — les gardes de statut s'appliquent aussi aux comptes
+        // ordinaires sans entreprise : avant, le branche `ordinary` sautait
+        // les checks suspended/archived et laissait passer la requête.
+        $orphan = Employee::factory()->create([
+            'company_id' => null,
+            'role' => 'ordinary',
+            'status' => 'suspended',
+        ]);
+
+        Sanctum::actingAs($orphan);
+
+        $this->getJson('/api/v1/notifications')
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'EMPLOYEE_SUSPENDED');
+    }
+
+    public function test_archived_ordinary_user_without_company_is_rejected(): void
+    {
+        $orphan = Employee::factory()->create([
+            'company_id' => null,
+            'role' => 'ordinary',
+            'status' => 'archived',
+        ]);
+
+        Sanctum::actingAs($orphan);
+
+        $this->getJson('/api/v1/notifications')
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'EMPLOYEE_ARCHIVED');
+    }
 }


### PR DESCRIPTION
## Résumé

**P2 security (#3942)** : un employé `role: ordinary` sans compagnie contournait les gardes de statut — `TenantMiddleware` branchait directement `$next($request)` sans les checks suspended/archived. Un compte suspendu/archivé gardait un accès API complet (le volet scope fail-open était déjà traité par #3727 ; il restait les gardes de statut).

## Correctif

- `TenantMiddleware` : les mêmes 403 `EMPLOYEE_SUSPENDED` / `EMPLOYEE_ARCHIVED` que les employés liés s'appliquent aux comptes ordinaires avant le marqueur fail-closed #3727.
- Tests : `TenantScopeFailClosedTest` (suspended + archived → 403).