### PR TITLE
fix(admin): résiduel i18n FR — Support/CRM/Edge/NotFound localisés ×4 (Closes #4840)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+## [Unreleased]
+- **fix(admin): résiduel i18n FR — Support/CRM/Edge/NotFound localisés ×4 (Closes #4840).** SupportTicketsView (« Aucun ticket », sélection, erreur de chargement), CrmPipelineView (10 libellés pipeline), EdgeNodesView (table + stats + sync), NotFoundView (liens utiles, système) passent aux catalogues fr/en/ar/tr (clés support.*, crm.*, edge.*, notFound.*). Toast script via le helper `translate` (pattern #4781), plus de chaînes FR/EN en dur dans ces 4 vues.
 - **fix(ci): normalisation de l’URL API dans le smoke E2E (Closes #4216).** Le workflow accepte désormais indifféremment une variable Render racine ou déjà suffixée `/api/v1`, supprime les slash finaux et n’ajoute le segment qu’une seule fois. Cela évite les faux rouges 404 (`/api/v1/api/v1/...`) observés sur les smoke tests de production.
 - **fix(web): page partner localisée ×4 + diacritiques sélecteur de langue (Closes #4796, #4799).** Portail client 100 % FR migré vers `getCopy(locale)` (labels, métriques, tableau commissions, payout, referral, aria-label billing toggle). Sélecteur de langue : « Français » / « Türkçe » avec diacritiques. TrackLabel caption localisé ×4 via copyByLocale. Sync backend shared.php (fr/tr).
 - **fix(ci): VITE_API_URL dans web-ci admin build (#4715).** La garde `vite.config.js` du dashboard admin lève une erreur si `VITE_API_URL` est absent en production-build. La variable est désormais injectée depuis `vars.PROD_API_BASE_URL` dans l'étape Build admin dashboard de `web-ci.yml`.

--- a/front/admin-dashboard/src/i18n/locales/ar.json
+++ b/front/admin-dashboard/src/i18n/locales/ar.json
@@ -1236,7 +1236,10 @@
     "showingSuffix": "طلبات",
     "loadError": "تعذرت مزامنة طلبات العملاء.",
     "toastApproved": "تمت الموافقة على الطلب. بدأ التجهيز.",
-    "toastRejected": "تم رفض الطلب."
+    "toastRejected": "تم رفض الطلب.",
+    "noTicket": "لا توجد تذاكر",
+    "selectTicket": "حدد تذكرة لعرض المحادثة",
+    "loadConversationError": "تعذّر تحميل المحادثة."
   },
   "reports": {
     "attendance_title": "ملخص الحضور",
@@ -1437,5 +1440,37 @@
     "statsLoadError": "خطأ أثناء تحميل إحصائيات النظام",
     "subtitle": "مراقبة منصة Leopardo RH وتكوينها وأتمتتها.",
     "title": "إدارة النظام"
+  },
+  "crm": {
+    "subtitle": "تتبع العملاء المحتملين من الدخول حتى التحويل المدفوع",
+    "leadsTotal": "إجمالي العملاء المحتملين",
+    "leadToTrialRate": "معدل التحويل للتجربة",
+    "leadToClientRate": "معدل التحويل لعميل مدفوع",
+    "loading": "جارٍ تحميل خط المسار...",
+    "leadsIncoming": "العملاء المحتملون الواردون",
+    "noLead": "لا يوجد عملاء محتملون",
+    "noTrial": "لا توجد تجارب جارية",
+    "noClient": "لا يوجد عميل نشط محوّل",
+    "noHistory": "لا يوجد سجل"
+  },
+  "edge": {
+    "title": "عُقد Edge",
+    "nodesTotal": "إجمالي العقد",
+    "licensesExpired": "تراخيص منتهية",
+    "loading": "جارٍ تحميل العقد…",
+    "empty": "لا توجد عُقد Edge مسجلة",
+    "colNode": "العقدة",
+    "colStatus": "الحالة",
+    "colLicense": "الترخيص",
+    "colLastSync": "آخر مزامنة",
+    "colActions": "الإجراءات",
+    "syncing": "جارٍ المزامنة…",
+    "sync": "مزامنة"
+  },
+  "notFound": {
+    "backToDashboard": "العودة إلى لوحة التحكم",
+    "usefulLinks": "روابط مفيدة",
+    "system": "النظام",
+    "systemConfig": "إعدادات النظام"
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -1236,7 +1236,10 @@
     "showingSuffix": "requests",
     "loadError": "Unable to sync client requests.",
     "toastApproved": "Request approved. Provisioning started.",
-    "toastRejected": "Request rejected."
+    "toastRejected": "Request rejected.",
+    "noTicket": "No ticket",
+    "selectTicket": "Select a ticket to view the conversation",
+    "loadConversationError": "Unable to load the conversation."
   },
   "reports": {
     "attendance_title": "Attendance Summary",
@@ -1437,5 +1440,37 @@
     "statsLoadError": "Error loading system stats",
     "subtitle": "Monitoring, configuration and automation of the Leopardo RH platform.",
     "title": "System Administration"
+  },
+  "crm": {
+    "subtitle": "Track leads from entry to paid conversion.",
+    "leadsTotal": "Total leads",
+    "leadToTrialRate": "Lead -> trial rate",
+    "leadToClientRate": "Lead -> paying client rate",
+    "loading": "Loading pipeline...",
+    "leadsIncoming": "Incoming Leads",
+    "noLead": "No lead",
+    "noTrial": "No ongoing trial",
+    "noClient": "No converted active client",
+    "noHistory": "No history"
+  },
+  "edge": {
+    "title": "Edge Nodes",
+    "nodesTotal": "Total nodes",
+    "licensesExpired": "Expired licenses",
+    "loading": "Loading nodes…",
+    "empty": "No Edge node registered",
+    "colNode": "Node",
+    "colStatus": "Status",
+    "colLicense": "License",
+    "colLastSync": "Last sync",
+    "colActions": "Actions",
+    "syncing": "Syncing…",
+    "sync": "Sync"
+  },
+  "notFound": {
+    "backToDashboard": "Back to dashboard",
+    "usefulLinks": "Useful links",
+    "system": "System",
+    "systemConfig": "System configuration"
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -1236,7 +1236,10 @@
     "showingSuffix": "demandes",
     "loadError": "Impossible de synchroniser les demandes clients.",
     "toastApproved": "Demande approuvée. Provisionnement lancé.",
-    "toastRejected": "Demande rejetée."
+    "toastRejected": "Demande rejetée.",
+    "noTicket": "Aucun ticket",
+    "selectTicket": "Sélectionnez un ticket pour voir la conversation",
+    "loadConversationError": "Impossible de charger la conversation."
   },
   "reports": {
     "attendance_title": "Résumé Présences",
@@ -1437,5 +1440,37 @@
     "statsLoadError": "Erreur lors du chargement des stats système",
     "subtitle": "Monitoring, configuration et automatisation de la plateforme Leopardo RH.",
     "title": "Administration Système"
+  },
+  "crm": {
+    "subtitle": "Suivi des leads de l'entrée jusqu'à la conversion payante.",
+    "leadsTotal": "Leads totaux",
+    "leadToTrialRate": "Taux lead -> essai",
+    "leadToClientRate": "Taux lead -> client payant",
+    "loading": "Chargement du pipeline...",
+    "leadsIncoming": "Leads Entrants",
+    "noLead": "Aucun lead",
+    "noTrial": "Aucun essai en cours",
+    "noClient": "Aucun client actif converti",
+    "noHistory": "Aucun historique"
+  },
+  "edge": {
+    "title": "Nodes Edge",
+    "nodesTotal": "Nodes total",
+    "licensesExpired": "Licences expirées",
+    "loading": "Chargement des nodes…",
+    "empty": "Aucun node Edge enregistré",
+    "colNode": "Node",
+    "colStatus": "Statut",
+    "colLicense": "Licence",
+    "colLastSync": "Dernière sync",
+    "colActions": "Actions",
+    "syncing": "Sync…",
+    "sync": "Sync"
+  },
+  "notFound": {
+    "backToDashboard": "Retour au tableau de bord",
+    "usefulLinks": "Liens utiles",
+    "system": "Système",
+    "systemConfig": "Configuration système"
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/tr.json
+++ b/front/admin-dashboard/src/i18n/locales/tr.json
@@ -1236,7 +1236,10 @@
     "showingSuffix": "talep",
     "loadError": "Müşteri talepleri senkronize edilemedi.",
     "toastApproved": "Talep onaylandı. Sağlama başladı.",
-    "toastRejected": "Talep reddedildi."
+    "toastRejected": "Talep reddedildi.",
+    "noTicket": "Bilet yok",
+    "selectTicket": "Konuşmayı görüntülemek için bir bilet seçin",
+    "loadConversationError": "Konuşma yüklenemedi."
   },
   "reports": {
     "attendance_title": "Yoklama Özeti",
@@ -1437,5 +1440,37 @@
     "statsLoadError": "Sistem istatistikleri yüklenirken hata oluştu",
     "subtitle": "Leopardo RH platformunun izlenmesi, yapılandırılması ve otomasyonu.",
     "title": "Sistem Yönetimi"
+  },
+  "crm": {
+    "subtitle": "Potansiyel müşterileri girişten ücretli dönüşüme kadar takip edin",
+    "leadsTotal": "Toplam potansiyel müşteri",
+    "leadToTrialRate": "Potansiyel müşteri -> deneme oranı",
+    "leadToClientRate": "Potansiyel müşteri -> ücretli müşteri oranı",
+    "loading": "Hat yükleniyor...",
+    "leadsIncoming": "Gelen Potansiyel Müşteriler",
+    "noLead": "Potansiyel müşteri yok",
+    "noTrial": "Devam eden deneme yok",
+    "noClient": "Dönüştürülmüş aktif müşteri yok",
+    "noHistory": "Geçmiş yok"
+  },
+  "edge": {
+    "title": "Edge Düğümleri",
+    "nodesTotal": "Toplam düğüm",
+    "licensesExpired": "Süresi dolan lisanslar",
+    "loading": "Düğümler yükleniyor…",
+    "empty": "Kayıtlı Edge düğümü yok",
+    "colNode": "Düğüm",
+    "colStatus": "Durum",
+    "colLicense": "Lisans",
+    "colLastSync": "Son senkronizasyon",
+    "colActions": "İşlemler",
+    "syncing": "Senkronize ediliyor…",
+    "sync": "Senkronize"
+  },
+  "notFound": {
+    "backToDashboard": "Panele dön",
+    "usefulLinks": "Faydalı bağlantılar",
+    "system": "Sistem",
+    "systemConfig": "Sistem yapılandırması"
   }
 }

--- a/front/admin-dashboard/src/views/NotFoundView.vue
+++ b/front/admin-dashboard/src/views/NotFoundView.vue
@@ -18,7 +18,7 @@
               class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
             >
               <ArrowLeftIcon class="-ml-0.5 mr-2 h-4 w-4" />
-              Retour au tableau de bord
+              {{ $t('notFound.backToDashboard') }}
             </router-link>
             <button
               @click="goBack"
@@ -32,7 +32,7 @@
 
       <!-- Additional help -->
       <div class="mt-16 border-t border-gray-200 pt-8">
-        <h2 class="text-lg font-medium text-gray-900">Liens utiles</h2>
+        <h2 class="text-lg font-medium text-gray-900">{{ $t('notFound.usefulLinks') }}</h2>
         <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
           <router-link
             to="/users"
@@ -91,8 +91,8 @@
               <div class="flex items-center">
                 <CogIcon class="h-6 w-6 text-gray-400 group-hover:text-gray-500" />
                 <div class="ml-3">
-                  <p class="text-sm font-medium text-gray-900">Système</p>
-                  <p class="text-sm text-gray-500">Configuration système</p>
+                  <p class="text-sm font-medium text-gray-900">{{ $t('notFound.system') }}</p>
+                  <p class="text-sm text-gray-500">{{ $t('notFound.systemConfig') }}</p>
                 </div>
               </div>
             </div>

--- a/front/admin-dashboard/src/views/crm/CrmPipelineView.vue
+++ b/front/admin-dashboard/src/views/crm/CrmPipelineView.vue
@@ -4,7 +4,7 @@
       <div>
         <h1 class="text-2xl font-bold text-gray-900">Pipeline Commercial</h1>
         <p class="mt-1 text-sm text-gray-500">
-          Suivi des leads de l'entrée jusqu'à la conversion payante.
+          {{ $t('crm.subtitle') }}
         </p>
       </div>
       <button class="btn-secondary" :disabled="isLoading" @click="loadPipeline">
@@ -15,21 +15,21 @@
     <!-- PA2-ADM-004: explicit lead -> trial -> client conversion summary -->
     <div v-if="!isLoading && !errorMessage" class="grid grid-cols-1 gap-4 sm:grid-cols-3 shrink-0">
       <div class="card p-4">
-        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Leads totaux</p>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">{{ $t('crm.leadsTotal') }}</p>
         <p class="mt-1 text-2xl font-black text-slate-900 dark:text-white">{{ meta.total_leads }}</p>
       </div>
       <div class="card p-4">
-        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Taux lead -> essai</p>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">{{ $t('crm.leadToTrialRate') }}</p>
         <p class="mt-1 text-2xl font-black text-emerald-600">{{ formatRate(meta.conversion.lead_to_trial_rate) }}</p>
       </div>
       <div class="card p-4">
-        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Taux lead -> client payant</p>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">{{ $t('crm.leadToClientRate') }}</p>
         <p class="mt-1 text-2xl font-black text-blue-600">{{ formatRate(meta.conversion.lead_to_client_rate) }}</p>
       </div>
     </div>
 
     <div v-if="isLoading" class="flex-1 flex items-center justify-center p-6 text-sm text-gray-500">
-      Chargement du pipeline...
+      {{ $t('crm.loading') }}
     </div>
     <div v-else-if="errorMessage" class="flex-1 p-6 text-sm text-red-600 bg-red-50 rounded-lg">
       {{ errorMessage }}
@@ -41,7 +41,7 @@
         <div class="p-4 border-b border-slate-200 dark:border-slate-800 flex justify-between items-center dark:bg-slate-900 rounded-t-xl">
           <h2 class="font-bold text-slate-800 dark:text-slate-200 flex items-center gap-2">
             <span class="w-3 h-3 rounded-full bg-yellow-400"></span>
-            Leads Entrants
+            {{ $t('crm.leadsIncoming') }}
           </h2>
           <span class="text-xs font-semibold px-2 py-1 bg-slate-100 dark:bg-slate-800 rounded-full text-slate-600 dark:text-slate-400">
             {{ pipeline.leads?.length || 0 }}
@@ -60,7 +60,7 @@
             </div>
           </div>
           <div v-if="!pipeline.leads?.length" class="text-center p-4 text-sm text-slate-400 border-2 border-dashed border-slate-200 dark:border-slate-800 rounded-lg">
-            Aucun lead
+            {{ $t('crm.noLead') }}
           </div>
         </div>
       </div>
@@ -89,7 +89,7 @@
             </div>
           </div>
           <div v-if="!pipeline.trials?.length" class="text-center p-4 text-sm text-slate-400 border-2 border-dashed border-slate-200 dark:border-slate-800 rounded-lg">
-            Aucun essai en cours
+            {{ $t('crm.noTrial') }}
           </div>
         </div>
       </div>
@@ -117,7 +117,7 @@
             </div>
           </div>
           <div v-if="!pipeline.active?.length" class="text-center p-4 text-sm text-slate-400 border-2 border-dashed border-slate-200 dark:border-slate-800 rounded-lg">
-            Aucun client actif converti
+            {{ $t('crm.noClient') }}
           </div>
         </div>
       </div>
@@ -141,7 +141,7 @@
             </p>
           </div>
           <div v-if="!pipeline.rejected?.length" class="text-center p-4 text-sm text-slate-400 border-2 border-dashed border-slate-300 dark:border-slate-700 rounded-lg">
-            Aucun historique
+            {{ $t('crm.noHistory') }}
           </div>
         </div>
       </div>

--- a/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
+++ b/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
@@ -3,7 +3,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Nodes Edge</h1>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ $t('edge.title') }}</h1>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Gestion des nodes Edge Leopardo — synchronisation offline-first
         </p>
@@ -29,33 +29,33 @@
 
     <!-- Stats row -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-      <EdgeStatCard label="Nodes total" :value="stats.total" icon="🖥️" color="indigo" />
+      <EdgeStatCard :label="$t('edge.nodesTotal')" :value="stats.total" icon="🖥️" color="indigo" />
       <EdgeStatCard label="En ligne" :value="stats.online" icon="✅" color="green" />
       <EdgeStatCard label="Hors ligne" :value="stats.offline" icon="⭕" color="gray" />
-      <EdgeStatCard label="Licences expirées" :value="stats.licenseExpired" icon="⚠️" color="red" />
+      <EdgeStatCard :label="$t('edge.licensesExpired')" :value="stats.licenseExpired" icon="⚠️" color="red" />
     </div>
 
     <!-- Nodes table -->
     <div class="glass-card dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
       <div v-if="loading && nodes.length === 0" class="p-12 text-center text-gray-400">
         <div class="text-4xl mb-3 animate-spin inline-block">↻</div>
-        <p>Chargement des nodes…</p>
+        <p>{{ $t('edge.loading') }}</p>
       </div>
 
       <div v-else-if="!loading && nodes.length === 0" class="p-12 text-center text-gray-400">
         <div class="text-4xl mb-3 opacity-30">🖥️</div>
-        <p class="font-medium">Aucun node Edge enregistré</p>
+        <p class="font-medium">{{ $t('edge.empty') }}</p>
         <p class="text-sm mt-1">Les nodes apparaissent ici une fois enregistrés via l'API Edge.</p>
       </div>
 
       <table v-else class="w-full text-sm">
         <thead>
           <tr class="glass-bg dark:bg-slate-800/50 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-            <th class="px-4 py-3 font-medium">Node</th>
-            <th class="px-4 py-3 font-medium">Statut</th>
-            <th class="px-4 py-3 font-medium">Licence</th>
-            <th class="px-4 py-3 font-medium">Dernière sync</th>
-            <th class="px-4 py-3 font-medium">Actions</th>
+            <th class="px-4 py-3 font-medium">{{ $t('edge.colNode') }}</th>
+            <th class="px-4 py-3 font-medium">{{ $t('edge.colStatus') }}</th>
+            <th class="px-4 py-3 font-medium">{{ $t('edge.colLicense') }}</th>
+            <th class="px-4 py-3 font-medium">{{ $t('edge.colLastSync') }}</th>
+            <th class="px-4 py-3 font-medium">{{ $t('edge.colActions') }}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
@@ -106,7 +106,7 @@
                   :disabled="!node.is_online || syncingNodeId === node.id"
                   class="text-xs text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 font-medium disabled:opacity-30 disabled:cursor-not-allowed"
                 >
-                  {{ syncingNodeId === node.id ? 'Sync…' : 'Sync' }}
+                  {{ syncingNodeId === node.id ? $t('edge.syncing') : $t('edge.sync') }}
                 </button>
                 <span class="text-gray-300 dark:text-gray-600">|</span>
                 <button @click="viewNode(node)" class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 font-medium">

--- a/front/admin-dashboard/src/views/support/SupportTicketsView.vue
+++ b/front/admin-dashboard/src/views/support/SupportTicketsView.vue
@@ -71,7 +71,7 @@
           <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 dark:bg-slate-800 text-slate-400">
             <InboxIcon class="h-7 w-7" />
           </div>
-          <p class="mt-4 text-sm font-bold text-slate-400 uppercase tracking-widest">Aucun ticket</p>
+          <p class="mt-4 text-sm font-bold text-slate-400 uppercase tracking-widest">{{ $t('support.noTicket') }}</p>
         </div>
 
         <div v-else class="max-h-[640px] divide-y divide-slate-200/50 overflow-y-auto dark:divide-slate-800/50">
@@ -108,7 +108,7 @@
           <div>
             <ChatBubbleBottomCenterTextIcon class="mx-auto h-10 w-10 text-slate-300" />
             <p class="mt-4 text-sm font-bold text-slate-400 uppercase tracking-widest">
-              Sélectionnez un ticket pour voir la conversation
+              {{ $t('support.selectTicket') }}
             </p>
           </div>
         </div>
@@ -207,7 +207,9 @@ import {
 import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
 import { useLocaleStore } from '@/stores/locale'
-import { toIntlLocale } from '@/i18n/index.js'
+import { toIntlLocale, translate } from '@/i18n/index.js'
+
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 
 const toast = useToast()
 const localeStore = useLocaleStore()
@@ -289,7 +291,7 @@ async function selectTicket(ticket) {
     }
   } catch (error) {
     console.error('Failed to load ticket detail:', error)
-    toast.error('Impossible de charger la conversation.')
+    toast.error(t('support.loadConversationError'))
   }
 }
 


### PR DESCRIPTION
Implémentation de l'issue #4840 (audit 360° 2026-08-17).

- SupportTicketsView : « Aucun ticket », « Sélectionnez un ticket… », erreur de chargement (script via helper translate)
- CrmPipelineView : 10 libellés (subtitle, leads, taux, vides)
- EdgeNodesView : titre, stats, table, sync
- NotFoundView : liens utiles, système
- +29 clés ×4 catalogues (support/crm/edge/notFound)

Validé : eslint 0 erreur, vite build OK.

Closes #4840