### PR TITLE
fix(web): Navbar — état aria du sous-menu mobile (Closes #4510)

### DIFF
--- a/front/web/src/modules/vitrine/components/Navbar.tsx
+++ b/front/web/src/modules/vitrine/components/Navbar.tsx
@@ -429,6 +429,8 @@ export function Navbar({ isDark, onToggleDark }: Props) {
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: index * 0.05 }}
                       className="w-full flex items-center justify-between px-4 py-3 text-lg font-semibold text-slate-900 dark:text-white rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                      aria-expanded={openDropdown === entry.label}
+                      aria-haspopup="true"
                       onClick={() => setOpenDropdown(openDropdown === entry.label ? null : entry.label)}
                     >
                       {entry.label}


### PR DESCRIPTION
## Contexte

Audit 360° 2026-08-16 (#4510) : le bouton de sous-menu mobile (Ressources/Installer/Communaute) du Navbar n'avait ni `aria-expanded` ni `aria-haspopup` (le variant desktop les a) — les lecteurs d'écran ne pouvaient pas connaître l'état du menu.

## Changements

- `front/web/src/modules/vitrine/components/Navbar.tsx` : `aria-expanded={openDropdown === entry.label}` + `aria-haspopup="true"`.

## Validation

- `eslint --max-warnings 0` OK. CI : Web Build + ESLint + TypeScript.

Closes #4510
