### PR TITLE
fix(admin): UsersView — placeholders :active/:newToday interpolés (Closes #4618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(admin): UsersView — sous-titre : placeholders :active/:newToday interpolés (plus de tokens bruts) (Closes #4618).** Le header affichait littéralement « 12 utilisateur(s) - :active actif(s) - :newToday nouveau(x) aujourd'hui » dans les 4 locales.
 - **fix(admin): dialog islamique — l'année est affichée au lieu de « undefined » (Closes #4617).** `HolidaysView.vue` utilisait `islamicYear.value` dans une expression template Vue 3 (ref auto-unwrapped → undefined) → « Confirmer toutes les dates islamiques de undefined ? » dans les 4 locales. Fix : `{ year: islamicYear }`.
 - **refactor(admin): UsersView — dernier pattern de carte legacy remplacé par le token glass-bg (Closes #4575).** Le bloc `<code>` d'affichage du jeton d'impersonation utilisait `bg-white dark:bg-slate-900` (cartes legacy) alors que le design system v4.16.250+ impose les tokens `glass-*`. Migration vers `glass-bg` (bg-white/50 + dark:bg-slate-800/50 + backdrop-blur-sm) — dernier fichier de l'admin avec le pattern `rounded-lg bg-white`.
 - **fix(web): garde de build — NEXT_PUBLIC_SITE_URL obligatoire en production (Closes #4600).** `DEFAULT_SITE_URL` pointe vers leopardo-rh.com, en NXDOMAIN (#3452) ; un build prod sans env var émettait des canonicals/sitemap/JSON-LD vers un domaine mort. `getSiteUrl()` lève désormais une erreur explicite au build (`NODE_ENV=production` + `NEXT_PHASE=phase-production-build`) si `NEXT_PUBLIC_SITE_URL` est absent — échec bruyant plutôt que canonicals invalides. Dev/test inchangés.

--- a/front/admin-dashboard/src/views/users/UsersView.vue
+++ b/front/admin-dashboard/src/views/users/UsersView.vue
@@ -269,8 +269,18 @@ function exportSelectedUsers() {
   exportUsers(selected)
 }
 const usersSummary = computed(() => {
-  return t('users.page.summary', ':count utilisateur(s) plateforme')
-    .replace(':count', String(totalItems.value))
+  const total = users.value.length
+  const active = users.value.filter((u) => u.status === 'active' || u.status === 'activated').length
+  const newToday = users.value.filter((u) => {
+    if (!u.created_at) return false
+    const d = new Date(u.created_at)
+    const now = new Date()
+    return d.toDateString() === now.toDateString()
+  }).length
+  return t('users.page.summary', '')
+    .replace(':count', String(total))
+    .replace(':active', String(active))
+    .replace(':newToday', String(newToday))
 })
 
 onMounted(async () => {


### PR DESCRIPTION
## Constat\nusers.page.summary = « :count utilisateur(s) - :active actif(s) - :newToday nouveau(x) aujourd'hui » mais seuls :count était remplacé → tokens bruts dans le header ×4 locales.\n\n## Correctif\nInterpolation des 3 placeholders depuis les données réelles (status + created_at du jour).\n\nCloses #4618