### PR TITLE
fix(mobile): bouton démo localisé via l10n.authTryDemoAccount (Closes #3956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(mobile): leopardo_hr — bouton « Tester avec un compte demo » localisé (Closes #3956).** Le libellé du bouton d'accès démo de l'écran de connexion était codé en dur en FR ; il passe par la clé l10n `authTryDemoAccount` (ARB × 4 locales de `leopardo_core`), en parité avec les apps sœurs. Spec : `docs/specifications/ISSUE_3956_HR_DEMO_BUTTON_L10N.md`.
 - **fix(web): métadonnées SEO de la vitrine localisées FR/EN/TR/AR (Closes #4004).** Les 27 blocs `pageMetadata` étaient 100% FR en dur → un visiteur EN/TR/AR recevait un `<title>`/description français sur toutes les pages. Nouveau dictionnaire `pageMetadataI18n` (27 pages × 3 locales) + helper `getPageMetadata(page, lang)` ; les 27 layouts landing passent en `generateMetadata()` dynamique lisant `searchParams.lang` (fallback FR sans `?lang`, `og:locale` aligné). `/pricing` et `/case-studies` préfèrent aussi `?lang=` à l'Accept-Language SSR. 5 tests unitaires ajoutés (défaut FR, override EN, fallback, couverture 27 pages × 3 locales).
 - **fix(api): SelfServiceTrialController — marqueurs de conflit retirés (régression #4074).** Le merge #4074 (dédup trial #3951) a atterri sur main avec un bloc de conflit git non résolu (`<<<<<<< HEAD`/`>>>>>>>`) + un return orphelin hors `if ($existingPending)` → erreur de parse PHP sur tout le contrôleur (signup trial 500). Bloc orphelin et marqueurs supprimés ; la logique combinée (anti-énumération #3945 → idempotence pending #3951 → création + catch 23505) est conservée.
 

--- a/docs/specifications/ISSUE_3956_HR_DEMO_BUTTON_L10N.md
+++ b/docs/specifications/ISSUE_3956_HR_DEMO_BUTTON_L10N.md
@@ -1,0 +1,19 @@
+# Issue #3956 — leopardo_hr : bouton « Tester avec un compte demo » codé en dur
+
+## Problème
+
+`leopardo_hr/lib/features/auth/screens/login_screen.dart:290` affichait
+`Text('Tester avec un compte demo')` en dur (FR uniquement) alors que les apps
+sœurs (`leopardo_employee`, `leopardo_manager`) utilisent la clé l10n
+`authTryDemoAccount` (ARB × 4 locales, `leopardo_core`).
+
+## Correctif
+
+- Import `package:leopardo_core/l10n/l10n.dart`
+- `final l10n = context.l10n;` en tête de `build()`
+- `label: Text(l10n.authTryDemoAccount)`
+
+## Critères de succès
+
+1. `flutter analyze` leopardo_hr : 0 erreur.
+2. Le libellé suit la locale active (fr/en/tr/ar) comme sur les apps sœurs.

--- a/front/mobile_apps/leopardo_hr/lib/features/auth/screens/login_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/auth/screens/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_core/core/theme/app_typography.dart';
 import 'package:leopardo_core/core/widgets/demo_user_bottom_sheet.dart';
+import 'package:leopardo_core/l10n/l10n.dart';
 import 'package:leopardo_hr/features/auth/providers/auth_provider.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
@@ -30,6 +31,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     final authState = ref.watch(authProvider);
     final bg = AppColors.backgroundFor(context);
     final text = AppColors.textPrimaryFor(context);
@@ -287,7 +289,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             }
                           },
                           icon: const Icon(Icons.science_outlined, size: 18),
-                          label: const Text('Tester avec un compte demo'),
+                          label: Text(l10n.authTryDemoAccount),
                           style: ElevatedButton.styleFrom(
                             backgroundColor: AppColors.rhDark,
                             foregroundColor: Colors.white,


### PR DESCRIPTION
## Problème\n\n`login_screen.dart` (leopardo_hr) affichait `'Tester avec un compte demo'` en dur (FR) alors que les apps sœurs utilisent `l10n.authTryDemoAccount` (4 locales).\n\n## Correctif\n\n- Import `leopardo_core/l10n/l10n.dart` + `final l10n = context.l10n`\n- `label: Text(l10n.authTryDemoAccount)`\n\nSpec : `docs/specifications/ISSUE_3956_HR_DEMO_BUTTON_L10N.md`.\n\nCloses #3956