### PR TITLE
fix(mobile): Smart Attendance — garde d erreur startMonitoring (Closes #4625)

### DIFF
--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/providers/smart_attendance_provider.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/providers/smart_attendance_provider.dart
@@ -180,11 +180,24 @@ class ActiveGeoSessionNotifier extends StateNotifier<ActiveGeoSessionState> {
   }
 
   /// Démarre la surveillance GPS en background.
+  ///
+  /// #4625 : toute exception (permission refusée, service indisponible,
+  /// plateforme non supportée…) est capturée et traduite en état d'erreur
+  /// visible — l'appelant (bouton UI) ne reçoit jamais d'exception non
+  /// gérée et peut afficher un retour utilisateur.
   Future<void> startMonitoring(SmartAttendanceConfig config) async {
     if (state.isMonitoring) return;
 
-    await _backgroundService.startMonitoring(config);
-    state = state.copyWith(isMonitoring: true);
+    try {
+      await _backgroundService.startMonitoring(config);
+      state = state.copyWith(isMonitoring: true, clearError: true);
+    } catch (_) {
+      state = state.copyWith(
+        isMonitoring: false,
+        error:
+            'Impossible de démarrer la surveillance GPS. Vérifiez les permissions de localisation et réessayez.',
+      );
+    }
   }
 
   /// Arrête la surveillance GPS.

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
@@ -123,9 +123,18 @@ class _SmartAttendanceScreenState extends ConsumerState<SmartAttendanceScreen> {
             config: config,
             sessionState: sessionState,
             onStartMonitoring: () async {
-              await ref
-                  .read(activeGeoSessionProvider.notifier)
-                  .startMonitoring(config);
+              // #4625 : startMonitoring capture désormais les erreurs dans
+              // l'état du provider — on affiche un retour utilisateur au lieu
+              // de laisser l'exception remonter au framework.
+              final notifier = ref.read(activeGeoSessionProvider.notifier);
+              await notifier.startMonitoring(config);
+              final current = ref.read(activeGeoSessionProvider);
+              if (current.error != null && !current.isMonitoring) {
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context)
+                  ..hideCurrentSnackBar()
+                  ..showSnackBar(SnackBar(content: Text(current.error!)));
+              }
             },
             onStopMonitoring: () {
               ref.read(activeGeoSessionProvider.notifier).stopMonitoring();


### PR DESCRIPTION
## #4625 — Smart Attendance : startMonitoring sans garde d'erreur
Le bouton UI appelait `startMonitoring(config)` sans try/catch : une exception (permission refusée, service indisponible) remontait au framework sans aucun retour utilisateur.

## Correctif
- **Provider** : `startMonitoring` capture l'exception → état `error` + `isMonitoring: false` (plus d'exception non gérée depuis le bouton).
- **Écran** : après l'appel, si l'état porte une erreur → SnackBar visible.

## Validation
Pattern calqué sur le reste de l'app (état `error` existant, SnackBar `ScaffoldMessenger`). CI mobile (`mobile-apps-ci.yml`) en charge du `flutter analyze`.

Closes #4625
