### PR TITLE
fix(web): /demo — champs associés aux labels (id/htmlFor, a11y) (Closes #4613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): formulaire /demo — 7 champs avec id/htmlFor (WCAG 1.3.1) (Closes #4613).** Les labels n'étaient associés à aucun champ (placeholder seul) → les lecteurs d'écran ne pouvaient pas associer libellés et champs.
 - **fix(admin): UsersView — sous-titre : placeholders :active/:newToday interpolés (plus de tokens bruts) (Closes #4618).** Le header affichait littéralement « 12 utilisateur(s) - :active actif(s) - :newToday nouveau(x) aujourd'hui » dans les 4 locales.
 - **fix(admin): dialog islamique — l'année est affichée au lieu de « undefined » (Closes #4617).** `HolidaysView.vue` utilisait `islamicYear.value` dans une expression template Vue 3 (ref auto-unwrapped → undefined) → « Confirmer toutes les dates islamiques de undefined ? » dans les 4 locales. Fix : `{ year: islamicYear }`.
 - **refactor(admin): UsersView — dernier pattern de carte legacy remplacé par le token glass-bg (Closes #4575).** Le bloc `<code>` d'affichage du jeton d'impersonation utilisait `bg-white dark:bg-slate-900` (cartes legacy) alors que le design system v4.16.250+ impose les tokens `glass-*`. Migration vers `glass-bg` (bg-white/50 + dark:bg-slate-800/50 + backdrop-blur-sm) — dernier fichier de l'admin avec le pattern `rounded-lg bg-white`.

--- a/front/web/src/app/(landing)/demo/page.tsx
+++ b/front/web/src/app/(landing)/demo/page.tsx
@@ -382,7 +382,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.name}
                       </label>
-                      <input
+                      <input id="name"
                         type="text"
                         name="name"
                         required
@@ -397,7 +397,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.email}
                       </label>
-                      <input
+                      <input id="email"
                         type="email"
                         name="email"
                         required
@@ -412,7 +412,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.company}
                       </label>
-                      <input
+                      <input id="company"
                         type="text"
                         name="company"
                         required
@@ -427,7 +427,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.phone}
                       </label>
-                      <input
+                      <input id="phone"
                         type="tel"
                         name="phone"
                         value={formData.phone}
@@ -441,7 +441,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.employees}
                       </label>
-                      <select
+                      <select id="employees"
                         name="employees"
                         value={formData.employees}
                         onChange={handleChange}
@@ -460,7 +460,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.preferredDate}
                       </label>
-                      <input
+                      <input id="preferredDate"
                         type="date"
                         name="preferredDate"
                         value={formData.preferredDate}
@@ -473,7 +473,7 @@ export default function DemoPage() {
                       <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         {copy.fields.message}
                       </label>
-                      <textarea
+                      <textarea id="message"
                         name="message"
                         value={formData.message}
                         onChange={handleChange}


### PR DESCRIPTION
## Constat\n7 champs du formulaire /demo sans association label↔champ (WCAG 1.3.1/4.1.2) ; le formulaire /contact fait référence.\n\n## Correctif\nid sur chaque champ + htmlFor sur chaque label.\n\nCloses #4613