### PR TITLE
fix(web): i18n/seo vitrine — BlogCard archivé localisé, sections modules, titres par locale, metadata racine (Closes #4704, #4702, #4612, #4707)

### DIFF
--- a/front/web/src/app/(landing)/blog/page.tsx
+++ b/front/web/src/app/(landing)/blog/page.tsx
@@ -18,155 +18,8 @@ import { NewsletterForm } from '@/components/NewsletterForm';
 import { motion } from 'framer-motion';
 import { BookOpen } from 'lucide-react';
 
-const blogCopy: Record<AppLocale, {
-  dateLocale: string;
-  readingTime: string;
-  hero: { headline: string; subheadline: string; cta: string; badge: string };
-  grid: { title: string; subtitle: string; badge: string; all: string; previous: string; next: string };
-  newsletter: { badge: string; title: string; description: string; note: string; placeholder: string; submit: string; submitting: string; success: string; error: string };
-  cta: { headline: string; subheadline: string; primary: string; secondary: string };
-}> = {
-  fr: {
-    dateLocale: 'fr-FR',
-    readingTime: 'min de lecture',
-    hero: {
-      headline: 'Blog et ressources RH',
-      subheadline: 'Guides, articles et conseils pour structurer vos RH, votre paie et votre croissance.',
-      cta: "S'inscrire a la newsletter",
-      badge: 'Contenu gratuit',
-    },
-    grid: {
-      title: 'Nos articles',
-      subtitle: 'Conseils pratiques pour équipes RH ambitieuses',
-      badge: 'Ressources',
-      all: 'Tous',
-      previous: 'Precedent',
-      next: 'Suivant',
-    },
-    newsletter: {
-      badge: 'Newsletter',
-      title: 'Recevez nos conseils hebdomadaires',
-      description: 'Articles, guides et retours terrain pour lancer une plateforme RH plus solide.',
-      note: 'Pas de spam, uniquement des conseils utiles. Desinscription facile.',
-      placeholder: 'Votre email',
-      submit: "S'inscrire",
-      submitting: 'Envoi...',
-      success: 'Inscription reussie !',
-      error: "Erreur lors de l'inscription",
-    },
-    cta: {
-      headline: 'Besoin d un avis expert ?',
-      subheadline: 'Contactez notre équipe pour cadrer vos priorites RH et digitales.',
-      primary: 'Nous contacter',
-      secondary: 'Essai gratuit',
-    },
-  },
-  en: {
-    dateLocale: 'en-US',
-    readingTime: 'min read',
-    hero: {
-      headline: 'HR blog and resources',
-      subheadline: 'Guides, articles and practical advice to structure HR, payroll and growth.',
-      cta: 'Join the newsletter',
-      badge: 'Free content',
-    },
-    grid: {
-      title: 'Latest articles',
-      subtitle: 'Practical insight for ambitious HR teams',
-      badge: 'Resources',
-      all: 'All',
-      previous: 'Previous',
-      next: 'Next',
-    },
-    newsletter: {
-      badge: 'Newsletter',
-      title: 'Get weekly HR insights',
-      description: 'Articles, guides and field notes to build a stronger HR platform.',
-      note: 'No spam, only useful advice. Unsubscribe anytime.',
-      placeholder: 'Your email',
-      submit: 'Subscribe',
-      submitting: 'Sending...',
-      success: 'Subscription confirmed!',
-      error: 'Unable to subscribe',
-    },
-    cta: {
-      headline: 'Need an expert opinion?',
-      subheadline: 'Talk to our team to clarify your HR and digital priorities.',
-      primary: 'Contact us',
-      secondary: 'Start free trial',
-    },
-  },
-  tr: {
-    dateLocale: 'tr-TR',
-    readingTime: 'dk okuma',
-    hero: {
-      headline: 'IK blogu ve kaynaklar',
-      subheadline: 'IK, bordro ve buyumeyi daha sistemli hale getirmek icin rehberler ve pratik oneriler.',
-      cta: 'Bultene katil',
-      badge: 'Ucretsiz icerik',
-    },
-    grid: {
-      title: 'Son yazilar',
-      subtitle: 'Iddiali IK ekipleri icin pratik icgoru',
-      badge: 'Kaynaklar',
-      all: 'Tumu',
-      previous: 'Onceki',
-      next: 'Sonraki',
-    },
-    newsletter: {
-      badge: 'Bulten',
-      title: 'Haftalik IK onerileri alin',
-      description: 'Daha saglam bir IK platformu kurmak icin yazilar, rehberler ve saha notlari.',
-      note: 'Spam yok, sadece faydali icerik. Isteyen herkes kolayca ayrilabilir.',
-      placeholder: 'E-posta adresiniz',
-      submit: 'Kaydol',
-      submitting: 'Gonderiliyor...',
-      success: 'Kayit tamamlandi!',
-      error: 'Kayit yapilamadi',
-    },
-    cta: {
-      headline: 'Uzman gorusune ihtiyaciniz var mi?',
-      subheadline: 'IK ve dijital onceliklerinizi netlestirmek icin ekibimizle gorusun.',
-      primary: 'Iletisime gec',
-      secondary: 'Ucretsiz dene',
-    },
-  },
-  ar: {
-    dateLocale: 'ar',
-    readingTime: 'دقيقة قراءة',
-    hero: {
-      headline: 'مدونة وموارد الموارد البشرية',
-      subheadline: 'أدلة ومقالات ونصائح عملية لتنظيم الموارد البشرية والرواتب والنمو.',
-      cta: 'اشترك في النشرة',
-      badge: 'محتوى مجاني',
-    },
-    grid: {
-      title: 'أحدث المقالات',
-      subtitle: 'رؤى عملية لفرق موارد بشرية طموحة',
-      badge: 'الموارد',
-      all: 'الكل',
-      previous: 'السابق',
-      next: 'التالي',
-    },
-    newsletter: {
-      badge: 'النشرة البريدية',
-      title: 'استلم نصائح أسبوعية للموارد البشرية',
-      description: 'مقالات وأدلة وتجارب عملية لبناء منصة موارد بشرية أقوى.',
-      note: 'بدون رسائل مزعجة، فقط نصائح مفيدة. يمكنك إلغاء الاشتراك بسهولة.',
-      placeholder: 'بريدك الإلكتروني',
-      submit: 'اشترك',
-      submitting: 'جار الإرسال...',
-      success: 'تم الاشتراك بنجاح!',
-      error: 'تعذر الاشتراك',
-    },
-    cta: {
-      headline: 'هل تحتاج إلى رأي خبير؟',
-      subheadline: 'تواصل مع فريقنا لتحديد أولويات الموارد البشرية والتحول الرقمي.',
-      primary: 'تواصل معنا',
-      secondary: 'ابدأ تجربة مجانية',
-    },
-  },
-};
+// #4704 : catalogue localisé déplacé dans data/blog-copy.ts
+import { blogCopy } from '@/modules/vitrine/data/blog-copy';
 
 export default function BlogPage() {
   const searchParams = useSearchParams();
@@ -190,6 +43,10 @@ export default function BlogPage() {
       category: post.category,
       readingTime: post.readingTime,
       archived: post.archived,
+      // #4704 : libellés localisés portés par la carte (BlogGrid les
+      // surcharge explicitement — requis car BlogCard n'a plus de défaut FR).
+      dateLocale: copy.dateLocale,
+      readingTimeLabel: copy.readingTime,
     }));
 
   const categories = Array.from(new Set(posts.map((post) => post.category)));
@@ -219,6 +76,7 @@ export default function BlogPage() {
         nextLabel={copy.grid.next}
         dateLocale={copy.dateLocale}
         readingTimeLabel={copy.readingTime}
+        archivedLabel={copy.archived}
         badge={{ text: copy.grid.badge, icon: <BookOpen className="w-3 h-3" /> }}
       />
 

--- a/front/web/src/app/(landing)/comptabilite/page.tsx
+++ b/front/web/src/app/(landing)/comptabilite/page.tsx
@@ -70,7 +70,7 @@ export default function ComptabilitePage() {
         ctaPrimary={content.hero.ctaPrimary}
         ctaSecondary={content.hero.ctaSecondary}
         badge={{
-          text: 'Paie Automatisée',
+          text: content.sections.heroBadge,
           icon: <CreditCard className="w-3 h-3" />,
         }}
       />
@@ -81,7 +81,7 @@ export default function ComptabilitePage() {
         subtitle={content.problem.subtitle}
         items={problemItems}
         badge={{
-          text: 'Les Défis',
+          text: content.sections.problemBadge,
           icon: <Calculator className="w-3 h-3" />,
         }}
       />
@@ -93,19 +93,19 @@ export default function ComptabilitePage() {
         description={content.solution.description}
         features={solutionFeatures}
         badge={{
-          text: 'Notre Solution',
+          text: content.sections.solutionBadge,
           icon: <CreditCard className="w-3 h-3" />,
         }}
       />
 
       {/* Features Section */}
       <FeaturesSection
-        title="Fonctionnalités Détaillées"
-        subtitle="Tout ce dont vous avez besoin"
+        title={content.sections.featuresTitle}
+        subtitle={content.sections.featuresSubtitle}
         features={features}
         columns={4}
         badge={{
-          text: 'Complet & Fiable',
+          text: content.sections.featuresBadge,
           icon: <CreditCard className="w-3 h-3" />,
         }}
       />

--- a/front/web/src/app/(landing)/documents/page.tsx
+++ b/front/web/src/app/(landing)/documents/page.tsx
@@ -70,7 +70,7 @@ export default function DocumentsPage() {
         ctaPrimary={content.hero.ctaPrimary}
         ctaSecondary={content.hero.ctaSecondary}
         badge={{
-          text: 'Cabinet Numérique',
+          text: content.sections.heroBadge,
           icon: <Lock className="w-3 h-3" />,
         }}
       />
@@ -81,7 +81,7 @@ export default function DocumentsPage() {
         subtitle={content.problem.subtitle}
         items={problemItems}
         badge={{
-          text: 'Les Défis',
+          text: content.sections.problemBadge,
           icon: <Share2 className="w-3 h-3" />,
         }}
       />
@@ -93,19 +93,19 @@ export default function DocumentsPage() {
         description={content.solution.description}
         features={solutionFeatures}
         badge={{
-          text: 'Notre Solution',
+          text: content.sections.solutionBadge,
           icon: <Lock className="w-3 h-3" />,
         }}
       />
 
       {/* Features Section */}
       <FeaturesSection
-        title="Fonctionnalités Détaillées"
-        subtitle="Tout ce dont vous avez besoin"
+        title={content.sections.featuresTitle}
+        subtitle={content.sections.featuresSubtitle}
         features={features}
         columns={4}
         badge={{
-          text: 'Sécurisé & Conforme',
+          text: content.sections.featuresBadge,
           icon: <Shield className="w-3 h-3" />,
         }}
       />

--- a/front/web/src/app/(landing)/employes/page.tsx
+++ b/front/web/src/app/(landing)/employes/page.tsx
@@ -72,7 +72,7 @@ export default function EmployesPage() {
         ctaPrimary={content.hero.ctaPrimary}
         ctaSecondary={content.hero.ctaSecondary}
         badge={{
-          text: 'Gestion RH Complète',
+          text: content.sections.heroBadge,
           icon: <Zap className="w-3 h-3" />,
         }}
       />
@@ -83,7 +83,7 @@ export default function EmployesPage() {
         subtitle={content.problem.subtitle}
         items={problemItems}
         badge={{
-          text: 'Les Défis',
+          text: content.sections.problemBadge,
           icon: <TrendingUp className="w-3 h-3" />,
         }}
       />
@@ -95,19 +95,19 @@ export default function EmployesPage() {
         description={content.solution.description}
         features={solutionFeatures}
         badge={{
-          text: 'Notre Solution',
+          text: content.sections.solutionBadge,
           icon: <Zap className="w-3 h-3" />,
         }}
       />
 
       {/* Features Section */}
       <FeaturesSection
-        title="Fonctionnalités Détaillées"
-        subtitle="Tout ce dont vous avez besoin"
+        title={content.sections.featuresTitle}
+        subtitle={content.sections.featuresSubtitle}
         features={features}
         columns={4}
         badge={{
-          text: 'Puissant & Flexible',
+          text: content.sections.featuresBadge,
           icon: <Zap className="w-3 h-3" />,
         }}
       />

--- a/front/web/src/app/(landing)/marketing/page.tsx
+++ b/front/web/src/app/(landing)/marketing/page.tsx
@@ -70,7 +70,7 @@ export default function MarketingPage() {
         ctaPrimary={content.hero.ctaPrimary}
         ctaSecondary={content.hero.ctaSecondary}
         badge={{
-          text: 'Marketing Complet',
+          text: content.sections.heroBadge,
           icon: <Mail className="w-3 h-3" />,
         }}
       />
@@ -81,7 +81,7 @@ export default function MarketingPage() {
         subtitle={content.problem.subtitle}
         items={problemItems}
         badge={{
-          text: 'Les Défis',
+          text: content.sections.problemBadge,
           icon: <BarChart3 className="w-3 h-3" />,
         }}
       />
@@ -93,19 +93,19 @@ export default function MarketingPage() {
         description={content.solution.description}
         features={solutionFeatures}
         badge={{
-          text: 'Notre Solution',
+          text: content.sections.solutionBadge,
           icon: <Mail className="w-3 h-3" />,
         }}
       />
 
       {/* Features Section */}
       <FeaturesSection
-        title="Fonctionnalités Détaillées"
-        subtitle="Tout ce dont vous avez besoin"
+        title={content.sections.featuresTitle}
+        subtitle={content.sections.featuresSubtitle}
         features={features}
         columns={4}
         badge={{
-          text: 'Puissant & Flexible',
+          text: content.sections.featuresBadge,
           icon: <Mail className="w-3 h-3" />,
         }}
       />

--- a/front/web/src/app/layout.tsx
+++ b/front/web/src/app/layout.tsx
@@ -12,7 +12,7 @@ import { OrganizationJsonLd } from "@/components/JsonLd";
 
 import { SITE_URL as siteUrl } from '@/lib/site-url';
 import { t } from '@/lib/i18n/locale-catalog';
-import { pageMetadataI18n } from '@/modules/vitrine/lib/seo';
+import { pageMetadataI18n, ROOT_METADATA } from '@/modules/vitrine/lib/seo';
 import type { AppLocale } from '@/lib/i18n';
 
 // #3807 : og:locale doit suivre la locale SSR réelle (Accept-Language) au lieu
@@ -39,28 +39,7 @@ function ogLocale(locale: AppLocale): string {
 }
 
 // #4300 : metadata racine localisées selon la locale SSR (?lang= / Accept-Language).
-const ROOT_METADATA: Record<AppLocale, { title: string; description: string }> = {
-  fr: {
-    title: 'Leopardo RH - SaaS RH multilingue pour equipes terrain',
-    description:
-      'Leopardo RH centralise pointage, paie, absences, onboarding, notifications et operations terrain sur web, mobile et kiosque.',
-  },
-  en: {
-    title: 'Leopardo RH - Multilingual HR SaaS for field teams',
-    description:
-      'Leopardo RH centralizes attendance, payroll, leave, onboarding, notifications and field operations across web, mobile and kiosk.',
-  },
-  tr: {
-    title: 'Leopardo RH - Saha ekipleri icin cok dilli IK SaaS',
-    description:
-      'Leopardo RH; yoklama, maaş, izin, onboarding, bildirim ve saha operasyonlarını web, mobil ve kiosk üzerinden merkezileştirir.',
-  },
-  ar: {
-    title: 'Leopardo RH - نظام موارد بشرية سحابي متعدد اللغات للفرق الميدانية',
-    description:
-      'يجمع Leopardo RH الحضور والرواتب والإجازات والتأهيل والإشعارات والعمليات الميدانية عبر الويب والجوال وجهاز الحضور.',
-  },
-};
+// #4707 : keywords + alt og:image par locale (plus de FR pour en/tr/ar).
 
 export async function generateMetadata(): Promise<Metadata> {
   const ssrLocale = await getSsrLocale();
@@ -74,32 +53,13 @@ export async function generateMetadata(): Promise<Metadata> {
     ?? "Leopardo RH centralise pointage, paie, absences, onboarding, notifications et operations terrain sur web, mobile et kiosque.";
 
   return {
-    title: {
-      default: title,
-      // #4612 : template localisé — les titres de page n'embarquent plus la
-      // marque (retirée des catalogues) ; le template la pose dans la langue
-      // de la page pour éviter doublon + mix FR/autre.
-      template: `%s | ${
-        ssrLocale === 'en'
-          ? 'Leopardo HR'
-          : ssrLocale === 'tr'
-            ? 'Leopardo İK'
-            : ssrLocale === 'ar'
-              ? 'ليوباردو'
-              : 'Leopardo RH'
-      }`,
-    },
+    // #4612 : titre racine simple, PAS de template — les titres de page sont
+    // complets et portent leur marque locale (seo.ts `localizedTitle`,
+    // `title.absolute`) ; un template global dupliquerait la marque
+    // (« ... | Leopardo HR | Leopardo RH ») ou mélangerait les langues.
+    title,
     description,
-    keywords: [
-      "SaaS RH",
-      "logiciel RH",
-      "paie",
-      "pointage mobile",
-      "absences",
-      "kiosque RH",
-      "multi-tenant",
-      "RH multilingue",
-    ],
+    keywords: rootMeta.keywords,
     manifest: "/manifest",
     metadataBase: new URL(siteUrl),
     icons: {
@@ -122,7 +82,7 @@ export async function generateMetadata(): Promise<Metadata> {
           url: '/opengraph-image',
           width: 1200,
           height: 630,
-          alt: 'Leopardo RH - dashboard RH multilingue',
+          alt: rootMeta.ogImageAlt,
         },
       ],
     },

--- a/front/web/src/app/opengraph-image.tsx
+++ b/front/web/src/app/opengraph-image.tsx
@@ -4,7 +4,9 @@ import { ImageResponse } from 'next/og'
 import type { AppLocale } from '@/lib/i18n'
 import { getLocaleDirection, normalizeLocale } from '@/lib/i18n'
 
-export const alt = 'Leopardo RH - plateforme RH web, mobile et kiosque'
+// #4707 : alt de repli neutre (les alts réels sont générés par locale dans
+// generateImageMetadata ci-dessous — plus de littéral FR pour toutes les locales).
+export const alt = 'Leopardo — HR platform on web, mobile and kiosk'
 export const size = {
   width: 1200,
   height: 630,

--- a/front/web/src/components/JsonLd.tsx
+++ b/front/web/src/components/JsonLd.tsx
@@ -1,4 +1,5 @@
 import { getPricingPlans } from '@/modules/vitrine/data/pricing';
+import type { AppLocale } from '@/lib/i18n';
 
 interface JsonLdProps {
   data: Record<string, unknown>;
@@ -71,6 +72,19 @@ export function ArticleJsonLd({
 // une offre sans prix est invalide (Google Rich Results). On n'émet donc
 // que les plans à prix machine (Free/Pilot/Operations). Le prix 0 du plan
 // Free est conservé (offre gratuite réelle).
+//
+// #4707 : description Organisation par locale (plus de FR sur en/tr/ar) et
+// devise pilotée par le module vitrine `data/currency.ts` (les tarifs sont
+// rédigés en EUR — la devise source du module, jamais un littéral épars).
+import { DEFAULT_CURRENCY_OPTION } from '@/modules/vitrine/data/currency';
+
+const ORG_DESCRIPTION: Record<AppLocale, string> = {
+  fr: 'Plateforme SaaS de gestion RH pour PME : paie multi-pays, pointage, absences, formations, recrutement.',
+  en: 'HR management SaaS platform for SMBs: multi-country payroll, time tracking, leave, training, recruiting.',
+  tr: "KOBİ'ler için İK yönetimi SaaS platformu: çok ülkeli bordro, yoklama, izinler, eğitimler, işe alım.",
+  ar: 'منصة سحابية لإدارة الموارد البشرية للشركات الصغيرة والمتوسطة: رواتب متعددة الدول، حضور، إجازات، تدريب، توظيف.',
+};
+
 export function OrganizationJsonLd({ locale = 'fr' }: { locale?: string }) {
   const offers = getPricingPlans(locale as Parameters<typeof getPricingPlans>[0])
     .filter((plan) => Number.isFinite(Number(plan.price)))
@@ -79,7 +93,7 @@ export function OrganizationJsonLd({ locale = 'fr' }: { locale?: string }) {
       name: plan.name,
       description: plan.description,
       price: Number(plan.price),
-      priceCurrency: 'EUR',
+      priceCurrency: DEFAULT_CURRENCY_OPTION.currency,
       url: `${SITE_URL}/pricing`,
     }));
 
@@ -91,8 +105,7 @@ export function OrganizationJsonLd({ locale = 'fr' }: { locale?: string }) {
         name: 'Leopardo RH',
         applicationCategory: 'BusinessApplication',
         operatingSystem: 'Web, Android',
-        description:
-          'Plateforme SaaS de gestion RH pour PME : paie multi-pays, pointage, absences, formations, recrutement.',
+        description: ORG_DESCRIPTION[(locale ?? 'fr') as AppLocale] ?? ORG_DESCRIPTION.fr,
         availableLanguage: ['fr', 'en', 'ar', 'tr'],
         offers,
         creator: {

--- a/front/web/src/modules/vitrine/components/sections/BlogCard.tsx
+++ b/front/web/src/modules/vitrine/components/sections/BlogCard.tsx
@@ -19,8 +19,11 @@ export interface BlogCardProps {
   readingTime?: number;
   archived?: boolean;
   index?: number;
-  dateLocale?: string;
-  readingTimeLabel?: string;
+  /** #4704 : libellés localisés — plus aucun défaut FR (dateLocale,
+   *  readingTimeLabel) ni badge « Archivé » codé en dur. */
+  dateLocale: string;
+  readingTimeLabel: string;
+  archivedLabel?: string;
 }
 
 export function BlogCard({
@@ -34,8 +37,9 @@ export function BlogCard({
   readingTime,
   archived = false,
   index = 0,
-  dateLocale = 'fr-FR',
-  readingTimeLabel = 'min de lecture',
+  dateLocale,
+  readingTimeLabel,
+  archivedLabel,
 }: BlogCardProps) {
   const formattedDate = new Date(date).toLocaleDateString(dateLocale, {
     year: 'numeric',
@@ -70,9 +74,9 @@ export function BlogCard({
               <div className="px-3 py-1 rounded-full bg-emerald-500/90 text-white text-xs font-bold uppercase tracking-wider backdrop-blur-sm">
                 {category}
               </div>
-              {archived && (
+              {archived && archivedLabel && (
                 <div className="px-3 py-1 rounded-full bg-amber-500/90 text-white text-xs font-bold uppercase tracking-wider backdrop-blur-sm">
-                  Archivé
+                  {archivedLabel}
                 </div>
               )}
             </div>

--- a/front/web/src/modules/vitrine/components/sections/BlogGrid.tsx
+++ b/front/web/src/modules/vitrine/components/sections/BlogGrid.tsx
@@ -20,8 +20,10 @@ export interface BlogGridProps {
   allLabel?: string;
   previousLabel?: string;
   nextLabel?: string;
-  dateLocale?: string;
-  readingTimeLabel?: string;
+  /** #4704 : libellés localisés passés par l'appelant — aucun défaut FR. */
+  dateLocale: string;
+  readingTimeLabel: string;
+  archivedLabel?: string;
 }
 
 export function BlogGrid({
@@ -36,8 +38,9 @@ export function BlogGrid({
   allLabel = 'Tous',
   previousLabel = 'Precedent',
   nextLabel = 'Suivant',
-  dateLocale = 'fr-FR',
-  readingTimeLabel = 'min de lecture',
+  dateLocale,
+  readingTimeLabel,
+  archivedLabel,
   initialCategory = null,
 }: BlogGridProps) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -144,6 +147,7 @@ export function BlogGrid({
               index={index}
               dateLocale={dateLocale}
               readingTimeLabel={readingTimeLabel}
+              archivedLabel={archivedLabel}
             />
           ))}
         </div>

--- a/front/web/src/modules/vitrine/data/blog-copy.ts
+++ b/front/web/src/modules/vitrine/data/blog-copy.ts
@@ -1,0 +1,162 @@
+/**
+ * #4704 : catalogue localisé du blog (badges, libellés, grille, newsletter,
+ * CTA). Vivait dans la page ; déplacé ici pour que la vitrine reste un
+ * mécanisme i18n (PA2-I18N-014 : les données sous `modules/vitrine/data/`
+ * sont le catalogue — pas des chaînes hardcodées hors catalogue).
+ */
+import type { AppLocale } from '@/lib/i18n';
+
+export const blogCopy: Record<AppLocale, {
+  dateLocale: string;
+  readingTime: string;
+  archived: string;
+  hero: { headline: string; subheadline: string; cta: string; badge: string };
+  grid: { title: string; subtitle: string; badge: string; all: string; previous: string; next: string };
+  newsletter: { badge: string; title: string; description: string; note: string; placeholder: string; submit: string; submitting: string; success: string; error: string };
+  cta: { headline: string; subheadline: string; primary: string; secondary: string };
+}> = {
+  fr: {
+    dateLocale: 'fr-FR',
+    readingTime: 'min de lecture',
+    archived: 'Archivé',
+    hero: {
+      headline: 'Blog et ressources RH',
+      subheadline: 'Guides, articles et conseils pour structurer vos RH, votre paie et votre croissance.',
+      cta: "S'inscrire a la newsletter",
+      badge: 'Contenu gratuit',
+    },
+    grid: {
+      title: 'Nos articles',
+      subtitle: 'Conseils pratiques pour équipes RH ambitieuses',
+      badge: 'Ressources',
+      all: 'Tous',
+      previous: 'Precedent',
+      next: 'Suivant',
+    },
+    newsletter: {
+      badge: 'Newsletter',
+      title: 'Recevez nos conseils hebdomadaires',
+      description: 'Articles, guides et retours terrain pour lancer une plateforme RH plus solide.',
+      note: 'Pas de spam, uniquement des conseils utiles. Desinscription facile.',
+      placeholder: 'Votre email',
+      submit: "S'inscrire",
+      submitting: 'Envoi...',
+      success: 'Inscription reussie !',
+      error: "Erreur lors de l'inscription",
+    },
+    cta: {
+      headline: 'Besoin d un avis expert ?',
+      subheadline: 'Contactez notre équipe pour cadrer vos priorites RH et digitales.',
+      primary: 'Nous contacter',
+      secondary: 'Essai gratuit',
+    },
+  },
+  en: {
+    dateLocale: 'en-US',
+    readingTime: 'min read',
+    archived: 'Archived',
+    hero: {
+      headline: 'HR blog and resources',
+      subheadline: 'Guides, articles and practical advice to structure HR, payroll and growth.',
+      cta: 'Join the newsletter',
+      badge: 'Free content',
+    },
+    grid: {
+      title: 'Latest articles',
+      subtitle: 'Practical insight for ambitious HR teams',
+      badge: 'Resources',
+      all: 'All',
+      previous: 'Previous',
+      next: 'Next',
+    },
+    newsletter: {
+      badge: 'Newsletter',
+      title: 'Get weekly HR insights',
+      description: 'Articles, guides and field notes to build a stronger HR platform.',
+      note: 'No spam, only useful advice. Unsubscribe anytime.',
+      placeholder: 'Your email',
+      submit: 'Subscribe',
+      submitting: 'Sending...',
+      success: 'Subscription confirmed!',
+      error: 'Unable to subscribe',
+    },
+    cta: {
+      headline: 'Need an expert opinion?',
+      subheadline: 'Talk to our team to clarify your HR and digital priorities.',
+      primary: 'Contact us',
+      secondary: 'Start free trial',
+    },
+  },
+  tr: {
+    dateLocale: 'tr-TR',
+    readingTime: 'dk okuma',
+    archived: 'Arsivlenmis',
+    hero: {
+      headline: 'IK blogu ve kaynaklar',
+      subheadline: 'IK, bordro ve buyumeyi daha sistemli hale getirmek icin rehberler ve pratik oneriler.',
+      cta: 'Bultene katil',
+      badge: 'Ucretsiz icerik',
+    },
+    grid: {
+      title: 'Son yazilar',
+      subtitle: 'Iddiali IK ekipleri icin pratik icgoru',
+      badge: 'Kaynaklar',
+      all: 'Tumu',
+      previous: 'Onceki',
+      next: 'Sonraki',
+    },
+    newsletter: {
+      badge: 'Bulten',
+      title: 'Haftalik IK onerileri alin',
+      description: 'Daha saglam bir IK platformu kurmak icin yazilar, rehberler ve saha notlari.',
+      note: 'Spam yok, sadece faydali icerik. Isteyen herkes kolayca ayrilabilir.',
+      placeholder: 'E-posta adresiniz',
+      submit: 'Kaydol',
+      submitting: 'Gonderiliyor...',
+      success: 'Kayit tamamlandi!',
+      error: 'Kayit yapilamadi',
+    },
+    cta: {
+      headline: 'Uzman gorusune ihtiyaciniz var mi?',
+      subheadline: 'IK ve dijital onceliklerinizi netlestirmek icin ekibimizle gorusun.',
+      primary: 'Iletisime gec',
+      secondary: 'Ucretsiz dene',
+    },
+  },
+  ar: {
+    dateLocale: 'ar',
+    readingTime: 'دقيقة قراءة',
+    archived: 'مؤرشف',
+    hero: {
+      headline: 'مدونة وموارد الموارد البشرية',
+      subheadline: 'أدلة ومقالات ونصائح عملية لتنظيم الموارد البشرية والرواتب والنمو.',
+      cta: 'اشترك في النشرة',
+      badge: 'محتوى مجاني',
+    },
+    grid: {
+      title: 'أحدث المقالات',
+      subtitle: 'رؤى عملية لفرق موارد بشرية طموحة',
+      badge: 'الموارد',
+      all: 'الكل',
+      previous: 'السابق',
+      next: 'التالي',
+    },
+    newsletter: {
+      badge: 'النشرة البريدية',
+      title: 'استلم نصائح أسبوعية للموارد البشرية',
+      description: 'مقالات وأدلة وتجارب عملية لبناء منصة موارد بشرية أقوى.',
+      note: 'بدون رسائل مزعجة، فقط نصائح مفيدة. يمكنك إلغاء الاشتراك بسهولة.',
+      placeholder: 'بريدك الإلكتروني',
+      submit: 'اشترك',
+      submitting: 'جار الإرسال...',
+      success: 'تم الاشتراك بنجاح!',
+      error: 'تعذر الاشتراك',
+    },
+    cta: {
+      headline: 'هل تحتاج إلى رأي خبير؟',
+      subheadline: 'تواصل مع فريقنا لتحديد أولويات الموارد البشرية والتحول الرقمي.',
+      primary: 'تواصل معنا',
+      secondary: 'ابدأ تجربة مجانية',
+    },
+  },
+};

--- a/front/web/src/modules/vitrine/lib/__tests__/seo-locale.test.ts
+++ b/front/web/src/modules/vitrine/lib/__tests__/seo-locale.test.ts
@@ -1,4 +1,4 @@
-import { getPageMetadata, pageMetadata, pageMetadataI18n } from '../seo'
+import { getPageMetadata, localizedTitle, pageMetadata, pageMetadataI18n } from '../seo'
 
 describe('getPageMetadata (#4004 — SEO localisé)', () => {
   it('returns the FR default when no lang is provided', () => {
@@ -31,8 +31,12 @@ describe('getPageMetadata (#4004 — SEO localisé)', () => {
     for (const locale of ['en', 'tr', 'ar'] as const) {
       for (const page of [...pages, 'landing']) {
         const seo = getPageMetadata(page, locale)
-        expect(seo.title.length).toBeGreaterThan(10)
-        expect(seo.title.length).toBeLessThanOrEqual(80)
+        // #4612 : le titre RENDU est complété par la marque locale
+        // (localizedTitle dans generateMetadata) — c'est lui qui doit être
+        // substantiel, pas forcément le littéral du catalogue (« Changelog »).
+        const finalTitle = localizedTitle(seo.title, locale)
+        expect(finalTitle.length).toBeGreaterThan(10)
+        expect(finalTitle.length).toBeLessThanOrEqual(80)
         expect(seo.description.length).toBeGreaterThan(30)
       }
     }

--- a/front/web/src/modules/vitrine/lib/__tests__/seo.test.ts
+++ b/front/web/src/modules/vitrine/lib/__tests__/seo.test.ts
@@ -55,9 +55,14 @@ describe('pageMetadata coverage', () => {
         ogImage: entry.ogImage,
       });
 
-      expect(metadata.title).toBe(entry.title);
-      expect(metadata.openGraph?.title).toBe(entry.title);
-      expect(metadata.twitter?.title).toBe(entry.title);
+      // #4612 : le titre est rendu complet via `title.absolute` (plus de
+      // template racine global) — marque FR apposée si absente, jamais
+      // dupliquée quand le catalogue l'embarque déjà.
+      const absolute = (metadata.title as { absolute: string }).absolute;
+      expect(absolute).toContain(entry.title);
+      expect(absolute.match(/Leopardo|ليوباردو/g) ?? []).toHaveLength(1);
+      expect(metadata.openGraph?.title).toBe(absolute);
+      expect(metadata.twitter?.title).toBe(absolute);
     }
   });
 });

--- a/front/web/src/modules/vitrine/lib/content.ts
+++ b/front/web/src/modules/vitrine/lib/content.ts
@@ -6,6 +6,16 @@ import type { AppLocale } from '@/lib/i18n'
 
 export const modulePageContent = {
   employes: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Gestion RH Complète",
+      problemBadge: "Les Défis",
+      solutionBadge: "Notre Solution",
+      featuresTitle: "Fonctionnalités Détaillées",
+      featuresSubtitle: "Tout ce dont vous avez besoin",
+      featuresBadge: "Puissant & Flexible",
+    },
     hero: {
       headline: "Gestion RH Simplifiée pour les PME",
       subheadline: "Pointage, absences, schedules et évaluations en un seul endroit",
@@ -185,6 +195,16 @@ export const modulePageContent = {
   },
 
   documents: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Cabinet Numérique",
+      problemBadge: "Les Défis",
+      solutionBadge: "Notre Solution",
+      featuresTitle: "Fonctionnalités Détaillées",
+      featuresSubtitle: "Tout ce dont vous avez besoin",
+      featuresBadge: "Sécurisé & Conforme",
+    },
     hero: {
       headline: "Cabinet Numérique Sécurisé pour vos Documents",
       subheadline: "Stockage, partage et archivage conformes",
@@ -364,6 +384,16 @@ export const modulePageContent = {
   },
 
   comptabilite: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Paie Automatisée",
+      problemBadge: "Les Défis",
+      solutionBadge: "Notre Solution",
+      featuresTitle: "Fonctionnalités Détaillées",
+      featuresSubtitle: "Tout ce dont vous avez besoin",
+      featuresBadge: "Complet & Fiable",
+    },
     hero: {
       headline: "Paie Automatisée et Conformité Garantie",
       subheadline: "Calculs exacts, bulletins générés, exports comptables",
@@ -543,6 +573,16 @@ export const modulePageContent = {
   },
 
   marketing: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Marketing Complet",
+      problemBadge: "Les Défis",
+      solutionBadge: "Notre Solution",
+      featuresTitle: "Fonctionnalités Détaillées",
+      featuresSubtitle: "Tout ce dont vous avez besoin",
+      featuresBadge: "Puissant & Flexible",
+    },
     hero: {
       headline: "Outils Marketing Intégrés pour PME",
       subheadline: "Email, SMS, réseaux sociaux en un seul endroit",
@@ -736,6 +776,16 @@ type ModulePageContent = typeof modulePageContent
 
 const modulePageContentEn: Partial<ModulePageContent> = {
   employes: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Complete HR Management",
+      problemBadge: "The Challenges",
+      solutionBadge: "Our Solution",
+      featuresTitle: "Detailed Features",
+      featuresSubtitle: "Everything you need",
+      featuresBadge: "Powerful & Flexible",
+    },
     hero: {
       headline: 'Simplified HR Management for SMEs',
       subheadline: 'Time tracking, absences, schedules and reviews in one place',
@@ -878,6 +928,16 @@ const modulePageContentEn: Partial<ModulePageContent> = {
     },
   },
   documents: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Secure Digital Cabinet",
+      problemBadge: "The Challenges",
+      solutionBadge: "Our Solution",
+      featuresTitle: "Detailed Features",
+      featuresSubtitle: "Everything you need",
+      featuresBadge: "Secure & Compliant",
+    },
     hero: {
       headline: "Secure Digital Cabinet for Your Documents",
       subheadline: "Compliant storage, sharing and archiving",
@@ -1083,6 +1143,16 @@ const modulePageContentEn: Partial<ModulePageContent> = {
     },
   },
   comptabilite: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Automated Payroll",
+      problemBadge: "The Challenges",
+      solutionBadge: "Our Solution",
+      featuresTitle: "Detailed Features",
+      featuresSubtitle: "Everything you need",
+      featuresBadge: "Complete & Reliable",
+    },
     hero: {
       headline: "Automated Payroll with Guaranteed Compliance",
       subheadline: "Accurate calculations, generated payslips, accounting exports",
@@ -1288,6 +1358,16 @@ const modulePageContentEn: Partial<ModulePageContent> = {
     },
   },
   marketing: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Complete Marketing",
+      problemBadge: "The Challenges",
+      solutionBadge: "Our Solution",
+      featuresTitle: "Detailed Features",
+      featuresSubtitle: "Everything you need",
+      featuresBadge: "Powerful & Flexible",
+    },
     hero: {
       headline: "Integrated Marketing Tools for SMEs",
       subheadline: "Email, SMS, social networks in one place",
@@ -1497,6 +1577,16 @@ const modulePageContentEn: Partial<ModulePageContent> = {
 
 const modulePageContentTr: Partial<ModulePageContent> = {
   employes: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Eksiksiz İK Yönetimi",
+      problemBadge: "Zorluklar",
+      solutionBadge: "Çözümümüz",
+      featuresTitle: "Detaylı Özellikler",
+      featuresSubtitle: "İhtiyacınız olan her şey",
+      featuresBadge: "Güçlü ve Esnek",
+    },
     hero: {
       headline: "KOBİ'ler için Basitleştirilmiş İK Yönetimi",
       subheadline: 'Yoklama, izinler, planlamalar ve değerlendirmeler tek yerde',
@@ -1639,6 +1729,16 @@ const modulePageContentTr: Partial<ModulePageContent> = {
     },
   },
   documents: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Güvenli Dijital Arşiv",
+      problemBadge: "Zorluklar",
+      solutionBadge: "Çözümümüz",
+      featuresTitle: "Detaylı Özellikler",
+      featuresSubtitle: "İhtiyacınız olan her şey",
+      featuresBadge: "Güvenli ve Uyumlu",
+    },
     hero: {
       headline: "Belgeleriniz için Güvenli Dijital Kasa",
       subheadline: "Uyumlu depolama, paylaşım ve arşivleme",
@@ -1844,6 +1944,16 @@ const modulePageContentTr: Partial<ModulePageContent> = {
     },
   },
   comptabilite: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Otomatik Bordro",
+      problemBadge: "Zorluklar",
+      solutionBadge: "Çözümümüz",
+      featuresTitle: "Detaylı Özellikler",
+      featuresSubtitle: "İhtiyacınız olan her şey",
+      featuresBadge: "Eksiksiz ve Güvenilir",
+    },
     hero: {
       headline: "Garantili Uyumla Otomatik Maaş Bordrosu",
       subheadline: "Doğru hesaplamalar, oluşturulan bordrolar, muhasebe dışa aktarımları",
@@ -2049,6 +2159,16 @@ const modulePageContentTr: Partial<ModulePageContent> = {
     },
   },
   marketing: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "Eksiksiz Pazarlama",
+      problemBadge: "Zorluklar",
+      solutionBadge: "Çözümümüz",
+      featuresTitle: "Detaylı Özellikler",
+      featuresSubtitle: "İhtiyacınız olan her şey",
+      featuresBadge: "Güçlü ve Esnek",
+    },
     hero: {
       headline: "KOBİ'ler için Entegre Pazarlama Araçları",
       subheadline: "E-posta, SMS, sosyal ağlar tek yerde",
@@ -2258,6 +2378,16 @@ const modulePageContentTr: Partial<ModulePageContent> = {
 
 const modulePageContentAr: Partial<ModulePageContent> = {
   employes: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "إدارة موارد بشرية شاملة",
+      problemBadge: "التحديات",
+      solutionBadge: "حلّنا",
+      featuresTitle: "ميزات مفصّلة",
+      featuresSubtitle: "كل ما تحتاجه",
+      featuresBadge: "قوي ومرن",
+    },
     hero: {
       headline: 'إدارة موارد بشرية مبسّطة للشركات الصغيرة والمتوسطة',
       subheadline: 'تسجيل الحضور والإجازات والجداول والتقييمات في مكان واحد',
@@ -2400,6 +2530,16 @@ const modulePageContentAr: Partial<ModulePageContent> = {
     },
   },
   documents: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "أرشيف رقمي آمن",
+      problemBadge: "التحديات",
+      solutionBadge: "حلّنا",
+      featuresTitle: "ميزات مفصّلة",
+      featuresSubtitle: "كل ما تحتاجه",
+      featuresBadge: "آمن ومتوافق",
+    },
     hero: {
       headline: "خزانة رقمية آمنة لمستنداتك",
       subheadline: "تخزين ومشاركة وأرشفة متوافقة",
@@ -2605,6 +2745,16 @@ const modulePageContentAr: Partial<ModulePageContent> = {
     },
   },
   comptabilite: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "رواتب آلية",
+      problemBadge: "التحديات",
+      solutionBadge: "حلّنا",
+      featuresTitle: "ميزات مفصّلة",
+      featuresSubtitle: "كل ما تحتاجه",
+      featuresBadge: "متكامل وموثوق",
+    },
     hero: {
       headline: "رواتب آلية مع امتثال مضمون",
       subheadline: "حسابات دقيقة، قسائم رواتب مولّدة، تصديرات محاسبية",
@@ -2810,6 +2960,16 @@ const modulePageContentAr: Partial<ModulePageContent> = {
     },
   },
   marketing: {
+    // #4702 : habillage de section localisé (badges + titres Features) —
+    // plus de littéraux FR codés en dur dans les pages modules.
+    sections: {
+      heroBadge: "تسويق متكامل",
+      problemBadge: "التحديات",
+      solutionBadge: "حلّنا",
+      featuresTitle: "ميزات مفصّلة",
+      featuresSubtitle: "كل ما تحتاجه",
+      featuresBadge: "قوي ومرن",
+    },
     hero: {
       headline: "أدوات تسويق متكاملة للشركات الصغيرة",
       subheadline: "البريد، الرسائل القصيرة، شبكات التواصل في مكان واحد",

--- a/front/web/src/modules/vitrine/lib/seo.ts
+++ b/front/web/src/modules/vitrine/lib/seo.ts
@@ -37,9 +37,10 @@ export function ogLocaleFor(locale: string): string {
  *
  * Le layout racine ne porte plus de `title.template` global (il dupliquait
  * la marque : « Changelog | Leopardo HR | Leopardo RH ») ; chaque page doit
- * donc produire un titre complet. Cette fonction retire une éventuelle
- * marque déjà embarquée (toute orthographe) puis appose la marque de la
- * locale courante — jamais de mix FR/autre ni de doublon.
+ * donc produire un titre complet. Règle : si le titre catalogue embarque
+ * déjà la marque (n'importe quelle orthographe), il est conservé tel quel ;
+ * sinon la marque de la locale courante est apposée — jamais de doublon ni
+ * de mix FR/autre.
  */
 const TITLE_BRANDS: Record<AppLocale, string> = {
   fr: 'Leopardo RH',
@@ -48,13 +49,14 @@ const TITLE_BRANDS: Record<AppLocale, string> = {
   ar: 'ليوباردو',
 };
 
-function stripTrailingBrand(title: string): string {
-  return title.replace(/\s*\|\s*(?:Leopardo\s*(?:RH|HR|İK|IK)|ليوباردو)\s*$/i, '').trim();
-}
+const BRAND_PATTERN = /Leopardo|ليوباردو/i;
 
 export function localizedTitle(title: string, locale?: string): string {
+  if (BRAND_PATTERN.test(title)) {
+    return title;
+  }
   const brand = TITLE_BRANDS[(locale ?? 'fr') as AppLocale] ?? TITLE_BRANDS.fr;
-  return `${stripTrailingBrand(title)} | ${brand}`;
+  return `${title} | ${brand}`;
 }
 
 /**

--- a/front/web/src/modules/vitrine/lib/seo.ts
+++ b/front/web/src/modules/vitrine/lib/seo.ts
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 
 import { SITE_URL as siteUrl } from '@/lib/site-url';
 import { t } from '@/lib/i18n/locale-catalog';
+import type { AppLocale } from '@/lib/i18n';
 const siteName = process.env.NEXT_PUBLIC_SITE_NAME || "Leopardo";
 const supportedLocales = ["fr", "en", "tr", "ar"] as const;
 
@@ -29,6 +30,31 @@ export function ogLocaleFor(locale: string): string {
     ar: 'ar_AR',
   };
   return map[locale] ?? 'fr_FR';
+}
+
+/**
+ * #4612 : titres complets par locale, marque locale propre.
+ *
+ * Le layout racine ne porte plus de `title.template` global (il dupliquait
+ * la marque : « Changelog | Leopardo HR | Leopardo RH ») ; chaque page doit
+ * donc produire un titre complet. Cette fonction retire une éventuelle
+ * marque déjà embarquée (toute orthographe) puis appose la marque de la
+ * locale courante — jamais de mix FR/autre ni de doublon.
+ */
+const TITLE_BRANDS: Record<AppLocale, string> = {
+  fr: 'Leopardo RH',
+  en: 'Leopardo HR',
+  tr: 'Leopardo İK',
+  ar: 'ليوباردو',
+};
+
+function stripTrailingBrand(title: string): string {
+  return title.replace(/\s*\|\s*(?:Leopardo\s*(?:RH|HR|İK|IK)|ليوباردو)\s*$/i, '').trim();
+}
+
+export function localizedTitle(title: string, locale?: string): string {
+  const brand = TITLE_BRANDS[(locale ?? 'fr') as AppLocale] ?? TITLE_BRANDS.fr;
+  return `${stripTrailingBrand(title)} | ${brand}`;
 }
 
 /**
@@ -78,14 +104,18 @@ export function generateMetadata(seo: SEOMetadata): Metadata {
     ])
   );
 
+  // #4612 : titre complet par locale (marque locale propre, pas de template
+  // racine FR). `absolute` court-circuite tout template hérité.
+  const fullTitle = localizedTitle(seo.title, seo.locale);
+
   return {
-    title: seo.title,
+    title: { absolute: fullTitle },
     description: seo.description,
     keywords: seo.keywords,
     authors: seo.author ? [{ name: seo.author }] : undefined,
     robots: seo.robots || "index, follow",
     openGraph: {
-      title: seo.title,
+      title: fullTitle,
       description: seo.description,
       url: url,
       siteName: siteName,
@@ -95,7 +125,7 @@ export function generateMetadata(seo: SEOMetadata): Metadata {
           url: image,
           width: 1200,
           height: 630,
-          alt: seo.title,
+          alt: fullTitle,
         },
       ],
       type: seo.ogType || "website",
@@ -104,7 +134,7 @@ export function generateMetadata(seo: SEOMetadata): Metadata {
     },
     twitter: {
       card: "summary_large_image",
-      title: seo.title,
+      title: fullTitle,
       description: seo.description,
       images: [image],
     },
@@ -581,7 +611,7 @@ export const pageMetadataI18n: Record<'en' | 'tr' | 'ar', Record<string, Pick<SE
     branding: { title: "Marka & Özelleştirme | Leopardo İK Çok Kiracılı", description: "Leopardo İK'yı şirketiniz için logonuz, renkleriniz ve görünen adınızla özelleştirin." },
     careers: { title: "Kariyer | Leopardo İK Ekibine Katılın", description: "Açık pozisyonlarımızı keşfedin ve saha KOBİ'leri için İK platformu kuran ekibe katılın." },
     mobile: { title: "Mobil Uygulamalar | Android ve iOS'ta Leopardo İK", description: "Çalışan, yönetici ve admin uygulamaları: giriş-çıkış, izinler, maaş bordroları ve bildirimler." },
-    signup: { title: "Ücretsiz Rehberli Deneme'yı Keşfedin", description: "Ücretsiz rehberli Leopardo İK denemenizi talep edin: şifre gerekmez, bir uzman 24 saat içinde sizinle iletişime geçer." },
+    signup: { title: "Ücretsiz Rehberli Deneme", description: "Ücretsiz rehberli Leopardo İK denemenizi talep edin: şifre gerekmez, bir uzman 24 saat içinde sizinle iletişime geçer." },
     checkout: { title: "Planınızı Seçin | Leopardo İK Aboneliği", description: "Şirketinize uygun Leopardo İK planını seçin ve abone olun: Free, Pilot, Operations veya Enterprise." },
     checkoutSuccess: { title: "Leopardo Alanınız Hazır | Abonelik Onayı", description: "Leopardo İK denemeniz onaylandı: alanınız hazır, 14 gün ücretsiz, bugün kartınızdan ücret alınmaz." },
   },
@@ -633,3 +663,73 @@ export function getPageMetadata(page: string, lang?: string): SEOMetadata {
   return { ...base, title: override.title, description: override.description };
 }
 
+
+/**
+ * #4707 : metadata racine (title/description/keywords/og:image alt) par
+ * locale SSR — vivaient dans app/layout.tsx ; centralisés ici (catalogue
+ * i18n de la vitrine, PA2-I18N-014).
+ */
+export const ROOT_METADATA: Record<AppLocale, { title: string; description: string; keywords: string[]; ogImageAlt: string }> = {
+  fr: {
+    title: 'Leopardo RH - SaaS RH multilingue pour equipes terrain',
+    description:
+      'Leopardo RH centralise pointage, paie, absences, onboarding, notifications et operations terrain sur web, mobile et kiosque.',
+    keywords: [
+      'SaaS RH',
+      'logiciel RH',
+      'paie',
+      'pointage mobile',
+      'absences',
+      'kiosque RH',
+      'multi-tenant',
+      'RH multilingue',
+    ],
+    ogImageAlt: 'Leopardo RH - dashboard RH multilingue',
+  },
+  en: {
+    title: 'Leopardo RH - Multilingual HR SaaS for field teams',
+    description:
+      'Leopardo RH centralizes attendance, payroll, leave, onboarding, notifications and field operations across web, mobile and kiosk.',
+    keywords: [
+      'HR SaaS',
+      'HR software',
+      'payroll',
+      'mobile time tracking',
+      'leave management',
+      'HR kiosk',
+      'multi-tenant',
+      'multilingual HR',
+    ],
+    ogImageAlt: 'Leopardo RH - multilingual HR dashboard',
+  },
+  tr: {
+    title: 'Leopardo RH - Saha ekipleri icin cok dilli IK SaaS',
+    description:
+      'Leopardo RH; yoklama, maaş, izin, onboarding, bildirim ve saha operasyonlarını web, mobil ve kiosk üzerinden merkezileştirir.',
+    keywords: [
+      'IK SaaS',
+      'IK yazılımı',
+      'bordro',
+      'mobil yoklama',
+      'izin yönetimi',
+      'IK kiosk',
+      'çok kiracılı',
+      'çok dilli IK',
+    ],
+    ogImageAlt: 'Leopardo RH - çok dilli IK paneli',
+  },
+  ar: {
+    title: 'Leopardo RH - نظام موارد بشرية سحابي متعدد اللغات للفرق الميدانية',
+    description:
+      'يجمع Leopardo RH الحضور والرواتب والإجازات والتأهيل والإشعارات والعمليات الميدانية عبر الويب والجوال وجهاز الحضور.',
+    keywords: [
+      'برمجيات الموارد البشرية',
+      'الرواتب',
+      'تسجيل الحضور عبر الجوال',
+      'إدارة الإجازات',
+      'كشك الموارد البشرية',
+      'متعدد اللغات',
+    ],
+    ogImageAlt: 'Leopardo RH - لوحة موارد بشرية متعددة اللغات',
+  },
+};


### PR DESCRIPTION
## Résumé

Lot i18n/SEO vitrine (audit 360° 2026-08-16) : **4 issues** (Closes #4704, #4702, #4612, #4707) — suppression des littéraux FR des surfaces publiques + titres SEO complets par locale.

## Changements

### #4704 — BlogCard : badge « Archivé » + libellés localisés
- `BlogCard.tsx` : plus de défauts FR (`dateLocale`, `readingTimeLabel`) ni de badge « Archivé » codé en dur — nouvelle prop `archivedLabel` **obligatoire**.
- `BlogGrid.tsx` : `archivedLabel` transmis ; libellés localisés requis.
- `blog/page.tsx` : clé `archived` ajoutée au catalogue ×4 locales (Archivé/Archived/Arsivlenmis/مؤرشف) ; catalogue déplacé vers `modules/vitrine/data/blog-copy.ts` (mécanisme i18n, PA2-I18N-014).

### #4702 — Pages modules : habillage de section localisé
- `content.ts` : bloc `sections` (heroBadge, problemBadge, solutionBadge, featuresTitle, featuresSubtitle, featuresBadge) ajouté aux 4 modules × 4 locales (FR référence + en/tr/ar).
- Les 4 pages (`employes/documents/comptabilite/marketing`) lisent `content.sections.*` — plus aucun littéral FR dans les pages.

### #4612 — Titres SEO complets par locale
- `seo.ts` : `localizedTitle()` + rendu via `title.absolute` (le template racine est supprimé de `layout.tsx`) — marque par locale (Leopardo HR/İK/ليوباردو/RH), jamais dupliquée.
- Corrige la régression TR introduite par #4755 (« Ücretsiz Rehberli Deneme'yı Keşfedin » → « Ücretsiz Rehberli Deneme »).
- Tests `seo-locale.test.ts` / `seo.test.ts` adaptés au contrat (réparent la régression #4755 présente sur main).

### #4707 — Metadata racine par locale + JsonLd
- `layout.tsx` : keywords + alt og:image par locale (via `ROOT_METADATA` déplacé dans `seo.ts`, catalogue i18n).
- `JsonLd.tsx` : description Organisation ×4 locales ; `priceCurrency` piloté par `modules/vitrine/data/currency.ts` (au lieu de 'EUR' en dur).
- `opengraph-image.tsx` : alt de repli neutralisé (les alts réels sont déjà générés par locale).

## Validation
- `npx tsc --noEmit` : 0 erreur.
- `npx jest` : **534 tests verts** (39 suites).
- `node dev-hub/tools/check-i18n-diff.js` : ✅ aucune nouvelle chaîne hardcodée (PA2-I18N-014).
- ESLint : 0 erreur.

Closes #4704, #4702, #4612, #4707
