### PR TITLE
fix(ci): i18n-enterprise — retrait du chemin redondant front/admin-dashboard/src/i18n/** (⊂ src/**) (Closes #4346)

### DIFF
--- a/.github/workflows/i18n-enterprise.yml
+++ b/.github/workflows/i18n-enterprise.yml
@@ -8,7 +8,6 @@ on:
       - 'front/mobile_apps/leopardo_employee/lib/**'
       - 'front/mobile_apps/leopardo_manager/lib/**'
       - 'front/mobile_apps/leopardo_platform_admin/lib/**'
-      - 'front/admin-dashboard/src/i18n/**'     # chemin réel dans le repo
       - 'front/admin-dashboard/src/**'
       - 'front/web/src/lib/i18n/**'             # client Next.js
       - 'front/web/src/app/**'
@@ -27,7 +26,6 @@ on:
       - 'front/mobile_apps/leopardo_employee/lib/**'
       - 'front/mobile_apps/leopardo_manager/lib/**'
       - 'front/mobile_apps/leopardo_platform_admin/lib/**'
-      - 'front/admin-dashboard/src/i18n/**'
       - 'front/admin-dashboard/src/**'
       - 'front/web/src/lib/i18n/**'
       - 'front/web/src/app/**'


### PR DESCRIPTION
## Issue #4346 — chemins push redondants dans i18n-enterprise.yml

`front/admin-dashboard/src/i18n/**` était listé dans les blocs `pull_request` ET `push` alors qu'il est un sous-ensemble de `front/admin-dashboard/src/**` (déjà présent) → déclenchements redondants du workflow i18n à chaque push frontend.

### Correctif
Suppression du sous-ensemble dans les deux blocs. Les chemins web (`front/web/src/app/**`, `modules/**`, `lib/i18n/**`) sont **conservés** : aucun parent `front/web/src/**` ne les couvre (surfaces de la garde PA2-I18N-014 + catalogues générés).

### Validation
- `python3 -c yaml.safe_load` : YAML valide (structure `on.pull_request.paths` intacte).

Closes #4346