### PR TITLE
fix(api): /p/{code} — throttle + entrées bornées (Closes #4606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(api): /p/{code} — throttle 60/min/IP + user_agent/referrer_url tronqués à 255 (500 évité sur Referer long) (Closes #4606).**
 - **fix(api): GET /kiosk/{deviceCode} throttlé (bucket kiosk-punch) — fin de l'énumération du device_code (Closes #4607).**
 - **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN + 2 lignes d'artefacts fantômes) (Closes #4626).**
 - **fix(ci/i18n): garde i18n alignée sur la surface leopardo_hr — paths i18n-enterprise.yml + watchedPathPrefixes de check-i18n-diff.js (Closes #4623).** Complète #4397 (scanner) : les PRs ne touchant que leopardo_hr/lib ne déclenchaient ni validate-and-sync ni check-new-hardcoded-strings.

--- a/api/app/Http/Middleware/PartnerLinkMiddleware.php
+++ b/api/app/Http/Middleware/PartnerLinkMiddleware.php
@@ -6,6 +6,7 @@ use App\Modules\Billing\Domain\Models\PartnerLink;
 use App\Modules\Billing\Domain\Models\PartnerClick;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartnerLinkMiddleware
@@ -37,11 +38,14 @@ class PartnerLinkMiddleware
 
             if ($link) {
                 // Record click
+                // #4606 : user_agent/referrer_url viennent de headers clients —
+                // colonnes VARCHAR(255) : troncature obligatoire (un Referer
+                // long provoquait un QueryException → 500 sur route publique).
                 PartnerClick::create([
                     'partner_link_id' => $link->id,
                     'ip_address' => $request->ip(),
-                    'user_agent' => $request->userAgent(),
-                    'referrer_url' => $request->header('referer'),
+                    'user_agent' => Str::limit((string) $request->userAgent(), 255, ''),
+                    'referrer_url' => Str::limit((string) $request->header('referer'), 255, ''),
                 ]);
 
                 // Store cookie for 30 days

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -20,9 +20,12 @@ Route::get('/', function () {
 });
 
 // Capture de lien partenaire (Middleware gère la redirection et le cookie)
+// #4606 : route publique écrite en DB à chaque hit (PartnerClick via le
+// middleware global) — throttle 60/min/IP + entrées bornées (voir
+// PartnerLinkMiddleware) pour éviter 500 (Referer > 255) et l'amplification.
 Route::get('/p/{code}', function () {
     return redirect('/signup');
-})->name('partner.link');
+})->middleware('throttle:60,1')->name('partner.link');
 
 // Issue #2253 — magic link d'accès au sandbox de démo (jeton à usage unique).
 Route::middleware('throttle:auth-sensitive')->get('/demo-login/{token}', DemoLoginController::class);


### PR DESCRIPTION
## Constat\nRoute publique sans throttle avec INSERT DB par hit ; referrer_url (VARCHAR 255) non borné → 500 sur Referer > 255 chars + amplification.\n\n## Correctif\nthrottle:60,1 + Str::limit sur user_agent/referrer_url.\n\nCloses #4606