### PR TITLE
fix(web): limites employés FR alignées sur PlanSeeder — 30/250 (Closes #4207)

### DIFF
--- a/front/web/src/app/(landing)/checkout/page.tsx
+++ b/front/web/src/app/(landing)/checkout/page.tsx
@@ -54,7 +54,7 @@ const PLAN_CONFIG = {
       'Support email 48h',
     ],
     trialDays: 14,
-    employeeLimit: "Jusqu'à 20 employés",
+    employeeLimit: "Jusqu'à 30 employés",
   },
   operations: {
     label: 'Operations',
@@ -73,7 +73,7 @@ const PLAN_CONFIG = {
       'Support prioritaire 24h',
     ],
     trialDays: 14,
-    employeeLimit: "Jusqu'à 200 employés",
+    employeeLimit: "Jusqu'à 250 employés",
   },
   enterprise: {
     label: 'Enterprise',

--- a/front/web/src/modules/vitrine/data/pricing.ts
+++ b/front/web/src/modules/vitrine/data/pricing.ts
@@ -39,7 +39,7 @@ const pricingByLocale: Record<AppLocale, PricingPlan[]> = {
       annualPeriod: '/mois, facturé annuellement',
       description: 'Pour tester Leopardo sur un site, une equipe ou une agence',
       priceNote: '14 jours offerts. 30 employés inclus.',
-      employeeLimit: "Jusqu'à 20 employés",
+      employeeLimit: "Jusqu'à 30 employés",
       features: [
         'Pointage web et mobile',
         'Absences, conges et soldes',
@@ -61,7 +61,7 @@ const pricingByLocale: Record<AppLocale, PricingPlan[]> = {
       annualPeriod: '/mois, facturé annuellement',
       description: 'Pour les PME multi-equipes qui veulent piloter terrain, RH et paie simple',
       priceNote: '14 jours offerts. 250 employés inclus.',
-      employeeLimit: "Jusqu'à 200 employés",
+      employeeLimit: "Jusqu'à 250 employés",
       features: [
         'Tout Pilot, plus :',
         'Paie multi-pays et validations RH',


### PR DESCRIPTION
Fixe #4207 : `employeeLimit` FR affichait « Jusqu'à 20/200 employés » sur /pricing et /checkout alors que PlanSeeder (#2977) définit **Pilot 30 / Operations 250** — la `priceNote` FR disait déjà 30/250 (auto-contradiction), et EN/TR/AR étaient correctes.\n\n- `data/pricing.ts` (fr) : Pilot 20→30, Operations 200→250\n- `checkout/page.tsx` : Pilot 20→30, Operations 200→250\n\nValidation : tsc 0 erreur, eslint 0, jest pricing 34/34.\n\nCloses #4207