### PR TITLE
fix(ci/i18n): garde i18n — surface leopardo_hr alignée (Closes #4623)

### DIFF
--- a/.github/workflows/i18n-enterprise.yml
+++ b/.github/workflows/i18n-enterprise.yml
@@ -7,7 +7,8 @@ on:
       - 'front/mobile_apps/leopardo_core/lib/l10n/**'
       - 'front/mobile_apps/leopardo_employee/lib/**'
       - 'front/mobile_apps/leopardo_manager/lib/**'
-      - 'front/mobile_apps/leopardo_platform_admin/lib/**'
+      - 'front/mobile_apps/leopardo_platform_admin/lib/**
+          - front/mobile_apps/leopardo_hr/lib/**'
       - 'front/admin-dashboard/src/**'
       - 'front/web/src/lib/i18n/**'             # client Next.js
       - 'front/web/src/app/**'
@@ -25,7 +26,8 @@ on:
       - 'front/mobile_apps/leopardo_core/lib/l10n/**'
       - 'front/mobile_apps/leopardo_employee/lib/**'
       - 'front/mobile_apps/leopardo_manager/lib/**'
-      - 'front/mobile_apps/leopardo_platform_admin/lib/**'
+      - 'front/mobile_apps/leopardo_platform_admin/lib/**
+          - front/mobile_apps/leopardo_hr/lib/**'
       - 'front/admin-dashboard/src/**'
       - 'front/web/src/lib/i18n/**'
       - 'front/web/src/app/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(ci/i18n): garde i18n alignée sur la surface leopardo_hr — paths i18n-enterprise.yml + watchedPathPrefixes de check-i18n-diff.js (Closes #4623).** Complète #4397 (scanner) : les PRs ne touchant que leopardo_hr/lib ne déclenchaient ni validate-and-sync ni check-new-hardcoded-strings.
 - **fix(ci/docs): CI_CD_SECRETS.md — référence au workflow inexistant deploy-web-vitrine.yml corrigée (Closes #4627).**
 - **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN inutilisé + artefacts annoncés inexistants) (Closes #4626).**
 - **fix(admin): api.js — retry cold-start limité aux méthodes idempotentes (GET/HEAD/OPTIONS) (Closes #4620).** Les 502/503/504 étaient rejoués sur TOUTES les méthodes : un POST/PUT traité mais à réponse perdue (cold-start Render) était exécuté 2× (webhook dupliqué, impersonation en double, désactivation rejouée).

--- a/dev-hub/tools/check-i18n-diff.js
+++ b/dev-hub/tools/check-i18n-diff.js
@@ -39,6 +39,7 @@ const watchedPathPrefixes = [
   'front/mobile_apps/leopardo_employee/lib/',
   'front/mobile_apps/leopardo_manager/lib/',
   'front/mobile_apps/leopardo_platform_admin/lib/',
+    'front/mobile_apps/leopardo_hr/lib/',
   'front/zkteco-kiosk/',
   'front/admin-dashboard/src/',
   'front/web/src/app/',


### PR DESCRIPTION
## Constat\nFix #4397 incomplet : le scanner inclut mobile_hr mais le workflow i18n-enterprise (paths) et check-i18n-diff.js (watchedPathPrefixes) ignorent leopardo_hr/lib → chaînes FR ajoutables sans garde.\n\n## Correctif\nPaths PR+push + watchedPathPrefixes étendus.\n\nCloses #4623