### PR TITLE
fix(web): .env.local.example — SITE_URL exemple sur le domaine de marque, domaine banni purgé (Closes #3918)

### DIFF
--- a/front/web/.env.local.example
+++ b/front/web/.env.local.example
@@ -27,10 +27,11 @@ SANDBOX_CHECKOUT=false
 NEXT_PUBLIC_CHECKOUT_SANDBOX=false
 
 # --- Site / branding ---
-# `leopardo-hr.vercel.app` renvoie 404 (verifie) ; l'URL reellement en ligne
-# aujourd'hui est `gestionemployer-backend.vercel.app` (voir
-# docs/GUIDES/GUIDE_LIENS_PLATEFORME_ET_COMMUNICATION.md pour la liste a jour).
-NEXT_PUBLIC_SITE_URL=https://gestionemployer-backend.vercel.app
+# Domaine de marque officiel (issue #3918 / #3852 / #1775) :
+# `gestionemployer-backend.vercel.app` appartient a une entreprise US sans
+# rapport — ne jamais l'utiliser comme SITE_URL (donnees structurees JsonLd,
+# canonicals, sitemap). Defaut aligne sur `src/lib/site.ts` (DEFAULT_SITE_URL).
+NEXT_PUBLIC_SITE_URL=https://leopardo-rh.com
 NEXT_PUBLIC_SITE_NAME=Leopardo RH
 NEXT_PUBLIC_ADMIN_URL=https://admin.leopardo-rh.com
 NEXT_PUBLIC_ENVIRONMENT=production


### PR DESCRIPTION
## Résumé

Issue #3918 : `JsonLd.tsx` utilisait `https://gestionemployer-backend.vercel.app` en fallback (domaine d'une entreprise US sans rapport — interdit dans les données structurées, #1775). Le code a été corrigé par #3852 (`getSiteUrl()`, source unique), mais **`.env.local.example:33` documentait encore le domaine banni comme valeur d'exemple** — un développeur copiant ce fichier repolluait la prod.

## Changement

- `.env.local.example` : `NEXT_PUBLIC_SITE_URL=https://leopardo-rh.com` (domaine de marque, aligné sur `DEFAULT_SITE_URL` de `src/lib/site.ts`) + commentaire explicitant l'interdiction du domaine `gestionemployer-backend.vercel.app`.

## Validation

- Le runtime utilisait déjà `getSiteUrl()` (#3852) — aucune autre occurrence runtime du domaine banni (seuls les commentaires documentant l'incident subsistent).

Closes #3918