### PR TITLE
fix(tests): assertions search_path Zkteco robustes — format PG indépendant du SET (volet #4853)

### DIFF
--- a/api/tests/Feature/ZktecoControllerTest.php
+++ b/api/tests/Feature/ZktecoControllerTest.php
@@ -177,9 +177,7 @@ class ZktecoControllerTest extends TestCase
             ->postJson('/api/v1/zkteco/heartbeat/SN-SP-001')
             ->assertOk();
 
-        $row = DB::selectOne('SHOW search_path');
-        $this->assertNotNull($row);
-        $this->assertSame('shared_tenants,public', $row->search_path);
+        $this->assertSearchPathRestored(['shared_tenants', 'public']);
     }
 
     public function test_heartbeat_restores_search_path_after_unknown_serial(): void
@@ -187,9 +185,7 @@ class ZktecoControllerTest extends TestCase
         $this->postJson('/api/v1/zkteco/heartbeat/SN-SP-UNKNOWN')
             ->assertStatus(404);
 
-        $row = DB::selectOne('SHOW search_path');
-        $this->assertNotNull($row);
-        $this->assertSame('shared_tenants,public', $row->search_path);
+        $this->assertSearchPathRestored(['shared_tenants', 'public']);
     }
 
     public function test_heartbeat_restores_search_path_after_rejected_token(): void
@@ -205,9 +201,7 @@ class ZktecoControllerTest extends TestCase
             ->postJson('/api/v1/zkteco/heartbeat/SN-SP-002')
             ->assertStatus(401);
 
-        $row = DB::selectOne('SHOW search_path');
-        $this->assertNotNull($row);
-        $this->assertSame('shared_tenants,public', $row->search_path);
+        $this->assertSearchPathRestored(['shared_tenants', 'public']);
     }
 
     public function test_sync_attendance_restores_search_path_after_success(): void
@@ -233,9 +227,7 @@ class ZktecoControllerTest extends TestCase
             ])
             ->assertStatus(201);
 
-        $row = DB::selectOne('SHOW search_path');
-        $this->assertNotNull($row);
-        $this->assertSame('shared_tenants,public', $row->search_path);
+        $this->assertSearchPathRestored(['shared_tenants', 'public']);
     }
 
     public function test_sync_attendance_rejects_unauthenticated_device_and_writes_nothing(): void
@@ -381,5 +373,25 @@ class ZktecoControllerTest extends TestCase
         $this->actingAs($this->manager)
             ->postJson('/api/v1/zkteco/devices/'.$ownDevice->serial_number.'/push-users')
             ->assertOk();
+    }
+
+    /**
+     * #4787/#4817 — vérifie que le search_path a été restauré (schémas et
+     * ordre). Comparaison normalisée : PostgreSQL formate SHOW search_path
+     * avec « , » (espace) après un SET alors que le défaut de connexion
+     * (option DSN) s'affiche sans espace — comparer les chaînes brutes
+     * casse la suite selon l'historique de SET de la session.
+     */
+    private function assertSearchPathRestored(array $expectedSchemas): void
+    {
+        $row = DB::selectOne('SHOW search_path');
+        $this->assertNotNull($row);
+
+        $normalize = static fn (string $path): array => array_values(array_filter(array_map(
+            'trim',
+            explode(',', str_replace('"', '', $path)),
+        ), static fn (string $s): bool => $s !== ''));
+
+        $this->assertSame($expectedSchemas, $normalize((string) $row->search_path));
     }
 }


### PR DESCRIPTION
## Problème
Les tests `heartbeat/sync attendance restores search path` (ajoutés #4817) comparent `SHOW search_path` à la chaîne brute `'shared_tenants,public'`. PostgreSQL formate le résultat avec `, ` (espace) **après tout SET**, alors que le défaut de connexion (option DSN) s'affiche sans espace. Dès qu'un SET a touché la session, les 4 assertions échouent — suite Feature fragile (même famille que #4853).

## Correctifs
- `assertSearchPathRestored()` : comparaison normalisée (schémas + ordre, quotes/espaces ignorés) — préserve l'intention (#4787/#4817 : le path est restauré) sans dépendre du formatage PG.

## Validation
- `php artisan test --filter ZktecoControllerTest` : 19 tests, 47 assertions, 0 échec (sur main + correctifs #4817/#4846).

Closes #4787 (volet test) — contribue à #4853