### PR TITLE
fix(api): Task.status fillable — PATCH persisté + score régularité exact (Closes #4861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+
+- **fix(api): Task.status réintégré au fillable — PATCH statut persisté + score régularité exact (Closes #4861).** `status` manquait au `$fillable` de `Task` : `update()` l'écartait silencieusement (un employé marquant sa tâche « done » ne changeait rien) et `AttendanceRegularityService::taskCompletion()` comptait 0 tâche terminée → `task_completion.score` toujours 0 → test `AttendanceRegularityTest` rouge.
 ## [Unreleased]
 - **fix(admin): résiduel i18n FR — Support/CRM/Edge/NotFound localisés ×4 (Closes #4840).** SupportTicketsView (« Aucun ticket », sélection, erreur de chargement), CrmPipelineView (10 libellés pipeline), EdgeNodesView (table + stats + sync), NotFoundView (liens utiles, système) passent aux catalogues fr/en/ar/tr (clés support.*, crm.*, edge.*, notFound.*). Toast script via le helper `translate` (pattern #4781), plus de chaînes FR/EN en dur dans ces 4 vues.
 - **fix(api/i18n): messages contrôleurs localisés (Closes #4841).** JobPostingActionController (publish/close/destroy) et TaskController (delete) renvoyaient des messages EN en dur. 5 clés ajoutées au catalogue errors.* ×4 locales (fr/en/ar/tr) : JOB_POSTING_DRAFT_ONLY_PUBLISH, JOB_POSTING_PUBLISHED_ONLY_CLOSE, JOB_POSTING_DRAFT_ONLY_DELETE, JOB_POSTING_DELETED, TASK_DELETED — référencées via `__('errors.…')`.

--- a/api/app/Modules/Planning/Domain/Models/Task.php
+++ b/api/app/Modules/Planning/Domain/Models/Task.php
@@ -47,7 +47,7 @@ class Task extends Model
 
     protected $table = 'tasks';
 
-    protected $fillable = ['company_id', 'title', 'description', 'created_by', 'assigned_to', 'project_id', 'due_date', 'priority', 'estimated_minutes', 'completed_minutes', 'completed_at', 'completion_note', 'recurrence_rule', 'template_key', 'category', 'checklist', 'visibility'];
+    protected $fillable = ['company_id', 'title', 'description', 'created_by', 'assigned_to', 'project_id', 'due_date', 'priority', 'estimated_minutes', 'completed_minutes', 'completed_at', 'completion_note', 'recurrence_rule', 'template_key', 'category', 'checklist', 'visibility', 'status'];
 
     protected $casts = ['assigned_to' => 'array', 'checklist' => 'array', 'due_date' => 'datetime', 'completed_at' => 'datetime', 'performance_score' => 'decimal:2', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
 


### PR DESCRIPTION
## Problème

`status` manquait au `$fillable` du modèle `Task` :

1. `PATCH /api/v1/tasks/{id}` valide `status` puis fait `$task->update($data)` → mass-assignment écarté → **un employé qui marque sa tâche « done » ne change rien** (statut silencieusement ignoré, reste 'todo').
2. `AttendanceRegularityService::taskCompletion()` filtre `status === 'done'` → toujours 0 tâche terminée → `task_completion.score` toujours 0 → `AttendanceRegularityTest::test_task_completion_ratio_is_included_and_weighted_with_punctuality` rouge (0.0 vs 50.0 attendu).

## Correctif

Ajout de `'status'` au `$fillable` de `Task` (colonne enum existante, défaut 'todo' en base — aucun changement de schéma).

## Validation

- Reproduction locale : `Task::create([... 'status' => 'done'])` → lecture → `'todo'` (avant fix) ; `'done'` (après fix).
- `AttendanceRegularityTest` : `1 failed → 0` (score 50.0, 2/1 tâches, combiné 85.0).
- `php -l` OK ; CHANGELOG mis à jour.

Closes #4861
