### PR TITLE
fix(web): noms accessibles sur 3 inputs sans label — newsletter, docs search, OTP (Closes #4323)

### DIFF
--- a/front/web/src/app/(landing)/docs/page.tsx
+++ b/front/web/src/app/(landing)/docs/page.tsx
@@ -154,6 +154,7 @@ export default function DocsPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={copy.hero.searchPlaceholder}
+              aria-label={copy.hero.searchPlaceholder}
               className="w-full pl-11 pr-4 py-3 rounded-2xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
             />
           </div>

--- a/front/web/src/modules/vitrine/components/NewsletterForm.tsx
+++ b/front/web/src/modules/vitrine/components/NewsletterForm.tsx
@@ -50,6 +50,7 @@ export function NewsletterForm() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder={t.placeholder}
+            aria-label={t.title}
             required
             className="flex-1 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
           />

--- a/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
+++ b/front/web/src/modules/vitrine/components/forms/SignupForm.tsx
@@ -525,6 +525,7 @@ export function SignupForm({
                   onChange={(e) => handleOtpChange(i, e.target.value)}
                   onKeyDown={(e) => handleOtpKeyDown(i, e)}
                   onPaste={i === 0 ? handleOtpPaste : undefined}
+                  aria-label={`${c.otpTitle} ${i + 1}`}
                   className={`h-14 w-12 rounded-xl border-2 text-center text-2xl font-bold outline-none transition-all
                     ${otpError
                       ? 'border-red-300 bg-red-50 text-red-900 dark:border-red-700 dark:bg-red-950/30 dark:text-red-200'


### PR DESCRIPTION
## Issue #4323 — inputs sans nom accessible

Trois inputs n'avaient aucun nom accessible (placeholder seul) : `NewsletterForm` (footer), la recherche `/docs` et les 6 champs OTP du signup (`SignupForm`).

### Correctif
- `NewsletterForm.tsx` : `aria-label={t.title}` sur l'input email.
- `docs/page.tsx` : `aria-label={copy.hero.searchPlaceholder}` sur la recherche.
- `SignupForm.tsx` : `aria-label={`${c.otpTitle} ${i + 1}`}` sur chaque champ OTP.

### Validation
- `npx tsc --noEmit` : 0 erreur ; `npx eslint` : 0 erreur.
- `npx jest SignupForm.test.tsx` : 19/19 verts.
- Runtime : aria-label présents sur les 3 surfaces.

Closes #4323