### PR TITLE
fix(mobile): deep links Android manager + hr — intent-filters (Closes #4304)

### DIFF
--- a/front/mobile_apps/leopardo_hr/android/app/src/main/AndroidManifest.xml
+++ b/front/mobile_apps/leopardo_hr/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,21 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Issue #3867 : deep links — les notifications et liens partagés
+                 ouvrent l'app sur la route cible (convention leopardo://hr/<route>).
+                 Les routes sont résolues par GoRouter (initialLocation depuis le lien). -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="leopardo" android:host="hr"/>
+            </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="app.leopardo-rh.com" android:pathPrefix="/hr"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/front/mobile_apps/leopardo_manager/android/app/src/main/AndroidManifest.xml
+++ b/front/mobile_apps/leopardo_manager/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,21 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Issue #3867 : deep links — les notifications et liens partagés
+                 ouvrent l'app sur la route cible (convention leopardo://manager/<route>).
+                 Les routes sont résolues par GoRouter (initialLocation depuis le lien). -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="leopardo" android:host="manager"/>
+            </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="app.leopardo-rh.com" android:pathPrefix="/manager"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
Résiduel #4304 — les apps manager/hr ne déclaraient aucun intent-filter de deep link (seul employee en avait, #3867) :

- leopardo_manager : `leopardo://manager/<route>` + `https://app.leopardo-rh.com/manager`
- leopardo_hr : `leopardo://hr/<route>` + `https://app.leopardo-rh.com/hr`
- GoRouter (déjà en place dans les 3 apps) intercepte les liens entrants ; aucune modification Dart nécessaire.
- iOS : les CFBundleURLTypes ne sont pas déclarés côté employee non plus — suivi séparé (requiert validation Flutter/iOS).