### PR TITLE
fix(ci): gardes CI durcies — branches mortes, analyze strict, gate pint réel, URL prod unifiée (Closes #4719, #4724, #4722, #4721)

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -2,7 +2,9 @@ name: Architecture Quality
 
 on:
   pull_request:
-    branches: [main, feat/clean-architecture, feat/modules-migration]
+    # #4719 (audit 360° 2026-08-16) : branches feat/* supprimées du trigger
+    # (elles n'existent nulle part — workflow porteur de 3 checks requis).
+    branches: [main]
   push:
     branches: [main]
   # Issue #2032 : checks requis (PHPStan Strict, Module Structure, Frontend

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  DEFAULT_STAGING_URL: ${{ vars.PROD_API_URL || 'https://gestionemployerbackend.onrender.com' }}
+  DEFAULT_STAGING_URL: ${{ vars.PROD_API_BASE_URL || 'https://gestionemployerbackend.onrender.com' }}
   DEFAULT_ADMIN_STAGING_URL: ${{ vars.PROD_ADMIN_URL || 'https://leo-admin.pages.dev' }}
   DEFAULT_WEB_STAGING_URL: ${{ vars.PROD_WEB_URL || 'https://gestionemployer-backend.vercel.app' }}
 

--- a/.github/workflows/launch-observability-smoke.yml
+++ b/.github/workflows/launch-observability-smoke.yml
@@ -54,7 +54,7 @@ jobs:
           LAUNCH_SMOKE_RETRY_DELAY_SECONDS: "15"
         run: |
           bash dev-hub/tools/launch-observability-smoke.sh \
-            "${{ github.event.inputs.api_url || vars.PROD_API_URL || 'https://gestionemployerbackend.onrender.com' }}" \
+            "${{ github.event.inputs.api_url || vars.PROD_API_BASE_URL || 'https://gestionemployerbackend.onrender.com' }}" \
             "${{ github.event.inputs.web_url || vars.PROD_WEB_URL || 'https://gestionemployer-backend.vercel.app' }}" \
             "${{ github.event.inputs.admin_url || vars.PROD_ADMIN_URL || 'https://leo-admin.pages.dev' }}"
 

--- a/.github/workflows/mobile-distribute-main.yml
+++ b/.github/workflows/mobile-distribute-main.yml
@@ -197,7 +197,7 @@ jobs:
             Build: ${{ matrix.app.version_prefix }}-main-${{ github.run_number }}
             Commit: ${{ github.sha }}
             Workflow: ${{ github.workflow }}
-            Backend: ${{ vars.PROD_API_URL || 'https://gestionemployerbackend.onrender.com' }}
+            Backend: ${{ vars.PROD_API_BASE_URL || 'https://gestionemployerbackend.onrender.com' }}
 
       - name: Verify Firebase App Distribution release is visible
         if: env.MOBILE_DISTRIBUTE_READY == 'true' && env.SHOULD_BUILD == 'true'

--- a/.github/workflows/mobile-distribute.yml
+++ b/.github/workflows/mobile-distribute.yml
@@ -235,7 +235,9 @@ jobs:
       - name: Flutter analyze
         if: env.SHOULD_BUILD == 'true'
         working-directory: ${{ matrix.app.project_path }}
-        run: flutter analyze --no-fatal-infos
+        # #4724 (audit 360°) : gate aligné sur mobile-apps-ci (strict —
+        # les infos bloquantes en CI étaient acceptées dans la distribution).
+        run: flutter analyze
 
       - name: Build release binary
         if: env.SHOULD_BUILD == 'true'
@@ -314,7 +316,7 @@ jobs:
             Leopardo ${{ matrix.app.name }} ${{ env.BUILD_NAME }}
             Ref: ${{ github.ref_name }}
             Notes: ${{ github.event.inputs.release_notes || 'Tag build' }}
-            Backend: ${{ vars.PROD_API_URL || 'https://gestionemployerbackend.onrender.com' }}
+            Backend: ${{ vars.PROD_API_BASE_URL || 'https://gestionemployerbackend.onrender.com' }}
 
       - name: Verify Firebase App Distribution release is visible
         if: env.SHOULD_BUILD == 'true' && env.TARGET == 'staging'

--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
 
 env:
-  DEFAULT_ZAP_TARGET_URL: ${{ vars.PROD_API_URL || 'https://gestionemployerbackend.onrender.com' }}
+  DEFAULT_ZAP_TARGET_URL: ${{ vars.PROD_API_BASE_URL || 'https://gestionemployerbackend.onrender.com' }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -287,6 +287,13 @@ jobs:
             pint_targets+=("${file#api/}")
           done < storage/test-results/pint-targets.txt
 
+          # #4722 (audit 360°) : garde réelle — pint --test échoue sur les
+          # fichiers modifiés non formatés (avant : || true + auto-fix rendaient
+          # le gate toujours vert).
+          if [[ -s storage/test-results/pint-targets.txt ]]; then
+            ./vendor/bin/pint --test "${pint_targets[@]}"
+          fi
+
           ./vendor/bin/pint "${pint_targets[@]}" || true
 
           # Audit #1708 : le push auto-fix ne doit JAMAIS cibler main (les

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **fix(ci): gardes CI — branches mortes retirées, analyze mobile strict, gate pint réel, PROD_API_URL unifié sur PROD_API_BASE_URL (Closes #4719, #4724, #4722, #4721).**
 
 - **fix(mobile/ios): leopardo_employee — UIBackgroundModes + location (Closes #4717).** La géofence iOS (Smart Attendance) promettait la position en arrière-plan (NSLocationAlwaysUsageDescription) et le code existe (geofence_service), mais UIBackgroundModes ne listait pas `location` → iOS ne délivrait pas les événements en arrière-plan. Ajout de `<string>location</string>` (flux Always).
 - **fix(web): a11y + i18n détail case-studies (Closes #4705, #4706, #4703).** Nom accessible rétabli sur la recherche /docs (régression #4566) ; aria-label localisé sur l'input newsletter du blog ; phrases FR de la page détail /case-studies/[slug] localisées ×4 (moduleIllustrates/moduleExplore/discoverModule, clé morte useCasePrefix supprimée).


### PR DESCRIPTION
## Résumé

Implémentation Phase 3 — 4 findings CI de l'audit 360° :

1. **#4719** — architecture-check.yml : trigger réduit à `[main]` (les branches feat/clean-architecture + feat/modules-migration n'existent nulle part ; workflow porteur de 3 checks requis).
2. **#4724** — mobile-distribute.yml : `flutter analyze` strict (le `--no-fatal-infos` acceptait en distribution des lints bloquants en CI).
3. **#4722** — tests.yml : `pint --test` sur les fichiers modifiés SANS `|| true` → le gate peut réellement échouer (l'auto-fix reste non bloquant).
4. **#4721** — 5 workflows passent de `vars.PROD_API_URL` à `vars.PROD_API_BASE_URL` : une seule variable canonique, celle protégée fail-closed (deploy-main.yml:46-53, mobile-apps-ci.yml:70-77).

## Validation

- YAML parse OK sur les 8 workflows touchés.
- Changements confinés aux workflows (aucun impact runtime).