### PR TITLE
fix(api): recentActivity limit borné + throttle /activate web (Closes #4499 #4498)

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DashboardController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/DashboardController.php
@@ -126,10 +126,14 @@ class DashboardController extends Controller
         $user = $request->user();
         $companyId = $user->company_id;
 
+        // #4499 : limit borné (1..100) — une valeur négative = « illimité » en
+        // PostgreSQL, une valeur énorme vidait tout audit_logs en une requête.
+        $limit = max(1, min(100, $request->integer('limit', 20)));
+
         $activities = DB::table('audit_logs')
             ->where('company_id', $companyId)
             ->orderByDesc('created_at')
-            ->limit($request->integer('limit', 20))
+            ->limit($limit)
             ->get(['id', 'user_id', 'action', 'auditable_type', 'auditable_id', 'created_at']);
 
         return response()->json(['data' => $activities]);

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -213,6 +213,17 @@ class AppServiceProvider extends ServiceProvider
                 ->by('web-login:'.$email.'|'.$request->ip());
         });
 
+        // #4498 — invitation activation (public, token-based, sets the employee
+        // password) : same brute-force exposure as the API twin
+        // /onboarding/invitation/{token} (throttled 10/min). Dedicated bucket
+        // keyed by token + IP.
+        RateLimiter::for('web-activate', function (Request $request) {
+            $token = (string) $request->route('token', 'unknown');
+
+            return Limit::perMinute((int) config('security.rate_limits.web_activate_per_minute', 10))
+                ->by('web-activate:'.$token.'|'.$request->ip());
+        });
+
         // PA2-API-005 — The kiosk web punch endpoint (public, device-code based,
         // no Sanctum auth) needs its own throttle bucket keyed by device code so a
         // single compromised/misbehaving kiosk cannot exhaust another kiosk's

--- a/api/config/security.php
+++ b/api/config/security.php
@@ -13,6 +13,7 @@ return [
         // sit outside the API 'auth-sensitive'/'api' limiters, so they need their
         // own dedicated buckets to stay protected against brute-force attempts.
         'web_login_per_minute' => (int) env('RATE_LIMIT_WEB_LOGIN_PER_MINUTE', 10),
+        'web_activate_per_minute' => (int) env('RATE_LIMIT_WEB_ACTIVATE_PER_MINUTE', 10),
         'kiosk_punch_per_minute' => (int) env('RATE_LIMIT_KIOSK_PUNCH_PER_MINUTE', 30),
         // Public careers portal (job listing, job detail, XML feed, and
         // candidate application submission) is unauthenticated by design,

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -81,8 +81,13 @@ Route::middleware('guest:web')->group(function (): void {
         ->name('login.store');
 });
 
-Route::get('/activate/{token}', [InvitationController::class, 'showActivationForm'])->name('invitation.activate.show');
-Route::post('/activate/{token}', [InvitationController::class, 'activate'])->name('invitation.activate.store');
+// #4498 : endpoints publics de pose de mot de passe — throttle dédié (token + IP).
+Route::get('/activate/{token}', [InvitationController::class, 'showActivationForm'])
+    ->middleware('throttle:web-activate')
+    ->name('invitation.activate.show');
+Route::post('/activate/{token}', [InvitationController::class, 'activate'])
+    ->middleware('throttle:web-activate')
+    ->name('invitation.activate.store');
 Route::get('/kiosk/{deviceCode}', [KioskController::class, 'show'])->name('kiosk.show');
 // PA2-API-005: public, device-code based, unauthenticated-by-Sanctum kiosk
 // punch endpoint gets its own 'kiosk-punch' throttle bucket (keyed by device


### PR DESCRIPTION
## Contexte

Audit 360° 2026-08-16 :

- **#4499** : `DashboardController::recentActivity` — `->limit($request->integer('limit', 20))` sans clamp : une valeur négative = « illimité » en PostgreSQL, une valeur énorme vidait tout `audit_logs` de la compagnie en une requête.
- **#4498** : `GET/POST /activate/{token}` (web, pose le mot de passe d'invitation) sans throttle alors que son jumeau API `/onboarding/invitation/{token}` est à 10/min.

## Changements

- `DashboardController.php` : `$limit = max(1, min(100, ...))`.
- `AppServiceProvider.php` : nouveau limiteur `web-activate` (10/min, clé token+IP).
- `routes/web.php` : `throttle:web-activate` sur les 2 routes /activate.
- `config/security.php` : `web_activate_per_minute` (env `RATE_LIMIT_WEB_ACTIVATE_PER_MINUTE`).

## Validation

- Validation locale PHP indisponible (sandbox) — CI : PHPStan strict + Backend Coverage + tests feature.

Closes #4499
Closes #4498
