### PR TITLE
fix(api): SelfServiceTrialController — marqueurs de conflit retirés (régression #4074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(api): SelfServiceTrialController — marqueurs de conflit retirés (régression #4074).** Le merge #4074 (dédup trial #3951) a atterri sur main avec un bloc de conflit git non résolu (`<<<<<<< HEAD`/`>>>>>>>`) + un return orphelin hors `if ($existingPending)` → erreur de parse PHP sur tout le contrôleur (signup trial 500). Bloc orphelin et marqueurs supprimés ; la logique combinée (anti-énumération #3945 → idempotence pending #3951 → création + catch 23505) est conservée.
 
 - **fix(api): pagination sur 3 listes non bornées (Closes #3948).** `DepartmentController::index`, `TrainingController::indexSessions` et `WebhookController::index` (Billing) utilisent désormais `paginate(per_page)` au lieu de `->get()` — alignés sur le contrat pagination existant (`data` + meta). ScheduleController conserve son cache (retour Collection, non paginable).
 - **fix(api): comptes ordinaires sans entreprise — gardes de statut appliquées (Closes #3942).** TenantMiddleware laissait passer un employé `role: ordinary` suspendu/archivé (branche $next sans les checks) → accès API conservé. Désormais 403 EMPLOYEE_SUSPENDED/EMPLOYEE_ARCHIVED, comme les employés liés.

--- a/api/app/Modules/Billing/Interfaces/Api/V1/SelfServiceTrialController.php
+++ b/api/app/Modules/Billing/Interfaces/Api/V1/SelfServiceTrialController.php
@@ -105,20 +105,6 @@ class SelfServiceTrialController extends Controller
                     ],
                 ], 200);
             }
-                return new JsonResponse([
-                    'success' => true,
-                    'message' => __('billing.trial_signup_received'),
-                    'data' => [
-                        'email' => $email,
-                        'status' => 'provisioning_sandbox',
-<<<<<<< HEAD
-                        'provisioning_token' => Str::random(64),
-=======
-                        'provisioning_token' => $existingPending->provisioning_token,
->>>>>>> d4dba580 (fix(api): trial/signup guided_trial — dédup provisionings pending, plus de double tenant (Closes #3951))
-                    ],
-                ], 200);
-            }
 
             // MULTI-PAYS (#1950) : le pays validé du signup est transmis au job
             // (plus de fallback silencieux DZ — invariant 10 de la spec).


### PR DESCRIPTION
## Problème (P0)\n\nLe merge #4074 a atterri sur main avec un bloc de conflit git non résolu (`<<<<<<< HEAD`/`>>>>>>> d4dba580`) dans `SelfServiceTrialController::signup` + un return orphelin hors `if ($existingPending)` → **erreur de parse PHP** : tout `POST /api/v1/trial/signup` (et tout chargement du contrôleur) répond 500.\n\n## Correctif\n\nSuppression du bloc orphelin + des marqueurs. La logique combinée est conservée :\n1. Anti-énumération (#3945) : email manager existant → réponse uniforme (token aléatoire)\n2. Idempotence (#3951) : ligne `trial_provisionings` pending existante → même token\n3. Création + catch 23505 (course) → token du gagnant\n\n## Validation\n\n- `grep` marqueurs : 0\n- Équilibre accolades/parenthèses vérifié\n- CI : attendre PHPStan/PHPUnit sur la PR