### PR TITLE
fix(admin): breadcrumb parent résolu via router.getRoutes() (Closes #3935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - **fix(admin): CompaniesView — pays via la source canonique useSupportedCountries (Closes #3940).** La liste de 21 pays en dur (fallback du provisioning) est remplacée par le composable `useSupportedCountries` (GET /supported-countries, registre #1867) enrichi des champs riches (label/language/currency/timezone) — une seule source de vérité des pays dans l'app.
 
 - **fix(admin): toasts temps réel dédupliqués (Closes #3936).** Plus de toast à chaque connexion/reconnexion WebSocket (l'état reste visible dans l'UI) ; une alerte critique `system.alert` ne déclenche plus qu'un seul toast (via addNotification), au lieu de toast.error + toast.warning dupliqués.
+
+- **fix(admin): breadcrumb parent résolu via router.getRoutes() (Closes #3935).** DashboardLayout cherchait le parent dans le tableau `routes` de premier niveau (login/logout//not-found) — `company-detail` (parent companies) était introuvable et le crumb intermédiaire sauté. Résolution désormais sur les records aplatis de `router.getRoutes()`.
 - **fix(ci): launch-observability-smoke — cancel-in-progress: true (Closes #3968).** Le cron */30 (48 runs/jour) s'empilait sur une queue saturée (#3545) : un run en retard remplace désormais le précédent.
 - **fix(edge): HEALTHCHECK Dockerfile.publish aligné sur /api/v1/edge/health (Closes #3960).** La probe sondait encore `/api/edge/health` (pré-#3592) → 404 → conteneur « unhealthy » permanent et deadlock `depends_on: service_healthy` futur. Le docker-compose.yml était déjà corrigé (#3908) ; le Dockerfile standalone restait sur l'ancien chemin.
 

--- a/front/admin-dashboard/src/layouts/DashboardLayout.vue
+++ b/front/admin-dashboard/src/layouts/DashboardLayout.vue
@@ -91,8 +91,10 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { useRoute } from 'vue-router'
-import { routes } from '@/router'
+import { useRoute, useRouter } from 'vue-router'
+// #3935 : résolution du parent via router.getRoutes() (records aplatis)
+// au lieu du tableau routes de premier niveau (qui ne contient que login/
+// logout//not-found — les enfants comme company-detail en sont absents).
 import { ChevronRightIcon } from '@heroicons/vue/24/outline'
 import { useAuthStore } from '@/stores/auth'
 import { useRealtimeStore } from '@/stores/realtime'
@@ -106,6 +108,7 @@ import CommandPalette from '@/components/common/CommandPalette.vue'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 
 const route = useRoute()
+const router = useRouter()
 const authStore = useAuthStore()
 const realtimeStore = useRealtimeStore()
 const dashboardStore = useDashboardStore()
@@ -120,8 +123,9 @@ const breadcrumbs = computed(() => {
   const crumbs = [{ name: 'dashboard', title: 'Tableau de bord', path: '/' }]
 
   if (route.meta.parent) {
-    // Find parent route
-    const parentRoute = routes.find(r => r.name === route.meta.parent)
+    // Find parent route in the FLATTENED route records (#3935) — children
+    // like company-detail are not in the top-level routes array.
+    const parentRoute = router.getRoutes().find(r => r.name === route.meta.parent)
     if (parentRoute) {
       crumbs.push({
         name: parentRoute.name,


### PR DESCRIPTION
## Problème (#3935)
DashboardLayout cherchait le parent via `routes.find(r => r.name === route.meta.parent)` sur le tableau de premier niveau (login/logout//not-found) — les enfants comme `company-detail` (parent companies) n\'y figurent pas → crumb intermédiaire silencieusement sauté.

## Correctif
Résolution sur `router.getRoutes()` (records aplatis, enfants inclus).

## Validation
`npm run lint` ✅ · `vite build` ✅

Closes #3935