### PR TITLE
fix(api): e-mails d'invitation — plus de liens App Store placeholder id000000000X (Closes #4180)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -414,3 +414,12 @@ SENTRY_DSN=
 
 # --- config/billing.php ---
 TRIAL_DAYS=14
+
+# --- config/mobile.php (issue #4180) ---
+# URLs réelles App Store par rôle — tant qu'elles sont vides, le bouton iOS
+# est omis des e-mails d'invitation (jamais de lien placeholder id000000000X).
+LEOPARDO_IOS_PRINCIPAL_URL=
+LEOPARDO_IOS_RH_URL=
+LEOPARDO_IOS_COMPTABLE_URL=
+LEOPARDO_IOS_MARKETING_URL=
+LEOPARDO_IOS_EMPLOYEE_URL=

--- a/api/app/Modules/HR/Infrastructure/Services/RoleInvitationService.php
+++ b/api/app/Modules/HR/Infrastructure/Services/RoleInvitationService.php
@@ -12,41 +12,52 @@ class RoleInvitationService
     /**
      * Returns the deep link URL for downloading the app based on manager_role.
      * Links use universal links / app store links with a fallback.
+     *
+     * Issue #4180 : les liens iOS ne sont inclus que si une URL réelle est
+     * configurée (config/mobile.php + LEOPARDO_IOS_*_URL) — les placeholders
+     * `id000000000X` ne doivent jamais atteindre les destinataires.
      */
     public static function getAppDownloadLink(string $role, string $managerRole, string $platform = 'both'): array
     {
-        return match($managerRole) {
+        $links = match($managerRole) {
             'rh'        => [
                 'android' => 'https://play.google.com/store/apps/details?id=com.leopardo.rh',
-                'ios'     => 'https://apps.apple.com/app/leopardo-rh/id0000000002',
                 'name'    => 'Leopardo RH',
                 'deep_link_scheme' => 'leopardo-rh',
             ],
             'comptable' => [
                 'android' => 'https://play.google.com/store/apps/details?id=com.leopardo.comptable',
-                'ios'     => 'https://apps.apple.com/app/leopardo-comptable/id0000000003',
                 'name'    => 'Leopardo Comptable',
                 'deep_link_scheme' => 'leopardo-comptable',
             ],
             'marketing' => [
                 'android' => 'https://play.google.com/store/apps/details?id=com.leopardo.marketing',
-                'ios'     => 'https://apps.apple.com/app/leopardo-marketing/id0000000004',
                 'name'    => 'Leopardo Marketing',
                 'deep_link_scheme' => 'leopardo-marketing',
             ],
             'principal' => [
                 'android' => 'https://play.google.com/store/apps/details?id=com.leopardo.admin',
-                'ios'     => 'https://apps.apple.com/app/leopardo-admin/id0000000001',
                 'name'    => 'Leopardo Admin',
                 'deep_link_scheme' => 'leopardo-admin',
             ],
             default => [
                 'android' => 'https://play.google.com/store/apps/details?id=com.leopardo.employee',
-                'ios'     => 'https://apps.apple.com/app/leopardo-employee/id0000000000',
                 'name'    => 'Leopardo Employee',
                 'deep_link_scheme' => 'leopardo-employee',
             ],
         };
+
+        // Lien App Store réel (config/env) — absent tant que l'app n'est pas
+        // publiée : le bouton iOS est alors omis (template + API), jamais un
+        // lien placeholder.
+        $iosUrl = config('mobile.app_store_urls.'.$managerRole)
+            ?? config('mobile.app_store_urls.employee');
+
+        if (is_string($iosUrl) && $iosUrl !== '') {
+            $links['ios'] = $iosUrl;
+        }
+
+        return $links;
     }
 
     /**

--- a/api/config/mobile.php
+++ b/api/config/mobile.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Liens des applications mobiles (issue #4180)
+    |--------------------------------------------------------------------------
+    | Les applications iOS ne sont pas encore publiées sur l'App Store : les
+    | identifiants placeholder `id000000000X` ne doivent JAMAIS être envoyés.
+    | Tant qu'une URL réelle n'est pas configurée (variable d'env par rôle),
+    | le bouton iOS est omis des e-mails et le champ `ios` absent des
+    | réponses API. Le rôle 'employee' sert de valeur de repli.
+    */
+    'app_store_urls' => [
+        'principal' => env('LEOPARDO_IOS_PRINCIPAL_URL'),
+        'rh' => env('LEOPARDO_IOS_RH_URL'),
+        'comptable' => env('LEOPARDO_IOS_COMPTABLE_URL'),
+        'marketing' => env('LEOPARDO_IOS_MARKETING_URL'),
+        'employee' => env('LEOPARDO_IOS_EMPLOYEE_URL'),
+    ],
+];

--- a/api/resources/views/emails/role-assignment.blade.php
+++ b/api/resources/views/emails/role-assignment.blade.php
@@ -50,10 +50,12 @@
                        style="display: inline-block; background: #1e293b; color: white; text-decoration: none; padding: 12px 20px; border-radius: 10px; font-weight: 700; font-size: 13px;">
                         🤖 {{ __('emails.role_assignment_android') }}
                     </a>
-                    <a href="{{ $appLinks['ios'] }}"
-                       style="display: inline-block; background: #1e293b; color: white; text-decoration: none; padding: 12px 20px; border-radius: 10px; font-weight: 700; font-size: 13px;">
-                        🍎 {{ __('emails.role_assignment_ios') }}
-                    </a>
+                    @if (! empty($appLinks['ios']))
+                        <a href="{{ $appLinks['ios'] }}"
+                           style="display: inline-block; background: #1e293b; color: white; text-decoration: none; padding: 12px 20px; border-radius: 10px; font-weight: 700; font-size: 13px;">
+                            🍎 {{ __('emails.role_assignment_ios') }}
+                        </a>
+                    @endif
                 </div>
             </div>
 

--- a/api/tests/Unit/RoleInvitationServiceTest.php
+++ b/api/tests/Unit/RoleInvitationServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Modules\HR\Infrastructure\Services\RoleInvitationService;
+use Tests\TestCase;
+
+/**
+ * Issue #4180 : les liens App Store placeholder `id000000000X` ne doivent
+ * jamais être renvoyés aux destinataires des e-mails d'invitation de rôle.
+ */
+class RoleInvitationServiceTest extends TestCase
+{
+    public function test_ios_links_are_absent_when_no_store_url_configured(): void
+    {
+        config()->set('mobile.app_store_urls', [
+            'principal' => null,
+            'rh' => null,
+            'comptable' => null,
+            'marketing' => null,
+            'employee' => null,
+        ]);
+
+        foreach (['rh', 'comptable', 'marketing', 'principal', 'employee'] as $role) {
+            $links = RoleInvitationService::getAppDownloadLink('manager', $role);
+
+            $this->assertArrayNotHasKey('ios', $links, "role {$role}: ios doit être absent sans URL configurée");
+            $this->assertStringNotContainsString('id000000000', json_encode($links), "role {$role}: aucun placeholder App Store");
+        }
+    }
+
+    public function test_ios_link_comes_from_config_when_configured(): void
+    {
+        config()->set('mobile.app_store_urls', [
+            'principal' => null,
+            'rh' => 'https://apps.apple.com/app/leopardo-rh/id1234567890',
+            'comptable' => null,
+            'marketing' => null,
+            'employee' => null,
+        ]);
+
+        $links = RoleInvitationService::getAppDownloadLink('manager', 'rh');
+
+        $this->assertSame('https://apps.apple.com/app/leopardo-rh/id1234567890', $links['ios']);
+        $this->assertArrayHasKey('android', $links);
+        $this->assertSame('Leopardo RH', $links['name']);
+    }
+
+    public function test_employee_store_url_is_the_fallback_for_unmapped_roles(): void
+    {
+        config()->set('mobile.app_store_urls', [
+            'principal' => null,
+            'rh' => null,
+            'comptable' => null,
+            'marketing' => null,
+            'employee' => 'https://apps.apple.com/app/leopardo-employee/id9876543210',
+        ]);
+
+        $links = RoleInvitationService::getAppDownloadLink('manager', 'principal');
+
+        $this->assertSame('https://apps.apple.com/app/leopardo-employee/id9876543210', $links['ios']);
+    }
+}


### PR DESCRIPTION
## Problème
`RoleInvitationService::getAppDownloadLink()` renvoyait des liens App Store avec des identifiants placeholder (`id0000000000/1/2/3/4`) jamais remplacés — chaque e-mail d'invitation de rôle contenait un lien mort vers l'App Store.

## Correctif
- `api/config/mobile.php` : URLs iOS réelles par rôle (`LEOPARDO_IOS_*_URL`), vide par défaut.
- `getAppDownloadLink()` : le champ `ios` n'est inclus QUE si une URL réelle est configurée (fallback rôle employee) — plus aucun placeholder possible.
- Template `role-assignment.blade.php` : bouton iOS conditionnel (`@if !empty($appLinks['ios'])`).
- Test unitaire `RoleInvitationServiceTest` : absence par défaut, valeur config, fallback employee.

## Vérifications
- `php -l` OK (service, config, test)
- Aucun `id000000000` restant dans le code applicatif

Closes #4180