### PR TITLE
fix(web): /blog/[slug] — metadata propre par article (Closes #4611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(web): /blog/[slug] — metadata propre par article (canonical, hreflang ×4, og:type article, publishedTime) via layout serveur (Closes #4611).** Avant : canonical=/blog sur tous les articles (soft-duplicates Google) et hreflang du sitemap contredits par le HTML.
 - **fix(web): /demo — ids des champs alignés sur les labels `htmlFor` (régression #4678).** Le dédoublonnage #4678 a retiré les `id` des champs mais les labels pointent toujours `htmlFor="demo-*"` → association a11y cassée (axe « form elements must have labels »). `id="demo-*"` rétabli sur les 7 champs.
 
 - **fix(api): UpdateEmployeeDTO::fromRequest — plus de fallback `$request->all()` (Closes #4609).** Le type de paramètre acceptait un `Request` brut et retombait sur `all()` sans validation → réactivation silencieuse du mass-assignment role/status/manager_role (contournement #3677/#4496). Signature restreinte à `UpdateEmployeeRequest|UpdateProfileRequest` + `validated()` uniquement (les 2 callers passent déjà des FormRequest). Tests : `UpdateEmployeeDtoGuardTest` (TypeError sur Request brut + garde structurelle).

--- a/front/web/src/app/(landing)/blog/[slug]/layout.tsx
+++ b/front/web/src/app/(landing)/blog/[slug]/layout.tsx
@@ -1,70 +1,48 @@
-import { SITE_URL } from '@/lib/site-url';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
-import { cache } from 'react';
-import { getBlogPost } from '@/modules/vitrine/data/blog';
+import { notFound } from 'next/navigation';
+import { SITE_URL } from '@/lib/site-url';
 import { generateMetadata as generateSEOMetadata } from '@/modules/vitrine/lib/seo';
+import { getBlogPost } from '@/modules/vitrine/data/blog';
 import type { AppLocale } from '@/lib/i18n';
 
-// Issue #3923 : les métadonnées suivent la locale SSR (Accept-Language) —
-// plus de titre/description FR pour les visiteurs en/tr/ar.
-// #4201 : ?lang= (x-vitrine-lang, normalisé par le middleware) prime sur
-// Accept-Language — parité avec les autres layouts de la vitrine.
-const getSsrLocale = cache(async (): Promise<AppLocale> => {
-  const headerList = await headers();
-  const lang = headerList.get('x-vitrine-lang');
-  if (lang && (['fr', 'en', 'ar', 'tr'] as const).includes(lang as AppLocale)) {
-    return lang as AppLocale;
-  }
-  const base = (headerList.get('accept-language') ?? '')
-    .split(',')[0]
-    .trim()
-    .toLowerCase()
-    .slice(0, 2);
-  return (['fr', 'en', 'ar', 'tr'] as const).includes(base as AppLocale) ? (base as AppLocale) : 'fr';
-});
-
-interface BlogArticleLayoutProps {
-  params: Promise<{
-    slug: string;
-  }>;
-  children: React.ReactNode;
-}
-
+/**
+ * #4611 : metadata PROPRE par article (title/description/canonical/hreflang +
+ * og:type article). Avant : le layout du listing (canonical=/blog, « Blog &
+ * Resources ») s'appliquait à tous les articles → soft-duplicates Google et
+ * hreflang du sitemap contredits par le HTML. Le rendu client de la page est
+ * inchangé (layout serveur, children pass-through).
+ */
 export async function generateMetadata({
   params,
-}: BlogArticleLayoutProps): Promise<Metadata> {
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
   const { slug } = await params;
-  const locale = await getSsrLocale();
-  const post = getBlogPost(slug, locale);
+  // #4004 : ?lang= normalisé en en-tête x-vitrine-lang par le middleware.
+  const headerList = await headers();
+  const lang = (headerList.get('x-vitrine-lang') ?? 'fr') as AppLocale;
+  const post = getBlogPost(slug, lang);
 
   if (!post) {
-    const notFoundCopy: Record<AppLocale, { title: string; description: string }> = {
-      fr: { title: 'Article non trouvé', description: "L'article que vous recherchez n'existe pas." },
-      en: { title: 'Article not found', description: 'The article you are looking for does not exist.' },
-      tr: { title: 'Makale bulunamadi', description: 'Aradiginiz makale mevcut degil.' },
-      ar: { title: 'المقال غير موجود', description: 'المقال الذي تبحث عنه غير موجود.' },
-    };
-    const nf = notFoundCopy[locale];
-    return { title: nf.title, description: nf.description };
+    notFound();
   }
 
   return generateSEOMetadata({
     title: post.title,
     description: post.excerpt,
-    keywords: post.tags,
     ogImage: post.image,
     ogType: 'article',
     canonical: `${SITE_URL}/blog/${post.slug}`,
-    // #4201 : og:locale + canonical ?lang= alignés sur la locale rendue.
-    locale,
-    publishedTime: post.date.toISOString(),
-    author: post.author.name,
+    locale: lang,
+    publishedTime: post.date instanceof Date ? post.date.toISOString() : undefined,
   });
 }
 
 export default function BlogArticleLayout({
   children,
-}: BlogArticleLayoutProps) {
+}: {
+  children: React.ReactNode;
+}) {
   return children;
 }


### PR DESCRIPTION
## Constat\nTous les articles émettaient canonical=/blog + titre « Blog & Resources » (layout du listing) → soft-duplicates Google ; le sitemap annonce des hreflang par article que le HTML ne porte pas.\n\n## Correctif\nLayout serveur blog/[slug]/layout.tsx : generateMetadata par slug (title, excerpt, og:type article, canonical /blog/<slug>, locale, publishedTime) ; alternates hreflang ×4 via le helper seo existant. Rendu client inchangé.\n\nCloses #4611