### PR TITLE
fix(api): kiosk.show — bucket dédié kiosk-show (120/min) (Closes #4607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(api): kiosk.show — bucket dédié kiosk-show (120/min, device+IP) au lieu de partager kiosk-punch (30/min pénalisait les bornes actives) (Closes #4607).**
 - **fix(api): /p/{code} — throttle 60/min/IP + user_agent/referrer_url tronqués à 255 (500 évité sur Referer long) (Closes #4606).**
 - **fix(api): GET /kiosk/{deviceCode} throttlé (bucket kiosk-punch) — fin de l'énumération du device_code (Closes #4607).**
 - **fix(ci): tests.yml — références mobiles mortes supprimées (DEFAULT_MOBILE_COVERAGE_MIN + 2 lignes d'artefacts fantômes) (Closes #4626).**

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -231,6 +231,18 @@ class AppServiceProvider extends ServiceProvider
                 ->by('kiosk-punch:'.$deviceCode.'|'.$request->ip());
         });
 
+        // #4607 : GET de la page kiosk (device_code = seule credential) —
+        // bucket DÉDIÉ (120/min) pour ne pas partager le quota d'écriture
+        // kiosk-punch (30/min) : une borne active qui recharge la page à
+        // chaque pointage consommerait GET+PUNCH dans le même bucket → 429
+        // sur le flux légitime. 120/min borne quand même l'énumération.
+        RateLimiter::for('kiosk-show', function (Request $request) {
+            $deviceCode = strtoupper((string) $request->route('deviceCode', 'unknown'));
+
+            return Limit::perMinute((int) config('security.rate_limits.kiosk_show_per_minute', 120))
+                ->by('kiosk-show:'.$deviceCode.'|'.$request->ip());
+        });
+
         // Public careers portal (job listing/detail/feed + candidate
         // applications) has no Sanctum guard, so it needs its own IP-keyed
         // throttle bucket rather than relying on the authenticated 'api' one.

--- a/api/config/security.php
+++ b/api/config/security.php
@@ -15,6 +15,7 @@ return [
         'web_login_per_minute' => (int) env('RATE_LIMIT_WEB_LOGIN_PER_MINUTE', 10),
         'web_activate_per_minute' => (int) env('RATE_LIMIT_WEB_ACTIVATE_PER_MINUTE', 10),
         'kiosk_punch_per_minute' => (int) env('RATE_LIMIT_KIOSK_PUNCH_PER_MINUTE', 30),
+        'kiosk_show_per_minute' => (int) env('RATE_LIMIT_KIOSK_SHOW_PER_MINUTE', 120),
         // Public careers portal (job listing, job detail, XML feed, and
         // candidate application submission) is unauthenticated by design,
         // so it gets its own dedicated throttle bucket keyed by IP.

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -91,12 +91,13 @@ Route::get('/activate/{token}', [InvitationController::class, 'showActivationFor
 Route::post('/activate/{token}', [InvitationController::class, 'activate'])
     ->middleware('throttle:web-activate')
     ->name('invitation.activate.store');
-// #4607 : le GET de la page kiosk (device_code = seule credential de la borne)
-// partage le bucket kiosk-punch (device_code + IP) — sans throttle, le
-// device_code était énumérable en force brute (lookup DB + écriture session
-// à chaque hit).
+// #4607 : le GET de la page kiosk (device_code = seule credential de la
+// borne) est throttlé sur un bucket DÉDIÉ (kiosk-show, 120/min, device+IP)
+// — ne pas partager kiosk-punch (30/min) pour ne pas pénaliser une borne
+// active qui recharge la page à chaque pointage. Sans throttle, le
+// device_code était énumérable en force brute (lookup DB + session par hit).
 Route::get('/kiosk/{deviceCode}', [KioskController::class, 'show'])
-    ->middleware('throttle:kiosk-punch')
+    ->middleware('throttle:kiosk-show')
     ->name('kiosk.show');
 // PA2-API-005: public, device-code based, unauthenticated-by-Sanctum kiosk
 // punch endpoint gets its own 'kiosk-punch' throttle bucket (keyed by device


### PR DESCRIPTION
## Correctif\nLe premier volet (#4653) partageait kiosk-punch (30/min) — une borne active rechargerait la page à chaque pointage (GET+PUNCH dans le même bucket → 429 sur le flux légitime). Bucket dédié  (config kiosk_show_per_minute, défaut 120/min, keyed device_code+IP) posé dans AppServiceProvider + config/security.php.\n\nCloses #4607