### PR TITLE
fix(api/tests): AccrueLeaveBalancesTest — RefreshTenantDatabase (suite Unit verte)

### DIFF
--- a/api/tests/Unit/AccrueLeaveBalancesTest.php
+++ b/api/tests/Unit/AccrueLeaveBalancesTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 class AccrueLeaveBalancesTest extends TestCase
 {
+    use RefreshTenantDatabase;
+
     public function test_command_skips_when_not_first_of_month(): void
     {
         $this->travelTo(now()->day(15));


### PR DESCRIPTION
## Suite Unit — dernier test rouge : AccrueLeaveBalancesTest
`test_command_runs_with_force` échoue en environnement propre : `relation "leave_policies" does not exist`. Le test (Unit, sans trait de migration) lançait `leave:accrue --force` qui requête une table TENANT (`shared_tenants.leave_policies`) jamais migrée dans le job Unit (la famine CI masquait l'échec).

## Correctif
Ajout du trait `RefreshTenantDatabase` au test → les migrations public + tenant tournent avant l'exécution (même stratégie que les autres tests Unit DB-backed).

## Validation locale
`php artisan test tests/Unit/AccrueLeaveBalancesTest.php` → 2 passed (3 assertions).

Closes #4656 (volet final)
