### PR TITLE
fix(web): Navbar — aria-haspopup sur le dropdown desktop (Closes #4614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): Navbar — bouton sous-menu desktop avec aria-haspopup (a11y, résiduel #4510) (Closes #4614).** Le toggle mobile avait aria-expanded+haspopup depuis #4510 ; le bouton desktop (click+hover) n'avait que aria-expanded.
 - **fix(web): formulaire /demo — 7 champs avec id/htmlFor (WCAG 1.3.1) (Closes #4613).** Les labels n'étaient associés à aucun champ (placeholder seul) → les lecteurs d'écran ne pouvaient pas associer libellés et champs.
 - **fix(admin): UsersView — sous-titre : placeholders :active/:newToday interpolés (plus de tokens bruts) (Closes #4618).** Le header affichait littéralement « 12 utilisateur(s) - :active actif(s) - :newToday nouveau(x) aujourd'hui » dans les 4 locales.
 - **fix(admin): dialog islamique — l'année est affichée au lieu de « undefined » (Closes #4617).** `HolidaysView.vue` utilisait `islamicYear.value` dans une expression template Vue 3 (ref auto-unwrapped → undefined) → « Confirmer toutes les dates islamiques de undefined ? » dans les 4 locales. Fix : `{ year: islamicYear }`.

--- a/front/web/src/modules/vitrine/components/Navbar.tsx
+++ b/front/web/src/modules/vitrine/components/Navbar.tsx
@@ -310,6 +310,7 @@ export function Navbar({ isDark, onToggleDark }: Props) {
                     className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors rounded-lg hover:bg-slate-100/80 dark:hover:bg-slate-800/80"
                     onClick={() => setOpenDropdown(openDropdown === entry.label ? null : entry.label)}
                     aria-expanded={openDropdown === entry.label}
+                    aria-haspopup="true"
                   >
                     {entry.label}
                     <ChevronDown className={`w-3.5 h-3.5 transition-transform ${openDropdown === entry.label ? 'rotate-180' : ''}`} />


### PR DESCRIPTION
## Constat\nBouton sous-menu desktop (Navbar.tsx ~309-316) avec aria-expanded mais sans aria-haspopup ni aria-controls (le mobile l'a depuis #4510).\n\n## Correctif\naria-haspopup="true" ajouté.\n\nCloses #4614