### PR TITLE
fix(web): checkout sandbox — encart sur clés canoniques, tsc vert (Closes #4615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): checkout sandbox — encart carte de test sur les clés canoniques cardLabel/expiryLabel/cvcLabel ×4 (Closes #4615).** Corrige la régression tsc TS2339 (clés inexistantes référencées par la page).
 - **fix(web): checkout sandbox — libellés branchés sur les clés canoniques cardLabel/expiryLabel/cvcLabel ×4 (Closes #4615).** Clés dupliquées retirées du catalogue (régression tsc TS2339 corrigée).
 - **fix(web): checkout sandbox — page branchée sur les libellés localisés (complément #4615).** L'encart carte de test utilise désormais `copy.payment.sandboxCardNumberLabel` / `sandboxExpiryCvcLabel`.
 - **fix(web): checkout sandbox — libellés carte de test localisés ×4 (Closes #4615).** « Carte : »/« Expiry : »/« CVC : » FR/EN en dur dans l'encart de test (staging).

--- a/front/web/src/app/(landing)/checkout/page.tsx
+++ b/front/web/src/app/(landing)/checkout/page.tsx
@@ -745,9 +745,9 @@ function StepPayment({
               {sandboxFilled ? copy.payment.filledTestCard : copy.payment.fillTestCard}
             </button>
             <div className="mt-2 font-mono text-xs text-amber-700 dark:text-amber-400 space-y-0.5">
-              <p>{copy.payment.sandboxCardNumberLabel} {SANDBOX_CARD.number}</p>
+              <p>{copy.payment.cardLabel} {SANDBOX_CARD.number}</p>
               <p>
-                {copy.payment.sandboxExpiryCvcLabel} {SANDBOX_CARD.expiry} · CVC : {SANDBOX_CARD.cvc}
+                {copy.payment.expiryLabel} {SANDBOX_CARD.expiry} · {copy.payment.cvcLabel} : {SANDBOX_CARD.cvc}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Correctif\nLa page référençait sandboxCardNumberLabel/sandboxExpiryCvcLabel (clés inexistantes → TS2339). Branchement sur les clés canoniques cardLabel/expiryLabel/cvcLabel (×4 locales).\n\nCloses #4615