### PR TITLE
fix(web): checkout sandbox — libellés carte de test localisés (Closes #4615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): checkout sandbox — libellés carte de test localisés ×4 (Closes #4615).** « Carte : »/« Expiry : »/« CVC : » FR/EN en dur dans l'encart de test (staging).
 - **fix(web): <title> — marque dupliquée retirée des titres localisés (le template racine garde « | Leopardo RH ») (Closes #4612).** Les titres en/tr/ar contenaient déjà leur marque traduite → « Changelog | Leopardo HR | Leopardo RH » (mix FR + doublon) dans 3 locales sur 4.
 - **fix(web): Navbar — bouton sous-menu desktop avec aria-haspopup (a11y, résiduel #4510) (Closes #4614).** Le toggle mobile avait aria-expanded+haspopup depuis #4510 ; le bouton desktop (click+hover) n'avait que aria-expanded.
 - **fix(web): formulaire /demo — 7 champs avec id/htmlFor (WCAG 1.3.1) (Closes #4613).** Les labels n'étaient associés à aucun champ (placeholder seul) → les lecteurs d'écran ne pouvaient pas associer libellés et champs.


### PR DESCRIPTION
## Constat\nBloc sandbox du checkout (page.tsx ~748-750) avec « Carte : »/« Expiry : »/« CVC : » hors catalogue.\n\n## Correctif\nClés sandboxCardNumberLabel/sandboxExpiryCvcLabel ×4 locales dans checkout.ts + usage dans la page.\n\nCloses #4615