### PR TITLE
fix(ci): guard I18N — translate() reconnu comme mécanisme i18n + tokens https:/wss: (faux positifs PA2-I18N-014)

### DIFF
--- a/dev-hub/tools/check-i18n-diff.js
+++ b/dev-hub/tools/check-i18n-diff.js
@@ -71,7 +71,7 @@ const ignorePathFragments = [
 // Lines that already route text through a translation mechanism — never
 // flagged even if they also contain a literal (e.g. the French fallback
 // key text of a translation catalog entry itself).
-const translationCallPattern = /(context\.l10n\.|AppLocalizations\.of|\bl10n\.|__\(|\$t\(|\bt\(['"]|i18n\.t\(|data-i18n|useTranslation|\bt`|Lang::get\(|trans\(|@lang\()/;
+const translationCallPattern = /(context\.l10n\.|AppLocalizations\.of|\bl10n\.|__\(|\$t\(|\bt\(['"]|i18n\.t\(|data-i18n|useTranslation|\bt`|Lang::get\(|trans\(|@lang\(|translate\()/;
 
 const devLogLinePattern = /\b(console\.(log|warn|error|info|debug)|debugPrint|print(?:ln)?|Log\.[dewiv]|logger\.(debug|info|warn|error)|dev\.log)\s*\(/i;
 const todoLinePattern = /\/\/\s*TODO|#\s*TODO/i;
@@ -109,7 +109,7 @@ function isTechnicalToken(value) {
   if (/^#[a-zA-Z][\w-]*$/.test(trimmed)) return true;
   if (trimmed === 'use client' || trimmed === 'use server' || trimmed === 'use strict') return true;
   if (/^@?[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+$/.test(trimmed)) return true;
-  return /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|Bearer\s|https?:\/\/|api\/|\/api|[A-Z_]{2,})$/.test(trimmed);
+  return /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|Bearer\s|https?:\/\/|wss?:\/\/|https?:|wss?:|api\/|\/api|[A-Z_]{2,})$/.test(trimmed);
 }
 
 function isCodeExpression(value) {


### PR DESCRIPTION
## Résumé
Le guard `check-i18n-diff.js` (PA2-I18N-014) produit des **faux positifs** sur du code i18n légitime — constaté sur #4760 (3 violations pour 2 vrais-faux + 1 technique) :

1. `translate(locale, key, fallback)` — helper i18n de premier rang dans l\u0027admin (ex. UserDetailModal, UsersView) — n\u0027était **pas** dans `translationCallPattern` (seuls `$t(`, `t(`, `i18n.t(`, `__()`… l\u0027étaient) → les fallbacks FR légitimes étaient flaggés.
2. `\u0027https:\u0027` / `\u0027wss:\u0027` (protocoles) flaggés comme chaînes user-visibles (faux positif technique, ex. realtime.js).

## Changements
- `translationCallPattern` : ajout de `translate\u0027(`.
- `isTechnicalToken` : ajout de `https?:` / `wss?:` (et `wss?:\/\/`).

## Validation
- Probe diff synthétique : `translate(…, \u0027À l\u0027instant\u0027)` + `\u0027https:\u0027` **non flaggés** ; une vraie chaîne FR brute (« Erreur de connexion brute ») **toujours flaggée**.
- Aucun changement de comportement pour les autres surfaces.

Closes #4818