### PR TITLE
fix(web): LegalPageShell — ?lang persiste dans l'URL (Closes #4506)

### DIFF
--- a/front/web/src/modules/vitrine/components/LegalPageShell.tsx
+++ b/front/web/src/modules/vitrine/components/LegalPageShell.tsx
@@ -1,6 +1,7 @@
 ﻿'use client'
 
 import Link from 'next/link'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { ArrowLeft, Globe2, ShieldCheck } from 'lucide-react'
 import type { AppLocale } from '@/lib/i18n'
 import { getLegalPageCopy, type LegalPageKind } from '../lib/legal-content'
@@ -13,6 +14,11 @@ type LegalPageShellProps = {
 export function LegalPageShell({ page }: LegalPageShellProps) {
   const { locale, direction, options, setLocale } = useVitrineLocale()
   const copy = getLegalPageCopy(locale, page)
+  // #4506 : le sélecteur de langue doit persister ?lang dans l'URL (comme le
+  // Navbar, #3806) — sinon un refresh perd la locale et le SSR re-sert du FR.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   return (
     <main dir={direction} className="min-h-screen bg-white text-slate-950 dark:bg-slate-950 dark:text-white">
@@ -32,7 +38,14 @@ export function LegalPageShell({ page }: LegalPageShellProps) {
             <select
               aria-label={copy.languageLabel}
               value={locale}
-              onChange={(event) => setLocale(event.target.value as AppLocale)}
+              onChange={(event) => {
+                const nextLocale = event.target.value as AppLocale
+                setLocale(nextLocale)
+                const params = new URLSearchParams(searchParams.toString())
+                params.set('lang', nextLocale)
+                const query = params.toString()
+                router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+              }}
               className="w-full bg-transparent font-semibold text-slate-900 outline-none dark:text-white"
             >
               {options.map((option) => (


### PR DESCRIPTION
## Contexte

Audit 360° 2026-08-16 (#4506) : le sélecteur de langue de `LegalPageShell` (pages /privacy /terms) appelait seulement `setLocale` — un refresh/perte de l'état client perdait la locale et le SSR re-servait du FR (contrairement au Navbar #3806 et /mobile #4468 qui synchronisent l'URL).

## Changements

- `front/web/src/modules/vitrine/components/LegalPageShell.tsx` : `router.replace(pathname + '?lang=' + nextLocale)` sur changement de langue (pattern `buildLocaleUrl` du Navbar).

## Validation

- `tsc --noEmit` + `eslint --max-warnings 0` OK. CI : Web Build, ESLint + TypeScript, garde i18n-diff.

Closes #4506
