### PR TITLE
hotfix(api): lang/errors.php ×4 — ParseError production (]; manquant)

### DIFF
--- a/api/lang/ar/errors.php
+++ b/api/lang/ar/errors.php
@@ -59,3 +59,5 @@ return [
     'ATTENDANCE_MODE_PERSONALIZATION_DISABLED' => 'تخصيص وضع التسجيل معطّل.',
     'PREFERENCE_UPDATED' => 'تم تحديث التفضيل.',
     'CONFIG_UPDATED' => 'تم تحديث الإعدادات.',
+
+];

--- a/api/lang/en/errors.php
+++ b/api/lang/en/errors.php
@@ -74,3 +74,5 @@ return [
     'ATTENDANCE_MODE_PERSONALIZATION_DISABLED' => 'Attendance mode personalization is disabled.',
     'PREFERENCE_UPDATED' => 'Preference updated.',
     'CONFIG_UPDATED' => 'Configuration updated.',
+
+];

--- a/api/lang/fr/errors.php
+++ b/api/lang/fr/errors.php
@@ -74,3 +74,5 @@ return [
     'ATTENDANCE_MODE_PERSONALIZATION_DISABLED' => 'La personnalisation du mode de pointage est désactivée.',
     'PREFERENCE_UPDATED' => 'Préférence mise à jour.',
     'CONFIG_UPDATED' => 'Configuration mise à jour.',
+
+];

--- a/api/lang/tr/errors.php
+++ b/api/lang/tr/errors.php
@@ -59,3 +59,5 @@ return [
     'ATTENDANCE_MODE_PERSONALIZATION_DISABLED' => 'Yoklama modu kişiselleştirmesi devre dışı.',
     'PREFERENCE_UPDATED' => 'Tercih güncellendi.',
     'CONFIG_UPDATED' => 'Yapılandırma güncellendi.',
+
+];


### PR DESCRIPTION
## 🔴 HOTFIX — ParseError en production

### Symptôme (logs Render 2026-08-16T09:46:14)

```
production.ERROR: Unclosed '[' on line 3 at /app/lang/en/errors.php:77
ParseError: Unclosed '[' on line 3
```

Chaque requête qui déclenche une traduction d'erreur (errors.SERVER_ERROR, etc.) crash en production.

### Cause racine

PR #4275 (`fix(api): messages d'erreur FR codés en dur localisés`) a créé/modifié les 4 fichiers `api/lang/{en,fr,ar,tr}/errors.php` sans ajouter le `];` de fermeture du tableau PHP.

### Fix

Ajout de `];` en fin de chaque fichier ×4 locales.

```php
// Avant (cassé) :
    'CONFIG_UPDATED' => 'Configuration updated.',
// EOF — tableau non fermé → ParseError

// Après :
    'CONFIG_UPDATED' => 'Configuration updated.',
];
```

### Validation

- `[` count = `]` count = 1 ×4 fichiers ✅
- Chaque fichier se termine par `];` ✅

### Impact si non mergé immédiatement

Toute requête déclenchant `trans('errors.*')` retourne 500 en production.
