### PR TITLE
fix(admin): toasts temps réel dédupliqués (Closes #3936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - **fix(api): trial/signup — réponse uniforme anti-énumération (Closes #3945).** L'endpoint public répondait 409 EMAIL_ALREADY_REGISTERED pour un email existant → énumération de comptes. Signup renvoie désormais la même réponse 200 (log serveur) ; la détection doublon vit à l'étape verify (OTP = preuve de possession de la boîte mail) ; pas de double provisioning en guided-trial.
 
 - **fix(admin): CompaniesView — pays via la source canonique useSupportedCountries (Closes #3940).** La liste de 21 pays en dur (fallback du provisioning) est remplacée par le composable `useSupportedCountries` (GET /supported-countries, registre #1867) enrichi des champs riches (label/language/currency/timezone) — une seule source de vérité des pays dans l'app.
+
+- **fix(admin): toasts temps réel dédupliqués (Closes #3936).** Plus de toast à chaque connexion/reconnexion WebSocket (l'état reste visible dans l'UI) ; une alerte critique `system.alert` ne déclenche plus qu'un seul toast (via addNotification), au lieu de toast.error + toast.warning dupliqués.
 - **fix(ci): launch-observability-smoke — cancel-in-progress: true (Closes #3968).** Le cron */30 (48 runs/jour) s'empilait sur une queue saturée (#3545) : un run en retard remplace désormais le précédent.
 - **fix(edge): HEALTHCHECK Dockerfile.publish aligné sur /api/v1/edge/health (Closes #3960).** La probe sondait encore `/api/edge/health` (pré-#3592) → 404 → conteneur « unhealthy » permanent et deadlock `depends_on: service_healthy` futur. Le docker-compose.yml était déjà corrigé (#3908) ; le Dockerfile standalone restait sur l'ancien chemin.
 

--- a/front/admin-dashboard/src/stores/realtime.js
+++ b/front/admin-dashboard/src/stores/realtime.js
@@ -93,13 +93,15 @@ export const useRealtimeStore = defineStore('realtime', () => {
       pushUnavailable.value = false
       clearPushGraceTimer()
       stopPolling()
-      toast.success('Connexion temps réel établie')
+      // #3936 : pas de toast à chaque connexion/reconnexion (rafales sur
+      // réseau instable) — l'état est déjà visible via l'icône temps réel.
     })
 
     socket.value.on('disconnect', () => {
       // console.log removed (audit 2026-08-15) — WebSocket déconnecté
       isConnected.value = false
-      toast.warning('Connexion temps réel perdue')
+      // #3936 : pas de toast à chaque déconnexion (le polling de repli prend
+      // le relais silencieusement ; l'état reste visible dans l'UI).
       // Push dropped after being connected: switch to fallback polling
       // immediately instead of waiting silently for a reconnection.
       startPolling()
@@ -295,9 +297,8 @@ export const useRealtimeStore = defineStore('realtime', () => {
         priority: data.level
       })
 
-      if (data.level === 'critical') {
-        toast.error(`Alerte critique: ${data.message}`)
-      }
+      // #3936 : pas de toast dédié ici — addNotification() affiche déjà un
+      // toast unique pour priority critical (une alerte = une surface).
     })
 
     // Points du globe en temps réel


### PR DESCRIPTION
## Problème (#3936)
- Toast à chaque connexion/reconnexion WebSocket (« Connexion temps réel établie/perdue ») → rafales sur réseau instable
- `system.alert` critical : `toast.error` dans le handler + `toast.warning` dans addNotification + notification du panneau → 3 surfaces

## Correctif
- Toasts de connexion/déconnexion supprimés (l'état est visible via l'icône temps réel ; le polling de repli reste silencieux)
- Alerte critique : un seul toast via addNotification (le toast.error dédié est retiré)

## Validation
`npm run lint` ✅

Closes #3936