### PR TITLE
fix(tests): bootstrap hermétique — reset shared_tenants avant migrate:fresh (Closes https://github.com/kitokoh/leopardo-hr/issues/4853)

### DIFF
--- a/api/tests/RefreshTenantDatabase.php
+++ b/api/tests/RefreshTenantDatabase.php
@@ -41,6 +41,18 @@ trait RefreshTenantDatabase
             config(["database.connections.{$name}.search_path" => 'public']);
             DB::purge($name);
             DB::reconnect($name);
+
+            // Réinitialisation COMPLÈTE des deux schémas. Sans ce DROP, les
+            // fichiers qui utilisent `CreatesMvpSchema` (AI*Test,
+            // QaHardeningEndpointsTest, Platform*Test...) laissent un schéma
+            // `shared_tenants` PARTIEL (fixture mvp + DROP SCHEMA du repo
+            // migrations) : le `migrate:fresh` suivant ne droppe que les
+            // tables publiques (db:wipe limité au search_path=public) et les
+            // migrations tenant re-créent des tables déjà présentes
+            // (`relation "projects" already exists`, 42P07) → toute la suite
+            // Feature en aval échoue en cascade. Observé 2026-08-17.
+            DB::statement('DROP SCHEMA IF EXISTS shared_tenants CASCADE');
+            DB::statement('CREATE SCHEMA IF NOT EXISTS shared_tenants');
         }
 
         try {


### PR DESCRIPTION
## Problème

La suite Feature complète (process unique) échoue en cascade à partir des fichiers `Absences/*` : `SQLSTATE[42P07] relation "projects" already exists`, causé par les fichiers `CreatesMvpSchema` qui laissent un schéma `shared_tenants` partiel (fixture mvp) sans repo migrations.

## Correctif

`runPublicMigrations()` : `DROP SCHEMA IF EXISTS shared_tenants CASCADE` + recréation avant le `migrate:fresh` — chaque bootstrap devient hermétique (aligné sur le comportement du CI qui part d'une base neuve).

## Validation

- Reproduit localement (PHP 8.4 + PG 16) : `AIWriteActionConfirmationTest|AIGatewayAndAnalyticsTest|AbsenceApproveTest` → **23 passed (102 assertions)** avant : 42P07 sur AbsenceApproveTest.
- Suite Feature complète en cours sur base fraîche.
- `php -l` OK.

Closes #4853
