### PR TITLE
fix(admin): AnalyticsView — état d'erreur visible + retry (Closes #4518)

### DIFF
--- a/front/admin-dashboard/src/views/analytics/AnalyticsView.vue
+++ b/front/admin-dashboard/src/views/analytics/AnalyticsView.vue
@@ -33,6 +33,18 @@
     </div>
 
     <!-- Key Metrics Overview (donnees reelles /admin/dashboard/stats) -->
+
+    <!-- #4518 : bannière d'erreur + retry (chargement échoué) -->
+    <div
+      v-if="errorMessage"
+      class="rounded-xl border border-red-200 bg-red-50 p-4 text-sm font-semibold text-red-700 dark:border-red-900/30 dark:bg-red-950/20 dark:text-red-400"
+      role="alert"
+    >
+      {{ errorMessage }}
+      <button class="ml-3 underline font-bold" @click="loadAll">Réessayer</button>
+    </div>
+
+    <!-- Key Metrics Overview (donnees reelles /admin/dashboard/stats) -->
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
       <MetricCard
         title="Utilisateurs"
@@ -168,6 +180,9 @@ const localeStore = useLocaleStore()
 const toast = useToast()
 
 const isLoading = ref(false)
+// #4518 : état d'erreur visible + retry (pattern #4333) — avant, un échec de
+// chargement rendait des stats à zéro sans bannière ni moyen de recharger.
+const errorMessage = ref('')
 const stats = reactive({
   totalUsers: 0,
   totalCompanies: 0,
@@ -188,6 +203,7 @@ onMounted(loadAll)
 
 async function loadAll() {
   isLoading.value = true
+  errorMessage.value = ''
   try {
     const [statsRes, activitiesRes, alertsRes] = await Promise.all([
       api.get('/admin/dashboard/stats'),
@@ -204,7 +220,7 @@ async function loadAll() {
     }
   } catch (error) {
     console.error('Failed to load analytics:', error)
-    toast.error("Erreur lors du chargement des analytics")
+    errorMessage.value = "Erreur lors du chargement des analytics. Réessayez."
   } finally {
     isLoading.value = false
   }


### PR DESCRIPTION
## Contexte

Audit 360° 2026-08-16 (#4518) : le catch de `loadAll` (AnalyticsView) ne faisait que logger + toast — la page rendait ensuite des stats à zéro / listes vides sans bannière ni bouton de rechargement (contrairement au pattern #4333 appliqué à ChatView/WebhooksView/SystemView).

## Changements

- `front/admin-dashboard/src/views/analytics/AnalyticsView.vue` : `errorMessage` ref + bannière d'erreur avec bouton « Réessayer » ; message effacé au début de chaque chargement.

## Validation

- `eslint --max-warnings 0` + `vite build` OK. CI : Frontend ESLint + TypeScript + Web Build.

Closes #4518
