### PR TITLE
fix: P0+P1 — EmployeeService 500, FAQSection accordéon, SystemView URL métriques + CI guard lang php -l (closes #4307, #4321, #4328)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -310,7 +310,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t php_files < <(find app bootstrap config database public routes tests -type f -name '*.php' | sort)
+          # Issue #4309 : lang/ était exclu → un ]; manquant passait inaperçu
+          # et atteignait la prod (ParseError fatal). On ajoute lang/ ici.
+          mapfile -t php_files < <(find app bootstrap config database lang public routes tests -type f -name '*.php' | sort)
           for file in "${php_files[@]}"; do
             php -l "$file" >/dev/null
           done

--- a/api/app/Modules/HR/Infrastructure/Services/EmployeeService.php
+++ b/api/app/Modules/HR/Infrastructure/Services/EmployeeService.php
@@ -55,7 +55,29 @@ class EmployeeService
         /** @var array<string, mixed> $payload */
         $this->applyBiometricConsent($payload);
 
+        // Issue #4307 : role/manager_role/status/company_id ne sont PAS dans
+        // Employee::$fillable depuis le durcissement #3677 — Eloquent les
+        // écarte silencieusement via create(). On les extrait et on les pose
+        // explicitement après la création pour éviter le 500 (role=null →
+        // TypeError dans EmployeeResource::getAppDownloadLink).
+        $sensitiveFields = [
+            'role'         => Arr::pull($payload, 'role', 'employee'),
+            'manager_role' => Arr::pull($payload, 'manager_role'),
+            'status'       => Arr::pull($payload, 'status', 'active'),
+            'company_id'   => Arr::pull($payload, 'company_id'),
+        ];
+
         $employee = Employee::query()->create($payload);
+
+        // Assignation directe des champs sensibles (contournement volontaire
+        // du fillable — l'acteur a déjà été autorisé par authorize() +
+        // FormRequest avant d'arriver ici).
+        foreach ($sensitiveFields as $field => $value) {
+            if ($value !== null) {
+                $employee->{$field} = $value;
+            }
+        }
+        $employee->save();
 
         if ($employee->company_id !== null) {
             $this->tenantCache->invalidateEmployees($employee->company_id);
@@ -130,7 +152,21 @@ class EmployeeService
         $previousManagerRole = $employee->manager_role;
         $roleChangeRequested = array_key_exists('manager_role', $payload) || array_key_exists('role', $payload);
 
+        // Issue #4307 : même protection que create() — extraire les champs
+        // hors fillable avant fill() pour les poser explicitement.
+        $sensitiveUpdate = [];
+        foreach (['role', 'manager_role', 'status', 'company_id'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $sensitiveUpdate[$field] = Arr::pull($payload, $field);
+            }
+        }
+
         $employee->fill($payload);
+
+        foreach ($sensitiveUpdate as $field => $value) {
+            $employee->{$field} = $value;
+        }
+
         $employee->save();
 
         if ($employee->company_id !== null) {

--- a/front/admin-dashboard/src/views/system/SystemView.vue
+++ b/front/admin-dashboard/src/views/system/SystemView.vue
@@ -113,7 +113,7 @@ const healthCheckTimestamp = ref(null)
 const apiLive = ref(null)
 const apiCheckTimestamp = ref(null)
 
-// Issue #2789 — GET /admin/metrics/overview : agrégats plateforme (Infrastructure)
+// Issue #4328 : la route réelle est /platform/metrics/overview (pas /admin/metrics/overview)
 const platformMetrics = ref(null)
 const infraCheckTimestamp = ref(null)
 
@@ -212,10 +212,10 @@ const apiDetails = computed(() => {
     : `Erreur: ${apiLive.value.error || 'service injoignable'}`
 })
 
-// Issue #2789 — GET /admin/metrics/overview (agrégats plateforme)
+// GET /platform/metrics/overview (agrégats plateforme — Issue #4328)
 const infraStatus = computed(() => (platformMetrics.value ? 'healthy' : 'unavailable'))
 const infraDetails = computed(() => {
-  if (!platformMetrics.value) return 'Non disponible — GET /admin/metrics/overview'
+  if (!platformMetrics.value) return 'Non disponible — GET /platform/metrics/overview'
   const companies = platformMetrics.value.companies
   const system = platformMetrics.value.system || {}
   return `${companies?.active ?? '?'} compagnies actives · PHP ${system.php_version ?? '?'} · queue ${system.queue_driver ?? '?'}`
@@ -233,13 +233,16 @@ async function loadApiLiveness() {
 }
 
 async function loadPlatformMetrics() {
+  // Issue #4328 : la route réelle est /platform/metrics/overview
+  // (l'intercepteur global affiche déjà un toast sur 404 — pas de toast local
+  // pour éviter le double toast signalé dans l'issue).
   try {
-    const response = await api.get('/admin/metrics/overview')
+    const response = await api.get('/platform/metrics/overview')
     platformMetrics.value = response.data?.data || null
     infraCheckTimestamp.value = new Date()
   } catch (error) {
     console.error('Failed to load platform metrics:', error)
-    toast.error('Erreur lors du chargement des métriques plateforme')
+    // Pas de toast.error ici : l'intercepteur global gère le message d'erreur.
   }
 }
 

--- a/front/web/src/modules/vitrine/components/sections/FAQSection.tsx
+++ b/front/web/src/modules/vitrine/components/sections/FAQSection.tsx
@@ -107,16 +107,25 @@ export function FAQSection({
 
         {/* FAQ Items */}
         <div className="space-y-4">
-          {filteredItems.map((item, index) => (
+          {filteredItems.map((item, index) => {
+            // Issue #4321 : item.id peut être undefined (pages modules) → on
+            // dérive un itemId stable des deux côtés (onClick + render) pour
+            // que l'accordéon fonctionne même sans id explicite.
+            const itemId = item.id ?? `faq-${index}`;
+            const isOpen = openId === itemId;
+            const answerId = `${itemId}-answer`;
+            return (
             <motion.div
-              key={item.id ?? `${item.question}-${index}`}
+              key={itemId}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: '-80px' }}
               transition={{ duration: 0.6, delay: index * 0.05, ease: [0.22, 1, 0.36, 1] }}
             >
               <button
-                onClick={() => setOpenId(openId === (item.id ?? `${index}`) ? null : (item.id ?? `${index}`))}
+                onClick={() => setOpenId(isOpen ? null : itemId)}
+                aria-expanded={isOpen}
+                aria-controls={answerId}
                 className="w-full text-left"
               >
                 <div className="group relative bg-white dark:bg-slate-900/80 backdrop-blur-sm rounded-2xl border border-slate-200/80 dark:border-slate-800/80 p-6 transition-all duration-300 hover:border-emerald-200/50 dark:hover:border-emerald-800/50 hover:shadow-lg cursor-pointer">
@@ -125,7 +134,7 @@ export function FAQSection({
                       {item.question}
                     </h3>
                     <motion.div
-                      animate={{ rotate: openId === item.id ? 180 : 0 }}
+                      animate={{ rotate: isOpen ? 180 : 0 }}
                       transition={{ duration: 0.3 }}
                       className="flex-shrink-0"
                     >
@@ -135,7 +144,7 @@ export function FAQSection({
 
                   {/* Answer */}
                   <AnimatePresence>
-                    {openId === item.id && (
+                    {isOpen && (
                       <motion.div
                         initial={{ opacity: 0, height: 0 }}
                         animate={{ opacity: 1, height: 'auto' }}
@@ -152,7 +161,8 @@ export function FAQSection({
                 </div>
               </button>
             </motion.div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## PR fermée — contenu distribué (superseded)

Chaque correctif de cette PR est déjà porté par une PR/branche dédiée plus complète :

| Partie de #4385 | PR canonique |
|---|---|
| EmployeeService #4307 (role/manager_role/status/company_id) | #4308 (fix/4307-employee-role-nonfillable) + #4550 |
| SystemView URL métriques #4328 | #4347 (fix/4328-systemview-metrics-endpoint) |
| FAQSection accordéon #4321 | branche fix/4321-faq-accordion-id (PR dédiée à venir) |
| Garde CI `lang/` php -l (#4309) | déjà sur main (#4291) |

Note : la variante EmployeeService de cette PR imposait des défauts `role=employee`/`status=active` via `Arr::pull(..., defaut)` — comportement plus risqué que le pattern forceFill validé #3677/#4151 porté par #4308/#4550. [agent-swe-qa]