### PR TITLE
fix(api): GET /sso/providers — throttle:api ajouté (seul endpoint public sans throttle) (Closes #4316)

### DIFF
--- a/api/routes/modules/sso.php
+++ b/api/routes/modules/sso.php
@@ -9,7 +9,9 @@ use App\Core\Auth\Interfaces\Api\V1\SSOController;
 use Illuminate\Support\Facades\Route;
 
 // Public: supported providers list
-Route::get('/sso/providers', [SSOController::class, 'providers']);
+// QA #3000 : throttle sur les endpoints publics (cf. callbacks ci-dessous) —
+// #4316 : /sso/providers était le seul endpoint public sans throttle.
+Route::get('/sso/providers', [SSOController::class, 'providers'])->middleware('throttle:api');
 
 // Public: SSO callbacks (no auth required — these receive IdP responses)
 // QA #3000 : throttles sur les endpoints publics (anti abuse SAMLResponse/redirects)


### PR DESCRIPTION
## Issue #4316 — GET /sso/providers sans throttle

`routes/modules/sso.php:12` : `/sso/providers` était le **seul endpoint public** du fichier sans throttle, alors que la politique QA #3000 (throttles sur les endpoints publics, anti-abuse) est déclarée dans le fichier même et appliquée aux 3 callbacks.

### Correctif
`->middleware('throttle:api')` (même limite que les callbacks SAML/OIDC du fichier).

### Validation
- `php -l api/routes/modules/sso.php` : 0 erreur de syntaxe.
- Aucun changement de comportement pour les clients légitimes (limite standard `api`).

Closes #4316