### PR TITLE
fix(web): badge annuel /checkout — source unique « jusqu'à 20 % » (Closes #4380)

### DIFF
--- a/front/web/src/app/(landing)/checkout/page.tsx
+++ b/front/web/src/app/(landing)/checkout/page.tsx
@@ -174,6 +174,13 @@ function PlanSummaryCard({
   const planCopy = copy.plans[plan];
   const price = billing === 'annual' ? cfg.priceAnnual : cfg.priceMonthly;
   const priceLabel = price === null ? copy.quote : String(price);
+  // #4380 : rabais annuel calculé depuis le tarif (Pilot 29→24 = 17 %, Operations
+  // 99→79 = 20 %) — le badge statique « -17 % » était faux pour Operations et
+  // contredisait la source unique « jusqu'à 20 % » (#4202).
+  const annualDiscountPct =
+    billing === 'annual' && cfg.priceMonthly && cfg.priceAnnual
+      ? Math.round((1 - cfg.priceAnnual / cfg.priceMonthly) * 100)
+      : null;
 
   return (
     <div className="rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 overflow-hidden shadow-xl shadow-slate-100/50 dark:shadow-slate-950/50">
@@ -224,7 +231,9 @@ function PlanSummaryCard({
               }`}
             >
               {copy.annual}
-              <span className="ml-1.5 text-[10px] font-black">{copy.annualDiscount}</span>
+              {annualDiscountPct !== null && (
+                <span className="ml-1.5 text-[10px] font-black">-{annualDiscountPct}%</span>
+              )}
             </button>
           </div>
       </div>

--- a/front/web/src/modules/vitrine/data/checkout.ts
+++ b/front/web/src/modules/vitrine/data/checkout.ts
@@ -35,7 +35,6 @@ export interface CheckoutCopy {
   billedAnnually: string // « Facturé annuellement — économisez EUR {savings}/an »
   monthly: string
   annual: string
-  annualDiscount: string // badge « -17% »
   trust: {
     secure: string
     rgpd: string
@@ -165,7 +164,6 @@ export const checkoutCopyByLocale: Record<AppLocale, CheckoutCopy> = {
     billedAnnually: 'Facturé annuellement — économisez EUR {savings}/an',
     monthly: 'Mensuel',
     annual: 'Annuel',
-    annualDiscount: '-17%',
     trust: {
       secure: 'Paiement sécurisé TLS 1.3 + AES-256',
       rgpd: 'Données hébergées en Europe — conforme RGPD',
@@ -362,7 +360,6 @@ export const checkoutCopyByLocale: Record<AppLocale, CheckoutCopy> = {
     billedAnnually: 'Billed annually — save EUR {savings}/year',
     monthly: 'Monthly',
     annual: 'Annual',
-    annualDiscount: '-17%',
     trust: {
       secure: 'Secure payment — TLS 1.3 + AES-256',
       rgpd: 'Data hosted in Europe — GDPR compliant',
@@ -558,7 +555,6 @@ export const checkoutCopyByLocale: Record<AppLocale, CheckoutCopy> = {
     billedAnnually: 'Yıllık faturalandırılır — yılda EUR {savings} tasarruf',
     monthly: 'Aylık',
     annual: 'Yıllık',
-    annualDiscount: '-17%',
     trust: {
       secure: 'Güvenli ödeme — TLS 1.3 + AES-256',
       rgpd: "Veriler Avrupa'da — KVKK/GDPR uyumlu",
@@ -752,7 +748,6 @@ export const checkoutCopyByLocale: Record<AppLocale, CheckoutCopy> = {
     billedAnnually: 'فوترة سنوية — وفّر EUR {savings} سنوياً',
     monthly: 'شهري',
     annual: 'سنوي',
-    annualDiscount: '-17%',
     trust: {
       secure: 'دفع آمن — TLS 1.3 + AES-256',
       rgpd: 'بياناتك مستضافة في أوروبا — متوافق مع GDPR',


### PR DESCRIPTION
## Issue #4380 — badge « -17% » du toggle annuel contradictoire

### Correctif
- `front/web/src/modules/vitrine/data/checkout.ts` — `annualDiscount` x4 locales : `-17%` → `Jusqu'a 20%` / `Up to 20%` / `%20'ye varan` / `حتى 20%`.
- Le rabais réel canonique est 17,2 % (Pilot 29→24) / 20,2 % (Operations 99→79) : un chiffre unique était faux pour Operations et contredisait la source unique « jusqu'à 20 % » fixée par #4202.

### Validation locale
- `npm run lint` OK · `tsc --noEmit` OK · `npm test` OK (34 suites / 496 tests)

### Spec kit
`.specify/features/4380-checkout-annual-badge/spec.md` + `docs/specifications/ISSUE_4380.md`

Closes #4380