### PR TITLE
fix(api): SSOControllerTest — parse error PHP (méthode hors classe) → PHPUnit fatal sur main (Closes #4070)

### DIFF
--- a/api/tests/Feature/SSOControllerTest.php
+++ b/api/tests/Feature/SSOControllerTest.php
@@ -223,7 +223,6 @@ class SSOControllerTest extends TestCase
         // Ne jamais renvoyer un succès vide : 501 explicite.
         $response->assertStatus(501);
     }
-}
 
     public function test_saml_callback_is_gated_by_feature_flag(): void
     {
@@ -236,3 +235,4 @@ class SSOControllerTest extends TestCase
         $response->assertStatus(501)
             ->assertJsonPath('error', 'SAML_FEATURE_DISABLED');
     }
+}


### PR DESCRIPTION
## Constat

`api/tests/Feature/SSOControllerTest.php` sur main : `test_saml_callback_is_gated_by_feature_flag` a été ajouté **après** l'accolade fermante de la classe (merge 4b2286c5, #3890) → `php -l` : *unexpected token "public"*, PHPUnit fatal au chargement du suite → **Backend Coverage / PHPStan rouges sur main** (et sur toutes les PRs).

## Correctif

Méthode déplacée à l'intérieur de la classe. `php8.4 -l` → OK.

## Critères d'acceptation

1. `php -l` OK, PHPUnit charge le fichier.
2. Backend CI repasse au vert sur main.