### PR TITLE
fix(web): /changelog — contenu localisé ×4 locales (Closes #4610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): /changelog — contenu des releases localisé ×4 (getChangelogReleases(locale), fallback FR) (Closes #4610).** Les 4 locales recevaient les titres/bullets FR alors que le sitemap/hreflang annoncent des variantes en/tr/ar.
 - **fix(admin): api.js — messages d'erreur de l'intercepteur localisés ×4 (namespace api.* ajouté aux catalogues) (Closes #4621).** Les toasts 404/429/5xx/réseau restaient FR pour les admins EN/TR/AR.
 - **fix(api): PHPStan Modules vert sur main — 2 erreurs post-merge #4558/#4580 (Closes #4660).** `EmployeeImportController` (unset défensif de `password_hash` sur un tableau non typé — annotation `array<string, mixed>`) et `SupportedCountryController::index()` (type de retour `JsonResponse` incompatible avec la branche 304 ETag de #4502 — les deux classes sont sœurs sous Symfony, retour typé `Symfony\Component\HttpFoundation\Response`).
 - **fix(admin): ExportsView — dates par défaut en composantes locales (plus de décalage UTC+1..+3 : 31 déc. N-1 / hier) (Closes #4619).**

--- a/front/web/src/app/(landing)/changelog/page.tsx
+++ b/front/web/src/app/(landing)/changelog/page.tsx
@@ -4,14 +4,15 @@ import { useState } from 'react';
 import { useDarkMode } from '@/modules/vitrine/hooks/useDarkMode';
 import { Navbar, Footer, HeroSection, useScrollReveal } from '@/modules/vitrine';
 import { useVitrineLocale } from '@/modules/vitrine/lib/vitrine-locale';
-import { publicChangelogReleases } from '@/modules/vitrine/data/changelog-public';
+import { getChangelogReleases } from '@/modules/vitrine/data/changelog-public';
 import { Sparkles } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 export default function ChangelogPage() {
   const { isDark, toggleDarkMode } = useDarkMode();
   useScrollReveal();
-  const { copy, direction } = useVitrineLocale();
+  const { locale, copy, direction } = useVitrineLocale();
+  const publicChangelogReleases = getChangelogReleases(locale);
   const ch = copy.changelog;
 
   const headline = `${ch.title} ${ch.titleHighlight}`;


### PR DESCRIPTION
## Constat\nLe contenu des releases (19 entrées, titres + bullets) était 100% FR pour les 4 locales ; le sitemap/hreflang annoncent des variantes en/tr/ar inexistantes.\n\n## Correctif\nchangelogByLocale (fr/en/tr/ar) + getChangelogReleases(locale) (fallback FR) ; page branchée sur la locale active.\n\nCloses #4610