### PR TITLE
fix(web): checkout sandbox — libellés via clés canoniques (tsc vert) (Closes #4615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): checkout sandbox — libellés branchés sur les clés canoniques cardLabel/expiryLabel/cvcLabel ×4 (Closes #4615).** Clés dupliquées retirées du catalogue (régression tsc TS2339 corrigée).
 - **fix(web): checkout sandbox — page branchée sur les libellés localisés (complément #4615).** L'encart carte de test utilise désormais `copy.payment.sandboxCardNumberLabel` / `sandboxExpiryCvcLabel`.
 - **fix(web): checkout sandbox — libellés carte de test localisés ×4 (Closes #4615).** « Carte : »/« Expiry : »/« CVC : » FR/EN en dur dans l'encart de test (staging).
 - **fix(web): <title> — marque dupliquée retirée des titres localisés (le template racine garde « | Leopardo RH ») (Closes #4612).** Les titres en/tr/ar contenaient déjà leur marque traduite → « Changelog | Leopardo HR | Leopardo RH » (mix FR + doublon) dans 3 locales sur 4.


### PR DESCRIPTION
## Correctif\nUtilise les clés existantes cardLabel/expiryLabel/cvcLabel (déjà ×4 locales) pour l'encart sandbox ; clés dupliquées retirées de checkout.ts → tsc vert (TS2339 corrigé).\n\nCloses #4615