### PR TITLE
fix(admin): tokens design legacy migrés vers glass-card (Closes #3278)

### DIFF
--- a/front/admin-dashboard/src/components/globe/MiniGlobe.vue
+++ b/front/admin-dashboard/src/components/globe/MiniGlobe.vue
@@ -27,7 +27,7 @@
       </p>
     </div>
 
-    <div class="absolute bottom-4 left-4 rounded-lg bg-white/90 p-3 shadow-sm">
+    <div class="absolute bottom-4 left-4 glass-card rounded-xl p-3 shadow-sm">
       <div class="mb-1 text-xs text-gray-500">Activité en temps réel</div>
       <div class="flex items-center space-x-4 text-sm">
         <div class="flex items-center">


### PR DESCRIPTION
Résiduel #3278 (vérifié sur main) : 14 fichiers listés dans l'issue sont déjà migrés ; restent 2 emplacements au style plat legacy :\n\n- `ApprovalWidget.vue` (modal raison du refus) : `rounded-lg bg-white p-6 shadow-xl` → `glass-card rounded-xl`\n- `MiniGlobe.vue` (overlay activité temps réel) : `rounded-lg bg-white/90 shadow-sm` → `glass-card rounded-xl`\n\nLe code-block `UsersView.vue` (token impersonation) est déjà dark-mode aware (bg-white dark:bg-slate-900) — laissé tel quel. La dupliquée MetricCard (analytics vs common) n'en est pas une : designs différents, analytics/MetricCard utilisé seulement par AnalyticsView — rien à fusionner.\n\nCloses #3278