### PR TITLE
fix(api): pagination sur 3 listes non bornées (Closes #3948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+
+- **fix(api): pagination sur 3 listes non bornées (Closes #3948).** `DepartmentController::index`, `TrainingController::indexSessions` et `WebhookController::index` (Billing) utilisent désormais `paginate(per_page)` au lieu de `->get()` — alignés sur le contrat pagination existant (`data` + meta). ScheduleController conserve son cache (retour Collection, non paginable).
 - **fix(api): comptes ordinaires sans entreprise — gardes de statut appliquées (Closes #3942).** TenantMiddleware laissait passer un employé `role: ordinary` suspendu/archivé (branche $next sans les checks) → accès API conservé. Désormais 403 EMPLOYEE_SUSPENDED/EMPLOYEE_ARCHIVED, comme les employés liés.
 - **fix(api): estimations paie — authorize('view') au lieu de viewAny (Closes #3943).** quickEstimate/receipt n'appliquaient aucun scope équipe : un manager dept/superviseur pouvait estimer/télécharger des reçus PDF de n'importe quel employé. Résolution de l'employé puis policy `view` (scope équipe + auto-accès), aligné sur dailySummary.
 - **fix(api): trial/signup — réponse uniforme anti-énumération (Closes #3945).** L'endpoint public répondait 409 EMAIL_ALREADY_REGISTERED pour un email existant → énumération de comptes. Signup renvoie désormais la même réponse 200 (log serveur) ; la détection doublon vit à l'étape verify (OTP = preuve de possession de la boîte mail) ; pas de double provisioning en guided-trial.

--- a/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/WebhookController.php
@@ -52,8 +52,11 @@ class WebhookController extends Controller
             abort(403);
         }
 
+        // #3948 : pagination alignée sur le contrat des autres listes.
         return WebhookEndpointResource::collection(
-            WebhookEndpoint::query()->orderByDesc('created_at')->get()
+            WebhookEndpoint::query()
+                ->orderByDesc('created_at')
+                ->paginate((int) ($request->input('per_page', 20)))
         );
     }
 

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DepartmentController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DepartmentController.php
@@ -32,7 +32,9 @@ class DepartmentController extends Controller
             $query->where('id', $user->department_id ?? -1);
         }
 
-        $departments = $query->orderBy('name')->get();
+        // #3948 : pagination alignée sur le contrat des autres listes.
+        $perPage = (int) ($request->input('per_page', 20));
+        $departments = $query->orderBy('name')->paginate($perPage);
 
         return DepartmentResource::collection($departments);
     }

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/TrainingController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/TrainingController.php
@@ -130,7 +130,13 @@ class TrainingController extends Controller
             abort(404);
         }
 
-        return TrainingSessionResource::collection($trainingCourse->sessions()->with('trainer:id,first_name,last_name')->orderByDesc('start_date')->get())
+        // #3948 : pagination alignée sur le contrat des autres listes.
+        return TrainingSessionResource::collection(
+            $trainingCourse->sessions()
+                ->with('trainer:id,first_name,last_name')
+                ->orderByDesc('start_date')
+                ->paginate((int) ($request->input('per_page', 20)))
+        )
             ->response();
     }
 


### PR DESCRIPTION
## Problème (#3948)
DepartmentController::index, TrainingController::indexSessions et Billing/WebhookController::index utilisaient `->get()` sans limite ni pagination — incohérent avec le contrat pagination du reste de l'API.

## Correctif
`paginate((int) $request->input('per_page', 20))` sur les 3 endpoints (Resource::collection ajoute automatiquement les meta pagination). ScheduleController volontairement exclu : sa liste passe par `tenantCache->rememberSchedules` dont le callback doit retourner une Collection (pas un paginator).

## Validation
Diff minimal (15 insertions), pattern identique à EmployeeController. PHPStan strict + tests CI à la merge.

Closes #3948