### PR TITLE
fix(admin): ExportsView — dates locales (fin du décalage UTC) (Closes #4619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(admin): ExportsView — dates par défaut en composantes locales (plus de décalage UTC+1..+3 : 31 déc. N-1 / hier) (Closes #4619).**
 - **fix(ci/mobile): mobile-distribute-main — filtre workflow_dispatch app= réellement bloquant (env SHOULD_BUILD) + input app documente hr (Closes #4622).** Avant : le step « exit 0 » ne sautait rien → les 4 apps étaient buildées et distribuées Firebase quel que soit app=.
 - **fix(api): kiosk.show — bucket dédié kiosk-show (120/min, device+IP) au lieu de partager kiosk-punch (30/min pénalisait les bornes actives) (Closes #4607).**
 - **fix(api): /p/{code} — throttle 60/min/IP + user_agent/referrer_url tronqués à 255 (500 évité sur Referer long) (Closes #4606).**

--- a/front/admin-dashboard/src/views/exports/ExportsView.vue
+++ b/front/admin-dashboard/src/views/exports/ExportsView.vue
@@ -152,10 +152,19 @@ const hrReportResult = ref(null)
 const generatingReport = ref(false)
 const hrReportError = ref('')
 
+// #4619 : dates en composantes LOCALES (toISOString = UTC → pour UTC+1..+3,
+// le 1er janvier local tombait au 31 déc. N-1 et « aujourd'hui » = hier
+// avant minuit UTC). Le rapport headcount par défaut était décalé d'un jour.
+const toLocalDate = (d) => {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
 const hrReport = reactive({
   type: 'headcount',
-  start_date: new Date(new Date().getFullYear(), 0, 1).toISOString().split('T')[0],
-  end_date: new Date().toISOString().split('T')[0],
+  start_date: toLocalDate(new Date(new Date().getFullYear(), 0, 1)),
+  end_date: toLocalDate(new Date()),
 })
 
 const reportTypes = reactive([


### PR DESCRIPTION
## Constat\ntoISOString() est UTC : à UTC+1..+3 (DZ/MA/TN/TR), start_date par défaut = 31 déc. N-1 et end_date = hier.\n\n## Correctif\nFormatage YYYY-MM-DD depuis les composantes locales.\n\nCloses #4619