### PR TITLE
fix(api): estimations paie — authorize('view') au lieu de viewAny (Closes #3943)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## [Unreleased]
 - **fix(api): comptes ordinaires sans entreprise — gardes de statut appliquées (Closes #3942).** TenantMiddleware laissait passer un employé `role: ordinary` suspendu/archivé (branche $next sans les checks) → accès API conservé. Désormais 403 EMPLOYEE_SUSPENDED/EMPLOYEE_ARCHIVED, comme les employés liés.
+- **fix(api): estimations paie — authorize('view') au lieu de viewAny (Closes #3943).** quickEstimate/receipt n'appliquaient aucun scope équipe : un manager dept/superviseur pouvait estimer/télécharger des reçus PDF de n'importe quel employé. Résolution de l'employé puis policy `view` (scope équipe + auto-accès), aligné sur dailySummary.
 - **fix(ci): launch-observability-smoke — cancel-in-progress: true (Closes #3968).** Le cron */30 (48 runs/jour) s'empilait sur une queue saturée (#3545) : un run en retard remplace désormais le précédent.
 - **fix(edge): HEALTHCHECK Dockerfile.publish aligné sur /api/v1/edge/health (Closes #3960).** La probe sondait encore `/api/edge/health` (pré-#3592) → 404 → conteneur « unhealthy » permanent et deadlock `depends_on: service_healthy` futur. Le docker-compose.yml était déjà corrigé (#3908) ; le Dockerfile standalone restait sur l'ancien chemin.
 

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/EstimationController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/EstimationController.php
@@ -21,7 +21,8 @@ use Illuminate\Support\Facades\App;
  *
  * Migrated from App\Http\Controllers\Api\V1\EstimationController.
  * Self-service equivalent lives in MeController (HR module).
- * All endpoints require the Employee policy (viewAny = manager).
+ * All endpoints require the Employee policy — `view` (scope équipe) pour
+ * quickEstimate/receipt/dailySummary (#3943).
  */
 class EstimationController extends Controller
 {
@@ -44,9 +45,10 @@ class EstimationController extends Controller
 
     public function quickEstimate(QuickEstimateRequest $request, string $employeeId): JsonResponse
     {
-        $this->authorize('viewAny', Employee::class);
-
+        // #3943 : `view` (et non `viewAny`) — le scope équipe (managesTeamMemberOf)
+        // s'applique aux managers dept/superviseur, et l'auto-accès employé aussi.
         $employee = Employee::query()->findOrFail($employeeId);
+        $this->authorize('view', $employee);
 
         $estimate = $this->estimationService->quickEstimate(
             employee: $employee,
@@ -59,9 +61,11 @@ class EstimationController extends Controller
 
     public function receipt(ReceiptRequest $request, string $employeeId): Response
     {
-        $this->authorize('viewAny', Employee::class);
-
+        // #3943 : `view` (et non `viewAny`) — même scope équipe que
+        // quickEstimate/dailySummary : un superviseur ne télécharge un reçu
+        // d'estimation que pour ses propres employés.
         $employee = Employee::query()->findOrFail($employeeId);
+        $this->authorize('view', $employee);
 
         $estimate = $this->estimationService->quickEstimate(
             employee: $employee,

--- a/api/tests/Feature/Payroll/EstimationApiTest.php
+++ b/api/tests/Feature/Payroll/EstimationApiTest.php
@@ -142,4 +142,37 @@ class EstimationApiTest extends TestCase
         $this->getJson('/api/v1/employees/999999999/quick-estimate?from=2026-07-01&to=2026-07-31')
             ->assertNotFound();
     }
+
+    public function test_team_scoped_manager_cannot_estimate_outside_team(): void
+    {
+        /** @var Employee $superviseur */
+        $superviseur = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'role' => 'manager',
+            'manager_role' => 'superviseur',
+        ]);
+        /** @var Employee $inTeam */
+        $inTeam = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'manager_id' => $superviseur->id,
+        ]);
+        /** @var Employee $outside */
+        $outside = Employee::factory()->create([
+            'company_id' => $this->company->id,
+        ]);
+
+        Sanctum::actingAs($superviseur);
+
+        // Employé de l'équipe → OK.
+        $this->getJson("/api/v1/employees/{$inTeam->id}/quick-estimate?from=2026-07-01&to=2026-07-31")
+            ->assertOk();
+
+        // Hors équipe → 403 (régression #3943 : viewAny n'appliquait aucun scope).
+        $this->getJson("/api/v1/employees/{$outside->id}/quick-estimate?from=2026-07-01&to=2026-07-31")
+            ->assertForbidden();
+
+        // Le reçu PDF suit le même scope.
+        $this->get("/api/v1/employees/{$outside->id}/receipt?from=2026-07-01&to=2026-07-31")
+            ->assertForbidden();
+    }
 }


### PR DESCRIPTION
## Résumé

**P2 security (#3943)** : `EstimationController::quickEstimate`/`receipt` autorisaient via `EmployeePolicy::viewAny` (manager sans scope équipe) → un manager dept/superviseur pouvait calculer et télécharger des reçus PDF d'estimations de paie de n'importe quel employé ; un employé se voyait refuser ses propres données.

## Correctif

- Résolution de l'employé puis `authorize('view', $employee)` (scope équipe `managesTeamMemberOf` + auto-accès), aligné sur `dailySummary`.
- Test : superviseur → OK dans l'équipe, 403 hors équipe (quick-estimate + receipt).