### PR TITLE
fix(api): kiosk.show — throttle kiosk-punch sur le GET public (Closes #4607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(api): GET /kiosk/{deviceCode} throttlé (bucket kiosk-punch) — fin de l'énumération du device_code (Closes #4607).**
 - **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN + 2 lignes d'artefacts fantômes) (Closes #4626).**
 - **fix(ci/i18n): garde i18n alignée sur la surface leopardo_hr — paths i18n-enterprise.yml + watchedPathPrefixes de check-i18n-diff.js (Closes #4623).** Complète #4397 (scanner) : les PRs ne touchant que leopardo_hr/lib ne déclenchaient ni validate-and-sync ni check-new-hardcoded-strings.
 - **fix(ci/docs): CI_CD_SECRETS.md — référence au workflow inexistant deploy-web-vitrine.yml corrigée (Closes #4627).**

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -88,7 +88,13 @@ Route::get('/activate/{token}', [InvitationController::class, 'showActivationFor
 Route::post('/activate/{token}', [InvitationController::class, 'activate'])
     ->middleware('throttle:web-activate')
     ->name('invitation.activate.store');
-Route::get('/kiosk/{deviceCode}', [KioskController::class, 'show'])->name('kiosk.show');
+// #4607 : le GET de la page kiosk (device_code = seule credential de la borne)
+// partage le bucket kiosk-punch (device_code + IP) — sans throttle, le
+// device_code était énumérable en force brute (lookup DB + écriture session
+// à chaque hit).
+Route::get('/kiosk/{deviceCode}', [KioskController::class, 'show'])
+    ->middleware('throttle:kiosk-punch')
+    ->name('kiosk.show');
 // PA2-API-005: public, device-code based, unauthenticated-by-Sanctum kiosk
 // punch endpoint gets its own 'kiosk-punch' throttle bucket (keyed by device
 // code + IP) to guard against brute force / abuse.


### PR DESCRIPTION
## Constat\nGET /kiosk/{deviceCode} (public, device_code = seule credential) sans throttle → brute-force + lookup DB + écriture session illimités. Le POST punch est déjà throttlé (kiosk-punch).\n\n## Correctif\nMême bucket kiosk-punch sur le GET.\n\nCloses #4607