### PR TITLE
fix(web): deep link /download?platform= opérationnel + web-offline PWA localisé (Closes #4799, #4806)

### DIFF
--- a/.github/workflows/web-offline-ci.yml
+++ b/.github/workflows/web-offline-ci.yml
@@ -37,7 +37,9 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: '20'
+          # jsdom 30.x (devDependency) requires Node ≥ 22 for
+          # webidl.util.markAsUncloneable — see issue #4829.
+          node-version: '22'
           cache: npm
           cache-dependency-path: front/web-offline/package-lock.json
 

--- a/front/web-offline/src/app/page.tsx
+++ b/front/web-offline/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   type EdgeHealth,
   type SyncStatus,
 } from '@/lib/edge-health';
+import { getUiCopy } from '@/lib/ui-copy';
 
 const EDGE_API = process.env.NEXT_PUBLIC_EDGE_API ?? 'http://leopardo.local:7878';
 
@@ -14,6 +15,10 @@ export default function HomePage() {
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('checking');
   const [health, setHealth] = useState<EdgeHealth | null>(null);
   const [checking, setChecking] = useState(false);
+
+  // #4806 : copie d'interface localisée (fr/en/tr/ar), détectée depuis
+  // navigator.language avec repli fr.
+  const t = getUiCopy();
 
   const checkEdge = async () => {
     setChecking(true);
@@ -38,10 +43,10 @@ export default function HomePage() {
   }[syncStatus];
 
   const statusLabel = {
-    checking: 'Vérification…',
-    online: 'Edge en ligne',
-    offline: 'Hors ligne',
-    error: 'Erreur de connexion',
+    checking: t.statusCheck,
+    online: t.statusOnline,
+    offline: t.statusOffline,
+    error: t.statusError,
   }[syncStatus];
 
   return (
@@ -62,7 +67,7 @@ export default function HomePage() {
       <main className="flex-1 px-6 py-8 max-w-2xl mx-auto w-full">
         {/* Status card */}
         <div className="bg-slate-800 rounded-xl border border-slate-700 p-6 mb-6">
-          <h2 className="text-white font-semibold text-base mb-4">Statut du node Edge</h2>
+          <h2 className="text-white font-semibold text-base mb-4">{t.statusCardTitle}</h2>
           {health ? (
             <div className="space-y-3">
               <div className="flex justify-between text-sm">
@@ -76,21 +81,19 @@ export default function HomePage() {
                 </span>
               </div>
               <div className="flex justify-between text-sm">
-                <span className="text-slate-400">En attente de sync</span>
-                <span className="text-white">{health.pending_sync ?? '—'}{typeof health.pending_sync === 'number' ? ' enregistrement(s)' : ''}</span>
+                <span className="text-slate-400">{t.pendingSync}</span>
+                <span className="text-white">{typeof health.pending_sync === 'number' ? t.pendingCount(health.pending_sync) : '—'}</span>
               </div>
               {health.last_sync && (
                 <div className="flex justify-between text-sm">
-                  <span className="text-slate-400">Dernière synchronisation</span>
+                  <span className="text-slate-400">{t.lastSync}</span>
                   <span className="text-white">{new Date(health.last_sync).toLocaleString(typeof window !== 'undefined' ? navigator.language : 'fr-FR')}</span>
                 </div>
               )}
             </div>
           ) : (
             <p className="text-slate-400 text-sm">
-              {syncStatus === 'checking'
-                ? 'Connexion à http://leopardo.local…'
-                : 'Node Edge non joignable. Les pointages seront enregistrés localement.'}
+              {syncStatus === 'checking' ? t.connecting : t.unreachable}
             </p>
           )}
         </div>
@@ -102,30 +105,29 @@ export default function HomePage() {
             disabled={checking}
             className="flex-1 bg-slate-700 hover:bg-slate-600 disabled:opacity-50 text-white text-sm font-medium py-2.5 px-4 rounded-lg transition-colors"
           >
-            {checking ? 'Vérification…' : 'Actualiser'}
+            {checking ? t.statusCheck : t.refresh}
           </button>
           <button
             disabled
-            title="La synchronisation nécessite un nodeId et un jeton Edge authentifié."
+            title={t.syncTitle}
 
             className="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium py-2.5 px-4 rounded-lg transition-colors"
           >
-            Synchronisation disponible depuis le node Edge authentifié
+            {t.syncButton}
           </button>
         </div>
 
         {/* Offline notice */}
         {syncStatus === 'offline' && (
           <div className="mt-6 bg-slate-800 border border-yellow-600/40 rounded-xl p-4 text-sm text-yellow-300">
-            ⚠️ Le node Edge local n&apos;est pas joignable. Assurez-vous d&apos;être connecté
-            au réseau local ou que le service Edge est démarré sur le serveur.
+            {t.offlineNotice}
           </div>
         )}
       </main>
 
       {/* Footer */}
       <footer className="px-6 py-4 text-center text-slate-600 text-xs">
-        Leopardo RH — Interface Edge locale · {EDGE_API}
+        {t.footer(EDGE_API)}
       </footer>
     </div>
   );

--- a/front/web-offline/src/lib/ui-copy.ts
+++ b/front/web-offline/src/lib/ui-copy.ts
@@ -1,0 +1,127 @@
+/**
+ * Leopardo Edge — copie d'interface localisée (issue #4806).
+ *
+ * L'app web-offline est une petite PWA sans infra i18n : on garde une carte
+ * locale minimale (fr/en/tr/ar) dans ce module, avec détection depuis
+ * `navigator.language` et repli sur le français (locale historique du produit).
+ *
+ * Les chaînes techniques (marques, URL, libellés API) restent volontairement
+ * non traduites : "Node ID", "Leopardo Edge", "Statut", "http://leopardo.local".
+ */
+
+export type UiLocale = 'fr' | 'en' | 'tr' | 'ar';
+
+export type UiCopy = {
+  statusCheck: string;
+  statusOnline: string;
+  statusOffline: string;
+  statusError: string;
+  statusCardTitle: string;
+  lastSync: string;
+  pendingSync: string;
+  pendingCount: (count: number) => string;
+  connecting: string;
+  unreachable: string;
+  refresh: string;
+  syncTitle: string;
+  syncButton: string;
+  offlineNotice: string;
+  footer: (url: string) => string;
+};
+
+export const UI_LOCALES: UiLocale[] = ['fr', 'en', 'tr', 'ar'];
+
+export const uiCopy: Record<UiLocale, UiCopy> = {
+  fr: {
+    statusCheck: 'Vérification…',
+    statusOnline: 'Edge en ligne',
+    statusOffline: 'Hors ligne',
+    statusError: 'Erreur de connexion',
+    statusCardTitle: 'Statut du node Edge',
+    lastSync: 'Dernière synchronisation',
+    pendingSync: 'En attente de sync',
+    pendingCount: (count) => `${count} enregistrement(s)`,
+    connecting: 'Connexion à http://leopardo.local…',
+    unreachable: 'Node Edge non joignable. Les pointages seront enregistrés localement.',
+    refresh: 'Actualiser',
+    syncTitle: 'La synchronisation nécessite un nodeId et un jeton Edge authentifié.',
+    syncButton: 'Synchronisation disponible depuis le node Edge authentifié',
+    offlineNotice:
+      "⚠️ Le node Edge local n'est pas joignable. Assurez-vous d'être connecté au réseau local ou que le service Edge est démarré sur le serveur.",
+    footer: (url) => `Leopardo RH — Interface Edge locale · ${url}`,
+  },
+  en: {
+    statusCheck: 'Checking…',
+    statusOnline: 'Edge online',
+    statusOffline: 'Offline',
+    statusError: 'Connection error',
+    statusCardTitle: 'Edge node status',
+    lastSync: 'Last synchronization',
+    pendingSync: 'Pending sync',
+    pendingCount: (count) => `${count} record(s)`,
+    connecting: 'Connecting to http://leopardo.local…',
+    unreachable: 'Edge node unreachable. Punches will be recorded locally.',
+    refresh: 'Refresh',
+    syncTitle: 'Synchronization requires a nodeId and an authenticated Edge token.',
+    syncButton: 'Synchronization available from the authenticated Edge node',
+    offlineNotice:
+      '⚠️ The local Edge node is unreachable. Make sure you are connected to the local network or that the Edge service is running on the server.',
+    footer: (url) => `Leopardo RH — Local Edge interface · ${url}`,
+  },
+  tr: {
+    statusCheck: 'Kontrol ediliyor…',
+    statusOnline: 'Edge çevrimiçi',
+    statusOffline: 'Çevrimdışı',
+    statusError: 'Bağlantı hatası',
+    statusCardTitle: 'Edge düğüm durumu',
+    lastSync: 'Son senkronizasyon',
+    pendingSync: 'Bekleyen senkronizasyon',
+    pendingCount: (count) => `${count} kayıt`,
+    connecting: 'http://leopardo.local bağlanılıyor…',
+    unreachable: 'Edge düğümüne ulaşılamıyor. Yoklamalar yerel olarak kaydedilecek.',
+    refresh: 'Yenile',
+    syncTitle: 'Senkronizasyon bir nodeId ve kimliği doğrulanmış Edge jetonu gerektirir.',
+    syncButton: 'Kimliği doğrulanmış Edge düğümünden senkronizasyon mevcut',
+    offlineNotice:
+      '⚠️ Yerel Edge düğümüne ulaşılamıyor. Yerel ağa bağlı olduğunuzdan veya Edge hizmetinin sunucuda çalıştığından emin olun.',
+    footer: (url) => `Leopardo RH — Yerel Edge Arayüzü · ${url}`,
+  },
+  ar: {
+    statusCheck: 'جارٍ التحقق…',
+    statusOnline: 'Edge متصل',
+    statusOffline: 'غير متصل',
+    statusError: 'خطأ في الاتصال',
+    statusCardTitle: 'حالة عقدة Edge',
+    lastSync: 'آخر مزامنة',
+    pendingSync: 'مزامنة معلقة',
+    pendingCount: (count) => `${count} تسجيل(ات)`,
+    connecting: 'جارٍ الاتصال بـ http://leopardo.local…',
+    unreachable: 'عقدة Edge غير قابلة للوصول. سيتم تسجيل الحضور محلياً.',
+    refresh: 'تحديث',
+    syncTitle: 'تتطلب المزامنة nodeId ورمز Edge موثقاً.',
+    syncButton: 'المزامنة متاحة من عقدة Edge الموثقة',
+    offlineNotice:
+      '⚠️ عقدة Edge المحلية غير قابلة للوصول. تأكد من اتصالك بالشبكة المحلية أو من أن خدمة Edge تعمل على الخادم.',
+    footer: (url) => `ليوباردو RH — واجهة Edge المحلية · ${url}`,
+  },
+};
+
+/**
+ * Résout la locale d'interface à partir de `navigator.language` (préfixe),
+ * avec repli sur le français. `tr-TR` → tr, `ar-MA` → ar, `en-US` → en,
+ * tout autre préfixe (ou environnement sans navigator, ex. SSR) → fr.
+ */
+export function detectUiLocale(): UiLocale {
+  if (typeof navigator === 'undefined') {
+    return 'fr';
+  }
+  const lang = navigator.language.toLowerCase();
+  if (lang.startsWith('tr')) return 'tr';
+  if (lang.startsWith('ar')) return 'ar';
+  if (lang.startsWith('en')) return 'en';
+  return 'fr';
+}
+
+export function getUiCopy(locale: UiLocale = detectUiLocale()): UiCopy {
+  return uiCopy[locale] ?? uiCopy.fr;
+}

--- a/front/web-offline/tests/page.test.tsx
+++ b/front/web-offline/tests/page.test.tsx
@@ -23,6 +23,13 @@ const mockedCheck = vi.mocked(checkEdgeHealth);
 
 beforeEach(() => {
   mockedCheck.mockReset();
+  // #4806 : la copie d'interface est détectée depuis navigator.language.
+  // jsdom définit en-US par défaut → on fige fr-FR pour conserver les
+  // assertions FR historiques de cette suite.
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    value: 'fr-FR',
+  });
 });
 
 afterEach(() => {
@@ -101,5 +108,28 @@ describe('HomePage (PWA Edge)', () => {
       expect(screen.getByText('Edge en ligne')).toBeInTheDocument();
     });
     expect(mockedCheck).toHaveBeenCalledTimes(2);
+  });
+
+  it('localizes the interface from navigator.language (issue #4806)', async () => {
+    mockedCheck.mockResolvedValue({
+      status: 'online',
+      health: { status: 'healthy', node_id: 'edge-42', pending_sync: 2 },
+    });
+
+    Object.defineProperty(window.navigator, 'language', {
+      configurable: true,
+      value: 'tr-TR',
+    });
+
+    render(<HomePage />);
+
+    expect(await screen.findByText('Edge çevrimiçi')).toBeInTheDocument();
+    expect(screen.getByText('Bekleyen senkronizasyon')).toBeInTheDocument();
+    expect(screen.getByText('2 kayıt')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Yenile' })).toBeInTheDocument();
+    // Chaînes techniques non traduites : la marque et le libellé Statut restent
+    // inchangés quelle que soit la locale.
+    expect(screen.getByText('Leopardo Edge')).toBeInTheDocument();
+    expect(screen.getByText('Statut')).toBeInTheDocument();
   });
 });

--- a/front/web/src/app/(landing)/download/page.tsx
+++ b/front/web/src/app/(landing)/download/page.tsx
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useDarkMode } from '@/modules/vitrine/hooks/useDarkMode';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
@@ -423,7 +424,26 @@ const platformLabels: Record<AppLocale, Array<{ platform: string; title: string;
   ],
 };
 
-export default function DownloadPage() {
+// #4799 (partie 2) : deep links /download?platform=<alias> provenant du Navbar
+// (et d'ailleurs). Les alias sont résolus case-insensitive vers le slug d'ancre
+// cible : cartes bureau (platform-windows / platform-macos), cartes mobile
+// (platform-android / platform-iphone) ou carte Platform Admin du bloc
+// applications mobiles (platform-platform-admin).
+const PLATFORM_SLUG_ALIASES: Record<string, string> = {
+  windows: 'windows',
+  win: 'windows',
+  macos: 'macos',
+  mac: 'macos',
+  android: 'android',
+  ios: 'iphone',
+  iphone: 'iphone',
+  'platform-admin': 'platform-admin',
+  admin: 'platform-admin',
+};
+
+const HIGHLIGHT_CLASS = 'ring-2 ring-emerald-400 ring-offset-2 dark:ring-offset-slate-950';
+
+function DownloadPageInner() {
   const { isDark, toggleDarkMode } = useDarkMode();
   useScrollReveal();
   const { locale, direction } = useVitrineLocale();
@@ -431,6 +451,39 @@ export default function DownloadPage() {
   const platforms = platformLabels[locale as AppLocale] ?? platformLabels.fr;
   const mobileApps = mobileAppsData[locale as AppLocale] ?? mobileAppsData.fr;
   const kiosk = kioskCopy[locale as AppLocale] ?? kioskCopy.fr;
+
+  const searchParams = useSearchParams();
+  const platformParam = searchParams.get('platform');
+  const [highlightedSlug, setHighlightedSlug] = useState<string | null>(null);
+  const highlightTimerRef = useRef<number | null>(null);
+
+  // #4799 : scroll + surbrillance temporaire (~2 s) vers la carte ciblée par
+  // ?platform=. Petit délai avant le scroll : le reflow initial (polices,
+  // layout, animations d'entrée) annulerait sinon le scrollIntoView.
+  useEffect(() => {
+    if (!platformParam) {
+      return;
+    }
+    const slug = PLATFORM_SLUG_ALIASES[platformParam.trim().toLowerCase()];
+    if (!slug) {
+      return;
+    }
+    const scrollTimer = window.setTimeout(() => {
+      const el = document.getElementById(`platform-${slug}`);
+      if (!el) {
+        return;
+      }
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setHighlightedSlug(slug);
+      highlightTimerRef.current = window.setTimeout(() => setHighlightedSlug(null), 2000);
+    }, 100);
+    return () => {
+      window.clearTimeout(scrollTimer);
+      if (highlightTimerRef.current) {
+        window.clearTimeout(highlightTimerRef.current);
+      }
+    };
+  }, [platformParam]);
 
   return (
     <div dir={direction} className={`min-h-screen transition-colors duration-500 ${isDark ? 'dark bg-slate-950' : 'bg-white'}`}>
@@ -475,20 +528,26 @@ export default function DownloadPage() {
       <section className="relative -mt-10 pb-16">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {platforms.map((item) => (
-              <Link
-                key={item.platform}
-                href={item.href}
-                className="rounded-2xl border border-slate-200/80 dark:border-slate-800/80 bg-white dark:bg-slate-900 p-5 shadow-sm hover:border-emerald-300 hover:shadow-lg transition-all"
-              >
-                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-950/50 dark:text-emerald-300">
-                  {item.platform === 'Android' || item.platform === 'iPhone' ? <Smartphone className="h-5 w-5" /> : <Laptop className="h-5 w-5" />}
-                </div>
-                <p className="text-xs font-bold uppercase tracking-[0.16em] text-emerald-600 dark:text-emerald-400">{item.platform}</p>
-                <h2 className="mt-2 text-base font-black text-slate-900 dark:text-white">{item.title}</h2>
-                <p className="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">{item.description}</p>
-              </Link>
-            ))}
+            {platforms.map((item) => {
+              const platformSlug = item.platform.toLowerCase();
+              return (
+                <Link
+                  key={item.platform}
+                  id={`platform-${platformSlug}`}
+                  href={item.href}
+                  className={`rounded-2xl border border-slate-200/80 dark:border-slate-800/80 bg-white dark:bg-slate-900 p-5 shadow-sm hover:border-emerald-300 hover:shadow-lg transition-all ${
+                    highlightedSlug === platformSlug ? HIGHLIGHT_CLASS : ''
+                  }`}
+                >
+                  <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-950/50 dark:text-emerald-300">
+                    {item.platform === 'Android' || item.platform === 'iPhone' ? <Smartphone className="h-5 w-5" /> : <Laptop className="h-5 w-5" />}
+                  </div>
+                  <p className="text-xs font-bold uppercase tracking-[0.16em] text-emerald-600 dark:text-emerald-400">{item.platform}</p>
+                  <h2 className="mt-2 text-base font-black text-slate-900 dark:text-white">{item.title}</h2>
+                  <p className="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">{item.description}</p>
+                </Link>
+              );
+            })}
           </div>
         </div>
       </section>
@@ -603,11 +662,14 @@ export default function DownloadPage() {
               return (
                 <motion.div
                   key={app.name}
+                  id={`platform-${app.slug}`}
                   initial={{ opacity: 0, y: 30 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.5, delay: index * 0.1 }}
-                  className="rounded-2xl bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800/80 p-6 shadow-sm hover:shadow-lg hover:border-emerald-200 dark:hover:border-emerald-800/50 transition-all"
+                  className={`rounded-2xl bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800/80 p-6 shadow-sm hover:shadow-lg hover:border-emerald-200 dark:hover:border-emerald-800/50 transition-all ${
+                    highlightedSlug === app.slug ? HIGHLIGHT_CLASS : ''
+                  }`}
                 >
                 <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-emerald-50 to-cyan-50 dark:from-emerald-950/50 dark:to-cyan-950/50 text-emerald-600 dark:text-emerald-400 flex items-center justify-center mb-4">
                   <Smartphone className="w-6 h-6" />
@@ -723,6 +785,16 @@ export default function DownloadPage() {
 
       <Footer />
     </div>
+  );
+}
+
+// #4799 : useSearchParams nécessite un boundary Suspense (Next.js 16) —
+// même pattern que /contact et /checkout.
+export default function DownloadPage() {
+  return (
+    <Suspense fallback={null}>
+      <DownloadPageInner />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
Audit 360° — résiduels web :

- **#4799** (volet 2) — Le deep link `/download?platform=` était inerte : la page réagit désormais au paramètre (aliases windows/macos/android/ios/platform-admin), scroll + surbrillance de la carte cible (Suspense pour useSearchParams, pattern /contact).
- **#4806** — web-offline (PWA secours kiosk/edge) : littéraux FR codés en dur → carte de copy fr/en/tr/ar détectée depuis navigator.language (nouveau `lib/ui-copy.ts`).

Validation : tsc 0 erreur, eslint 0, vitest 23/23 (dont nouveau test tr-TR), front/web tsc 0.