### PR TITLE
fix(ci/mobile): suppression branche morte push→main (Closes #4526)

### DIFF
--- a/.github/workflows/mobile-distribute.yml
+++ b/.github/workflows/mobile-distribute.yml
@@ -120,9 +120,9 @@ jobs:
           elif [[ "$INPUT_ENV" == "prod" ]]; then
             TARGET="prod"
             BUILD_NAME="${APP_VERSION_PREFIX}-manual-$(date +%Y%m%d)"
-          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "main" ]]; then
-            TARGET="staging"
-            BUILD_NAME="${APP_VERSION_PREFIX}-main-${GITHUB_RUN_NUMBER}"
+          # #4526 : la branche push→main était morte (on: ne déclenche que des
+          # tags v*-staging/v*-prod + workflow_dispatch depuis la scission vers
+          # mobile-distribute-main.yml) — le fallback else couvre déjà ce cas.
           else
             TARGET="staging"
             BUILD_NAME="${APP_VERSION_PREFIX}-manual-$(date +%Y%m%d)"


### PR DESCRIPTION
## Contexte

Audit 360° 2026-08-16 (#4526) : `mobile-distribute.yml` contenait une branche `elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "main" ]]` **inatteignable** — le `on:` du workflow ne déclenche que des tags `v*-staging`/`v*-prod` et `workflow_dispatch` (reliquat de la scission vers `mobile-distribute-main.yml`).

## Changements

- `.github/workflows/mobile-distribute.yml` : branche morte supprimée avec commentaire (le fallback `else` couvre déjà le cas).

## Validation

- YAML validé. CI : actionlint (+ shellcheck).

Closes #4526
