### PR TITLE
fix(web): checkout sandbox — page branchée sur les libellés localisés (Closes #4615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): checkout sandbox — page branchée sur les libellés localisés (complément #4615).** L'encart carte de test utilise désormais `copy.payment.sandboxCardNumberLabel` / `sandboxExpiryCvcLabel`.
 - **fix(web): checkout sandbox — libellés carte de test localisés ×4 (Closes #4615).** « Carte : »/« Expiry : »/« CVC : » FR/EN en dur dans l'encart de test (staging).
 - **fix(web): <title> — marque dupliquée retirée des titres localisés (le template racine garde « | Leopardo RH ») (Closes #4612).** Les titres en/tr/ar contenaient déjà leur marque traduite → « Changelog | Leopardo HR | Leopardo RH » (mix FR + doublon) dans 3 locales sur 4.
 - **fix(web): Navbar — bouton sous-menu desktop avec aria-haspopup (a11y, résiduel #4510) (Closes #4614).** Le toggle mobile avait aria-expanded+haspopup depuis #4510 ; le bouton desktop (click+hover) n'avait que aria-expanded.

--- a/front/web/src/app/(landing)/checkout/page.tsx
+++ b/front/web/src/app/(landing)/checkout/page.tsx
@@ -745,9 +745,9 @@ function StepPayment({
               {sandboxFilled ? copy.payment.filledTestCard : copy.payment.fillTestCard}
             </button>
             <div className="mt-2 font-mono text-xs text-amber-700 dark:text-amber-400 space-y-0.5">
-              <p>Carte : {SANDBOX_CARD.number}</p>
+              <p>{copy.payment.sandboxCardNumberLabel} {SANDBOX_CARD.number}</p>
               <p>
-                Expiry : {SANDBOX_CARD.expiry} · CVC : {SANDBOX_CARD.cvc}
+                {copy.payment.sandboxExpiryCvcLabel} {SANDBOX_CARD.expiry} · CVC : {SANDBOX_CARD.cvc}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Complément\nLe premier volet (#4637) a ajouté les clés au catalogue ; ce volet branche la page (bloc carte de test) sur  / .\n\nCloses #4615