### PR TITLE
fix(admin): formats de date alignés sur la locale active ×3 vues (Closes #4517)

### DIFF
--- a/front/admin-dashboard/src/views/growth/GrowthDashboardView.vue
+++ b/front/admin-dashboard/src/views/growth/GrowthDashboardView.vue
@@ -95,7 +95,7 @@
               <tr v-for="payout in payouts" :key="payout.id">
                 <td class="px-6 py-4 font-bold text-slate-900">{{ payout.partner?.user?.first_name }}</td>
                 <td class="px-6 py-4 font-black text-slate-900">{{ (payout.amount / 100).toFixed(2) }} {{ payout.currency }}</td>
-                <td class="px-6 py-4 text-sm text-slate-500">{{ new Date(payout.created_at).toLocaleDateString() }}</td>
+                <td class="px-6 py-4 text-sm text-slate-500">{{ formatDate(payout.created_at) }}</td>
                 <td class="px-6 py-4">
                   <span :class="getStatusClass(payout.status)" class="px-2.5 py-1 text-[10px] font-black rounded-full uppercase tracking-tighter">
                     {{ payout.status }}
@@ -155,6 +155,13 @@
 import { ref, onMounted } from 'vue';
 import api from '@/services/api';
 import { useToast } from 'vue-toastification';
+import { useLocaleStore } from '@/stores/locale';
+import { toIntlLocale } from '@/i18n/index.js';
+
+const localeStore = useLocaleStore();
+// #4517 : dates au format de la locale active.
+const formatDate = (value) =>
+  new Intl.DateTimeFormat(toIntlLocale(localeStore.current), { dateStyle: 'medium' }).format(new Date(value));
 
 const toast = useToast();
 

--- a/front/admin-dashboard/src/views/users/UsersView.vue
+++ b/front/admin-dashboard/src/views/users/UsersView.vue
@@ -187,7 +187,7 @@
             </p>
             <code class="mt-2 block break-all rounded-lg bg-white p-2 text-xs dark:bg-slate-900">{{ impersonationResult.token }}</code>
             <p class="mt-2 text-xs text-emerald-700 dark:text-emerald-400">
-              {{ t('users.impersonation.expires', 'Expire le :date').replace(':date', new Date(impersonationResult.expires_at).toLocaleString()) }}
+              {{ t('users.impersonation.expires', 'Expire le :date').replace(':date', new Date(impersonationResult.expires_at).toLocaleString(toIntlLocale(localeStore.current))) }}
             </p>
           </div>
           <div class="flex justify-end gap-2">
@@ -218,7 +218,7 @@ import {
 } from '@heroicons/vue/24/outline'
 import { useToast } from 'vue-toastification'
 import api from '@/services/api'
-import { translate } from '@/i18n/index.js'
+import { translate, toIntlLocale } from '@/i18n/index.js'
 import { useLocaleStore } from '@/stores/locale.js'
 
 // Components
@@ -513,7 +513,7 @@ async function exportUsers(rows = null) {
       return `"${str.replace(/"/g, '""')}"`
     }
     const formatDate = (d) => (d instanceof Date && !Number.isNaN(d.getTime()))
-      ? d.toLocaleDateString('fr-FR')
+      ? d.toLocaleDateString(toIntlLocale(localeStore.current))
       : ''
     const csvContent = "data:text/csv;charset=utf-8," +
       "Nom,Email,Statut,Entreprise,Inscription,Dernière connexion\n" +

--- a/front/admin-dashboard/src/views/webhooks/WebhooksView.vue
+++ b/front/admin-dashboard/src/views/webhooks/WebhooksView.vue
@@ -46,7 +46,7 @@
         </span>
       </template>
       <template #cell-last_triggered_at="{ value }">
-        <span v-if="value" class="text-xs text-gray-500">{{ new Date(value).toLocaleString() }}</span>
+        <span v-if="value" class="text-xs text-gray-500">{{ formatDate(value) }}</span>
         <span v-else class="text-xs text-gray-400">Jamais</span>
       </template>
       <template #row-actions="{ row }">
@@ -133,6 +133,16 @@ import { PlusIcon } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import { useToast } from 'vue-toastification'
 import DataTable from '@/components/common/DataTable.vue'
+import { useLocaleStore } from '@/stores/locale'
+import { toIntlLocale } from '@/i18n/index.js'
+
+const localeStore = useLocaleStore()
+// #4517 : dates au format de la locale active (pas la locale du navigateur).
+const formatDate = (value) =>
+  new Intl.DateTimeFormat(toIntlLocale(localeStore.current), {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
 
 const loading = ref(false)
 const saving = ref(false)


### PR DESCRIPTION
## Contexte

Audit 360° 2026-08-16 (#4517) : `UsersView.vue:516` hardcodait `toLocaleDateString('fr-FR')` ; `UsersView.vue:190`, `WebhooksView.vue:49`, `GrowthDashboardView.vue:98` utilisaient `toLocaleString()`/`toLocaleDateString()` sans locale (sortie dépendante du navigateur) — en contradiction avec la convention `toIntlLocale()`.

## Changements

- `UsersView.vue` : `toLocaleString(toIntlLocale(localeStore.current))` + export CSV `toLocaleDateString(toIntlLocale(localeStore.current))` ; import `toIntlLocale` ajouté.
- `WebhooksView.vue` / `GrowthDashboardView.vue` : helper `formatDate` basé sur `Intl.DateTimeFormat(toIntlLocale(localeStore.current))`.

## Validation

- `eslint --max-warnings 0` + `vite build` OK. CI : Frontend ESLint + TypeScript + Web Build.

Closes #4517
