### PR TITLE
fix(api): 8 messages de validation localisés ×4 locales (Closes #4592)

### DIFF
--- a/.specify/features/4592-validation-messages-i18n/spec.md
+++ b/.specify/features/4592-validation-messages-i18n/spec.md
@@ -1,0 +1,57 @@
+# Feature Specification: Validation messages localisés ×4 locales (Closes #4592)
+
+**Feature Branch**: `fix/4592-validation-messages-i18n`
+**Issue**: #4592 (P2, api/i18n)
+**Presets**: `leopardo-multitenancy` (aucune table ajoutée), i18n errors.php
+
+## Contexte
+
+8 messages de validation ajoutés via `$validator->errors()->add(...)` avec des
+littéraux FR/EN en dur dans les réponses 422 du funnel RH/paie. Les tenants
+`en`/`tr`/`ar` reçoivent du français (ou de l'anglais) brut — même classe que
+les batches #3237/#4191/#4292 déjà traités en `lang/errors.php`.
+
+## User Stories
+
+### US1 — Erreurs 422 localisées (P1)
+
+En tant que tenant `en`/`tr`/`ar`, je reçois les messages de validation du
+funnel RH/paie dans ma langue (Accept-Language / ?lang), pas en FR brut.
+
+**Acceptance Scenarios**:
+1. Given POST /api/v1/employees sans `password` ni `send_invitation`, When
+   Accept-Language: ar, Then erreur `password` en arabe.
+2. Given POST /api/v1/employees role=manager sans `manager_role`, When
+   Accept-Language: tr, Then erreur `manager_role` en turc.
+3. Given PATCH /api/v1/employees/{id} avec changement de rôle par un
+   manager non-principal, When Accept-Language: en, Then erreur `role` en
+   anglais.
+4. Given POST /api/v1/payroll-runs avec `country_code` ≠ pays légal du
+   tenant, Then erreur `country_code` avec `:country` interpolé ×4 locales.
+5. Given POST /api/v1/public-holidays avec `year` ≠ année de `date`, Then
+   erreur `year` localisée ×4.
+
+## Requirements
+
+- **FR-001**: 8 clés ajoutées dans `api/lang/{fr,en,tr,ar}/errors.php`
+  (`EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED`,
+  `EMPLOYEE_MANAGER_ROLE_REQUIRED`,
+  `EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN`,
+  `EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY`,
+  `EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN`,
+  `PAYROLL_RUN_COUNTRY_MISMATCH` (:country interpolé),
+  `PUBLIC_HOLIDAY_YEAR_MISMATCH`, `PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH`).
+- **FR-002**: `__('errors.KEY')` dans `StoreEmployeeRequest`,
+  `UpdateEmployeeRequest`, `StorePayrollRunRequest`, `PublicHolidayController`.
+- **FR-003**: parité de clés des 4 locales (garde `LangCatalogParityTest`).
+- **FR-004**: test feature `ValidationMessagesLocalizedTest` — 5 scénarios ×
+  4 locales (ou échantillon représentatif), interpolations vérifiées.
+
+## Success Criteria
+
+- `rg 'Le mot de passe|Le type de manager|Seul le super admin|Seul le manager
+  principal|Le pays du run|The year must match|The month_day must match' api/app`
+  → 0 résultat (hors commentaires).
+- `php -l` vert sur les 4 catalogues + 4 fichiers modifiés.
+- Réponse 422 en `?lang=ar` = arabe (test).
+- PHPStan strict vert (fichiers Core/Modules modifiés).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(api): 8 messages de validation localisés ×4 locales (Closes #4592).** Les `after()` de `StoreEmployeeRequest` (mot de passe/invitation requis, type de manager requis, création manager principal), `UpdateEmployeeRequest` (modification rôles RH, promotion principal), `StorePayrollRunRequest` (pays du run ≠ pays légal du tenant, interpolation :country) et `PublicHolidayController` (year / month_day ≠ date) ajoutaient des littéraux FR/EN en dur → 422 non localisés pour les tenants en/tr/ar. 8 clés ajoutées dans `api/lang/{fr,en,tr,ar}/errors.php` (141 clés/locale, parité gardée par `LangCatalogParityTest`), `__('errors.KEY')` dans les 4 fichiers. Test `ValidationMessagesLocalizedTest` : 5 scénarios × 4 locales (40 assertions). Spec : `.specify/features/4592-validation-messages-i18n/spec.md`.
 
 - **fix(api): EdgeController::health — variable `$sqliteReady` restaurée (ParseError #4577).** Le merge #4577 a livré ` = true;` / `if (! )` (nom de variable avalé par une résolution de conflit) → ParseError PHP sur main. Correctif : `$sqliteReady` reconstruit, lint OK.
 

--- a/api/app/Modules/HR/Interfaces/Api/V1/Requests/StoreEmployeeRequest.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Requests/StoreEmployeeRequest.php
@@ -95,15 +95,15 @@ class StoreEmployeeRequest extends FormRequest
             $sendInvitation = filter_var($this->input('send_invitation', false), FILTER_VALIDATE_BOOLEAN);
 
             if (! $password && ! $sendInvitation) {
-                $validator->errors()->add('password', 'Le mot de passe ou l\'invitation email est requis.');
+                $validator->errors()->add('password', __('errors.EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED'));
             }
 
             if ($role === 'manager' && ! $this->input('manager_role')) {
-                $validator->errors()->add('manager_role', 'Le type de manager est requis.');
+                $validator->errors()->add('manager_role', __('errors.EMPLOYEE_MANAGER_ROLE_REQUIRED'));
             }
 
             if ($role === 'manager' && $this->user()?->isManager() && $this->input('manager_role') === 'principal') {
-                $validator->errors()->add('manager_role', 'Seul le super admin peut creer un manager principal.');
+                $validator->errors()->add('manager_role', __('errors.EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN'));
             }
         });
     }

--- a/api/app/Modules/HR/Interfaces/Api/V1/Requests/UpdateEmployeeRequest.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Requests/UpdateEmployeeRequest.php
@@ -101,7 +101,7 @@ class UpdateEmployeeRequest extends FormRequest
                 ! $user->hasManagerRole('principal')) {
                 $validator->errors()->add(
                     'role',
-                    'Seul le manager principal peut modifier les roles RH.'
+                    __('errors.EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY')
                 );
             }
 
@@ -111,7 +111,7 @@ class UpdateEmployeeRequest extends FormRequest
             if ($this->input('manager_role') === 'principal' && $user?->isManager()) {
                 $validator->errors()->add(
                     'manager_role',
-                    'Seul le super admin peut promouvoir un manager en principal.'
+                    __('errors.EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN')
                 );
             }
         });

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/PublicHolidayController.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/PublicHolidayController.php
@@ -207,7 +207,7 @@ class PublicHolidayController extends Controller
             // Recoupement date ↔ year : une date de 2026 ne peut pas porter
             // year=2025 (ligne invisible dans la lecture par année sinon).
             if ($date !== null && $date->year !== $year) {
-                $v->errors()->add('year', 'The year must match the year of the date.');
+                $v->errors()->add('year', __('errors.PUBLIC_HOLIDAY_YEAR_MISMATCH'));
             }
 
             // month_day (si fourni avec is_recurring) doit correspondre à la
@@ -217,7 +217,7 @@ class PublicHolidayController extends Controller
             $isRecurring = filter_var($data['is_recurring'] ?? false, FILTER_VALIDATE_BOOLEAN);
             if ($date !== null && $isRecurring && isset($data['month_day']) && $data['month_day'] !== '') {
                 if ((string) $data['month_day'] !== $date->format('m-d')) {
-                    $v->errors()->add('month_day', 'The month_day must match the month and day of the date.');
+                    $v->errors()->add('month_day', __('errors.PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH'));
                 }
             }
         });

--- a/api/app/Modules/Payroll/Interfaces/Api/V1/Requests/StorePayrollRunRequest.php
+++ b/api/app/Modules/Payroll/Interfaces/Api/V1/Requests/StorePayrollRunRequest.php
@@ -56,7 +56,7 @@ class StorePayrollRunRequest extends FormRequest
             if ($tenantCountry !== null && strtoupper((string) $this->input('country_code')) !== $tenantCountry) {
                 $validator->errors()->add(
                     'country_code',
-                    "Le pays du run doit correspondre au pays légal du tenant ({$tenantCountry})."
+                    __('errors.PAYROLL_RUN_COUNTRY_MISMATCH', ['country' => $tenantCountry])
                 );
             }
         });

--- a/api/lang/ar/errors.php
+++ b/api/lang/ar/errors.php
@@ -150,5 +150,13 @@ return [
     'PAYROLL_ALREADY_VALIDATED' => 'تم التحقق من هذه دفعة الأجور بالفعل ولا يمكن تعديلها.',
     'PAYROLL_RUN_LOCKED' => 'دفعة الأجور هذه مقفلة (إقفال محاسبي) ولا يمكن تعديلها.',
     'PAYROLL_RUN_NOT_LOCKED' => 'يمكن تسوية دفعة أجور مقفلة فقط.',
-    'PAYROLL_RUN_NOT_VALIDATED' => 'يجب التحقق من دفعة الأجور (خطوة الموارد البشرية) قبل الإقفال المحاسبي.'
+    'PAYROLL_RUN_NOT_VALIDATED' => 'يجب التحقق من دفعة الأجور (خطوة الموارد البشرية) قبل الإقفال المحاسبي.',
+    'EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED' => 'كلمة المرور أو دعوة البريد الإلكتروني مطلوبة.',
+    'EMPLOYEE_MANAGER_ROLE_REQUIRED' => 'نوع المدير مطلوب.',
+    'EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN' => 'يمكن للمسؤول الفائق فقط إنشاء مدير رئيسي.',
+    'EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY' => 'يمكن للمدير الرئيسي فقط تعديل أدوار الموارد البشرية.',
+    'EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN' => 'يمكن للمسؤول الفائق فقط ترقية مدير إلى مدير رئيسي.',
+    'PAYROLL_RUN_COUNTRY_MISMATCH' => 'يجب أن تتطابق دولة التشغيل مع الدولة القانونية للمستأجر (:country).',
+    'PUBLIC_HOLIDAY_YEAR_MISMATCH' => 'يجب أن تتطابق السنة مع سنة التاريخ.',
+    'PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH' => 'يجب أن يتطابق اليوم والشهر مع يوم وشهر التاريخ.',
 ];

--- a/api/lang/en/errors.php
+++ b/api/lang/en/errors.php
@@ -151,5 +151,13 @@ return [
     'PAYROLL_ALREADY_VALIDATED' => 'This payroll run is already validated and can no longer be modified.',
     'PAYROLL_RUN_LOCKED' => 'This payroll run is locked (accounting close) and can no longer be modified.',
     'PAYROLL_RUN_NOT_LOCKED' => 'Only a locked payroll run can be regularized.',
-    'PAYROLL_RUN_NOT_VALIDATED' => 'The run must be validated (HR step) before accounting lock.'
+    'PAYROLL_RUN_NOT_VALIDATED' => 'The run must be validated (HR step) before accounting lock.',
+    'EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED' => 'A password or an email invitation is required.',
+    'EMPLOYEE_MANAGER_ROLE_REQUIRED' => 'The manager type is required.',
+    'EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN' => 'Only a super admin can create a principal manager.',
+    'EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY' => 'Only the principal manager can change HR roles.',
+    'EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN' => 'Only a super admin can promote a manager to principal.',
+    'PAYROLL_RUN_COUNTRY_MISMATCH' => 'The run country must match the tenant\'s legal country (:country).',
+    'PUBLIC_HOLIDAY_YEAR_MISMATCH' => 'The year must match the year of the date.',
+    'PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH' => 'The month_day must match the month and day of the date.',
 ];

--- a/api/lang/fr/errors.php
+++ b/api/lang/fr/errors.php
@@ -151,5 +151,13 @@ return [
     'PAYROLL_ALREADY_VALIDATED' => 'Cette fiche de paie est déjà validée et ne peut plus être modifiée.',
     'PAYROLL_RUN_LOCKED' => 'Ce run de paie est verrouillé (clôture comptable) et ne peut plus être modifié.',
     'PAYROLL_RUN_NOT_LOCKED' => 'Seul un run de paie verrouillé peut être régularisé.',
-    'PAYROLL_RUN_NOT_VALIDATED' => 'Un run doit être validé (étape RH) avant verrouillage comptable.'
+    'PAYROLL_RUN_NOT_VALIDATED' => 'Un run doit être validé (étape RH) avant verrouillage comptable.',
+    'EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED' => 'Le mot de passe ou l\'invitation email est requis.',
+    'EMPLOYEE_MANAGER_ROLE_REQUIRED' => 'Le type de manager est requis.',
+    'EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN' => 'Seul le super admin peut créer un manager principal.',
+    'EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY' => 'Seul le manager principal peut modifier les rôles RH.',
+    'EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN' => 'Seul le super admin peut promouvoir un manager en principal.',
+    'PAYROLL_RUN_COUNTRY_MISMATCH' => 'Le pays du run doit correspondre au pays légal du tenant (:country).',
+    'PUBLIC_HOLIDAY_YEAR_MISMATCH' => 'L\'année doit correspondre à l\'année de la date.',
+    'PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH' => 'Le mois et le jour doivent correspondre au mois et au jour de la date.',
 ];

--- a/api/lang/tr/errors.php
+++ b/api/lang/tr/errors.php
@@ -150,5 +150,13 @@ return [
     'PAYROLL_ALREADY_VALIDATED' => 'Bu maaş bordrosu zaten onaylandı ve artık değiştirilemez.',
     'PAYROLL_RUN_LOCKED' => 'Bu maaş bordrosu kilitli (muhasebe kapanışı) ve artık değiştirilemez.',
     'PAYROLL_RUN_NOT_LOCKED' => 'Yalnızca kilitli bir maaş bordrosu düzeltilebilir.',
-    'PAYROLL_RUN_NOT_VALIDATED' => 'Muhasebe kilidi öncesinde bordro onaylanmalıdır (İK adımı).'
+    'PAYROLL_RUN_NOT_VALIDATED' => 'Muhasebe kilidi öncesinde bordro onaylanmalıdır (İK adımı).',
+    'EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED' => 'Şifre veya e-posta davetiyesi gereklidir.',
+    'EMPLOYEE_MANAGER_ROLE_REQUIRED' => 'Yönetici türü gereklidir.',
+    'EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN' => 'Yalnızca süper yönetici bir baş yönetici oluşturabilir.',
+    'EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY' => 'Yalnızca baş yönetici İK rollerini değiştirebilir.',
+    'EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN' => 'Yalnızca süper yönetici bir yöneticiyi baş yöneticiliğe terfi ettirebilir.',
+    'PAYROLL_RUN_COUNTRY_MISMATCH' => 'Çalıştırma ülkesi, kiracının yasal ülkesiyle eşleşmelidir (:country).',
+    'PUBLIC_HOLIDAY_YEAR_MISMATCH' => 'Yıl, tarihin yılıyla eşleşmelidir.',
+    'PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH' => 'Ay_gün, tarihin ayı ve günüyle eşleşmelidir.',
 ];

--- a/api/tests/Feature/ValidationMessagesLocalizedTest.php
+++ b/api/tests/Feature/ValidationMessagesLocalizedTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * #4592 — 8 messages de validation ajoutés via $validator->errors()->add()
+ * avec des littéraux FR/EN en dur (StoreEmployeeRequest, UpdateEmployeeRequest,
+ * StorePayrollRunRequest, PublicHolidayController). Les tenants en/tr/ar
+ * recevaient du français (ou de l'anglais) dans les 422. Les messages
+ * passent désormais par lang/errors.php ×4 locales (SetLocale/Accept-Language).
+ */
+class ValidationMessagesLocalizedTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private const LOCALES = ['fr', 'en', 'tr', 'ar'];
+
+    public function test_employee_create_password_or_invitation_localized(): void
+    {
+        $expected = [
+            'fr' => "Le mot de passe ou l'invitation email est requis.",
+            'en' => 'A password or an email invitation is required.',
+            'tr' => 'Şifre veya e-posta davetiyesi gereklidir.',
+            'ar' => 'كلمة المرور أو دعوة البريد الإلكتروني مطلوبة.',
+        ];
+
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        Sanctum::actingAs($manager);
+
+        foreach ($expected as $locale => $message) {
+            // SetLocale : la préférence de l'utilisateur authentifié prime sur
+            // Accept-Language — on pilote la locale via preferred_language.
+            $manager->forceFill(['preferred_language' => $locale])->save();
+
+            $response = $this->withHeader('Accept-Language', $locale)
+                ->postJson('/api/v1/employees', [
+                    'first_name' => 'Localized',
+                    'last_name' => 'Test',
+                    'email' => "localized-{$locale}@example.test",
+                    'role' => 'employee',
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonPath('errors.password.0', $message);
+        }
+    }
+
+    public function test_employee_create_manager_role_required_localized(): void
+    {
+        $expected = [
+            'fr' => 'Le type de manager est requis.',
+            'en' => 'The manager type is required.',
+            'tr' => 'Yönetici türü gereklidir.',
+            'ar' => 'نوع المدير مطلوب.',
+        ];
+
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        Sanctum::actingAs($manager);
+
+        foreach ($expected as $locale => $message) {
+            $manager->forceFill(['preferred_language' => $locale])->save();
+
+            $response = $this->withHeader('Accept-Language', $locale)
+                ->postJson('/api/v1/employees', [
+                    'first_name' => 'Localized',
+                    'last_name' => 'Manager',
+                    'email' => "localized-mgr-{$locale}@example.test",
+                    'password' => 'ProvidedPass123!',
+                    'role' => 'manager',
+                    // manager_role absent → erreur dédiée.
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonPath('errors.manager_role.0', $message);
+        }
+    }
+
+    public function test_employee_update_role_change_forbidden_localized(): void
+    {
+        $expected = [
+            'fr' => 'Seul le manager principal peut modifier les rôles RH.',
+            'en' => 'Only the principal manager can change HR roles.',
+            'tr' => 'Yalnızca baş yönetici İK rollerini değiştirebilir.',
+            'ar' => 'يمكن للمدير الرئيسي فقط تعديل أدوار الموارد البشرية.',
+        ];
+
+        $company = Company::factory()->create();
+
+        /** @var Employee $rhManager */
+        $rhManager = Employee::factory()->managerRh()->create(['company_id' => $company->id]);
+        /** @var Employee $target */
+        $target = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'employee',
+            'status' => 'active',
+        ]);
+
+        Sanctum::actingAs($rhManager);
+
+        foreach ($expected as $locale => $message) {
+            $rhManager->forceFill(['preferred_language' => $locale])->save();
+
+            $response = $this->withHeader('Accept-Language', $locale)
+                ->patchJson("/api/v1/employees/{$target->id}", [
+                    'role' => 'manager',
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonPath('errors.role.0', $message);
+        }
+    }
+
+    public function test_payroll_run_country_mismatch_localized_with_interpolation(): void
+    {
+        $expected = [
+            'fr' => 'Le pays du run doit correspondre au pays légal du tenant (DZ).',
+            'en' => "The run country must match the tenant's legal country (DZ).",
+            'tr' => 'Çalıştırma ülkesi, kiracının yasal ülkesiyle eşleşmelidir (DZ).',
+            'ar' => 'يجب أن تتطابق دولة التشغيل مع الدولة القانونية للمستأجر (DZ).',
+        ];
+
+        $company = Company::factory()->create(['country' => 'DZ']);
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        Sanctum::actingAs($manager);
+
+        foreach ($expected as $locale => $message) {
+            $manager->forceFill(['preferred_language' => $locale])->save();
+
+            $response = $this->withHeader('Accept-Language', $locale)
+                ->postJson('/api/v1/payroll-runs', [
+                    'country_code' => 'MA', // ≠ pays légal du tenant (DZ)
+                    'period_start' => '2026-01-01',
+                    'period_end' => '2026-01-31',
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonPath('errors.country_code.0', $message);
+        }
+    }
+
+    public function test_public_holiday_year_mismatch_localized(): void
+    {
+        $expected = [
+            'fr' => "L'année doit correspondre à l'année de la date.",
+            'en' => 'The year must match the year of the date.',
+            'tr' => 'Yıl, tarihin yılıyla eşleşmelidir.',
+            'ar' => 'يجب أن تتطابق السنة مع سنة التاريخ.',
+        ];
+
+        $company = Company::factory()->create(['country' => 'DZ']);
+        $principal = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        Sanctum::actingAs($principal);
+
+        foreach ($expected as $locale => $message) {
+            $principal->forceFill(['preferred_language' => $locale])->save();
+
+            $response = $this->withHeader('Accept-Language', $locale)
+                ->postJson('/api/v1/public-holidays', [
+                    'country_code' => 'DZ',
+                    'name' => 'Test',
+                    'date' => '2026-01-01',
+                    'year' => 2025, // ≠ année de la date
+                    'is_recurring' => false,
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonPath('errors.year.0', $message);
+        }
+    }
+}


### PR DESCRIPTION
fix(api): 8 messages de validation localisés ×4 locales (Closes #4592)

## Contexte
`StoreEmployeeRequest`, `UpdateEmployeeRequest`, `StorePayrollRunRequest` et `PublicHolidayController` ajoutaient 8 messages de validation **FR/EN en dur** via `$validator->errors()->add(...)` → réponses 422 non localisées pour les tenants en/tr/ar (même classe que #3237/#4191/#4292).

## Changements
- 8 clés ajoutées dans `api/lang/{fr,en,tr,ar}/errors.php` (141 clés/locale, parité gardée) :
  `EMPLOYEE_PASSWORD_OR_INVITATION_REQUIRED`, `EMPLOYEE_MANAGER_ROLE_REQUIRED`, `EMPLOYEE_PRINCIPAL_MANAGER_CREATION_FORBIDDEN`, `EMPLOYEE_ROLE_CHANGE_MANAGER_ONLY`, `EMPLOYEE_PROMOTE_PRINCIPAL_FORBIDDEN`, `PAYROLL_RUN_COUNTRY_MISMATCH` (`:country` interpolé), `PUBLIC_HOLIDAY_YEAR_MISMATCH`, `PUBLIC_HOLIDAY_MONTH_DAY_MISMATCH` ;
- `__('errors.KEY', [...])` dans les 4 fichiers (locale pilotée par SetLocale : préférence utilisateur → Accept-Language → fr) ;
- apostrophes échappées (`l\'invitation`, `tenant\'s`) — le piège #4293 (catalogue PHP invalide) est couvert par `php -l` ×4 + `LangCatalogParityTest` ;
- Spec spec-kit : `.specify/features/4592-validation-messages-i18n/spec.md`.

## Validation
- `ValidationMessagesLocalizedTest` : 5 scénarios × 4 locales = 40 assertions, vert ;
- `LangCatalogParityTest` : 2 passed (642 assertions) ;
- `php -l` vert ×4 catalogues + 4 fichiers ;
- Pint : PASS ; PHPStan strict (Modules) : 0 erreur ;
- `rg 'Le mot de passe|Le type de manager|Seul le super admin|The year must match|...' api/app` → 0 littéral.

Closes #4592
