### PR TITLE
fix(mobile): SyncService — log pull failed référence _currentMode (undefined _mode) (Closes #4780)

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
@@ -252,7 +252,7 @@ class SyncService {
     } catch (e) {
       // Issue #3867 : échec de pull loggé (mode, erreur) — silencieux avant,
       // impossible à diagnostiquer sur le terrain.
-      debugPrint('[SyncService] pull failed (${_mode}) — ${e.runtimeType}: $e');
+      debugPrint('[SyncService] pull failed ($_currentMode) — ${e.runtimeType}: $e');
     }
   }
 


### PR DESCRIPTION
## Résumé

`flutter analyze` sur `leopardo_core` échoue sur main : `sync_service.dart:255` référence `_mode` (champ inexistant — le champ est `_currentMode`). Régression introduite par #3867 (commit f4f910908). Corrigé + lint `unnecessary_brace_in_string_interps` nettoyé.

## Validation
- `flutter analyze --no-pub` : **No issues found!** (leopardo_core, Flutter 3.47).

Closes #4780