### PR TITLE
fix(ci): tests.yml — refs mobiles mortes supprimées (Closes #4626)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEFAULT_BACKEND_COVERAGE_MIN: "65"
-  DEFAULT_MOBILE_COVERAGE_MIN: "21"
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
@@ -712,9 +711,6 @@ jobs:
           - Backend quality summary artifact: backend-quality-summary
           - Backend coverage artifacts: backend-coverage-reports
           - Backend coverage summary artifact: backend-coverage-summary
-          - Mobile quality artifacts: mobile-test-reports
-          - Mobile quality summary artifact: mobile-quality-summary
-
           ## Backend Coverage Intent
           - Unit: services et logique metier pure
           - Feature: auth, auth guardrails, RBAC, multitenant, attendance, estimation, health, contrats JSON mobile, SmartAttendance (GPS geofencing, validation manager, multi-tenant isolation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN + 2 lignes d'artefacts fantômes) (Closes #4626).**
 - **fix(ci/i18n): garde i18n alignée sur la surface leopardo_hr — paths i18n-enterprise.yml + watchedPathPrefixes de check-i18n-diff.js (Closes #4623).** Complète #4397 (scanner) : les PRs ne touchant que leopardo_hr/lib ne déclenchaient ni validate-and-sync ni check-new-hardcoded-strings.
 - **fix(ci/docs): CI_CD_SECRETS.md — référence au workflow inexistant deploy-web-vitrine.yml corrigée (Closes #4627).**
 - **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN inutilisé + artefacts annoncés inexistants) (Closes #4626).**


### PR DESCRIPTION
## Correctif\nDEFAULT_MOBILE_COVERAGE_MIN (jamais référencé) + 2 lignes d'artefacts mobiles fantômes dans le rapport CI retirées (le premier essai #4647 n'avait pas couvert les lignes du rapport).\n\nCloses #4626