### PR TITLE
fix(ci/docs): CI_CD_SECRETS.md — refs workflow inexistant corrigées (Closes #4627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(ci/docs): CI_CD_SECRETS.md — référence au workflow inexistant deploy-web-vitrine.yml corrigée (Closes #4627).**
 - **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN inutilisé + artefacts annoncés inexistants) (Closes #4626).**
 - **fix(admin): api.js — retry cold-start limité aux méthodes idempotentes (GET/HEAD/OPTIONS) (Closes #4620).** Les 502/503/504 étaient rejoués sur TOUTES les méthodes : un POST/PUT traité mais à réponse perdue (cold-start Render) était exécuté 2× (webhook dupliqué, impersonation en double, désactivation rejouée).
 - **fix(web): checkout sandbox — encart carte de test sur les clés canoniques cardLabel/expiryLabel/cvcLabel ×4 (Closes #4615).** Corrige la régression tsc TS2339 (clés inexistantes référencées par la page).

--- a/docs/CI_CD_SECRETS.md
+++ b/docs/CI_CD_SECRETS.md
@@ -15,13 +15,17 @@
 
 | Secret | Used by | Purpose | Required? |
 |---|---|---|---|
-| `CLOUDFLARE_API_TOKEN` | `deploy-admin-dashboard.yml`, `deploy-web-vitrine.yml` | Déploiement Cloudflare Pages/Workers de l'admin et de la vitrine | Required for Cloudflare deploys |
-| `CLOUDFLARE_ACCOUNT_ID` | `deploy-admin-dashboard.yml`, `deploy-web-vitrine.yml` | Compte Cloudflare cible | Required for Cloudflare deploys |
+| `CLOUDFLARE_API_TOKEN` | `deploy-admin-dashboard.yml` | Déploiement Cloudflare Pages/Workers de l'admin et de la vitrine | Required for Cloudflare deploys |
+| `CLOUDFLARE_ACCOUNT_ID` | `deploy-admin-dashboard.yml` | Compte Cloudflare cible | Required for Cloudflare deploys |
 | `GOOGLE_SERVICES_JSON` | `mobile-distribute*.yml` | `google-services.json` injecté dans les builds Android (employee/manager/hr/platform_admin) | Required for mobile distribution |
-| `VITE_WEBSOCKET_URL` | `deploy-web-vitrine.yml`, `e2e-staging.yml` | URL WebSocket vitrine (probes/observabilité) | Optional (fallback) |
+| `VITE_WEBSOCKET_URL` | `e2e-staging.yml` | URL WebSocket vitrine (probes/observabilité) | Optional (fallback) |
 | `FIREBASE_APP_ID` | `mobile-distribute*.yml` | Fallback générique App ID (légacy) — l'app `hr` préfère `FIREBASE_APP_ID_HR` (#4343) | Deprecated, gardé pour compat |
 | `K6_EMPLOYEE_TOKENS` / `K6_MANAGER_TOKENS` / `K6_PAYROLL_RUN_IDS` | `k6-load-smoke.yml` | Tokens/scénarios k6 des parcours authentifiés | Optional (health-only sans) |
 | `BRANCH_PROTECTION_TOKEN` | `branch-protection-guard.yml` | Lecture de la protection de branche (check cron) | Required for the guard |
+
+> Note (2026-08-16) : le déploiement de la vitrine passe par l'intégration
+> Cloudflare Pages Git (pas de workflow `deploy-web-vitrine.yml` — voir
+> `web-marketing-ci.yml` pour la CI).
 
 ## Secrets
 


### PR DESCRIPTION
## Constat\ndeploy-web-vitrine.yml n'existe pas (déploiement vitrine = intégration Cloudflare Pages) ; 3 lignes du tableau des secrets le référençaient.\n\n## Correctif\nUsages réels + note explicative.\n\nCloses #4627