### PR TITLE
fix(admin): api.js — retry cold-start réservé aux GET/HEAD (Closes #4620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(admin): api.js — retry cold-start limité aux méthodes idempotentes (GET/HEAD/OPTIONS) (Closes #4620).** Les 502/503/504 étaient rejoués sur TOUTES les méthodes : un POST/PUT traité mais à réponse perdue (cold-start Render) était exécuté 2× (webhook dupliqué, impersonation en double, désactivation rejouée).
 - **fix(web): checkout sandbox — encart carte de test sur les clés canoniques cardLabel/expiryLabel/cvcLabel ×4 (Closes #4615).** Corrige la régression tsc TS2339 (clés inexistantes référencées par la page).
 - **fix(web): checkout sandbox — libellés branchés sur les clés canoniques cardLabel/expiryLabel/cvcLabel ×4 (Closes #4615).** Clés dupliquées retirées du catalogue (régression tsc TS2339 corrigée).
 - **fix(web): checkout sandbox — page branchée sur les libellés localisés (complément #4615).** L'encart carte de test utilise désormais `copy.payment.sandboxCardNumberLabel` / `sandboxExpiryCvcLabel`.

--- a/front/admin-dashboard/src/services/api.js
+++ b/front/admin-dashboard/src/services/api.js
@@ -156,6 +156,16 @@ api.interceptors.response.use(
       const requestUrl = originalRequest?.url || ''
 
       if (COLD_START_STATUSES.includes(status) && originalRequest) {
+        // #4620 : ne rejouer que les méthodes idempotentes (GET/HEAD) — un
+        // retry de POST/PUT peut exécuter deux fois une mutation (webhook
+        // dupliqué, session d'impersonation en double, désactivation rejouée)
+        // quand le serveur a traité la requête mais que la réponse s'est
+        // perdue (fenêtre cold-start Render).
+        const method = (originalRequest.method || 'get').toUpperCase()
+        if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+          console.warn(`api: cold-start ${status} sur ${method} ${requestUrl} — non rejoué (non idempotent)`)
+          return Promise.reject(error)
+        }
         const attempt = originalRequest._coldStartAttempt || 0
         if (attempt < COLD_START_MAX_RETRIES) {
           originalRequest._coldStartAttempt = attempt + 1


### PR DESCRIPTION
## Constat\nL'intercepteur rejouait les 502/503/504 sur toutes les méthodes → mutations non idempotentes exécutées 2×.\n\n## Correctif\nRetry uniquement GET/HEAD/OPTIONS ; les mutations sont rejetées avec warning.\n\nCloses #4620