### PR TITLE
fix(mobile/l10n): régénère les localizations — 137 clés ARB manquantes (récurrence #4762)

### DIFF
--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -128,6 +128,13 @@ jobs:
         shell: bash
         run: 'bash ./dev-hub/tools/check-mobile-number-locale.sh'
 
+      - name: Validate ARB keys exist in generated localizations
+        # #4762 (récurrence) : toute clé ARB absente des générés casse la
+        # compile des apps qui la référencent. Garde = `flutter gen-l10n`
+        # doit être exécuté dans leopardo_core à chaque ajout de clé.
+        shell: bash
+        run: 'bash ./dev-hub/tools/check-mobile-l10n-sync.sh'
+
   flutter-analyze:
     timeout-minutes: 90
     name: Analyze ${{ matrix.project.name }}

--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -17,6 +17,7 @@ on:
       - 'dev-hub/tools/validate-mobile-plan29.ps1'
       - 'dev-hub/tools/validate-mobile-color-tokens.ps1'
       - 'dev-hub/tools/check-mobile-number-locale.sh'
+      - 'dev-hub/tools/check-mobile-l10n-sync.sh'
       - 'dev-hub/tools/check-mobile-manifest-routes.sh'
       - 'dev-hub/tools/mobile-workflow-contracts.json'
       - 'api/app/Modules/HR/Infrastructure/Services/MobileExperienceService.php'
@@ -36,6 +37,7 @@ on:
       - 'dev-hub/tools/validate-mobile-plan29.ps1'
       - 'dev-hub/tools/validate-mobile-color-tokens.ps1'
       - 'dev-hub/tools/check-mobile-number-locale.sh'
+      - 'dev-hub/tools/check-mobile-l10n-sync.sh'
       - 'dev-hub/tools/check-mobile-manifest-routes.sh'
       - 'dev-hub/tools/mobile-workflow-contracts.json'
       - 'api/app/Modules/HR/Infrastructure/Services/MobileExperienceService.php'
@@ -127,6 +129,13 @@ jobs:
         # sur des montants = locale forcée FR pour les utilisateurs AR/TR/EN.
         shell: bash
         run: 'bash ./dev-hub/tools/check-mobile-number-locale.sh'
+
+      - name: Validate ARB keys exist in generated localizations
+        # #4762 (récurrence) : toute clé ARB absente des générés casse la
+        # compile des apps qui la référencent. Garde = `flutter gen-l10n`
+        # doit être exécuté dans leopardo_core à chaque ajout de clé.
+        shell: bash
+        run: 'bash ./dev-hub/tools/check-mobile-l10n-sync.sh'
 
       - name: Validate ARB keys exist in generated localizations
         # #4762 (récurrence) : toute clé ARB absente des générés casse la

--- a/dev-hub/tools/check-mobile-l10n-sync.sh
+++ b/dev-hub/tools/check-mobile-l10n-sync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Garde CI — désynchronisation ARB <-> localizations générées (récurrence #4762).
+#
+# Vérifie que TOUTES les clés des ARB de leopardo_core (fr/en/ar/tr) sont
+# déclarées dans generated/app_localizations.dart. Une clé ARB absente des
+# générés = erreur de compile dans les apps qui la référencent (ex. #4762 :
+# 13 clés userAuth* ajoutées aux ARB sans `flutter gen-l10n`).
+#
+# Usage: bash dev-hub/tools/check-mobile-l10n-sync.sh
+# Exit 0 = synchro OK ; exit 1 = clés ARB manquantes dans les générés.
+set -u
+
+L10N="front/mobile_apps/leopardo_core/lib/l10n"
+GEN="$L10N/generated/app_localizations.dart"
+
+if [[ ! -f "$GEN" || ! -f "$L10N/app_fr.arb" ]]; then
+  echo "::error::check-mobile-l10n-sync : fichiers introuvables ($L10N). Lancer depuis la racine du repo."
+  exit 1
+fi
+
+python3 - "$L10N" "$GEN" <<'PYEOF'
+import json, re, sys
+
+l10n, gen_path = sys.argv[1], sys.argv[2]
+
+def arb_keys(path):
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return {k for k in data if not k.startswith("@")}
+
+with open(gen_path, encoding="utf-8") as f:
+    src = f.read()
+existing = set()
+for m in re.finditer(r"^  (?:String|int|double|DateTime|bool|Object|List<String>) get (\w+);", src, re.M):
+    existing.add(m.group(1))
+for m in re.finditer(r"^  (?:String|int|double|DateTime|bool|Object|List<String>) (\w+)\(", src, re.M):
+    existing.add(m.group(1))
+
+missing_total = 0
+for loc in ["fr", "en", "ar", "tr"]:
+    path = f"{l10n}/app_{loc}.arb"
+    keys = arb_keys(path)
+    missing = sorted(keys - existing)
+    for k in missing:
+        print(f"::error::Clé ARB '{k}' (app_{loc}.arb) absente de {gen_path} — lancer 'flutter gen-l10n' dans leopardo_core.")
+    missing_total += len(missing)
+
+if missing_total:
+    print(f"::error::check-mobile-l10n-sync : {missing_total} clé(s) ARB manquante(s) dans les localizations générées (cf. #4762).")
+    sys.exit(1)
+
+print("check-mobile-l10n-sync : OK — toutes les clés ARB (fr/en/ar/tr) sont présentes dans les générés.")
+PYEOF

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
@@ -992,5 +992,155 @@
   "trainingTitleplaceholder": "العنوان *",
   "trainingDurationplaceholder": "المدة (ساعة)",
   "trainingMaxparticipantsplaceholder": "الحد الأقصى للمشاركين",
-  "trainingOnline": "عبر الإنترنت"
+  "trainingOnline": "عبر الإنترنت",
+  "retry": "إعادة المحاولة",
+  "featureComingSoon": "الميزة قريبًا",
+  "backToHome": "العودة إلى الرئيسية",
+  "pageNotFound": "الصفحة المطلوبة غير موجودة أو فشل التنقل.",
+  "registerCreateAccount": "أنشئ حسابك",
+  "registerFirstName": "الاسم الأول",
+  "registerRequired": "مطلوب",
+  "registerPassword": "كلمة المرور",
+  "registerMinChars": "8 أحرف على الأقل",
+  "registerCreating": "جارٍ إنشاء الحساب...",
+  "registerSubmit": "أنشئ حسابي",
+  "accessDeniedTitle": "تم رفض الوصول",
+  "accessDeniedBody": "لا يملك حسابك دور المدير المطلوب لهذا التطبيق. استخدم التطبيق المطابق لدورك (موظف، موارد بشرية…) أو تواصل مع المسؤول.",
+  "accessDeniedLogout": "تسجيل الخروج",
+  "accessDeniedBodyHr": "لا يملك حسابك دور الموارد البشرية المطلوب لهذا التطبيق. استخدم التطبيق المطابق لدورك (موظف، مدير…) أو تواصل مع المسؤول.",
+  "evaluationsTitle": "تقييماتي",
+  "evaluationsEmpty": "لا توجد تقييمات",
+  "evaluationsEmptyHint": "ليس لديك أي تقييم مسجل بعد.",
+  "evaluationPeriod": "الفترة: {period}",
+  "@evaluationPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceOnTime": "في الموعد",
+  "attendanceLate": "متأخر",
+  "attendanceAbsent": "غائب",
+  "attendanceInProgress": "قيد التقدم",
+  "attendanceNoClock": "لا يوجد تسجيل حضور",
+  "attendanceTimeRange": "من {from} إلى {to}",
+  "@attendanceTimeRange": {
+    "placeholders": {
+      "from": {
+        "type": "String"
+      },
+      "to": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceHourWorked": "ساعة عمل",
+  "attendanceHoursWorked": "ساعات عمل",
+  "attendanceDaySummary": "يوم {date}، الحالة {status}، {range}، {hours}.",
+  "@attendanceDaySummary": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "range": {
+        "type": "String"
+      },
+      "hours": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionApproved": "تمت الموافقة على الجلسة ✓",
+  "sessionRejected": "تم رفض الجلسة",
+  "pendingSessionsToValidate": "للموافقة",
+  "pendingSessionsUpToDate": "كل شيء محدث",
+  "pendingSessionsEmpty": "لا توجد جلسة GPS بانتظار الموافقة.",
+  "employeeNumber": "الموظف #{id}",
+  "@employeeNumber": {
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionEntryAt": "الدخول: {time}",
+  "@sessionEntryAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionsToValidate": "جلسات للموافقة",
+  "errorPrefix": "خطأ: {message}",
+  "@errorPrefix": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "saDashboardTitle": "حضور GPS — لوحة تحكم الفريق",
+  "saDetected": "تم الكشف",
+  "saApproved": "تمت الموافقة",
+  "saRejected": "مرفوضة",
+  "saRecentSessions": "الجلسات الأخيرة",
+  "saForced": "مفروض",
+  "saPresenceInProgress": "حضور قيد التقدم منذ {time}",
+  "@saPresenceInProgress": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "saGpsZoneNotConfigured": "لم يتم إعداد منطقة GPS لشركتك بعد.",
+  "saDisableAutoGps": "تعطيل GPS التلقائي",
+  "saStatusApproved": "تمت الموافقة",
+  "saStatusDetected": "تم الكشف",
+  "saStatusRejected": "مرفوضة",
+  "saStatusCancelled": "ملغاة",
+  "saStatusPending": "قيد التحقق",
+  "saEnableAutoGps": "تفعيل GPS التلقائي",
+  "attendanceOvertime": "ساعات إضافية",
+  "approvalsUpToDate": "كل شيء محدث",
+  "approvalsEmpty": "لا توجد موافقات معلقة.",
+  "saConfigLoadError": "تعذر تحميل الإعدادات.\n{error}",
+  "@saConfigLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "ampAutoDetectDesc": "يتم اكتشاف حضورك تلقائيًا عند دخولك منطقة الشركة. لا حاجة لأي إجراء منك.",
+  "ampRecommended": "موصى به",
+  "ampQrScanDesc": "امسح رمز QR المعروض عند مدخل الشركة لتسجيل دخولك وخروجك.",
+  "ampManualDesc": "سجل يدويًا بالضغط على زرّي الوصول والمغادرة في شاشة الحضور.",
+  "ampSaveError": "تعذر حفظ تفضيلاتك. تحقق من اتصالك.",
+  "ampTitle": "اختر كيف تريد تسجيل حضورك كل يوم.",
+  "ampModeTitle": "وضع التسجيل",
+  "back": "رجوع",
+  "refresh": "تحديث",
+  "saSessionsLoadError": "تعذر تحميل جلسات GPS. تحقق من اتصالك.",
+  "saStartMonitoringError": "تعذر بدء مراقبة GPS. تحقق من أذونات الموقع وأعد المحاولة.",
+  "shellTeam": "الفريق",
+  "shellSettings": "الإعدادات",
+  "homeCompleteOnboarding": "إكمال تأهيلي",
+  "homeOnboardingHint": "هيئ مساحة عملك في بضع خطوات.",
+  "welcomeMyTeam": "فريقي",
+  "welcomePresences": "الحضور",
+  "welcomeTasks": "المهام",
+  "welcomeLeaves": "الإجازات",
+  "monthlySummaryLoading": "جارٍ تحميل الملخص الشهري...",
+  "orgChartEmpty": "سيتوفر الهيكل التنظيمي بمجرد إعداد الموظفين.",
+  "orgChartCollapse": "طي",
+  "orgChartExpand": "توسيع",
+  "errorUnexpected": "حدث خطأ",
+  "approvalApproved": "تمت الموافقة على الطلب",
+  "approvalRejected": "تم رفض الطلب"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
@@ -992,5 +992,155 @@
   "trainingTitleplaceholder": "Title *",
   "trainingDurationplaceholder": "Duration (h)",
   "trainingMaxparticipantsplaceholder": "Max participants",
-  "trainingOnline": "Online"
+  "trainingOnline": "Online",
+  "retry": "Retry",
+  "featureComingSoon": "Feature coming soon",
+  "backToHome": "Back to home",
+  "pageNotFound": "The requested page was not found or the navigation failed.",
+  "registerCreateAccount": "Create your account",
+  "registerFirstName": "First name",
+  "registerRequired": "Required",
+  "registerPassword": "Password",
+  "registerMinChars": "8 characters minimum",
+  "registerCreating": "Creating your account...",
+  "registerSubmit": "Create my account",
+  "accessDeniedTitle": "Access denied",
+  "accessDeniedBody": "Your account does not have the required Manager role for this application. Use the application matching your role (Employee, HR…) or contact your administrator.",
+  "accessDeniedLogout": "Log out",
+  "accessDeniedBodyHr": "Your account does not have the required HR role for this application. Use the application matching your role (Employee, Manager…) or contact your administrator.",
+  "evaluationsTitle": "My Evaluations",
+  "evaluationsEmpty": "No evaluations",
+  "evaluationsEmptyHint": "You don't have any recorded evaluation yet.",
+  "evaluationPeriod": "Period: {period}",
+  "@evaluationPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceOnTime": "on time",
+  "attendanceLate": "late",
+  "attendanceAbsent": "absent",
+  "attendanceInProgress": "in progress",
+  "attendanceNoClock": "no clock-in",
+  "attendanceTimeRange": "from {from} to {to}",
+  "@attendanceTimeRange": {
+    "placeholders": {
+      "from": {
+        "type": "String"
+      },
+      "to": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceHourWorked": "hour worked",
+  "attendanceHoursWorked": "hours worked",
+  "attendanceDaySummary": "Day of {date}, status {status}, {range}, {hours}.",
+  "@attendanceDaySummary": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "range": {
+        "type": "String"
+      },
+      "hours": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionApproved": "Session approved ✓",
+  "sessionRejected": "Session rejected",
+  "pendingSessionsToValidate": "To validate",
+  "pendingSessionsUpToDate": "All up to date",
+  "pendingSessionsEmpty": "No GPS session waiting for validation.",
+  "employeeNumber": "Employee #{id}",
+  "@employeeNumber": {
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionEntryAt": "Entry: {time}",
+  "@sessionEntryAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionsToValidate": "Sessions to validate",
+  "errorPrefix": "Error: {message}",
+  "@errorPrefix": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "saDashboardTitle": "GPS attendance — team dashboard",
+  "saDetected": "Detected",
+  "saApproved": "Approved",
+  "saRejected": "Rejected",
+  "saRecentSessions": "Recent sessions",
+  "saForced": "Enforced",
+  "saPresenceInProgress": "Presence in progress since {time}",
+  "@saPresenceInProgress": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "saGpsZoneNotConfigured": "Your company's GPS zone is not configured yet.",
+  "saDisableAutoGps": "Disable automatic GPS",
+  "saStatusApproved": "Approved",
+  "saStatusDetected": "Detected",
+  "saStatusRejected": "Rejected",
+  "saStatusCancelled": "Cancelled",
+  "saStatusPending": "Pending validation",
+  "saEnableAutoGps": "Enable automatic GPS",
+  "attendanceOvertime": "Overtime hours",
+  "approvalsUpToDate": "All up to date",
+  "approvalsEmpty": "No pending approvals.",
+  "saConfigLoadError": "Unable to load the configuration.\n{error}",
+  "@saConfigLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "ampAutoDetectDesc": "Your presence is detected automatically as soon as you enter the company zone. No action required from you.",
+  "ampRecommended": "Recommended",
+  "ampQrScanDesc": "Scan the QR Code displayed at the company entrance to clock in and out.",
+  "ampManualDesc": "Clock in manually using the Arrival and Departure buttons in the attendance screen.",
+  "ampSaveError": "Unable to save your preference. Check your connection.",
+  "ampTitle": "Choose how you want to clock your presence every day.",
+  "ampModeTitle": "Attendance mode",
+  "back": "Back",
+  "refresh": "Refresh",
+  "saSessionsLoadError": "Unable to load GPS sessions. Check your connection.",
+  "saStartMonitoringError": "Unable to start GPS monitoring. Check location permissions and try again.",
+  "shellTeam": "Team",
+  "shellSettings": "Settings",
+  "homeCompleteOnboarding": "Complete my onboarding",
+  "homeOnboardingHint": "Set up your workspace in a few steps.",
+  "welcomeMyTeam": "My team",
+  "welcomePresences": "Attendance",
+  "welcomeTasks": "Tasks",
+  "welcomeLeaves": "Leave",
+  "monthlySummaryLoading": "Loading monthly summary...",
+  "orgChartEmpty": "The org chart will be available once employees are configured.",
+  "orgChartCollapse": "Collapse",
+  "orgChartExpand": "Expand",
+  "errorUnexpected": "An error occurred",
+  "approvalApproved": "Request approved",
+  "approvalRejected": "Request rejected"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
@@ -992,5 +992,155 @@
   "trainingTitleplaceholder": "Titre *",
   "trainingDurationplaceholder": "Duree (h)",
   "trainingMaxparticipantsplaceholder": "Participants max",
-  "trainingOnline": "En ligne"
+  "trainingOnline": "En ligne",
+  "retry": "Réessayer",
+  "featureComingSoon": "Fonction bientôt disponible",
+  "backToHome": "Retour à l'accueil",
+  "pageNotFound": "La page demandée est introuvable ou la navigation a échoué.",
+  "registerCreateAccount": "Créer votre compte",
+  "registerFirstName": "Prénom",
+  "registerRequired": "Obligatoire",
+  "registerPassword": "Mot de passe",
+  "registerMinChars": "8 caractères minimum",
+  "registerCreating": "Création de compte en cours...",
+  "registerSubmit": "Créer mon compte",
+  "accessDeniedTitle": "Accès refusé",
+  "accessDeniedBody": "Votre compte n'a pas le rôle Manager requis pour cette application. Utilisez l'application correspondant à votre rôle (Employee, RH…) ou contactez votre administrateur.",
+  "accessDeniedLogout": "Se déconnecter",
+  "accessDeniedBodyHr": "Votre compte n'a pas le rôle RH requis pour cette application. Utilisez l'application correspondant à votre rôle (Employee, Manager…) ou contactez votre administrateur.",
+  "evaluationsTitle": "Mes Évaluations",
+  "evaluationsEmpty": "Aucune évaluation",
+  "evaluationsEmptyHint": "Vous n'avez pas encore d'évaluation enregistrée.",
+  "evaluationPeriod": "Période : {period}",
+  "@evaluationPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceOnTime": "à l'heure",
+  "attendanceLate": "en retard",
+  "attendanceAbsent": "absent",
+  "attendanceInProgress": "en cours",
+  "attendanceNoClock": "pas de pointage",
+  "attendanceTimeRange": "de {from} à {to}",
+  "@attendanceTimeRange": {
+    "placeholders": {
+      "from": {
+        "type": "String"
+      },
+      "to": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceHourWorked": "heure travaillée",
+  "attendanceHoursWorked": "heures travaillées",
+  "attendanceDaySummary": "Journée du {date}, statut {status}, {range}, {hours}.",
+  "@attendanceDaySummary": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "range": {
+        "type": "String"
+      },
+      "hours": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionApproved": "Session approuvée ✓",
+  "sessionRejected": "Session rejetée",
+  "pendingSessionsToValidate": "À valider",
+  "pendingSessionsUpToDate": "Tout est à jour",
+  "pendingSessionsEmpty": "Aucune session GPS en attente de validation.",
+  "employeeNumber": "Employé #{id}",
+  "@employeeNumber": {
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionEntryAt": "Entrée : {time}",
+  "@sessionEntryAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionsToValidate": "Sessions à valider",
+  "errorPrefix": "Erreur : {message}",
+  "@errorPrefix": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "saDashboardTitle": "Pointage GPS — tableau de bord équipe",
+  "saDetected": "Détectées",
+  "saApproved": "Approuvées",
+  "saRejected": "Rejetées",
+  "saRecentSessions": "Sessions récentes",
+  "saForced": "Imposé",
+  "saPresenceInProgress": "Présence en cours depuis {time}",
+  "@saPresenceInProgress": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "saGpsZoneNotConfigured": "La zone GPS de votre entreprise n'est pas encore configurée.",
+  "saDisableAutoGps": "Désactiver le GPS automatique",
+  "saStatusApproved": "Approuvée",
+  "saStatusDetected": "Détectée",
+  "saStatusRejected": "Rejetée",
+  "saStatusCancelled": "Annulée",
+  "saStatusPending": "En validation",
+  "saEnableAutoGps": "Activer le GPS automatique",
+  "attendanceOvertime": "Heures supplémentaires",
+  "approvalsUpToDate": "Tout est à jour",
+  "approvalsEmpty": "Aucune approbation en attente.",
+  "saConfigLoadError": "Impossible de charger la configuration.\n{error}",
+  "@saConfigLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "ampAutoDetectDesc": "Votre présence est détectée automatiquement dès que vous entrez dans la zone de l'entreprise. Aucune action requise de votre part.",
+  "ampRecommended": "Recommandé",
+  "ampQrScanDesc": "Scannez le QR Code affiché à l'entrée de l'entreprise pour pointer votre arrivée et votre départ.",
+  "ampManualDesc": "Pointez manuellement en appuyant sur les boutons Arrivée et Départ dans l'écran de présence.",
+  "ampSaveError": "Impossible de sauvegarder votre préférence. Vérifiez votre connexion.",
+  "ampTitle": "Choisissez comment vous souhaitez pointer votre présence chaque jour.",
+  "ampModeTitle": "Mode de pointage",
+  "back": "Retour",
+  "refresh": "Actualiser",
+  "saSessionsLoadError": "Impossible de charger les sessions GPS. Vérifiez votre connexion.",
+  "saStartMonitoringError": "Impossible de démarrer la surveillance GPS. Vérifiez les permissions de localisation et réessayez.",
+  "shellTeam": "Équipe",
+  "shellSettings": "Réglages",
+  "homeCompleteOnboarding": "Compléter mon onboarding",
+  "homeOnboardingHint": "Configurez votre espace en quelques étapes.",
+  "welcomeMyTeam": "Mon équipe",
+  "welcomePresences": "Présences",
+  "welcomeTasks": "Tâches",
+  "welcomeLeaves": "Congés",
+  "monthlySummaryLoading": "Chargement du résumé mensuel...",
+  "orgChartEmpty": "L'organigramme sera disponible une fois les employés configurés.",
+  "orgChartCollapse": "Réduire",
+  "orgChartExpand": "Développer",
+  "errorUnexpected": "Une erreur est survenue",
+  "approvalApproved": "Demande approuvée",
+  "approvalRejected": "Demande refusée"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
@@ -992,5 +992,155 @@
   "trainingTitleplaceholder": "Başlık *",
   "trainingDurationplaceholder": "Süre (saat)",
   "trainingMaxparticipantsplaceholder": "Maks. katılımcı",
-  "trainingOnline": "Çevrimiçi"
+  "trainingOnline": "Çevrimiçi",
+  "retry": "Yeniden dene",
+  "featureComingSoon": "Özellik yakında",
+  "backToHome": "Ana sayfaya dön",
+  "pageNotFound": "İstenen sayfa bulunamadı veya gezinme başarısız oldu.",
+  "registerCreateAccount": "Hesabınızı oluşturun",
+  "registerFirstName": "Ad",
+  "registerRequired": "Zorunlu",
+  "registerPassword": "Şifre",
+  "registerMinChars": "En az 8 karakter",
+  "registerCreating": "Hesap oluşturuluyor...",
+  "registerSubmit": "Hesabımı oluştur",
+  "accessDeniedTitle": "Erişim reddedildi",
+  "accessDeniedBody": "Hesabınız bu uygulama için gerekli Yönetici rolüne sahip değil. Rolünüze uygun uygulamayı kullanın (Çalışan, İK…) veya yöneticinizle iletişime geçin.",
+  "accessDeniedLogout": "Çıkış yap",
+  "accessDeniedBodyHr": "Hesabınız bu uygulama için gerekli İK rolüne sahip değil. Rolünüze uygun uygulamayı kullanın (Çalışan, Yönetici…) veya yöneticinizle iletişime geçin.",
+  "evaluationsTitle": "Değerlendirmelerim",
+  "evaluationsEmpty": "Değerlendirme yok",
+  "evaluationsEmptyHint": "Henüz kayıtlı bir değerlendirmeniz yok.",
+  "evaluationPeriod": "Dönem: {period}",
+  "@evaluationPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceOnTime": "zamanında",
+  "attendanceLate": "geç",
+  "attendanceAbsent": "yok",
+  "attendanceInProgress": "devam ediyor",
+  "attendanceNoClock": "kayıt yok",
+  "attendanceTimeRange": "{from} - {to}",
+  "@attendanceTimeRange": {
+    "placeholders": {
+      "from": {
+        "type": "String"
+      },
+      "to": {
+        "type": "String"
+      }
+    }
+  },
+  "attendanceHourWorked": "çalışılan saat",
+  "attendanceHoursWorked": "çalışılan saatler",
+  "attendanceDaySummary": "{date} günü, durum {status}, {range}, {hours}.",
+  "@attendanceDaySummary": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "range": {
+        "type": "String"
+      },
+      "hours": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionApproved": "Oturum onaylandı ✓",
+  "sessionRejected": "Oturum reddedildi",
+  "pendingSessionsToValidate": "Onaylanacak",
+  "pendingSessionsUpToDate": "Her şey güncel",
+  "pendingSessionsEmpty": "Onay bekleyen GPS oturumu yok.",
+  "employeeNumber": "Çalışan #{id}",
+  "@employeeNumber": {
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionEntryAt": "Giriş: {time}",
+  "@sessionEntryAt": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionsToValidate": "Onaylanacak oturumlar",
+  "errorPrefix": "Hata: {message}",
+  "@errorPrefix": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "saDashboardTitle": "GPS yoklama — ekip paneli",
+  "saDetected": "Algılanan",
+  "saApproved": "Onaylanan",
+  "saRejected": "Reddedilen",
+  "saRecentSessions": "Son oturumlar",
+  "saForced": "Zorunlu",
+  "saPresenceInProgress": "{time} itibarıyla devam eden katılım",
+  "@saPresenceInProgress": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "saGpsZoneNotConfigured": "Şirketinizin GPS bölgesi henüz yapılandırılmadı.",
+  "saDisableAutoGps": "Otomatik GPS'i kapat",
+  "saStatusApproved": "Onaylandı",
+  "saStatusDetected": "Algılandı",
+  "saStatusRejected": "Reddedildi",
+  "saStatusCancelled": "İptal edildi",
+  "saStatusPending": "Onay bekleniyor",
+  "saEnableAutoGps": "Otomatik GPS'i aç",
+  "attendanceOvertime": "Fazla mesai",
+  "approvalsUpToDate": "Her şey güncel",
+  "approvalsEmpty": "Bekleyen onay yok.",
+  "saConfigLoadError": "Yapılandırma yüklenemedi.\n{error}",
+  "@saConfigLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "ampAutoDetectDesc": "Şirket bölgesine girdiğinizde varlığınız otomatik algılanır. Sizden hiçbir işlem gerekmez.",
+  "ampRecommended": "Önerilen",
+  "ampQrScanDesc": "Şirket girişinde gösterilen QR Kodu tarayarak giriş ve çıkışınızı yapın.",
+  "ampManualDesc": "Yoklama ekranındaki Giriş ve Çıkış butonlarına basarak manuel kayıt yapın.",
+  "ampSaveError": "Tercihiniz kaydedilemedi. Bağlantınızı kontrol edin.",
+  "ampTitle": "Her gün katılımınızı nasıl kaydetmek istediğinizi seçin.",
+  "ampModeTitle": "Kayıt modu",
+  "back": "Geri",
+  "refresh": "Yenile",
+  "saSessionsLoadError": "GPS oturumları yüklenemedi. Bağlantınızı kontrol edin.",
+  "saStartMonitoringError": "GPS izleme başlatılamadı. Konum izinlerini kontrol edip tekrar deneyin.",
+  "shellTeam": "Ekip",
+  "shellSettings": "Ayarlar",
+  "homeCompleteOnboarding": "İşe alıştırmamı tamamla",
+  "homeOnboardingHint": "Çalışma alanınızı birkaç adımda kurun.",
+  "welcomeMyTeam": "Ekibim",
+  "welcomePresences": "Yoklamalar",
+  "welcomeTasks": "Görevler",
+  "welcomeLeaves": "İzinler",
+  "monthlySummaryLoading": "Aylık özet yükleniyor...",
+  "orgChartEmpty": "Çalışanlar yapılandırıldığında organizasyon şeması kullanılabilir olacak.",
+  "orgChartCollapse": "Daralt",
+  "orgChartExpand": "Genişlet",
+  "errorUnexpected": "Bir hata oluştu",
+  "approvalApproved": "Talep onaylandı",
+  "approvalRejected": "Talep reddedildi"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -65,7 +65,7 @@ import 'app_localizations_tr.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -88,18 +88,18 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('ar'),
     Locale('en'),
     Locale('fr'),
-    Locale('tr'),
+    Locale('tr')
   ];
 
   /// No description provided for @appTitle.
@@ -6089,11 +6089,7 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'Journée du {date}, statut {status}, {range}, {hours}.'**
   String attendanceDaySummary(
-    String date,
-    String status,
-    String range,
-    String hours,
-  );
+      String date, String status, String range, String hours);
 
   /// No description provided for @sessionApproved.
   ///
@@ -6451,9 +6447,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -65,7 +65,7 @@ import 'app_localizations_tr.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -88,18 +88,18 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('ar'),
     Locale('en'),
     Locale('fr'),
-    Locale('tr')
+    Locale('tr'),
   ];
 
   /// No description provided for @appTitle.
@@ -5126,7 +5126,12 @@ abstract class AppLocalizations {
   String attendanceTimeRange(String from, String to);
   String get attendanceHourWorked;
   String get attendanceHoursWorked;
-  String attendanceDaySummary(String date, String status, String range, String hours);
+  String attendanceDaySummary(
+    String date,
+    String status,
+    String range,
+    String hours,
+  );
   String get sessionApproved;
   String get sessionRejected;
   String get pendingSessionsToValidate;
@@ -5179,6 +5184,143 @@ abstract class AppLocalizations {
   String get orgChartCollapse;
   String get orgChartExpand;
   String get errorUnexpected;
+  String get apiAccessdenied;
+  String get apiConnectionerror;
+  String get apiGenericerror;
+  String get apiInvaliddata;
+  String get apiNotfound;
+  String get apiServererror;
+  String get apiServererrorretry;
+  String get apiServerunavailable;
+  String get apiSessionexpired;
+  String get apiToomanyrequests;
+  String get authDemoAccess;
+  String get authTogglePasswordVisibility;
+  String get commonRequired;
+  String get partnerpageApplyerrorprefix;
+  String get partnerpageCommissionsEmpty;
+  String get partnerpageCommissionsTitle;
+  String get partnerpageDashboardSubtitle;
+  String get partnerpageDashboardTitle;
+  String get partnerpageLoading;
+  String get partnerpageMetricsConversions;
+  String get partnerpageMetricsPending;
+  String get partnerpageMetricsTotalearned;
+  String get partnerpageMetricsWithdrawable;
+  String get partnerpageNotappliedAgency;
+  String get partnerpageNotappliedIndividual;
+  String get partnerpageNotappliedSubtitle;
+  String get partnerpageNotappliedTitle;
+  String get partnerpagePayoutBody;
+  String get partnerpagePayoutErrorprefix;
+  String get partnerpagePayoutInsufficient;
+  String get partnerpagePayoutRequest;
+  String get partnerpagePayoutSending;
+  String get partnerpagePayoutSuccess;
+  String get partnerpagePayoutTitle;
+  String get partnerpagePendingBody;
+  String get partnerpagePendingTitle;
+  String get partnerpageReferralCopied;
+  String get partnerpageReferralCopy;
+  String get partnerpageReferralCopyerror;
+  String get partnerpageReferralTitle;
+  String get partnerpageReferralUnavailable;
+  String get partnerpageTableAmount;
+  String get partnerpageTableDate;
+  String get partnerpageTableStatus;
+  String get partnerpageTableStatuspaid;
+  String get partnerpageTableStatuspending;
+  String get partnerpageTableTenantid;
+  String get settingspageCancel;
+  String get settingspageConfirmpassword;
+  String get settingspageCurrentpassword;
+  String get settingspageDisable2fa;
+  String get settingspageDisabled;
+  String get settingspageEmail;
+  String get settingspageEnable2fa;
+  String get settingspageEnabled;
+  String get settingspageEntercodestep;
+  String get settingspageFullname;
+  String get settingspageGeneratesecret;
+  String get settingspageGeneratesecrethint;
+  String get settingspageManualsecret;
+  String get settingspageMinlengthhint;
+  String get settingspageNewpassword;
+  String get settingspagePassword;
+  String get settingspagePasswordsmismatch;
+  String get settingspagePasswordsubtitle;
+  String get settingspagePasswordtitle;
+  String get settingspagePasswordupdated;
+  String get settingspageProfilesubtitle;
+  String get settingspageProfiletitle;
+  String get settingspageProfileupdated;
+  String get settingspageSavechanges;
+  String get settingspageScanstep;
+  String get settingspageSubtitle;
+  String get settingspageTitle;
+  String get settingspageTwofactoractivehint;
+  String get settingspageTwofactordisabled;
+  String get settingspageTwofactorenabled;
+  String get settingspageTwofactorsubtitle;
+  String get settingspageTwofactortitle;
+  String get settingspageUpdatepassword;
+  String get systempageApierror;
+  String get systempageApioperational;
+  String get systempageApioperationaldb;
+  String get systempageApiservices;
+  String get systempageApiunavailable;
+  String get systempageDatabase;
+  String get systempageDberror;
+  String get systempageDblatency;
+  String get systempageDbunavailable;
+  String get systempageDbunreachable;
+  String get systempageGlobalerror;
+  String get systempageGlobalhealthy;
+  String get systempageGlobalstatus;
+  String get systempageGlobalunavailable;
+  String get systempageGlobalwarning;
+  String get systempageHealthcheck;
+  String get systempageHealthcheckrunning;
+  String get systempageHealtherror;
+  String get systempageHealthliveunreachable;
+  String get systempageHealthok;
+  String get systempageHealthunreachable;
+  String get systempageInfradetails;
+  String get systempageInfrastructure;
+  String get systempageInfraunavailable;
+  String get systempageMetricsloaderror;
+  String get systempageNotifobsloaderror;
+  String get systempageQueueobsloaderror;
+  String get systempageRetry;
+  String get systempageServiceunreachable;
+  String get systempageStatsloaderror;
+  String get systempageSubtitle;
+  String get systempageTitle;
+  String get userAuthAlreadyAccount;
+  String get userAuthBackToHome;
+  String get userAuthCity;
+  String get userAuthCompanyEmail;
+  String get userAuthCompanyName;
+  String get userAuthCompanyRequestBody;
+  String get userAuthCompanyRequestInfo;
+  String get userAuthCompanyRequestTitle;
+  String get userAuthCountry;
+  String get userAuthCreateCompany;
+  String get userAuthDescription;
+  String get userAuthFirstName;
+  String userAuthGoogleError(Object error);
+  String get userAuthLastName;
+  String get userAuthLoginSubtitle;
+  String get userAuthNoAccount;
+  String get userAuthPersonalLogin;
+  String get userAuthPhone;
+  String get userAuthPhoneOptional;
+  String get userAuthRegisterButton;
+  String get userAuthRegisterSubtitleAlt;
+  String get userAuthRegisterTitle;
+  String get userAuthSector;
+  String get userAuthSubmitError;
+  String get userAuthSubmitRequest;
 }
 
 class _AppLocalizationsDelegate
@@ -5212,8 +5354,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations.dart
@@ -282,6 +282,18 @@ abstract class AppLocalizations {
   /// **'Le code 2FA est requis.'**
   String get authTwoFactorRequired;
 
+  /// No description provided for @authDemoAccess.
+  ///
+  /// In fr, this message translates to:
+  /// **'Acces Demo'**
+  String get authDemoAccess;
+
+  /// No description provided for @authTogglePasswordVisibility.
+  ///
+  /// In fr, this message translates to:
+  /// **'Afficher ou masquer le mot de passe'**
+  String get authTogglePasswordVisibility;
+
   /// No description provided for @commonLanguageLabel.
   ///
   /// In fr, this message translates to:
@@ -467,6 +479,12 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'États-Unis'**
   String get commonCountriesUs;
+
+  /// No description provided for @commonRequired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Requis'**
+  String get commonRequired;
 
   /// No description provided for @modulesAttendance.
   ///
@@ -5099,228 +5117,1307 @@ abstract class AppLocalizations {
   /// In fr, this message translates to:
   /// **'Aucun employé visible pour ce compte.'**
   String get employeesEmptyList;
+
+  /// No description provided for @userAuthCompanyRequestTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Demande soumise !'**
+  String get userAuthCompanyRequestTitle;
+
+  /// No description provided for @userAuthCompanyRequestBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Un administrateur examinera votre demande. Vous recevrez une notification dès qu\'elle sera traitée.'**
+  String get userAuthCompanyRequestBody;
+
+  /// No description provided for @userAuthCompanyRequestInfo.
+  ///
+  /// In fr, this message translates to:
+  /// **'Remplissez les informations de votre entreprise. Un administrateur validera votre demande.'**
+  String get userAuthCompanyRequestInfo;
+
+  /// No description provided for @userAuthBackToHome.
+  ///
+  /// In fr, this message translates to:
+  /// **'À l\'accueil'**
+  String get userAuthBackToHome;
+
+  /// No description provided for @userAuthCreateCompany.
+  ///
+  /// In fr, this message translates to:
+  /// **'Créer une entreprise'**
+  String get userAuthCreateCompany;
+
+  /// No description provided for @userAuthCompanyName.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nom de l\'entreprise'**
+  String get userAuthCompanyName;
+
+  /// No description provided for @userAuthCompanyEmail.
+  ///
+  /// In fr, this message translates to:
+  /// **'Email entreprise'**
+  String get userAuthCompanyEmail;
+
+  /// No description provided for @userAuthSector.
+  ///
+  /// In fr, this message translates to:
+  /// **'Secteur d\'activité'**
+  String get userAuthSector;
+
+  /// No description provided for @userAuthCountry.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pays'**
+  String get userAuthCountry;
+
+  /// No description provided for @userAuthCity.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ville'**
+  String get userAuthCity;
+
+  /// No description provided for @userAuthPhone.
+  ///
+  /// In fr, this message translates to:
+  /// **'Téléphone'**
+  String get userAuthPhone;
+
+  /// No description provided for @userAuthDescription.
+  ///
+  /// In fr, this message translates to:
+  /// **'Description'**
+  String get userAuthDescription;
+
+  /// No description provided for @userAuthSubmitRequest.
+  ///
+  /// In fr, this message translates to:
+  /// **'Soumettre la demande'**
+  String get userAuthSubmitRequest;
+
+  /// No description provided for @userAuthSubmitError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors de la soumission'**
+  String get userAuthSubmitError;
+
+  /// No description provided for @userAuthAlreadyAccount.
+  ///
+  /// In fr, this message translates to:
+  /// **'Deja un compte ? Se connecter'**
+  String get userAuthAlreadyAccount;
+
+  /// No description provided for @userAuthFirstName.
+  ///
+  /// In fr, this message translates to:
+  /// **'Prenom'**
+  String get userAuthFirstName;
+
+  /// No description provided for @userAuthGoogleError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur Google : {error}'**
+  String userAuthGoogleError(Object error);
+
+  /// No description provided for @userAuthLastName.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nom'**
+  String get userAuthLastName;
+
+  /// No description provided for @userAuthLoginSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retrouvez votre espace, vos documents et vos demandes.'**
+  String get userAuthLoginSubtitle;
+
+  /// No description provided for @userAuthNoAccount.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pas encore de compte ? S\'inscrire'**
+  String get userAuthNoAccount;
+
+  /// No description provided for @userAuthPersonalLogin.
+  ///
+  /// In fr, this message translates to:
+  /// **'Connexion personnelle'**
+  String get userAuthPersonalLogin;
+
+  /// No description provided for @userAuthPhoneOptional.
+  ///
+  /// In fr, this message translates to:
+  /// **'Telephone (optionnel)'**
+  String get userAuthPhoneOptional;
+
+  /// No description provided for @userAuthRegisterButton.
+  ///
+  /// In fr, this message translates to:
+  /// **'Creer mon compte'**
+  String get userAuthRegisterButton;
+
+  /// No description provided for @userAuthRegisterSubtitleAlt.
+  ///
+  /// In fr, this message translates to:
+  /// **'Accedez a votre espace personnel et organisez vos documents.'**
+  String get userAuthRegisterSubtitleAlt;
+
+  /// No description provided for @userAuthRegisterTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Creer mon compte'**
+  String get userAuthRegisterTitle;
+
+  /// No description provided for @partnerpageLoading.
+  ///
+  /// In fr, this message translates to:
+  /// **'Chargement de votre espace...'**
+  String get partnerpageLoading;
+
+  /// No description provided for @partnerpageApplyerrorprefix.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors de la candidature : '**
+  String get partnerpageApplyerrorprefix;
+
+  /// No description provided for @partnerpageNotappliedTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Devenir Partenaire'**
+  String get partnerpageNotappliedTitle;
+
+  /// No description provided for @partnerpageNotappliedSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Rejoignez l\'écosystème Leopardo RH et gagnez des commissions sur chaque entreprise que vous parrainez. Jusqu\'à 20 % de commission récurrente.'**
+  String get partnerpageNotappliedSubtitle;
+
+  /// No description provided for @partnerpageNotappliedIndividual.
+  ///
+  /// In fr, this message translates to:
+  /// **'Postuler en tant qu\'Individuel'**
+  String get partnerpageNotappliedIndividual;
+
+  /// No description provided for @partnerpageNotappliedAgency.
+  ///
+  /// In fr, this message translates to:
+  /// **'Postuler en tant qu\'Agence'**
+  String get partnerpageNotappliedAgency;
+
+  /// No description provided for @partnerpagePendingTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Candidature en cours'**
+  String get partnerpagePendingTitle;
+
+  /// No description provided for @partnerpagePendingBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Votre demande est en cours de validation par notre équipe commerciale. Vous recevrez un email dès que votre accès sera activé.'**
+  String get partnerpagePendingBody;
+
+  /// No description provided for @partnerpageDashboardTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Dashboard Partenaire'**
+  String get partnerpageDashboardTitle;
+
+  /// No description provided for @partnerpageDashboardSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Suivez vos conversions et vos commissions Leopardo RH — statut partenaire actif.'**
+  String get partnerpageDashboardSubtitle;
+
+  /// No description provided for @partnerpageMetricsConversions.
+  ///
+  /// In fr, this message translates to:
+  /// **'Conversions'**
+  String get partnerpageMetricsConversions;
+
+  /// No description provided for @partnerpageMetricsTotalearned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Gains totaux'**
+  String get partnerpageMetricsTotalearned;
+
+  /// No description provided for @partnerpageMetricsPending.
+  ///
+  /// In fr, this message translates to:
+  /// **'En attente'**
+  String get partnerpageMetricsPending;
+
+  /// No description provided for @partnerpageMetricsWithdrawable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Solde retirable'**
+  String get partnerpageMetricsWithdrawable;
+
+  /// No description provided for @partnerpageCommissionsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Dernières commissions'**
+  String get partnerpageCommissionsTitle;
+
+  /// No description provided for @partnerpageCommissionsEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'Aucune commission enregistrée.'**
+  String get partnerpageCommissionsEmpty;
+
+  /// No description provided for @partnerpageTableTenantid.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tenant ID'**
+  String get partnerpageTableTenantid;
+
+  /// No description provided for @partnerpageTableDate.
+  ///
+  /// In fr, this message translates to:
+  /// **'Date'**
+  String get partnerpageTableDate;
+
+  /// No description provided for @partnerpageTableStatus.
+  ///
+  /// In fr, this message translates to:
+  /// **'Statut'**
+  String get partnerpageTableStatus;
+
+  /// No description provided for @partnerpageTableAmount.
+  ///
+  /// In fr, this message translates to:
+  /// **'Montant'**
+  String get partnerpageTableAmount;
+
+  /// No description provided for @partnerpageTableStatuspaid.
+  ///
+  /// In fr, this message translates to:
+  /// **'Payée'**
+  String get partnerpageTableStatuspaid;
+
+  /// No description provided for @partnerpageTableStatuspending.
+  ///
+  /// In fr, this message translates to:
+  /// **'En attente'**
+  String get partnerpageTableStatuspending;
+
+  /// No description provided for @partnerpagePayoutTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Paiement'**
+  String get partnerpagePayoutTitle;
+
+  /// No description provided for @partnerpagePayoutBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Vos commissions sont payées une fois le seuil atteint. Vérifiez que vos coordonnées bancaires sont à jour.'**
+  String get partnerpagePayoutBody;
+
+  /// No description provided for @partnerpagePayoutRequest.
+  ///
+  /// In fr, this message translates to:
+  /// **'Demander un virement'**
+  String get partnerpagePayoutRequest;
+
+  /// No description provided for @partnerpagePayoutSending.
+  ///
+  /// In fr, this message translates to:
+  /// **'Envoi...'**
+  String get partnerpagePayoutSending;
+
+  /// No description provided for @partnerpagePayoutInsufficient.
+  ///
+  /// In fr, this message translates to:
+  /// **'Solde insuffisant pour demander un virement (minimum 100,00 €).'**
+  String get partnerpagePayoutInsufficient;
+
+  /// No description provided for @partnerpagePayoutSuccess.
+  ///
+  /// In fr, this message translates to:
+  /// **'Demande de virement envoyée avec succès.'**
+  String get partnerpagePayoutSuccess;
+
+  /// No description provided for @partnerpagePayoutErrorprefix.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors de la demande de virement : '**
+  String get partnerpagePayoutErrorprefix;
+
+  /// No description provided for @partnerpageReferralTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Lien de parrainage'**
+  String get partnerpageReferralTitle;
+
+  /// No description provided for @partnerpageReferralUnavailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Lien indisponible'**
+  String get partnerpageReferralUnavailable;
+
+  /// No description provided for @partnerpageReferralCopy.
+  ///
+  /// In fr, this message translates to:
+  /// **'Copier mon lien'**
+  String get partnerpageReferralCopy;
+
+  /// No description provided for @partnerpageReferralCopied.
+  ///
+  /// In fr, this message translates to:
+  /// **'Copié !'**
+  String get partnerpageReferralCopied;
+
+  /// No description provided for @partnerpageReferralCopyerror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impossible de copier le lien. Copiez-le manuellement.'**
+  String get partnerpageReferralCopyerror;
+
+  /// No description provided for @apiSessionexpired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Session expirée. Reconnexion en cours...'**
+  String get apiSessionexpired;
+
+  /// No description provided for @apiAccessdenied.
+  ///
+  /// In fr, this message translates to:
+  /// **'Accès refusé sur :endpoint. Permissions insuffisantes.'**
+  String get apiAccessdenied;
+
+  /// No description provided for @apiNotfound.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ressource introuvable : :endpoint'**
+  String get apiNotfound;
+
+  /// No description provided for @apiToomanyrequests.
+  ///
+  /// In fr, this message translates to:
+  /// **'Trop de requêtes. Veuillez patienter quelques secondes.'**
+  String get apiToomanyrequests;
+
+  /// No description provided for @apiServererror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur serveur sur :endpoint. :detail'**
+  String get apiServererror;
+
+  /// No description provided for @apiServererrorretry.
+  ///
+  /// In fr, this message translates to:
+  /// **'Réessayez plus tard.'**
+  String get apiServererrorretry;
+
+  /// No description provided for @apiServerunavailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le serveur est temporairement indisponible (:status). Réessayez dans quelques instants.'**
+  String get apiServerunavailable;
+
+  /// No description provided for @apiGenericerror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur :status sur :endpoint.'**
+  String get apiGenericerror;
+
+  /// No description provided for @apiInvaliddata.
+  ///
+  /// In fr, this message translates to:
+  /// **'Données invalides.'**
+  String get apiInvaliddata;
+
+  /// No description provided for @apiConnectionerror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur de connexion. Vérifiez votre connexion internet.'**
+  String get apiConnectionerror;
+
+  /// No description provided for @settingspageCancel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Annuler'**
+  String get settingspageCancel;
+
+  /// No description provided for @settingspageConfirmpassword.
+  ///
+  /// In fr, this message translates to:
+  /// **'Confirmer le mot de passe'**
+  String get settingspageConfirmpassword;
+
+  /// No description provided for @settingspageCurrentpassword.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mot de passe actuel'**
+  String get settingspageCurrentpassword;
+
+  /// No description provided for @settingspageDisable2fa.
+  ///
+  /// In fr, this message translates to:
+  /// **'Désactiver le 2FA'**
+  String get settingspageDisable2fa;
+
+  /// No description provided for @settingspageDisabled.
+  ///
+  /// In fr, this message translates to:
+  /// **'Désactivé'**
+  String get settingspageDisabled;
+
+  /// No description provided for @settingspageEmail.
+  ///
+  /// In fr, this message translates to:
+  /// **'Adresse email'**
+  String get settingspageEmail;
+
+  /// No description provided for @settingspageEnable2fa.
+  ///
+  /// In fr, this message translates to:
+  /// **'Activer le 2FA'**
+  String get settingspageEnable2fa;
+
+  /// No description provided for @settingspageEnabled.
+  ///
+  /// In fr, this message translates to:
+  /// **'Activé'**
+  String get settingspageEnabled;
+
+  /// No description provided for @settingspageEntercodestep.
+  ///
+  /// In fr, this message translates to:
+  /// **'2. Entrez le code à 6 chiffres généré'**
+  String get settingspageEntercodestep;
+
+  /// No description provided for @settingspageFullname.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nom complet'**
+  String get settingspageFullname;
+
+  /// No description provided for @settingspageGeneratesecret.
+  ///
+  /// In fr, this message translates to:
+  /// **'Générer un secret 2FA'**
+  String get settingspageGeneratesecret;
+
+  /// No description provided for @settingspageGeneratesecrethint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Générez un secret et scannez-le avec une application d\'authentification (Google Authenticator, Authy, 1Password...).'**
+  String get settingspageGeneratesecrethint;
+
+  /// No description provided for @settingspageManualsecret.
+  ///
+  /// In fr, this message translates to:
+  /// **'Secret manuel :'**
+  String get settingspageManualsecret;
+
+  /// No description provided for @settingspageMinlengthhint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Minimum 8 caractères.'**
+  String get settingspageMinlengthhint;
+
+  /// No description provided for @settingspageNewpassword.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nouveau mot de passe'**
+  String get settingspageNewpassword;
+
+  /// No description provided for @settingspagePassword.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mot de passe'**
+  String get settingspagePassword;
+
+  /// No description provided for @settingspagePasswordsubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Changer votre mot de passe déconnectera automatiquement toutes vos autres sessions actives.'**
+  String get settingspagePasswordsubtitle;
+
+  /// No description provided for @settingspagePasswordtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mot de passe'**
+  String get settingspagePasswordtitle;
+
+  /// No description provided for @settingspagePasswordupdated.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mot de passe mis à jour avec succès.'**
+  String get settingspagePasswordupdated;
+
+  /// No description provided for @settingspagePasswordsmismatch.
+  ///
+  /// In fr, this message translates to:
+  /// **'Les mots de passe ne correspondent pas.'**
+  String get settingspagePasswordsmismatch;
+
+  /// No description provided for @settingspageProfilesubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nom et adresse email utilisés pour vous connecter.'**
+  String get settingspageProfilesubtitle;
+
+  /// No description provided for @settingspageProfiletitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Informations du profil'**
+  String get settingspageProfiletitle;
+
+  /// No description provided for @settingspageProfileupdated.
+  ///
+  /// In fr, this message translates to:
+  /// **'Profil mis à jour avec succès.'**
+  String get settingspageProfileupdated;
+
+  /// No description provided for @settingspageSavechanges.
+  ///
+  /// In fr, this message translates to:
+  /// **'Enregistrer les modifications'**
+  String get settingspageSavechanges;
+
+  /// No description provided for @settingspageScanstep.
+  ///
+  /// In fr, this message translates to:
+  /// **'1. Scannez ce lien / secret dans votre application 2FA :'**
+  String get settingspageScanstep;
+
+  /// No description provided for @settingspageSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Gérez vos informations, votre mot de passe et la sécurité de votre compte super-administrateur.'**
+  String get settingspageSubtitle;
+
+  /// No description provided for @settingspageTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mon compte'**
+  String get settingspageTitle;
+
+  /// No description provided for @settingspageTwofactoractivehint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le 2FA est actif. Pour le désactiver, confirmez votre mot de passe.'**
+  String get settingspageTwofactoractivehint;
+
+  /// No description provided for @settingspageTwofactordisabled.
+  ///
+  /// In fr, this message translates to:
+  /// **'2FA désactivé.'**
+  String get settingspageTwofactordisabled;
+
+  /// No description provided for @settingspageTwofactorenabled.
+  ///
+  /// In fr, this message translates to:
+  /// **'2FA activé avec succès.'**
+  String get settingspageTwofactorenabled;
+
+  /// No description provided for @settingspageTwofactorsubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ajoutez une couche de sécurité supplémentaire à votre compte de super-administrateur.'**
+  String get settingspageTwofactorsubtitle;
+
+  /// No description provided for @settingspageTwofactortitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Authentification à deux facteurs (2FA)'**
+  String get settingspageTwofactortitle;
+
+  /// No description provided for @settingspageUpdatepassword.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mettre à jour le mot de passe'**
+  String get settingspageUpdatepassword;
+
+  /// No description provided for @systempageApierror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur : :error'**
+  String get systempageApierror;
+
+  /// No description provided for @systempageApioperational.
+  ///
+  /// In fr, this message translates to:
+  /// **'API opérationnelle'**
+  String get systempageApioperational;
+
+  /// No description provided for @systempageApioperationaldb.
+  ///
+  /// In fr, this message translates to:
+  /// **'API opérationnelle — DB :ms ms'**
+  String get systempageApioperationaldb;
+
+  /// No description provided for @systempageApiservices.
+  ///
+  /// In fr, this message translates to:
+  /// **'Services API'**
+  String get systempageApiservices;
+
+  /// No description provided for @systempageApiunavailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Non disponible — GET /health/live'**
+  String get systempageApiunavailable;
+
+  /// No description provided for @systempageDatabase.
+  ///
+  /// In fr, this message translates to:
+  /// **'Base de Données'**
+  String get systempageDatabase;
+
+  /// No description provided for @systempageDberror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur : :error'**
+  String get systempageDberror;
+
+  /// No description provided for @systempageDblatency.
+  ///
+  /// In fr, this message translates to:
+  /// **'Latence : :ms ms'**
+  String get systempageDblatency;
+
+  /// No description provided for @systempageDbunavailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Non disponible — lancez un Health Check.'**
+  String get systempageDbunavailable;
+
+  /// No description provided for @systempageDbunreachable.
+  ///
+  /// In fr, this message translates to:
+  /// **'base injoignable'**
+  String get systempageDbunreachable;
+
+  /// No description provided for @systempageGlobalerror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sonde agrégée : base de données injoignable.'**
+  String get systempageGlobalerror;
+
+  /// No description provided for @systempageGlobalhealthy.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sonde agrégée DB + Redis opérationnelle.'**
+  String get systempageGlobalhealthy;
+
+  /// No description provided for @systempageGlobalstatus.
+  ///
+  /// In fr, this message translates to:
+  /// **'Statut Global'**
+  String get systempageGlobalstatus;
+
+  /// No description provided for @systempageGlobalunavailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Non disponible — GET /admin/dashboard/stats'**
+  String get systempageGlobalunavailable;
+
+  /// No description provided for @systempageGlobalwarning.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sonde agrégée : dégradation détectée.'**
+  String get systempageGlobalwarning;
+
+  /// No description provided for @systempageHealthcheck.
+  ///
+  /// In fr, this message translates to:
+  /// **'Health Check'**
+  String get systempageHealthcheck;
+
+  /// No description provided for @systempageHealthcheckrunning.
+  ///
+  /// In fr, this message translates to:
+  /// **'Analyse...'**
+  String get systempageHealthcheckrunning;
+
+  /// No description provided for @systempageHealtherror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Health check terminé — base de données en erreur'**
+  String get systempageHealtherror;
+
+  /// No description provided for @systempageHealthliveunreachable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sonde /health/live injoignable.'**
+  String get systempageHealthliveunreachable;
+
+  /// No description provided for @systempageHealthok.
+  ///
+  /// In fr, this message translates to:
+  /// **'Health check terminé — base de données opérationnelle'**
+  String get systempageHealthok;
+
+  /// No description provided for @systempageHealthunreachable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Health check terminé — base de données injoignable'**
+  String get systempageHealthunreachable;
+
+  /// No description provided for @systempageInfradetails.
+  ///
+  /// In fr, this message translates to:
+  /// **':active compagnies actives · PHP :php · queue :queue'**
+  String get systempageInfradetails;
+
+  /// No description provided for @systempageInfraunavailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Non disponible — GET /platform/metrics/overview'**
+  String get systempageInfraunavailable;
+
+  /// No description provided for @systempageInfrastructure.
+  ///
+  /// In fr, this message translates to:
+  /// **'Infrastructure'**
+  String get systempageInfrastructure;
+
+  /// No description provided for @systempageMetricsloaderror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors du chargement des métriques plateforme'**
+  String get systempageMetricsloaderror;
+
+  /// No description provided for @systempageNotifobsloaderror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors du chargement de l\'observabilité des notifications'**
+  String get systempageNotifobsloaderror;
+
+  /// No description provided for @systempageQueueobsloaderror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors du chargement de l\'observabilité des jobs'**
+  String get systempageQueueobsloaderror;
+
+  /// No description provided for @systempageRetry.
+  ///
+  /// In fr, this message translates to:
+  /// **'Réessayer'**
+  String get systempageRetry;
+
+  /// No description provided for @systempageServiceunreachable.
+  ///
+  /// In fr, this message translates to:
+  /// **'service injoignable'**
+  String get systempageServiceunreachable;
+
+  /// No description provided for @systempageStatsloaderror.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors du chargement des stats système'**
+  String get systempageStatsloaderror;
+
+  /// No description provided for @systempageSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Monitoring, configuration et automatisation de la plateforme Leopardo RH.'**
+  String get systempageSubtitle;
+
+  /// No description provided for @systempageTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Administration Système'**
+  String get systempageTitle;
+
+  /// No description provided for @retry.
+  ///
+  /// In fr, this message translates to:
+  /// **'Réessayer'**
   String get retry;
+
+  /// No description provided for @featureComingSoon.
+  ///
+  /// In fr, this message translates to:
+  /// **'Fonction bientôt disponible'**
   String get featureComingSoon;
+
+  /// No description provided for @backToHome.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retour à l\'accueil'**
   String get backToHome;
+
+  /// No description provided for @pageNotFound.
+  ///
+  /// In fr, this message translates to:
+  /// **'La page demandée est introuvable ou la navigation a échoué.'**
   String get pageNotFound;
+
+  /// No description provided for @registerCreateAccount.
+  ///
+  /// In fr, this message translates to:
+  /// **'Créer votre compte'**
   String get registerCreateAccount;
+
+  /// No description provided for @registerFirstName.
+  ///
+  /// In fr, this message translates to:
+  /// **'Prénom'**
   String get registerFirstName;
+
+  /// No description provided for @registerRequired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Obligatoire'**
   String get registerRequired;
+
+  /// No description provided for @registerPassword.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mot de passe'**
   String get registerPassword;
+
+  /// No description provided for @registerMinChars.
+  ///
+  /// In fr, this message translates to:
+  /// **'8 caractères minimum'**
   String get registerMinChars;
+
+  /// No description provided for @registerCreating.
+  ///
+  /// In fr, this message translates to:
+  /// **'Création de compte en cours...'**
   String get registerCreating;
+
+  /// No description provided for @registerSubmit.
+  ///
+  /// In fr, this message translates to:
+  /// **'Créer mon compte'**
   String get registerSubmit;
+
+  /// No description provided for @accessDeniedTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Accès refusé'**
   String get accessDeniedTitle;
+
+  /// No description provided for @accessDeniedBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Votre compte n\'a pas le rôle Manager requis pour cette application. Utilisez l\'application correspondant à votre rôle (Employee, RH…) ou contactez votre administrateur.'**
   String get accessDeniedBody;
+
+  /// No description provided for @accessDeniedLogout.
+  ///
+  /// In fr, this message translates to:
+  /// **'Se déconnecter'**
   String get accessDeniedLogout;
+
+  /// No description provided for @accessDeniedBodyHr.
+  ///
+  /// In fr, this message translates to:
+  /// **'Votre compte n\'a pas le rôle RH requis pour cette application. Utilisez l\'application correspondant à votre rôle (Employee, Manager…) ou contactez votre administrateur.'**
   String get accessDeniedBodyHr;
+
+  /// No description provided for @evaluationsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mes Évaluations'**
   String get evaluationsTitle;
+
+  /// No description provided for @evaluationsEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'Aucune évaluation'**
   String get evaluationsEmpty;
+
+  /// No description provided for @evaluationsEmptyHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Vous n\'avez pas encore d\'évaluation enregistrée.'**
   String get evaluationsEmptyHint;
+
+  /// No description provided for @evaluationPeriod.
+  ///
+  /// In fr, this message translates to:
+  /// **'Période : {period}'**
   String evaluationPeriod(String period);
+
+  /// No description provided for @attendanceOnTime.
+  ///
+  /// In fr, this message translates to:
+  /// **'à l\'heure'**
   String get attendanceOnTime;
+
+  /// No description provided for @attendanceLate.
+  ///
+  /// In fr, this message translates to:
+  /// **'en retard'**
   String get attendanceLate;
+
+  /// No description provided for @attendanceAbsent.
+  ///
+  /// In fr, this message translates to:
+  /// **'absent'**
   String get attendanceAbsent;
+
+  /// No description provided for @attendanceInProgress.
+  ///
+  /// In fr, this message translates to:
+  /// **'en cours'**
   String get attendanceInProgress;
+
+  /// No description provided for @attendanceNoClock.
+  ///
+  /// In fr, this message translates to:
+  /// **'pas de pointage'**
   String get attendanceNoClock;
+
+  /// No description provided for @attendanceTimeRange.
+  ///
+  /// In fr, this message translates to:
+  /// **'de {from} à {to}'**
   String attendanceTimeRange(String from, String to);
+
+  /// No description provided for @attendanceHourWorked.
+  ///
+  /// In fr, this message translates to:
+  /// **'heure travaillée'**
   String get attendanceHourWorked;
+
+  /// No description provided for @attendanceHoursWorked.
+  ///
+  /// In fr, this message translates to:
+  /// **'heures travaillées'**
   String get attendanceHoursWorked;
+
+  /// No description provided for @attendanceDaySummary.
+  ///
+  /// In fr, this message translates to:
+  /// **'Journée du {date}, statut {status}, {range}, {hours}.'**
   String attendanceDaySummary(
     String date,
     String status,
     String range,
     String hours,
   );
+
+  /// No description provided for @sessionApproved.
+  ///
+  /// In fr, this message translates to:
+  /// **'Session approuvée ✓'**
   String get sessionApproved;
+
+  /// No description provided for @sessionRejected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Session rejetée'**
   String get sessionRejected;
+
+  /// No description provided for @pendingSessionsToValidate.
+  ///
+  /// In fr, this message translates to:
+  /// **'À valider'**
   String get pendingSessionsToValidate;
+
+  /// No description provided for @pendingSessionsUpToDate.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tout est à jour'**
   String get pendingSessionsUpToDate;
+
+  /// No description provided for @pendingSessionsEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'Aucune session GPS en attente de validation.'**
   String get pendingSessionsEmpty;
+
+  /// No description provided for @employeeNumber.
+  ///
+  /// In fr, this message translates to:
+  /// **'Employé #{id}'**
   String employeeNumber(String id);
+
+  /// No description provided for @sessionEntryAt.
+  ///
+  /// In fr, this message translates to:
+  /// **'Entrée : {time}'**
   String sessionEntryAt(String time);
+
+  /// No description provided for @sessionsToValidate.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sessions à valider'**
   String get sessionsToValidate;
+
+  /// No description provided for @errorPrefix.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur : {message}'**
   String errorPrefix(String message);
+
+  /// No description provided for @saDashboardTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pointage GPS — tableau de bord équipe'**
   String get saDashboardTitle;
+
+  /// No description provided for @saDetected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Détectées'**
   String get saDetected;
+
+  /// No description provided for @saApproved.
+  ///
+  /// In fr, this message translates to:
+  /// **'Approuvées'**
   String get saApproved;
+
+  /// No description provided for @saRejected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Rejetées'**
   String get saRejected;
+
+  /// No description provided for @saRecentSessions.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sessions récentes'**
   String get saRecentSessions;
+
+  /// No description provided for @saForced.
+  ///
+  /// In fr, this message translates to:
+  /// **'Imposé'**
   String get saForced;
+
+  /// No description provided for @saPresenceInProgress.
+  ///
+  /// In fr, this message translates to:
+  /// **'Présence en cours depuis {time}'**
   String saPresenceInProgress(String time);
+
+  /// No description provided for @saGpsZoneNotConfigured.
+  ///
+  /// In fr, this message translates to:
+  /// **'La zone GPS de votre entreprise n\'est pas encore configurée.'**
   String get saGpsZoneNotConfigured;
+
+  /// No description provided for @saDisableAutoGps.
+  ///
+  /// In fr, this message translates to:
+  /// **'Désactiver le GPS automatique'**
   String get saDisableAutoGps;
+
+  /// No description provided for @saStatusApproved.
+  ///
+  /// In fr, this message translates to:
+  /// **'Approuvée'**
   String get saStatusApproved;
+
+  /// No description provided for @saStatusDetected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Détectée'**
   String get saStatusDetected;
+
+  /// No description provided for @saStatusRejected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Rejetée'**
   String get saStatusRejected;
+
+  /// No description provided for @saStatusCancelled.
+  ///
+  /// In fr, this message translates to:
+  /// **'Annulée'**
   String get saStatusCancelled;
+
+  /// No description provided for @saStatusPending.
+  ///
+  /// In fr, this message translates to:
+  /// **'En validation'**
   String get saStatusPending;
+
+  /// No description provided for @saEnableAutoGps.
+  ///
+  /// In fr, this message translates to:
+  /// **'Activer le GPS automatique'**
   String get saEnableAutoGps;
+
+  /// No description provided for @attendanceOvertime.
+  ///
+  /// In fr, this message translates to:
+  /// **'Heures supplémentaires'**
   String get attendanceOvertime;
+
+  /// No description provided for @approvalsUpToDate.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tout est à jour'**
   String get approvalsUpToDate;
+
+  /// No description provided for @approvalsEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'Aucune approbation en attente.'**
   String get approvalsEmpty;
+
+  /// No description provided for @saConfigLoadError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impossible de charger la configuration.\n{error}'**
   String saConfigLoadError(String error);
+
+  /// No description provided for @ampAutoDetectDesc.
+  ///
+  /// In fr, this message translates to:
+  /// **'Votre présence est détectée automatiquement dès que vous entrez dans la zone de l\'entreprise. Aucune action requise de votre part.'**
   String get ampAutoDetectDesc;
+
+  /// No description provided for @ampRecommended.
+  ///
+  /// In fr, this message translates to:
+  /// **'Recommandé'**
   String get ampRecommended;
+
+  /// No description provided for @ampQrScanDesc.
+  ///
+  /// In fr, this message translates to:
+  /// **'Scannez le QR Code affiché à l\'entrée de l\'entreprise pour pointer votre arrivée et votre départ.'**
   String get ampQrScanDesc;
+
+  /// No description provided for @ampManualDesc.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pointez manuellement en appuyant sur les boutons Arrivée et Départ dans l\'écran de présence.'**
   String get ampManualDesc;
+
+  /// No description provided for @ampSaveError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impossible de sauvegarder votre préférence. Vérifiez votre connexion.'**
   String get ampSaveError;
+
+  /// No description provided for @ampTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Choisissez comment vous souhaitez pointer votre présence chaque jour.'**
   String get ampTitle;
+
+  /// No description provided for @ampModeTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mode de pointage'**
   String get ampModeTitle;
+
+  /// No description provided for @back.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retour'**
   String get back;
+
+  /// No description provided for @refresh.
+  ///
+  /// In fr, this message translates to:
+  /// **'Actualiser'**
   String get refresh;
+
+  /// No description provided for @saSessionsLoadError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impossible de charger les sessions GPS. Vérifiez votre connexion.'**
   String get saSessionsLoadError;
+
+  /// No description provided for @saStartMonitoringError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impossible de démarrer la surveillance GPS. Vérifiez les permissions de localisation et réessayez.'**
   String get saStartMonitoringError;
+
+  /// No description provided for @shellTeam.
+  ///
+  /// In fr, this message translates to:
+  /// **'Équipe'**
   String get shellTeam;
+
+  /// No description provided for @shellSettings.
+  ///
+  /// In fr, this message translates to:
+  /// **'Réglages'**
   String get shellSettings;
+
+  /// No description provided for @homeCompleteOnboarding.
+  ///
+  /// In fr, this message translates to:
+  /// **'Compléter mon onboarding'**
   String get homeCompleteOnboarding;
+
+  /// No description provided for @homeOnboardingHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Configurez votre espace en quelques étapes.'**
   String get homeOnboardingHint;
+
+  /// No description provided for @welcomeMyTeam.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mon équipe'**
   String get welcomeMyTeam;
+
+  /// No description provided for @welcomePresences.
+  ///
+  /// In fr, this message translates to:
+  /// **'Présences'**
   String get welcomePresences;
+
+  /// No description provided for @welcomeTasks.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tâches'**
   String get welcomeTasks;
+
+  /// No description provided for @welcomeLeaves.
+  ///
+  /// In fr, this message translates to:
+  /// **'Congés'**
   String get welcomeLeaves;
+
+  /// No description provided for @monthlySummaryLoading.
+  ///
+  /// In fr, this message translates to:
+  /// **'Chargement du résumé mensuel...'**
   String get monthlySummaryLoading;
+
+  /// No description provided for @orgChartEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'L\'organigramme sera disponible une fois les employés configurés.'**
   String get orgChartEmpty;
+
+  /// No description provided for @orgChartCollapse.
+  ///
+  /// In fr, this message translates to:
+  /// **'Réduire'**
   String get orgChartCollapse;
+
+  /// No description provided for @orgChartExpand.
+  ///
+  /// In fr, this message translates to:
+  /// **'Développer'**
   String get orgChartExpand;
+
+  /// No description provided for @errorUnexpected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Une erreur est survenue'**
   String get errorUnexpected;
-  String get apiAccessdenied;
-  String get apiConnectionerror;
-  String get apiGenericerror;
-  String get apiInvaliddata;
-  String get apiNotfound;
-  String get apiServererror;
-  String get apiServererrorretry;
-  String get apiServerunavailable;
-  String get apiSessionexpired;
-  String get apiToomanyrequests;
-  String get authDemoAccess;
-  String get authTogglePasswordVisibility;
-  String get commonRequired;
-  String get partnerpageApplyerrorprefix;
-  String get partnerpageCommissionsEmpty;
-  String get partnerpageCommissionsTitle;
-  String get partnerpageDashboardSubtitle;
-  String get partnerpageDashboardTitle;
-  String get partnerpageLoading;
-  String get partnerpageMetricsConversions;
-  String get partnerpageMetricsPending;
-  String get partnerpageMetricsTotalearned;
-  String get partnerpageMetricsWithdrawable;
-  String get partnerpageNotappliedAgency;
-  String get partnerpageNotappliedIndividual;
-  String get partnerpageNotappliedSubtitle;
-  String get partnerpageNotappliedTitle;
-  String get partnerpagePayoutBody;
-  String get partnerpagePayoutErrorprefix;
-  String get partnerpagePayoutInsufficient;
-  String get partnerpagePayoutRequest;
-  String get partnerpagePayoutSending;
-  String get partnerpagePayoutSuccess;
-  String get partnerpagePayoutTitle;
-  String get partnerpagePendingBody;
-  String get partnerpagePendingTitle;
-  String get partnerpageReferralCopied;
-  String get partnerpageReferralCopy;
-  String get partnerpageReferralCopyerror;
-  String get partnerpageReferralTitle;
-  String get partnerpageReferralUnavailable;
-  String get partnerpageTableAmount;
-  String get partnerpageTableDate;
-  String get partnerpageTableStatus;
-  String get partnerpageTableStatuspaid;
-  String get partnerpageTableStatuspending;
-  String get partnerpageTableTenantid;
-  String get settingspageCancel;
-  String get settingspageConfirmpassword;
-  String get settingspageCurrentpassword;
-  String get settingspageDisable2fa;
-  String get settingspageDisabled;
-  String get settingspageEmail;
-  String get settingspageEnable2fa;
-  String get settingspageEnabled;
-  String get settingspageEntercodestep;
-  String get settingspageFullname;
-  String get settingspageGeneratesecret;
-  String get settingspageGeneratesecrethint;
-  String get settingspageManualsecret;
-  String get settingspageMinlengthhint;
-  String get settingspageNewpassword;
-  String get settingspagePassword;
-  String get settingspagePasswordsmismatch;
-  String get settingspagePasswordsubtitle;
-  String get settingspagePasswordtitle;
-  String get settingspagePasswordupdated;
-  String get settingspageProfilesubtitle;
-  String get settingspageProfiletitle;
-  String get settingspageProfileupdated;
-  String get settingspageSavechanges;
-  String get settingspageScanstep;
-  String get settingspageSubtitle;
-  String get settingspageTitle;
-  String get settingspageTwofactoractivehint;
-  String get settingspageTwofactordisabled;
-  String get settingspageTwofactorenabled;
-  String get settingspageTwofactorsubtitle;
-  String get settingspageTwofactortitle;
-  String get settingspageUpdatepassword;
-  String get systempageApierror;
-  String get systempageApioperational;
-  String get systempageApioperationaldb;
-  String get systempageApiservices;
-  String get systempageApiunavailable;
-  String get systempageDatabase;
-  String get systempageDberror;
-  String get systempageDblatency;
-  String get systempageDbunavailable;
-  String get systempageDbunreachable;
-  String get systempageGlobalerror;
-  String get systempageGlobalhealthy;
-  String get systempageGlobalstatus;
-  String get systempageGlobalunavailable;
-  String get systempageGlobalwarning;
-  String get systempageHealthcheck;
-  String get systempageHealthcheckrunning;
-  String get systempageHealtherror;
-  String get systempageHealthliveunreachable;
-  String get systempageHealthok;
-  String get systempageHealthunreachable;
-  String get systempageInfradetails;
-  String get systempageInfrastructure;
-  String get systempageInfraunavailable;
-  String get systempageMetricsloaderror;
-  String get systempageNotifobsloaderror;
-  String get systempageQueueobsloaderror;
-  String get systempageRetry;
-  String get systempageServiceunreachable;
-  String get systempageStatsloaderror;
-  String get systempageSubtitle;
-  String get systempageTitle;
-  String get userAuthAlreadyAccount;
-  String get userAuthBackToHome;
-  String get userAuthCity;
-  String get userAuthCompanyEmail;
-  String get userAuthCompanyName;
-  String get userAuthCompanyRequestBody;
-  String get userAuthCompanyRequestInfo;
-  String get userAuthCompanyRequestTitle;
-  String get userAuthCountry;
-  String get userAuthCreateCompany;
-  String get userAuthDescription;
-  String get userAuthFirstName;
-  String userAuthGoogleError(Object error);
-  String get userAuthLastName;
-  String get userAuthLoginSubtitle;
-  String get userAuthNoAccount;
-  String get userAuthPersonalLogin;
-  String get userAuthPhone;
-  String get userAuthPhoneOptional;
-  String get userAuthRegisterButton;
-  String get userAuthRegisterSubtitleAlt;
-  String get userAuthRegisterTitle;
-  String get userAuthSector;
-  String get userAuthSubmitError;
-  String get userAuthSubmitRequest;
+
+  /// No description provided for @approvalApproved.
+  ///
+  /// In fr, this message translates to:
+  /// **'Demande approuvée'**
+  String get approvalApproved;
+
+  /// No description provided for @approvalRejected.
+  ///
+  /// In fr, this message translates to:
+  /// **'Demande refusée'**
+  String get approvalRejected;
 }
 
 class _AppLocalizationsDelegate

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2693,7 +2694,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String evaluationPeriod(String period) {
-    return 'الفترة: \$period';
+    return 'الفترة: $period';
   }
 
   @override
@@ -2713,7 +2714,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String attendanceTimeRange(String from, String to) {
-    return 'من \$from إلى \$to';
+    return 'من $from إلى $to';
   }
 
   @override
@@ -2723,8 +2724,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get attendanceHoursWorked => 'ساعات عمل';
 
   @override
-  String attendanceDaySummary(String date, String status, String range, String hours) {
-    return 'يوم \$date، الحالة \$status، \$range، \$hours.';
+  String attendanceDaySummary(
+    String date,
+    String status,
+    String range,
+    String hours,
+  ) {
+    return 'يوم $date، الحالة $status، $range، $hours.';
   }
 
   @override
@@ -2744,12 +2750,12 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String employeeNumber(String id) {
-    return 'الموظف #\$id';
+    return 'الموظف #$id';
   }
 
   @override
   String sessionEntryAt(String time) {
-    return 'الدخول: \$time';
+    return 'الدخول: $time';
   }
 
   @override
@@ -2757,7 +2763,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String errorPrefix(String message) {
-    return 'خطأ: \$message';
+    return 'خطأ: $message';
   }
 
   @override
@@ -2780,7 +2786,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String saPresenceInProgress(String time) {
-    return 'حضور قيد التقدم منذ \$time';
+    return 'حضور قيد التقدم منذ $time';
   }
 
   @override
@@ -2818,7 +2824,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String saConfigLoadError(String error) {
-    return 'تعذر تحميل الإعدادات.\n\$error';
+    return 'تعذر تحميل الإعدادات.\n$error';
   }
 
   @override
@@ -2895,4 +2901,309 @@ class AppLocalizationsAr extends AppLocalizations {
   String get orgChartExpand => 'توسيع';
   @override
   String get errorUnexpected => 'حدث خطأ';
+  @override
+  String get apiAccessdenied =>
+      'تم رفض الوصول إلى :endpoint. صلاحيات غير كافية.';
+  @override
+  String get apiConnectionerror => 'خطأ في الاتصال. تحقق من اتصالك بالإنترنت.';
+  @override
+  String get apiGenericerror => 'خطأ :status على :endpoint.';
+  @override
+  String get apiInvaliddata => 'بيانات غير صالحة.';
+  @override
+  String get apiNotfound => 'الموارد غير موجودة: :endpoint';
+  @override
+  String get apiServererror => 'خطأ في الخادم على :endpoint. :detail';
+  @override
+  String get apiServererrorretry => 'حاول مرة أخرى لاحقًا.';
+  @override
+  String get apiServerunavailable =>
+      'الخادم غير متاح مؤقتًا (:status). يرجى المحاولة مرة أخرى بعد قليل.';
+  @override
+  String get apiSessionexpired => 'انتهت الجلسة. إعادة الاتصال...';
+  @override
+  String get apiToomanyrequests => 'طلبات كثيرة جدًا. يرجى الانتظار بضع ثوانٍ.';
+  @override
+  String get authDemoAccess => 'وصول تجريبي';
+  @override
+  String get authTogglePasswordVisibility => 'إظهار أو إخفاء كلمة المرور';
+  @override
+  String get commonRequired => 'مطلوب';
+  @override
+  String get partnerpageApplyerrorprefix => 'خطأ أثناء التقديم: ';
+  @override
+  String get partnerpageCommissionsEmpty => 'لا توجد عمولات مسجلة.';
+  @override
+  String get partnerpageCommissionsTitle => 'أحدث العمولات';
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'تابع تحويلاتك وعمولاتك في Leopardo RH — حالة شريك نشط.';
+  @override
+  String get partnerpageDashboardTitle => 'لوحة تحكم الشريك';
+  @override
+  String get partnerpageLoading => 'جارٍ تحميل مساحتك...';
+  @override
+  String get partnerpageMetricsConversions => 'التحويلات';
+  @override
+  String get partnerpageMetricsPending => 'قيد الانتظار';
+  @override
+  String get partnerpageMetricsTotalearned => 'إجمالي الأرباح';
+  @override
+  String get partnerpageMetricsWithdrawable => 'الرصيد القابل للسحب';
+  @override
+  String get partnerpageNotappliedAgency => 'التقديم كوكالة';
+  @override
+  String get partnerpageNotappliedIndividual => 'التقديم كفرد';
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'انضم إلى منظومة Leopardo RH واربح عمولات عن كل شركة تحيلها. عمولة متكررة تصل إلى 20%.';
+  @override
+  String get partnerpageNotappliedTitle => 'كن شريكاً';
+  @override
+  String get partnerpagePayoutBody =>
+      'تُدفع عمولاتك بمجرد بلوغ الحد الأدنى. تأكد من أن بياناتك البنكية محدّثة.';
+  @override
+  String get partnerpagePayoutErrorprefix => 'خطأ أثناء طلب التحويل: ';
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'الرصيد غير كافٍ لطلب تحويل (الحد الأدنى 100,00 €).';
+  @override
+  String get partnerpagePayoutRequest => 'طلب تحويل';
+  @override
+  String get partnerpagePayoutSending => 'جارٍ الإرسال...';
+  @override
+  String get partnerpagePayoutSuccess => 'تم إرسال طلب التحويل بنجاح.';
+  @override
+  String get partnerpagePayoutTitle => 'الدفع';
+  @override
+  String get partnerpagePendingBody =>
+      'يتم حالياً مراجعة طلبك من قبل فريق المبيعات. ستتلقى بريداً إلكترونياً فور تفعيل وصولك.';
+  @override
+  String get partnerpagePendingTitle => 'الطلب قيد المراجعة';
+  @override
+  String get partnerpageReferralCopied => 'تم النسخ!';
+  @override
+  String get partnerpageReferralCopy => 'نسخ رابطه';
+  @override
+  String get partnerpageReferralCopyerror => 'تعذر نسخ الرابط. انسخه يدوياً.';
+  @override
+  String get partnerpageReferralTitle => 'رابط الإحالة';
+  @override
+  String get partnerpageReferralUnavailable => 'الرابط غير متاح';
+  @override
+  String get partnerpageTableAmount => 'المبلغ';
+  @override
+  String get partnerpageTableDate => 'التاريخ';
+  @override
+  String get partnerpageTableStatus => 'الحالة';
+  @override
+  String get partnerpageTableStatuspaid => 'مدفوعة';
+  @override
+  String get partnerpageTableStatuspending => 'قيد الانتظار';
+  @override
+  String get partnerpageTableTenantid => 'معرّف المستأجر';
+  @override
+  String get settingspageCancel => 'إلغاء';
+  @override
+  String get settingspageConfirmpassword => 'تأكيد كلمة المرور';
+  @override
+  String get settingspageCurrentpassword => 'كلمة المرور الحالية';
+  @override
+  String get settingspageDisable2fa => 'إيقاف المصادقة الثنائية';
+  @override
+  String get settingspageDisabled => 'معطّل';
+  @override
+  String get settingspageEmail => 'عنوان البريد الإلكتروني';
+  @override
+  String get settingspageEnable2fa => 'تفعيل المصادقة الثنائية';
+  @override
+  String get settingspageEnabled => 'مفعّل';
+  @override
+  String get settingspageEntercodestep => '2. أدخل الرمز المكوّن من 6 أرقام';
+  @override
+  String get settingspageFullname => 'الاسم الكامل';
+  @override
+  String get settingspageGeneratesecret => 'إنشاء رمز 2FA السري';
+  @override
+  String get settingspageGeneratesecrethint =>
+      'أنشئ رمزًا سريًا وامسحه ضوئيًا باستخدام تطبيق مصادقة (Google Authenticator أو Authy أو 1Password...).';
+  @override
+  String get settingspageManualsecret => 'الرمز اليدوي:';
+  @override
+  String get settingspageMinlengthhint => '8 أحرف على الأقل.';
+  @override
+  String get settingspageNewpassword => 'كلمة المرور الجديدة';
+  @override
+  String get settingspagePassword => 'كلمة المرور';
+  @override
+  String get settingspagePasswordsmismatch => 'كلمتا المرور غير متطابقتين.';
+  @override
+  String get settingspagePasswordsubtitle =>
+      'سيؤدي تغيير كلمة المرور إلى تسجيل خروج جميع جلساتك النشطة الأخرى تلقائيًا.';
+  @override
+  String get settingspagePasswordtitle => 'كلمة المرور';
+  @override
+  String get settingspagePasswordupdated => 'تم تحديث كلمة المرور بنجاح.';
+  @override
+  String get settingspageProfilesubtitle =>
+      'الاسم وعنوان البريد الإلكتروني المستخدمان لتسجيل الدخول.';
+  @override
+  String get settingspageProfiletitle => 'معلومات الملف الشخصي';
+  @override
+  String get settingspageProfileupdated => 'تم تحديث الملف الشخصي بنجاح.';
+  @override
+  String get settingspageSavechanges => 'حفظ التغييرات';
+  @override
+  String get settingspageScanstep =>
+      '1. امسح هذا الرابط / الرمز في تطبيق المصادقة الثنائية:';
+  @override
+  String get settingspageSubtitle =>
+      'إدارة معلوماتك وكلمة المرور وأمان حساب المسؤول الأعلى.';
+  @override
+  String get settingspageTitle => 'حسابي';
+  @override
+  String get settingspageTwofactoractivehint =>
+      'المصادقة الثنائية مفعّلة. لإيقافها، أكّد كلمة المرور.';
+  @override
+  String get settingspageTwofactordisabled => 'تم إيقاف المصادقة الثنائية.';
+  @override
+  String get settingspageTwofactorenabled =>
+      'تم تفعيل المصادقة الثنائية بنجاح.';
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'أضف طبقة أمان إضافية إلى حساب المسؤول الأعلى.';
+  @override
+  String get settingspageTwofactortitle => 'المصادقة الثنائية (2FA)';
+  @override
+  String get settingspageUpdatepassword => 'تحديث كلمة المرور';
+  @override
+  String get systempageApierror => 'خطأ: :error';
+  @override
+  String get systempageApioperational => 'API يعمل';
+  @override
+  String get systempageApioperationaldb =>
+      'API يعمل — قاعدة البيانات :ms مللي ثانية';
+  @override
+  String get systempageApiservices => 'خدمات API';
+  @override
+  String get systempageApiunavailable => 'غير متاح — GET /health/live';
+  @override
+  String get systempageDatabase => 'قاعدة البيانات';
+  @override
+  String get systempageDberror => 'خطأ: :error';
+  @override
+  String get systempageDblatency => 'زمن الاستجابة: :ms مللي ثانية';
+  @override
+  String get systempageDbunavailable => 'غير متاح — قم بتشغيل فحص الصحة.';
+  @override
+  String get systempageDbunreachable => 'تعذر الوصول إلى قاعدة البيانات';
+  @override
+  String get systempageGlobalerror =>
+      'الفحص المجمّع: تعذر الوصول إلى قاعدة البيانات.';
+  @override
+  String get systempageGlobalhealthy =>
+      'فحص قاعدة البيانات وRedis المجمّع يعمل.';
+  @override
+  String get systempageGlobalstatus => 'الحالة العامة';
+  @override
+  String get systempageGlobalunavailable =>
+      'غير متاح — GET /admin/dashboard/stats';
+  @override
+  String get systempageGlobalwarning =>
+      'الفحص المجمّع: تم اكتشاف تدهور في الأداء.';
+  @override
+  String get systempageHealthcheck => 'فحص الصحة';
+  @override
+  String get systempageHealthcheckrunning => 'جارٍ الفحص...';
+  @override
+  String get systempageHealtherror =>
+      'اكتمل فحص الصحة — قاعدة البيانات في حالة خطأ';
+  @override
+  String get systempageHealthliveunreachable =>
+      'تعذر الوصول إلى فحص /health/live.';
+  @override
+  String get systempageHealthok => 'اكتمل فحص الصحة — قاعدة البيانات تعمل';
+  @override
+  String get systempageHealthunreachable =>
+      'اكتمل فحص الصحة — تعذر الوصول إلى قاعدة البيانات';
+  @override
+  String get systempageInfradetails =>
+      ':active شركة نشطة · PHP :php · قائمة الانتظار :queue';
+  @override
+  String get systempageInfrastructure => 'البنية التحتية';
+  @override
+  String get systempageInfraunavailable =>
+      'غير متاح — GET /platform/metrics/overview';
+  @override
+  String get systempageMetricsloaderror => 'خطأ أثناء تحميل مقاييس المنصة';
+  @override
+  String get systempageNotifobsloaderror => 'خطأ أثناء تحميل مراقبة الإشعارات';
+  @override
+  String get systempageQueueobsloaderror => 'خطأ أثناء تحميل مراقبة الوظائف';
+  @override
+  String get systempageRetry => 'إعادة المحاولة';
+  @override
+  String get systempageServiceunreachable => 'تعذر الوصول إلى الخدمة';
+  @override
+  String get systempageStatsloaderror => 'خطأ أثناء تحميل إحصائيات النظام';
+  @override
+  String get systempageSubtitle => 'مراقبة منصة Leopardo RH وتكوينها وأتمتتها.';
+  @override
+  String get systempageTitle => 'إدارة النظام';
+  @override
+  String get userAuthAlreadyAccount => 'لديك حساب بالفعل؟ تسجيل الدخول';
+  @override
+  String get userAuthBackToHome => 'العودة إلى الرئيسية';
+  @override
+  String get userAuthCity => 'المدينة';
+  @override
+  String get userAuthCompanyEmail => 'بريد الشركة الإلكتروني';
+  @override
+  String get userAuthCompanyName => 'اسم الشركة';
+  @override
+  String get userAuthCompanyRequestBody =>
+      'سيراجع مسؤول طلبك. ستتلقى إشعارًا بمجرد معالجته.';
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'أدخل معلومات شركتك. سيتحقق مسؤول من طلبك.';
+  @override
+  String get userAuthCompanyRequestTitle => 'تم إرسال الطلب!';
+  @override
+  String get userAuthCountry => 'البلد';
+  @override
+  String get userAuthCreateCompany => 'إنشاء شركة';
+  @override
+  String get userAuthDescription => 'الوصف';
+  @override
+  String get userAuthFirstName => 'الاسم الأول';
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'خطأ Google: $error';
+  }
+
+  @override
+  String get userAuthLastName => 'اسم العائلة';
+  @override
+  String get userAuthLoginSubtitle => 'اعثر على مساحتك ومستنداتك وطلباتك.';
+  @override
+  String get userAuthNoAccount => 'لا حساب بعد؟ إنشاء حساب';
+  @override
+  String get userAuthPersonalLogin => 'تسجيل الدخول الشخصي';
+  @override
+  String get userAuthPhone => 'الهاتف';
+  @override
+  String get userAuthPhoneOptional => 'الهاتف (اختياري)';
+  @override
+  String get userAuthRegisterButton => 'إنشاء حسابي';
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'اعثر على مساحتك الشخصية ونظم مستنداتك.';
+  @override
+  String get userAuthRegisterTitle => 'إنشاء حسابي';
+  @override
+  String get userAuthSector => 'قطاع الأعمال';
+  @override
+  String get userAuthSubmitError => 'خطأ في إرسال الطلب';
+  @override
+  String get userAuthSubmitRequest => 'إرسال الطلب';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -3166,11 +3166,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String attendanceDaySummary(
-    String date,
-    String status,
-    String range,
-    String hours,
-  ) {
+      String date, String status, String range, String hours) {
     return 'يوم $date، الحالة $status، $range، $hours.';
   }
 

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_ar.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -106,6 +105,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authTwoFactorRequired => 'رمز التحقق الثنائي مطلوب.';
 
   @override
+  String get authDemoAccess => 'وصول تجريبي';
+
+  @override
+  String get authTogglePasswordVisibility => 'إظهار أو إخفاء كلمة المرور';
+
+  @override
   String get commonLanguageLabel => 'اللغة';
 
   @override
@@ -197,6 +202,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get commonCountriesUs => 'الولايات المتحدة';
+
+  @override
+  String get commonRequired => 'مطلوب';
 
   @override
   String get modulesAttendance => 'الحضور';
@@ -2636,6 +2644,439 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get employeesEmptyList => 'لا يوجد موظفون مرئيون لهذا الحساب.';
+
+  @override
+  String get userAuthCompanyRequestTitle => 'تم إرسال الطلب!';
+
+  @override
+  String get userAuthCompanyRequestBody =>
+      'سيراجع مسؤول طلبك. ستتلقى إشعارًا بمجرد معالجته.';
+
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'أدخل معلومات شركتك. سيتحقق مسؤول من طلبك.';
+
+  @override
+  String get userAuthBackToHome => 'العودة إلى الرئيسية';
+
+  @override
+  String get userAuthCreateCompany => 'إنشاء شركة';
+
+  @override
+  String get userAuthCompanyName => 'اسم الشركة';
+
+  @override
+  String get userAuthCompanyEmail => 'بريد الشركة الإلكتروني';
+
+  @override
+  String get userAuthSector => 'قطاع الأعمال';
+
+  @override
+  String get userAuthCountry => 'البلد';
+
+  @override
+  String get userAuthCity => 'المدينة';
+
+  @override
+  String get userAuthPhone => 'الهاتف';
+
+  @override
+  String get userAuthDescription => 'الوصف';
+
+  @override
+  String get userAuthSubmitRequest => 'إرسال الطلب';
+
+  @override
+  String get userAuthSubmitError => 'خطأ في إرسال الطلب';
+
+  @override
+  String get userAuthAlreadyAccount => 'لديك حساب بالفعل؟ تسجيل الدخول';
+
+  @override
+  String get userAuthFirstName => 'الاسم الأول';
+
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'خطأ Google: $error';
+  }
+
+  @override
+  String get userAuthLastName => 'اسم العائلة';
+
+  @override
+  String get userAuthLoginSubtitle => 'اعثر على مساحتك ومستنداتك وطلباتك.';
+
+  @override
+  String get userAuthNoAccount => 'لا حساب بعد؟ إنشاء حساب';
+
+  @override
+  String get userAuthPersonalLogin => 'تسجيل الدخول الشخصي';
+
+  @override
+  String get userAuthPhoneOptional => 'الهاتف (اختياري)';
+
+  @override
+  String get userAuthRegisterButton => 'إنشاء حسابي';
+
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'اعثر على مساحتك الشخصية ونظم مستنداتك.';
+
+  @override
+  String get userAuthRegisterTitle => 'إنشاء حسابي';
+
+  @override
+  String get partnerpageLoading => 'جارٍ تحميل مساحتك...';
+
+  @override
+  String get partnerpageApplyerrorprefix => 'خطأ أثناء التقديم: ';
+
+  @override
+  String get partnerpageNotappliedTitle => 'كن شريكاً';
+
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'انضم إلى منظومة Leopardo RH واربح عمولات عن كل شركة تحيلها. عمولة متكررة تصل إلى 20%.';
+
+  @override
+  String get partnerpageNotappliedIndividual => 'التقديم كفرد';
+
+  @override
+  String get partnerpageNotappliedAgency => 'التقديم كوكالة';
+
+  @override
+  String get partnerpagePendingTitle => 'الطلب قيد المراجعة';
+
+  @override
+  String get partnerpagePendingBody =>
+      'يتم حالياً مراجعة طلبك من قبل فريق المبيعات. ستتلقى بريداً إلكترونياً فور تفعيل وصولك.';
+
+  @override
+  String get partnerpageDashboardTitle => 'لوحة تحكم الشريك';
+
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'تابع تحويلاتك وعمولاتك في Leopardo RH — حالة شريك نشط.';
+
+  @override
+  String get partnerpageMetricsConversions => 'التحويلات';
+
+  @override
+  String get partnerpageMetricsTotalearned => 'إجمالي الأرباح';
+
+  @override
+  String get partnerpageMetricsPending => 'قيد الانتظار';
+
+  @override
+  String get partnerpageMetricsWithdrawable => 'الرصيد القابل للسحب';
+
+  @override
+  String get partnerpageCommissionsTitle => 'أحدث العمولات';
+
+  @override
+  String get partnerpageCommissionsEmpty => 'لا توجد عمولات مسجلة.';
+
+  @override
+  String get partnerpageTableTenantid => 'معرّف المستأجر';
+
+  @override
+  String get partnerpageTableDate => 'التاريخ';
+
+  @override
+  String get partnerpageTableStatus => 'الحالة';
+
+  @override
+  String get partnerpageTableAmount => 'المبلغ';
+
+  @override
+  String get partnerpageTableStatuspaid => 'مدفوعة';
+
+  @override
+  String get partnerpageTableStatuspending => 'قيد الانتظار';
+
+  @override
+  String get partnerpagePayoutTitle => 'الدفع';
+
+  @override
+  String get partnerpagePayoutBody =>
+      'تُدفع عمولاتك بمجرد بلوغ الحد الأدنى. تأكد من أن بياناتك البنكية محدّثة.';
+
+  @override
+  String get partnerpagePayoutRequest => 'طلب تحويل';
+
+  @override
+  String get partnerpagePayoutSending => 'جارٍ الإرسال...';
+
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'الرصيد غير كافٍ لطلب تحويل (الحد الأدنى 100,00 €).';
+
+  @override
+  String get partnerpagePayoutSuccess => 'تم إرسال طلب التحويل بنجاح.';
+
+  @override
+  String get partnerpagePayoutErrorprefix => 'خطأ أثناء طلب التحويل: ';
+
+  @override
+  String get partnerpageReferralTitle => 'رابط الإحالة';
+
+  @override
+  String get partnerpageReferralUnavailable => 'الرابط غير متاح';
+
+  @override
+  String get partnerpageReferralCopy => 'نسخ رابطه';
+
+  @override
+  String get partnerpageReferralCopied => 'تم النسخ!';
+
+  @override
+  String get partnerpageReferralCopyerror => 'تعذر نسخ الرابط. انسخه يدوياً.';
+
+  @override
+  String get apiSessionexpired => 'انتهت الجلسة. إعادة الاتصال...';
+
+  @override
+  String get apiAccessdenied =>
+      'تم رفض الوصول إلى :endpoint. صلاحيات غير كافية.';
+
+  @override
+  String get apiNotfound => 'الموارد غير موجودة: :endpoint';
+
+  @override
+  String get apiToomanyrequests => 'طلبات كثيرة جدًا. يرجى الانتظار بضع ثوانٍ.';
+
+  @override
+  String get apiServererror => 'خطأ في الخادم على :endpoint. :detail';
+
+  @override
+  String get apiServererrorretry => 'حاول مرة أخرى لاحقًا.';
+
+  @override
+  String get apiServerunavailable =>
+      'الخادم غير متاح مؤقتًا (:status). يرجى المحاولة مرة أخرى بعد قليل.';
+
+  @override
+  String get apiGenericerror => 'خطأ :status على :endpoint.';
+
+  @override
+  String get apiInvaliddata => 'بيانات غير صالحة.';
+
+  @override
+  String get apiConnectionerror => 'خطأ في الاتصال. تحقق من اتصالك بالإنترنت.';
+
+  @override
+  String get settingspageCancel => 'إلغاء';
+
+  @override
+  String get settingspageConfirmpassword => 'تأكيد كلمة المرور';
+
+  @override
+  String get settingspageCurrentpassword => 'كلمة المرور الحالية';
+
+  @override
+  String get settingspageDisable2fa => 'إيقاف المصادقة الثنائية';
+
+  @override
+  String get settingspageDisabled => 'معطّل';
+
+  @override
+  String get settingspageEmail => 'عنوان البريد الإلكتروني';
+
+  @override
+  String get settingspageEnable2fa => 'تفعيل المصادقة الثنائية';
+
+  @override
+  String get settingspageEnabled => 'مفعّل';
+
+  @override
+  String get settingspageEntercodestep => '2. أدخل الرمز المكوّن من 6 أرقام';
+
+  @override
+  String get settingspageFullname => 'الاسم الكامل';
+
+  @override
+  String get settingspageGeneratesecret => 'إنشاء رمز 2FA السري';
+
+  @override
+  String get settingspageGeneratesecrethint =>
+      'أنشئ رمزًا سريًا وامسحه ضوئيًا باستخدام تطبيق مصادقة (Google Authenticator أو Authy أو 1Password...).';
+
+  @override
+  String get settingspageManualsecret => 'الرمز اليدوي:';
+
+  @override
+  String get settingspageMinlengthhint => '8 أحرف على الأقل.';
+
+  @override
+  String get settingspageNewpassword => 'كلمة المرور الجديدة';
+
+  @override
+  String get settingspagePassword => 'كلمة المرور';
+
+  @override
+  String get settingspagePasswordsubtitle =>
+      'سيؤدي تغيير كلمة المرور إلى تسجيل خروج جميع جلساتك النشطة الأخرى تلقائيًا.';
+
+  @override
+  String get settingspagePasswordtitle => 'كلمة المرور';
+
+  @override
+  String get settingspagePasswordupdated => 'تم تحديث كلمة المرور بنجاح.';
+
+  @override
+  String get settingspagePasswordsmismatch => 'كلمتا المرور غير متطابقتين.';
+
+  @override
+  String get settingspageProfilesubtitle =>
+      'الاسم وعنوان البريد الإلكتروني المستخدمان لتسجيل الدخول.';
+
+  @override
+  String get settingspageProfiletitle => 'معلومات الملف الشخصي';
+
+  @override
+  String get settingspageProfileupdated => 'تم تحديث الملف الشخصي بنجاح.';
+
+  @override
+  String get settingspageSavechanges => 'حفظ التغييرات';
+
+  @override
+  String get settingspageScanstep =>
+      '1. امسح هذا الرابط / الرمز في تطبيق المصادقة الثنائية:';
+
+  @override
+  String get settingspageSubtitle =>
+      'إدارة معلوماتك وكلمة المرور وأمان حساب المسؤول الأعلى.';
+
+  @override
+  String get settingspageTitle => 'حسابي';
+
+  @override
+  String get settingspageTwofactoractivehint =>
+      'المصادقة الثنائية مفعّلة. لإيقافها، أكّد كلمة المرور.';
+
+  @override
+  String get settingspageTwofactordisabled => 'تم إيقاف المصادقة الثنائية.';
+
+  @override
+  String get settingspageTwofactorenabled =>
+      'تم تفعيل المصادقة الثنائية بنجاح.';
+
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'أضف طبقة أمان إضافية إلى حساب المسؤول الأعلى.';
+
+  @override
+  String get settingspageTwofactortitle => 'المصادقة الثنائية (2FA)';
+
+  @override
+  String get settingspageUpdatepassword => 'تحديث كلمة المرور';
+
+  @override
+  String get systempageApierror => 'خطأ: :error';
+
+  @override
+  String get systempageApioperational => 'API يعمل';
+
+  @override
+  String get systempageApioperationaldb =>
+      'API يعمل — قاعدة البيانات :ms مللي ثانية';
+
+  @override
+  String get systempageApiservices => 'خدمات API';
+
+  @override
+  String get systempageApiunavailable => 'غير متاح — GET /health/live';
+
+  @override
+  String get systempageDatabase => 'قاعدة البيانات';
+
+  @override
+  String get systempageDberror => 'خطأ: :error';
+
+  @override
+  String get systempageDblatency => 'زمن الاستجابة: :ms مللي ثانية';
+
+  @override
+  String get systempageDbunavailable => 'غير متاح — قم بتشغيل فحص الصحة.';
+
+  @override
+  String get systempageDbunreachable => 'تعذر الوصول إلى قاعدة البيانات';
+
+  @override
+  String get systempageGlobalerror =>
+      'الفحص المجمّع: تعذر الوصول إلى قاعدة البيانات.';
+
+  @override
+  String get systempageGlobalhealthy =>
+      'فحص قاعدة البيانات وRedis المجمّع يعمل.';
+
+  @override
+  String get systempageGlobalstatus => 'الحالة العامة';
+
+  @override
+  String get systempageGlobalunavailable =>
+      'غير متاح — GET /admin/dashboard/stats';
+
+  @override
+  String get systempageGlobalwarning =>
+      'الفحص المجمّع: تم اكتشاف تدهور في الأداء.';
+
+  @override
+  String get systempageHealthcheck => 'فحص الصحة';
+
+  @override
+  String get systempageHealthcheckrunning => 'جارٍ الفحص...';
+
+  @override
+  String get systempageHealtherror =>
+      'اكتمل فحص الصحة — قاعدة البيانات في حالة خطأ';
+
+  @override
+  String get systempageHealthliveunreachable =>
+      'تعذر الوصول إلى فحص /health/live.';
+
+  @override
+  String get systempageHealthok => 'اكتمل فحص الصحة — قاعدة البيانات تعمل';
+
+  @override
+  String get systempageHealthunreachable =>
+      'اكتمل فحص الصحة — تعذر الوصول إلى قاعدة البيانات';
+
+  @override
+  String get systempageInfradetails =>
+      ':active شركة نشطة · PHP :php · قائمة الانتظار :queue';
+
+  @override
+  String get systempageInfraunavailable =>
+      'غير متاح — GET /platform/metrics/overview';
+
+  @override
+  String get systempageInfrastructure => 'البنية التحتية';
+
+  @override
+  String get systempageMetricsloaderror => 'خطأ أثناء تحميل مقاييس المنصة';
+
+  @override
+  String get systempageNotifobsloaderror => 'خطأ أثناء تحميل مراقبة الإشعارات';
+
+  @override
+  String get systempageQueueobsloaderror => 'خطأ أثناء تحميل مراقبة الوظائف';
+
+  @override
+  String get systempageRetry => 'إعادة المحاولة';
+
+  @override
+  String get systempageServiceunreachable => 'تعذر الوصول إلى الخدمة';
+
+  @override
+  String get systempageStatsloaderror => 'خطأ أثناء تحميل إحصائيات النظام';
+
+  @override
+  String get systempageSubtitle => 'مراقبة منصة Leopardo RH وتكوينها وأتمتتها.';
+
+  @override
+  String get systempageTitle => 'إدارة النظام';
+
   @override
   String get retry => 'إعادة المحاولة';
 
@@ -2899,311 +3340,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get orgChartExpand => 'توسيع';
-  @override
-  String get errorUnexpected => 'حدث خطأ';
-  @override
-  String get apiAccessdenied =>
-      'تم رفض الوصول إلى :endpoint. صلاحيات غير كافية.';
-  @override
-  String get apiConnectionerror => 'خطأ في الاتصال. تحقق من اتصالك بالإنترنت.';
-  @override
-  String get apiGenericerror => 'خطأ :status على :endpoint.';
-  @override
-  String get apiInvaliddata => 'بيانات غير صالحة.';
-  @override
-  String get apiNotfound => 'الموارد غير موجودة: :endpoint';
-  @override
-  String get apiServererror => 'خطأ في الخادم على :endpoint. :detail';
-  @override
-  String get apiServererrorretry => 'حاول مرة أخرى لاحقًا.';
-  @override
-  String get apiServerunavailable =>
-      'الخادم غير متاح مؤقتًا (:status). يرجى المحاولة مرة أخرى بعد قليل.';
-  @override
-  String get apiSessionexpired => 'انتهت الجلسة. إعادة الاتصال...';
-  @override
-  String get apiToomanyrequests => 'طلبات كثيرة جدًا. يرجى الانتظار بضع ثوانٍ.';
-  @override
-  String get authDemoAccess => 'وصول تجريبي';
-  @override
-  String get authTogglePasswordVisibility => 'إظهار أو إخفاء كلمة المرور';
-  @override
-  String get commonRequired => 'مطلوب';
-  @override
-  String get partnerpageApplyerrorprefix => 'خطأ أثناء التقديم: ';
-  @override
-  String get partnerpageCommissionsEmpty => 'لا توجد عمولات مسجلة.';
-  @override
-  String get partnerpageCommissionsTitle => 'أحدث العمولات';
-  @override
-  String get partnerpageDashboardSubtitle =>
-      'تابع تحويلاتك وعمولاتك في Leopardo RH — حالة شريك نشط.';
-  @override
-  String get partnerpageDashboardTitle => 'لوحة تحكم الشريك';
-  @override
-  String get partnerpageLoading => 'جارٍ تحميل مساحتك...';
-  @override
-  String get partnerpageMetricsConversions => 'التحويلات';
-  @override
-  String get partnerpageMetricsPending => 'قيد الانتظار';
-  @override
-  String get partnerpageMetricsTotalearned => 'إجمالي الأرباح';
-  @override
-  String get partnerpageMetricsWithdrawable => 'الرصيد القابل للسحب';
-  @override
-  String get partnerpageNotappliedAgency => 'التقديم كوكالة';
-  @override
-  String get partnerpageNotappliedIndividual => 'التقديم كفرد';
-  @override
-  String get partnerpageNotappliedSubtitle =>
-      'انضم إلى منظومة Leopardo RH واربح عمولات عن كل شركة تحيلها. عمولة متكررة تصل إلى 20%.';
-  @override
-  String get partnerpageNotappliedTitle => 'كن شريكاً';
-  @override
-  String get partnerpagePayoutBody =>
-      'تُدفع عمولاتك بمجرد بلوغ الحد الأدنى. تأكد من أن بياناتك البنكية محدّثة.';
-  @override
-  String get partnerpagePayoutErrorprefix => 'خطأ أثناء طلب التحويل: ';
-  @override
-  String get partnerpagePayoutInsufficient =>
-      'الرصيد غير كافٍ لطلب تحويل (الحد الأدنى 100,00 €).';
-  @override
-  String get partnerpagePayoutRequest => 'طلب تحويل';
-  @override
-  String get partnerpagePayoutSending => 'جارٍ الإرسال...';
-  @override
-  String get partnerpagePayoutSuccess => 'تم إرسال طلب التحويل بنجاح.';
-  @override
-  String get partnerpagePayoutTitle => 'الدفع';
-  @override
-  String get partnerpagePendingBody =>
-      'يتم حالياً مراجعة طلبك من قبل فريق المبيعات. ستتلقى بريداً إلكترونياً فور تفعيل وصولك.';
-  @override
-  String get partnerpagePendingTitle => 'الطلب قيد المراجعة';
-  @override
-  String get partnerpageReferralCopied => 'تم النسخ!';
-  @override
-  String get partnerpageReferralCopy => 'نسخ رابطه';
-  @override
-  String get partnerpageReferralCopyerror => 'تعذر نسخ الرابط. انسخه يدوياً.';
-  @override
-  String get partnerpageReferralTitle => 'رابط الإحالة';
-  @override
-  String get partnerpageReferralUnavailable => 'الرابط غير متاح';
-  @override
-  String get partnerpageTableAmount => 'المبلغ';
-  @override
-  String get partnerpageTableDate => 'التاريخ';
-  @override
-  String get partnerpageTableStatus => 'الحالة';
-  @override
-  String get partnerpageTableStatuspaid => 'مدفوعة';
-  @override
-  String get partnerpageTableStatuspending => 'قيد الانتظار';
-  @override
-  String get partnerpageTableTenantid => 'معرّف المستأجر';
-  @override
-  String get settingspageCancel => 'إلغاء';
-  @override
-  String get settingspageConfirmpassword => 'تأكيد كلمة المرور';
-  @override
-  String get settingspageCurrentpassword => 'كلمة المرور الحالية';
-  @override
-  String get settingspageDisable2fa => 'إيقاف المصادقة الثنائية';
-  @override
-  String get settingspageDisabled => 'معطّل';
-  @override
-  String get settingspageEmail => 'عنوان البريد الإلكتروني';
-  @override
-  String get settingspageEnable2fa => 'تفعيل المصادقة الثنائية';
-  @override
-  String get settingspageEnabled => 'مفعّل';
-  @override
-  String get settingspageEntercodestep => '2. أدخل الرمز المكوّن من 6 أرقام';
-  @override
-  String get settingspageFullname => 'الاسم الكامل';
-  @override
-  String get settingspageGeneratesecret => 'إنشاء رمز 2FA السري';
-  @override
-  String get settingspageGeneratesecrethint =>
-      'أنشئ رمزًا سريًا وامسحه ضوئيًا باستخدام تطبيق مصادقة (Google Authenticator أو Authy أو 1Password...).';
-  @override
-  String get settingspageManualsecret => 'الرمز اليدوي:';
-  @override
-  String get settingspageMinlengthhint => '8 أحرف على الأقل.';
-  @override
-  String get settingspageNewpassword => 'كلمة المرور الجديدة';
-  @override
-  String get settingspagePassword => 'كلمة المرور';
-  @override
-  String get settingspagePasswordsmismatch => 'كلمتا المرور غير متطابقتين.';
-  @override
-  String get settingspagePasswordsubtitle =>
-      'سيؤدي تغيير كلمة المرور إلى تسجيل خروج جميع جلساتك النشطة الأخرى تلقائيًا.';
-  @override
-  String get settingspagePasswordtitle => 'كلمة المرور';
-  @override
-  String get settingspagePasswordupdated => 'تم تحديث كلمة المرور بنجاح.';
-  @override
-  String get settingspageProfilesubtitle =>
-      'الاسم وعنوان البريد الإلكتروني المستخدمان لتسجيل الدخول.';
-  @override
-  String get settingspageProfiletitle => 'معلومات الملف الشخصي';
-  @override
-  String get settingspageProfileupdated => 'تم تحديث الملف الشخصي بنجاح.';
-  @override
-  String get settingspageSavechanges => 'حفظ التغييرات';
-  @override
-  String get settingspageScanstep =>
-      '1. امسح هذا الرابط / الرمز في تطبيق المصادقة الثنائية:';
-  @override
-  String get settingspageSubtitle =>
-      'إدارة معلوماتك وكلمة المرور وأمان حساب المسؤول الأعلى.';
-  @override
-  String get settingspageTitle => 'حسابي';
-  @override
-  String get settingspageTwofactoractivehint =>
-      'المصادقة الثنائية مفعّلة. لإيقافها، أكّد كلمة المرور.';
-  @override
-  String get settingspageTwofactordisabled => 'تم إيقاف المصادقة الثنائية.';
-  @override
-  String get settingspageTwofactorenabled =>
-      'تم تفعيل المصادقة الثنائية بنجاح.';
-  @override
-  String get settingspageTwofactorsubtitle =>
-      'أضف طبقة أمان إضافية إلى حساب المسؤول الأعلى.';
-  @override
-  String get settingspageTwofactortitle => 'المصادقة الثنائية (2FA)';
-  @override
-  String get settingspageUpdatepassword => 'تحديث كلمة المرور';
-  @override
-  String get systempageApierror => 'خطأ: :error';
-  @override
-  String get systempageApioperational => 'API يعمل';
-  @override
-  String get systempageApioperationaldb =>
-      'API يعمل — قاعدة البيانات :ms مللي ثانية';
-  @override
-  String get systempageApiservices => 'خدمات API';
-  @override
-  String get systempageApiunavailable => 'غير متاح — GET /health/live';
-  @override
-  String get systempageDatabase => 'قاعدة البيانات';
-  @override
-  String get systempageDberror => 'خطأ: :error';
-  @override
-  String get systempageDblatency => 'زمن الاستجابة: :ms مللي ثانية';
-  @override
-  String get systempageDbunavailable => 'غير متاح — قم بتشغيل فحص الصحة.';
-  @override
-  String get systempageDbunreachable => 'تعذر الوصول إلى قاعدة البيانات';
-  @override
-  String get systempageGlobalerror =>
-      'الفحص المجمّع: تعذر الوصول إلى قاعدة البيانات.';
-  @override
-  String get systempageGlobalhealthy =>
-      'فحص قاعدة البيانات وRedis المجمّع يعمل.';
-  @override
-  String get systempageGlobalstatus => 'الحالة العامة';
-  @override
-  String get systempageGlobalunavailable =>
-      'غير متاح — GET /admin/dashboard/stats';
-  @override
-  String get systempageGlobalwarning =>
-      'الفحص المجمّع: تم اكتشاف تدهور في الأداء.';
-  @override
-  String get systempageHealthcheck => 'فحص الصحة';
-  @override
-  String get systempageHealthcheckrunning => 'جارٍ الفحص...';
-  @override
-  String get systempageHealtherror =>
-      'اكتمل فحص الصحة — قاعدة البيانات في حالة خطأ';
-  @override
-  String get systempageHealthliveunreachable =>
-      'تعذر الوصول إلى فحص /health/live.';
-  @override
-  String get systempageHealthok => 'اكتمل فحص الصحة — قاعدة البيانات تعمل';
-  @override
-  String get systempageHealthunreachable =>
-      'اكتمل فحص الصحة — تعذر الوصول إلى قاعدة البيانات';
-  @override
-  String get systempageInfradetails =>
-      ':active شركة نشطة · PHP :php · قائمة الانتظار :queue';
-  @override
-  String get systempageInfrastructure => 'البنية التحتية';
-  @override
-  String get systempageInfraunavailable =>
-      'غير متاح — GET /platform/metrics/overview';
-  @override
-  String get systempageMetricsloaderror => 'خطأ أثناء تحميل مقاييس المنصة';
-  @override
-  String get systempageNotifobsloaderror => 'خطأ أثناء تحميل مراقبة الإشعارات';
-  @override
-  String get systempageQueueobsloaderror => 'خطأ أثناء تحميل مراقبة الوظائف';
-  @override
-  String get systempageRetry => 'إعادة المحاولة';
-  @override
-  String get systempageServiceunreachable => 'تعذر الوصول إلى الخدمة';
-  @override
-  String get systempageStatsloaderror => 'خطأ أثناء تحميل إحصائيات النظام';
-  @override
-  String get systempageSubtitle => 'مراقبة منصة Leopardo RH وتكوينها وأتمتتها.';
-  @override
-  String get systempageTitle => 'إدارة النظام';
-  @override
-  String get userAuthAlreadyAccount => 'لديك حساب بالفعل؟ تسجيل الدخول';
-  @override
-  String get userAuthBackToHome => 'العودة إلى الرئيسية';
-  @override
-  String get userAuthCity => 'المدينة';
-  @override
-  String get userAuthCompanyEmail => 'بريد الشركة الإلكتروني';
-  @override
-  String get userAuthCompanyName => 'اسم الشركة';
-  @override
-  String get userAuthCompanyRequestBody =>
-      'سيراجع مسؤول طلبك. ستتلقى إشعارًا بمجرد معالجته.';
-  @override
-  String get userAuthCompanyRequestInfo =>
-      'أدخل معلومات شركتك. سيتحقق مسؤول من طلبك.';
-  @override
-  String get userAuthCompanyRequestTitle => 'تم إرسال الطلب!';
-  @override
-  String get userAuthCountry => 'البلد';
-  @override
-  String get userAuthCreateCompany => 'إنشاء شركة';
-  @override
-  String get userAuthDescription => 'الوصف';
-  @override
-  String get userAuthFirstName => 'الاسم الأول';
-  @override
-  String userAuthGoogleError(Object error) {
-    return 'خطأ Google: $error';
-  }
 
   @override
-  String get userAuthLastName => 'اسم العائلة';
+  String get errorUnexpected => 'حدث خطأ';
+
   @override
-  String get userAuthLoginSubtitle => 'اعثر على مساحتك ومستنداتك وطلباتك.';
+  String get approvalApproved => 'تمت الموافقة على الطلب';
+
   @override
-  String get userAuthNoAccount => 'لا حساب بعد؟ إنشاء حساب';
-  @override
-  String get userAuthPersonalLogin => 'تسجيل الدخول الشخصي';
-  @override
-  String get userAuthPhone => 'الهاتف';
-  @override
-  String get userAuthPhoneOptional => 'الهاتف (اختياري)';
-  @override
-  String get userAuthRegisterButton => 'إنشاء حسابي';
-  @override
-  String get userAuthRegisterSubtitleAlt =>
-      'اعثر على مساحتك الشخصية ونظم مستنداتك.';
-  @override
-  String get userAuthRegisterTitle => 'إنشاء حسابي';
-  @override
-  String get userAuthSector => 'قطاع الأعمال';
-  @override
-  String get userAuthSubmitError => 'خطأ في إرسال الطلب';
-  @override
-  String get userAuthSubmitRequest => 'إرسال الطلب';
+  String get approvalRejected => 'تم رفض الطلب';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2715,7 +2716,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String evaluationPeriod(String period) {
-    return 'Period: \$period';
+    return 'Period: $period';
   }
 
   @override
@@ -2735,7 +2736,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String attendanceTimeRange(String from, String to) {
-    return 'from \$from to \$to';
+    return 'from $from to $to';
   }
 
   @override
@@ -2745,8 +2746,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get attendanceHoursWorked => 'hours worked';
 
   @override
-  String attendanceDaySummary(String date, String status, String range, String hours) {
-    return 'Day of \$date, status \$status, \$range, \$hours.';
+  String attendanceDaySummary(
+    String date,
+    String status,
+    String range,
+    String hours,
+  ) {
+    return 'Day of $date, status $status, $range, $hours.';
   }
 
   @override
@@ -2766,12 +2772,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String employeeNumber(String id) {
-    return 'Employee #\$id';
+    return 'Employee #$id';
   }
 
   @override
   String sessionEntryAt(String time) {
-    return 'Entry: \$time';
+    return 'Entry: $time';
   }
 
   @override
@@ -2779,7 +2785,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String errorPrefix(String message) {
-    return 'Error: \$message';
+    return 'Error: $message';
   }
 
   @override
@@ -2802,7 +2808,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String saPresenceInProgress(String time) {
-    return 'Presence in progress since \$time';
+    return 'Presence in progress since $time';
   }
 
   @override
@@ -2841,7 +2847,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String saConfigLoadError(String error) {
-    return 'Unable to load the configuration.\n\$error';
+    return 'Unable to load the configuration.\n$error';
   }
 
   @override
@@ -2922,4 +2928,314 @@ class AppLocalizationsEn extends AppLocalizations {
   String get orgChartExpand => 'Expand';
   @override
   String get errorUnexpected => 'An error occurred';
+  @override
+  String get apiAccessdenied =>
+      'Access denied on :endpoint. Insufficient permissions.';
+  @override
+  String get apiConnectionerror =>
+      'Connection error. Check your internet connection.';
+  @override
+  String get apiGenericerror => 'Error :status on :endpoint.';
+  @override
+  String get apiInvaliddata => 'Invalid data.';
+  @override
+  String get apiNotfound => 'Resource not found: :endpoint';
+  @override
+  String get apiServererror => 'Server error on :endpoint. :detail';
+  @override
+  String get apiServererrorretry => 'Try again later.';
+  @override
+  String get apiServerunavailable =>
+      'The server is temporarily unavailable (:status). Please try again shortly.';
+  @override
+  String get apiSessionexpired => 'Session expired. Reconnecting...';
+  @override
+  String get apiToomanyrequests =>
+      'Too many requests. Please wait a few seconds.';
+  @override
+  String get authDemoAccess => 'Demo access';
+  @override
+  String get authTogglePasswordVisibility => 'Show or hide password';
+  @override
+  String get commonRequired => 'Required';
+  @override
+  String get partnerpageApplyerrorprefix => 'Error while applying: ';
+  @override
+  String get partnerpageCommissionsEmpty => 'No commission recorded.';
+  @override
+  String get partnerpageCommissionsTitle => 'Latest commissions';
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'Track your Leopardo RH conversions and commissions — active partner status.';
+  @override
+  String get partnerpageDashboardTitle => 'Partner Dashboard';
+  @override
+  String get partnerpageLoading => 'Loading your workspace...';
+  @override
+  String get partnerpageMetricsConversions => 'Conversions';
+  @override
+  String get partnerpageMetricsPending => 'Pending';
+  @override
+  String get partnerpageMetricsTotalearned => 'Total earned';
+  @override
+  String get partnerpageMetricsWithdrawable => 'Withdrawable balance';
+  @override
+  String get partnerpageNotappliedAgency => 'Apply as an Agency';
+  @override
+  String get partnerpageNotappliedIndividual => 'Apply as an Individual';
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'Join the Leopardo RH ecosystem and earn commissions on every company you refer. Up to 20% recurring commission.';
+  @override
+  String get partnerpageNotappliedTitle => 'Become a Partner';
+  @override
+  String get partnerpagePayoutBody =>
+      'Your commissions are paid once the threshold is reached. Make sure your bank details are up to date.';
+  @override
+  String get partnerpagePayoutErrorprefix =>
+      'Error while requesting the transfer: ';
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'Insufficient balance to request a transfer (minimum €100.00).';
+  @override
+  String get partnerpagePayoutRequest => 'Request a transfer';
+  @override
+  String get partnerpagePayoutSending => 'Sending...';
+  @override
+  String get partnerpagePayoutSuccess => 'Transfer request sent successfully.';
+  @override
+  String get partnerpagePayoutTitle => 'Payout';
+  @override
+  String get partnerpagePendingBody =>
+      'Your application is being reviewed by our sales team. You will receive an email as soon as your access is activated.';
+  @override
+  String get partnerpagePendingTitle => 'Application in progress';
+  @override
+  String get partnerpageReferralCopied => 'Copied!';
+  @override
+  String get partnerpageReferralCopy => 'Copy my link';
+  @override
+  String get partnerpageReferralCopyerror =>
+      'Unable to copy the link. Copy it manually.';
+  @override
+  String get partnerpageReferralTitle => 'Referral link';
+  @override
+  String get partnerpageReferralUnavailable => 'Link unavailable';
+  @override
+  String get partnerpageTableAmount => 'Amount';
+  @override
+  String get partnerpageTableDate => 'Date';
+  @override
+  String get partnerpageTableStatus => 'Status';
+  @override
+  String get partnerpageTableStatuspaid => 'Paid';
+  @override
+  String get partnerpageTableStatuspending => 'Pending';
+  @override
+  String get partnerpageTableTenantid => 'Tenant ID';
+  @override
+  String get settingspageCancel => 'Cancel';
+  @override
+  String get settingspageConfirmpassword => 'Confirm password';
+  @override
+  String get settingspageCurrentpassword => 'Current password';
+  @override
+  String get settingspageDisable2fa => 'Disable 2FA';
+  @override
+  String get settingspageDisabled => 'Disabled';
+  @override
+  String get settingspageEmail => 'Email address';
+  @override
+  String get settingspageEnable2fa => 'Enable 2FA';
+  @override
+  String get settingspageEnabled => 'Enabled';
+  @override
+  String get settingspageEntercodestep => '2. Enter the generated 6-digit code';
+  @override
+  String get settingspageFullname => 'Full name';
+  @override
+  String get settingspageGeneratesecret => 'Generate 2FA secret';
+  @override
+  String get settingspageGeneratesecrethint =>
+      'Generate a secret and scan it with an authenticator app (Google Authenticator, Authy, 1Password...).';
+  @override
+  String get settingspageManualsecret => 'Manual secret:';
+  @override
+  String get settingspageMinlengthhint => 'Minimum 8 characters.';
+  @override
+  String get settingspageNewpassword => 'New password';
+  @override
+  String get settingspagePassword => 'Password';
+  @override
+  String get settingspagePasswordsmismatch => 'Passwords do not match.';
+  @override
+  String get settingspagePasswordsubtitle =>
+      'Changing your password will automatically sign out all your other active sessions.';
+  @override
+  String get settingspagePasswordtitle => 'Password';
+  @override
+  String get settingspagePasswordupdated => 'Password updated successfully.';
+  @override
+  String get settingspageProfilesubtitle =>
+      'Name and email address used to sign in.';
+  @override
+  String get settingspageProfiletitle => 'Profile information';
+  @override
+  String get settingspageProfileupdated => 'Profile updated successfully.';
+  @override
+  String get settingspageSavechanges => 'Save changes';
+  @override
+  String get settingspageScanstep =>
+      '1. Scan this link / secret in your 2FA app:';
+  @override
+  String get settingspageSubtitle =>
+      'Manage your information, password and the security of your super-admin account.';
+  @override
+  String get settingspageTitle => 'My account';
+  @override
+  String get settingspageTwofactoractivehint =>
+      '2FA is active. To disable it, confirm your password.';
+  @override
+  String get settingspageTwofactordisabled => '2FA disabled.';
+  @override
+  String get settingspageTwofactorenabled => '2FA enabled successfully.';
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'Add an extra layer of security to your super-admin account.';
+  @override
+  String get settingspageTwofactortitle => 'Two-factor authentication (2FA)';
+  @override
+  String get settingspageUpdatepassword => 'Update password';
+  @override
+  String get systempageApierror => 'Error: :error';
+  @override
+  String get systempageApioperational => 'API operational';
+  @override
+  String get systempageApioperationaldb => 'API operational — DB :ms ms';
+  @override
+  String get systempageApiservices => 'API Services';
+  @override
+  String get systempageApiunavailable => 'Unavailable — GET /health/live';
+  @override
+  String get systempageDatabase => 'Database';
+  @override
+  String get systempageDberror => 'Error: :error';
+  @override
+  String get systempageDblatency => 'Latency: :ms ms';
+  @override
+  String get systempageDbunavailable => 'Unavailable — run a Health Check.';
+  @override
+  String get systempageDbunreachable => 'database unreachable';
+  @override
+  String get systempageGlobalerror => 'Aggregated probe: database unreachable.';
+  @override
+  String get systempageGlobalhealthy =>
+      'Aggregated DB + Redis probe operational.';
+  @override
+  String get systempageGlobalstatus => 'Global Status';
+  @override
+  String get systempageGlobalunavailable =>
+      'Unavailable — GET /admin/dashboard/stats';
+  @override
+  String get systempageGlobalwarning =>
+      'Aggregated probe: degradation detected.';
+  @override
+  String get systempageHealthcheck => 'Health Check';
+  @override
+  String get systempageHealthcheckrunning => 'Checking...';
+  @override
+  String get systempageHealtherror =>
+      'Health check completed — database in error';
+  @override
+  String get systempageHealthliveunreachable =>
+      '/health/live probe unreachable.';
+  @override
+  String get systempageHealthok =>
+      'Health check completed — database operational';
+  @override
+  String get systempageHealthunreachable =>
+      'Health check completed — database unreachable';
+  @override
+  String get systempageInfradetails =>
+      ':active active companies · PHP :php · queue :queue';
+  @override
+  String get systempageInfrastructure => 'Infrastructure';
+  @override
+  String get systempageInfraunavailable =>
+      'Unavailable — GET /platform/metrics/overview';
+  @override
+  String get systempageMetricsloaderror => 'Error loading platform metrics';
+  @override
+  String get systempageNotifobsloaderror =>
+      'Error loading notifications observability';
+  @override
+  String get systempageQueueobsloaderror => 'Error loading jobs observability';
+  @override
+  String get systempageRetry => 'Retry';
+  @override
+  String get systempageServiceunreachable => 'service unreachable';
+  @override
+  String get systempageStatsloaderror => 'Error loading system stats';
+  @override
+  String get systempageSubtitle =>
+      'Monitoring, configuration and automation of the Leopardo RH platform.';
+  @override
+  String get systempageTitle => 'System Administration';
+  @override
+  String get userAuthAlreadyAccount => 'Already have an account? Sign in';
+  @override
+  String get userAuthBackToHome => 'Back to home';
+  @override
+  String get userAuthCity => 'City';
+  @override
+  String get userAuthCompanyEmail => 'Company email';
+  @override
+  String get userAuthCompanyName => 'Company name';
+  @override
+  String get userAuthCompanyRequestBody =>
+      'An administrator will review your request. You will receive a notification once it is processed.';
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'Fill in your company information. An administrator will validate your request.';
+  @override
+  String get userAuthCompanyRequestTitle => 'Request submitted!';
+  @override
+  String get userAuthCountry => 'Country';
+  @override
+  String get userAuthCreateCompany => 'Create a company';
+  @override
+  String get userAuthDescription => 'Description';
+  @override
+  String get userAuthFirstName => 'First name';
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'Google error: $error';
+  }
+
+  @override
+  String get userAuthLastName => 'Last name';
+  @override
+  String get userAuthLoginSubtitle =>
+      'Access your workspace, documents and requests.';
+  @override
+  String get userAuthNoAccount => 'No account yet? Sign up';
+  @override
+  String get userAuthPersonalLogin => 'Personal login';
+  @override
+  String get userAuthPhone => 'Phone';
+  @override
+  String get userAuthPhoneOptional => 'Phone (optional)';
+  @override
+  String get userAuthRegisterButton => 'Create my account';
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'Access your personal workspace and organise your documents.';
+  @override
+  String get userAuthRegisterTitle => 'Create my account';
+  @override
+  String get userAuthSector => 'Business sector';
+  @override
+  String get userAuthSubmitError => 'Error submitting request';
+  @override
+  String get userAuthSubmitRequest => 'Submit request';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -107,6 +106,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authTwoFactorRequired => 'The 2FA code is required.';
 
   @override
+  String get authDemoAccess => 'Demo access';
+
+  @override
+  String get authTogglePasswordVisibility => 'Show or hide password';
+
+  @override
   String get commonLanguageLabel => 'Language';
 
   @override
@@ -198,6 +203,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get commonCountriesUs => 'United States';
+
+  @override
+  String get commonRequired => 'Required';
 
   @override
   String get modulesAttendance => 'Attendance';
@@ -2656,6 +2664,444 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get employeesEmptyList => 'No employee visible for this account.';
+
+  @override
+  String get userAuthCompanyRequestTitle => 'Request submitted!';
+
+  @override
+  String get userAuthCompanyRequestBody =>
+      'An administrator will review your request. You will receive a notification once it is processed.';
+
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'Fill in your company information. An administrator will validate your request.';
+
+  @override
+  String get userAuthBackToHome => 'Back to home';
+
+  @override
+  String get userAuthCreateCompany => 'Create a company';
+
+  @override
+  String get userAuthCompanyName => 'Company name';
+
+  @override
+  String get userAuthCompanyEmail => 'Company email';
+
+  @override
+  String get userAuthSector => 'Business sector';
+
+  @override
+  String get userAuthCountry => 'Country';
+
+  @override
+  String get userAuthCity => 'City';
+
+  @override
+  String get userAuthPhone => 'Phone';
+
+  @override
+  String get userAuthDescription => 'Description';
+
+  @override
+  String get userAuthSubmitRequest => 'Submit request';
+
+  @override
+  String get userAuthSubmitError => 'Error submitting request';
+
+  @override
+  String get userAuthAlreadyAccount => 'Already have an account? Sign in';
+
+  @override
+  String get userAuthFirstName => 'First name';
+
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'Google error: $error';
+  }
+
+  @override
+  String get userAuthLastName => 'Last name';
+
+  @override
+  String get userAuthLoginSubtitle =>
+      'Access your workspace, documents and requests.';
+
+  @override
+  String get userAuthNoAccount => 'No account yet? Sign up';
+
+  @override
+  String get userAuthPersonalLogin => 'Personal login';
+
+  @override
+  String get userAuthPhoneOptional => 'Phone (optional)';
+
+  @override
+  String get userAuthRegisterButton => 'Create my account';
+
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'Access your personal workspace and organise your documents.';
+
+  @override
+  String get userAuthRegisterTitle => 'Create my account';
+
+  @override
+  String get partnerpageLoading => 'Loading your workspace...';
+
+  @override
+  String get partnerpageApplyerrorprefix => 'Error while applying: ';
+
+  @override
+  String get partnerpageNotappliedTitle => 'Become a Partner';
+
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'Join the Leopardo RH ecosystem and earn commissions on every company you refer. Up to 20% recurring commission.';
+
+  @override
+  String get partnerpageNotappliedIndividual => 'Apply as an Individual';
+
+  @override
+  String get partnerpageNotappliedAgency => 'Apply as an Agency';
+
+  @override
+  String get partnerpagePendingTitle => 'Application in progress';
+
+  @override
+  String get partnerpagePendingBody =>
+      'Your application is being reviewed by our sales team. You will receive an email as soon as your access is activated.';
+
+  @override
+  String get partnerpageDashboardTitle => 'Partner Dashboard';
+
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'Track your Leopardo RH conversions and commissions — active partner status.';
+
+  @override
+  String get partnerpageMetricsConversions => 'Conversions';
+
+  @override
+  String get partnerpageMetricsTotalearned => 'Total earned';
+
+  @override
+  String get partnerpageMetricsPending => 'Pending';
+
+  @override
+  String get partnerpageMetricsWithdrawable => 'Withdrawable balance';
+
+  @override
+  String get partnerpageCommissionsTitle => 'Latest commissions';
+
+  @override
+  String get partnerpageCommissionsEmpty => 'No commission recorded.';
+
+  @override
+  String get partnerpageTableTenantid => 'Tenant ID';
+
+  @override
+  String get partnerpageTableDate => 'Date';
+
+  @override
+  String get partnerpageTableStatus => 'Status';
+
+  @override
+  String get partnerpageTableAmount => 'Amount';
+
+  @override
+  String get partnerpageTableStatuspaid => 'Paid';
+
+  @override
+  String get partnerpageTableStatuspending => 'Pending';
+
+  @override
+  String get partnerpagePayoutTitle => 'Payout';
+
+  @override
+  String get partnerpagePayoutBody =>
+      'Your commissions are paid once the threshold is reached. Make sure your bank details are up to date.';
+
+  @override
+  String get partnerpagePayoutRequest => 'Request a transfer';
+
+  @override
+  String get partnerpagePayoutSending => 'Sending...';
+
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'Insufficient balance to request a transfer (minimum €100.00).';
+
+  @override
+  String get partnerpagePayoutSuccess => 'Transfer request sent successfully.';
+
+  @override
+  String get partnerpagePayoutErrorprefix =>
+      'Error while requesting the transfer: ';
+
+  @override
+  String get partnerpageReferralTitle => 'Referral link';
+
+  @override
+  String get partnerpageReferralUnavailable => 'Link unavailable';
+
+  @override
+  String get partnerpageReferralCopy => 'Copy my link';
+
+  @override
+  String get partnerpageReferralCopied => 'Copied!';
+
+  @override
+  String get partnerpageReferralCopyerror =>
+      'Unable to copy the link. Copy it manually.';
+
+  @override
+  String get apiSessionexpired => 'Session expired. Reconnecting...';
+
+  @override
+  String get apiAccessdenied =>
+      'Access denied on :endpoint. Insufficient permissions.';
+
+  @override
+  String get apiNotfound => 'Resource not found: :endpoint';
+
+  @override
+  String get apiToomanyrequests =>
+      'Too many requests. Please wait a few seconds.';
+
+  @override
+  String get apiServererror => 'Server error on :endpoint. :detail';
+
+  @override
+  String get apiServererrorretry => 'Try again later.';
+
+  @override
+  String get apiServerunavailable =>
+      'The server is temporarily unavailable (:status). Please try again shortly.';
+
+  @override
+  String get apiGenericerror => 'Error :status on :endpoint.';
+
+  @override
+  String get apiInvaliddata => 'Invalid data.';
+
+  @override
+  String get apiConnectionerror =>
+      'Connection error. Check your internet connection.';
+
+  @override
+  String get settingspageCancel => 'Cancel';
+
+  @override
+  String get settingspageConfirmpassword => 'Confirm password';
+
+  @override
+  String get settingspageCurrentpassword => 'Current password';
+
+  @override
+  String get settingspageDisable2fa => 'Disable 2FA';
+
+  @override
+  String get settingspageDisabled => 'Disabled';
+
+  @override
+  String get settingspageEmail => 'Email address';
+
+  @override
+  String get settingspageEnable2fa => 'Enable 2FA';
+
+  @override
+  String get settingspageEnabled => 'Enabled';
+
+  @override
+  String get settingspageEntercodestep => '2. Enter the generated 6-digit code';
+
+  @override
+  String get settingspageFullname => 'Full name';
+
+  @override
+  String get settingspageGeneratesecret => 'Generate 2FA secret';
+
+  @override
+  String get settingspageGeneratesecrethint =>
+      'Generate a secret and scan it with an authenticator app (Google Authenticator, Authy, 1Password...).';
+
+  @override
+  String get settingspageManualsecret => 'Manual secret:';
+
+  @override
+  String get settingspageMinlengthhint => 'Minimum 8 characters.';
+
+  @override
+  String get settingspageNewpassword => 'New password';
+
+  @override
+  String get settingspagePassword => 'Password';
+
+  @override
+  String get settingspagePasswordsubtitle =>
+      'Changing your password will automatically sign out all your other active sessions.';
+
+  @override
+  String get settingspagePasswordtitle => 'Password';
+
+  @override
+  String get settingspagePasswordupdated => 'Password updated successfully.';
+
+  @override
+  String get settingspagePasswordsmismatch => 'Passwords do not match.';
+
+  @override
+  String get settingspageProfilesubtitle =>
+      'Name and email address used to sign in.';
+
+  @override
+  String get settingspageProfiletitle => 'Profile information';
+
+  @override
+  String get settingspageProfileupdated => 'Profile updated successfully.';
+
+  @override
+  String get settingspageSavechanges => 'Save changes';
+
+  @override
+  String get settingspageScanstep =>
+      '1. Scan this link / secret in your 2FA app:';
+
+  @override
+  String get settingspageSubtitle =>
+      'Manage your information, password and the security of your super-admin account.';
+
+  @override
+  String get settingspageTitle => 'My account';
+
+  @override
+  String get settingspageTwofactoractivehint =>
+      '2FA is active. To disable it, confirm your password.';
+
+  @override
+  String get settingspageTwofactordisabled => '2FA disabled.';
+
+  @override
+  String get settingspageTwofactorenabled => '2FA enabled successfully.';
+
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'Add an extra layer of security to your super-admin account.';
+
+  @override
+  String get settingspageTwofactortitle => 'Two-factor authentication (2FA)';
+
+  @override
+  String get settingspageUpdatepassword => 'Update password';
+
+  @override
+  String get systempageApierror => 'Error: :error';
+
+  @override
+  String get systempageApioperational => 'API operational';
+
+  @override
+  String get systempageApioperationaldb => 'API operational — DB :ms ms';
+
+  @override
+  String get systempageApiservices => 'API Services';
+
+  @override
+  String get systempageApiunavailable => 'Unavailable — GET /health/live';
+
+  @override
+  String get systempageDatabase => 'Database';
+
+  @override
+  String get systempageDberror => 'Error: :error';
+
+  @override
+  String get systempageDblatency => 'Latency: :ms ms';
+
+  @override
+  String get systempageDbunavailable => 'Unavailable — run a Health Check.';
+
+  @override
+  String get systempageDbunreachable => 'database unreachable';
+
+  @override
+  String get systempageGlobalerror => 'Aggregated probe: database unreachable.';
+
+  @override
+  String get systempageGlobalhealthy =>
+      'Aggregated DB + Redis probe operational.';
+
+  @override
+  String get systempageGlobalstatus => 'Global Status';
+
+  @override
+  String get systempageGlobalunavailable =>
+      'Unavailable — GET /admin/dashboard/stats';
+
+  @override
+  String get systempageGlobalwarning =>
+      'Aggregated probe: degradation detected.';
+
+  @override
+  String get systempageHealthcheck => 'Health Check';
+
+  @override
+  String get systempageHealthcheckrunning => 'Checking...';
+
+  @override
+  String get systempageHealtherror =>
+      'Health check completed — database in error';
+
+  @override
+  String get systempageHealthliveunreachable =>
+      '/health/live probe unreachable.';
+
+  @override
+  String get systempageHealthok =>
+      'Health check completed — database operational';
+
+  @override
+  String get systempageHealthunreachable =>
+      'Health check completed — database unreachable';
+
+  @override
+  String get systempageInfradetails =>
+      ':active active companies · PHP :php · queue :queue';
+
+  @override
+  String get systempageInfraunavailable =>
+      'Unavailable — GET /platform/metrics/overview';
+
+  @override
+  String get systempageInfrastructure => 'Infrastructure';
+
+  @override
+  String get systempageMetricsloaderror => 'Error loading platform metrics';
+
+  @override
+  String get systempageNotifobsloaderror =>
+      'Error loading notifications observability';
+
+  @override
+  String get systempageQueueobsloaderror => 'Error loading jobs observability';
+
+  @override
+  String get systempageRetry => 'Retry';
+
+  @override
+  String get systempageServiceunreachable => 'service unreachable';
+
+  @override
+  String get systempageStatsloaderror => 'Error loading system stats';
+
+  @override
+  String get systempageSubtitle =>
+      'Monitoring, configuration and automation of the Leopardo RH platform.';
+
+  @override
+  String get systempageTitle => 'System Administration';
+
   @override
   String get retry => 'Retry';
 
@@ -2926,316 +3372,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get orgChartExpand => 'Expand';
-  @override
-  String get errorUnexpected => 'An error occurred';
-  @override
-  String get apiAccessdenied =>
-      'Access denied on :endpoint. Insufficient permissions.';
-  @override
-  String get apiConnectionerror =>
-      'Connection error. Check your internet connection.';
-  @override
-  String get apiGenericerror => 'Error :status on :endpoint.';
-  @override
-  String get apiInvaliddata => 'Invalid data.';
-  @override
-  String get apiNotfound => 'Resource not found: :endpoint';
-  @override
-  String get apiServererror => 'Server error on :endpoint. :detail';
-  @override
-  String get apiServererrorretry => 'Try again later.';
-  @override
-  String get apiServerunavailable =>
-      'The server is temporarily unavailable (:status). Please try again shortly.';
-  @override
-  String get apiSessionexpired => 'Session expired. Reconnecting...';
-  @override
-  String get apiToomanyrequests =>
-      'Too many requests. Please wait a few seconds.';
-  @override
-  String get authDemoAccess => 'Demo access';
-  @override
-  String get authTogglePasswordVisibility => 'Show or hide password';
-  @override
-  String get commonRequired => 'Required';
-  @override
-  String get partnerpageApplyerrorprefix => 'Error while applying: ';
-  @override
-  String get partnerpageCommissionsEmpty => 'No commission recorded.';
-  @override
-  String get partnerpageCommissionsTitle => 'Latest commissions';
-  @override
-  String get partnerpageDashboardSubtitle =>
-      'Track your Leopardo RH conversions and commissions — active partner status.';
-  @override
-  String get partnerpageDashboardTitle => 'Partner Dashboard';
-  @override
-  String get partnerpageLoading => 'Loading your workspace...';
-  @override
-  String get partnerpageMetricsConversions => 'Conversions';
-  @override
-  String get partnerpageMetricsPending => 'Pending';
-  @override
-  String get partnerpageMetricsTotalearned => 'Total earned';
-  @override
-  String get partnerpageMetricsWithdrawable => 'Withdrawable balance';
-  @override
-  String get partnerpageNotappliedAgency => 'Apply as an Agency';
-  @override
-  String get partnerpageNotappliedIndividual => 'Apply as an Individual';
-  @override
-  String get partnerpageNotappliedSubtitle =>
-      'Join the Leopardo RH ecosystem and earn commissions on every company you refer. Up to 20% recurring commission.';
-  @override
-  String get partnerpageNotappliedTitle => 'Become a Partner';
-  @override
-  String get partnerpagePayoutBody =>
-      'Your commissions are paid once the threshold is reached. Make sure your bank details are up to date.';
-  @override
-  String get partnerpagePayoutErrorprefix =>
-      'Error while requesting the transfer: ';
-  @override
-  String get partnerpagePayoutInsufficient =>
-      'Insufficient balance to request a transfer (minimum €100.00).';
-  @override
-  String get partnerpagePayoutRequest => 'Request a transfer';
-  @override
-  String get partnerpagePayoutSending => 'Sending...';
-  @override
-  String get partnerpagePayoutSuccess => 'Transfer request sent successfully.';
-  @override
-  String get partnerpagePayoutTitle => 'Payout';
-  @override
-  String get partnerpagePendingBody =>
-      'Your application is being reviewed by our sales team. You will receive an email as soon as your access is activated.';
-  @override
-  String get partnerpagePendingTitle => 'Application in progress';
-  @override
-  String get partnerpageReferralCopied => 'Copied!';
-  @override
-  String get partnerpageReferralCopy => 'Copy my link';
-  @override
-  String get partnerpageReferralCopyerror =>
-      'Unable to copy the link. Copy it manually.';
-  @override
-  String get partnerpageReferralTitle => 'Referral link';
-  @override
-  String get partnerpageReferralUnavailable => 'Link unavailable';
-  @override
-  String get partnerpageTableAmount => 'Amount';
-  @override
-  String get partnerpageTableDate => 'Date';
-  @override
-  String get partnerpageTableStatus => 'Status';
-  @override
-  String get partnerpageTableStatuspaid => 'Paid';
-  @override
-  String get partnerpageTableStatuspending => 'Pending';
-  @override
-  String get partnerpageTableTenantid => 'Tenant ID';
-  @override
-  String get settingspageCancel => 'Cancel';
-  @override
-  String get settingspageConfirmpassword => 'Confirm password';
-  @override
-  String get settingspageCurrentpassword => 'Current password';
-  @override
-  String get settingspageDisable2fa => 'Disable 2FA';
-  @override
-  String get settingspageDisabled => 'Disabled';
-  @override
-  String get settingspageEmail => 'Email address';
-  @override
-  String get settingspageEnable2fa => 'Enable 2FA';
-  @override
-  String get settingspageEnabled => 'Enabled';
-  @override
-  String get settingspageEntercodestep => '2. Enter the generated 6-digit code';
-  @override
-  String get settingspageFullname => 'Full name';
-  @override
-  String get settingspageGeneratesecret => 'Generate 2FA secret';
-  @override
-  String get settingspageGeneratesecrethint =>
-      'Generate a secret and scan it with an authenticator app (Google Authenticator, Authy, 1Password...).';
-  @override
-  String get settingspageManualsecret => 'Manual secret:';
-  @override
-  String get settingspageMinlengthhint => 'Minimum 8 characters.';
-  @override
-  String get settingspageNewpassword => 'New password';
-  @override
-  String get settingspagePassword => 'Password';
-  @override
-  String get settingspagePasswordsmismatch => 'Passwords do not match.';
-  @override
-  String get settingspagePasswordsubtitle =>
-      'Changing your password will automatically sign out all your other active sessions.';
-  @override
-  String get settingspagePasswordtitle => 'Password';
-  @override
-  String get settingspagePasswordupdated => 'Password updated successfully.';
-  @override
-  String get settingspageProfilesubtitle =>
-      'Name and email address used to sign in.';
-  @override
-  String get settingspageProfiletitle => 'Profile information';
-  @override
-  String get settingspageProfileupdated => 'Profile updated successfully.';
-  @override
-  String get settingspageSavechanges => 'Save changes';
-  @override
-  String get settingspageScanstep =>
-      '1. Scan this link / secret in your 2FA app:';
-  @override
-  String get settingspageSubtitle =>
-      'Manage your information, password and the security of your super-admin account.';
-  @override
-  String get settingspageTitle => 'My account';
-  @override
-  String get settingspageTwofactoractivehint =>
-      '2FA is active. To disable it, confirm your password.';
-  @override
-  String get settingspageTwofactordisabled => '2FA disabled.';
-  @override
-  String get settingspageTwofactorenabled => '2FA enabled successfully.';
-  @override
-  String get settingspageTwofactorsubtitle =>
-      'Add an extra layer of security to your super-admin account.';
-  @override
-  String get settingspageTwofactortitle => 'Two-factor authentication (2FA)';
-  @override
-  String get settingspageUpdatepassword => 'Update password';
-  @override
-  String get systempageApierror => 'Error: :error';
-  @override
-  String get systempageApioperational => 'API operational';
-  @override
-  String get systempageApioperationaldb => 'API operational — DB :ms ms';
-  @override
-  String get systempageApiservices => 'API Services';
-  @override
-  String get systempageApiunavailable => 'Unavailable — GET /health/live';
-  @override
-  String get systempageDatabase => 'Database';
-  @override
-  String get systempageDberror => 'Error: :error';
-  @override
-  String get systempageDblatency => 'Latency: :ms ms';
-  @override
-  String get systempageDbunavailable => 'Unavailable — run a Health Check.';
-  @override
-  String get systempageDbunreachable => 'database unreachable';
-  @override
-  String get systempageGlobalerror => 'Aggregated probe: database unreachable.';
-  @override
-  String get systempageGlobalhealthy =>
-      'Aggregated DB + Redis probe operational.';
-  @override
-  String get systempageGlobalstatus => 'Global Status';
-  @override
-  String get systempageGlobalunavailable =>
-      'Unavailable — GET /admin/dashboard/stats';
-  @override
-  String get systempageGlobalwarning =>
-      'Aggregated probe: degradation detected.';
-  @override
-  String get systempageHealthcheck => 'Health Check';
-  @override
-  String get systempageHealthcheckrunning => 'Checking...';
-  @override
-  String get systempageHealtherror =>
-      'Health check completed — database in error';
-  @override
-  String get systempageHealthliveunreachable =>
-      '/health/live probe unreachable.';
-  @override
-  String get systempageHealthok =>
-      'Health check completed — database operational';
-  @override
-  String get systempageHealthunreachable =>
-      'Health check completed — database unreachable';
-  @override
-  String get systempageInfradetails =>
-      ':active active companies · PHP :php · queue :queue';
-  @override
-  String get systempageInfrastructure => 'Infrastructure';
-  @override
-  String get systempageInfraunavailable =>
-      'Unavailable — GET /platform/metrics/overview';
-  @override
-  String get systempageMetricsloaderror => 'Error loading platform metrics';
-  @override
-  String get systempageNotifobsloaderror =>
-      'Error loading notifications observability';
-  @override
-  String get systempageQueueobsloaderror => 'Error loading jobs observability';
-  @override
-  String get systempageRetry => 'Retry';
-  @override
-  String get systempageServiceunreachable => 'service unreachable';
-  @override
-  String get systempageStatsloaderror => 'Error loading system stats';
-  @override
-  String get systempageSubtitle =>
-      'Monitoring, configuration and automation of the Leopardo RH platform.';
-  @override
-  String get systempageTitle => 'System Administration';
-  @override
-  String get userAuthAlreadyAccount => 'Already have an account? Sign in';
-  @override
-  String get userAuthBackToHome => 'Back to home';
-  @override
-  String get userAuthCity => 'City';
-  @override
-  String get userAuthCompanyEmail => 'Company email';
-  @override
-  String get userAuthCompanyName => 'Company name';
-  @override
-  String get userAuthCompanyRequestBody =>
-      'An administrator will review your request. You will receive a notification once it is processed.';
-  @override
-  String get userAuthCompanyRequestInfo =>
-      'Fill in your company information. An administrator will validate your request.';
-  @override
-  String get userAuthCompanyRequestTitle => 'Request submitted!';
-  @override
-  String get userAuthCountry => 'Country';
-  @override
-  String get userAuthCreateCompany => 'Create a company';
-  @override
-  String get userAuthDescription => 'Description';
-  @override
-  String get userAuthFirstName => 'First name';
-  @override
-  String userAuthGoogleError(Object error) {
-    return 'Google error: $error';
-  }
 
   @override
-  String get userAuthLastName => 'Last name';
+  String get errorUnexpected => 'An error occurred';
+
   @override
-  String get userAuthLoginSubtitle =>
-      'Access your workspace, documents and requests.';
+  String get approvalApproved => 'Request approved';
+
   @override
-  String get userAuthNoAccount => 'No account yet? Sign up';
-  @override
-  String get userAuthPersonalLogin => 'Personal login';
-  @override
-  String get userAuthPhone => 'Phone';
-  @override
-  String get userAuthPhoneOptional => 'Phone (optional)';
-  @override
-  String get userAuthRegisterButton => 'Create my account';
-  @override
-  String get userAuthRegisterSubtitleAlt =>
-      'Access your personal workspace and organise your documents.';
-  @override
-  String get userAuthRegisterTitle => 'Create my account';
-  @override
-  String get userAuthSector => 'Business sector';
-  @override
-  String get userAuthSubmitError => 'Error submitting request';
-  @override
-  String get userAuthSubmitRequest => 'Submit request';
+  String get approvalRejected => 'Request rejected';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_en.dart
@@ -3193,11 +3193,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String attendanceDaySummary(
-    String date,
-    String status,
-    String range,
-    String hours,
-  ) {
+      String date, String status, String range, String hours) {
     return 'Day of $date, status $status, $range, $hours.';
   }
 

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -3238,11 +3238,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String attendanceDaySummary(
-    String date,
-    String status,
-    String range,
-    String hours,
-  ) {
+      String date, String status, String range, String hours) {
     return 'Journée du $date, statut $status, $range, $hours.';
   }
 

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2749,7 +2750,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String evaluationPeriod(String period) {
-    return 'Période : \$period';
+    return 'Période : $period';
   }
 
   @override
@@ -2769,7 +2770,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String attendanceTimeRange(String from, String to) {
-    return 'de \$from à \$to';
+    return 'de $from à $to';
   }
 
   @override
@@ -2779,8 +2780,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get attendanceHoursWorked => 'heures travaillées';
 
   @override
-  String attendanceDaySummary(String date, String status, String range, String hours) {
-    return 'Journée du \$date, statut \$status, \$range, \$hours.';
+  String attendanceDaySummary(
+    String date,
+    String status,
+    String range,
+    String hours,
+  ) {
+    return 'Journée du $date, statut $status, $range, $hours.';
   }
 
   @override
@@ -2801,12 +2807,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String employeeNumber(String id) {
-    return 'Employé #\$id';
+    return 'Employé #$id';
   }
 
   @override
   String sessionEntryAt(String time) {
-    return 'Entrée : \$time';
+    return 'Entrée : $time';
   }
 
   @override
@@ -2814,7 +2820,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String errorPrefix(String message) {
-    return 'Erreur : \$message';
+    return 'Erreur : $message';
   }
 
   @override
@@ -2837,7 +2843,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String saPresenceInProgress(String time) {
-    return 'Présence en cours depuis \$time';
+    return 'Présence en cours depuis $time';
   }
 
   @override
@@ -2876,7 +2882,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String saConfigLoadError(String error) {
-    return 'Impossible de charger la configuration.\n\$error';
+    return 'Impossible de charger la configuration.\n$error';
   }
 
   @override
@@ -2958,4 +2964,325 @@ class AppLocalizationsFr extends AppLocalizations {
   String get orgChartExpand => 'Développer';
   @override
   String get errorUnexpected => 'Une erreur est survenue';
+  @override
+  String get apiAccessdenied =>
+      'Accès refusé sur :endpoint. Permissions insuffisantes.';
+  @override
+  String get apiConnectionerror =>
+      'Erreur de connexion. Vérifiez votre connexion internet.';
+  @override
+  String get apiGenericerror => 'Erreur :status sur :endpoint.';
+  @override
+  String get apiInvaliddata => 'Données invalides.';
+  @override
+  String get apiNotfound => 'Ressource introuvable : :endpoint';
+  @override
+  String get apiServererror => 'Erreur serveur sur :endpoint. :detail';
+  @override
+  String get apiServererrorretry => 'Réessayez plus tard.';
+  @override
+  String get apiServerunavailable =>
+      'Le serveur est temporairement indisponible (:status). Réessayez dans quelques instants.';
+  @override
+  String get apiSessionexpired => 'Session expirée. Reconnexion en cours...';
+  @override
+  String get apiToomanyrequests =>
+      'Trop de requêtes. Veuillez patienter quelques secondes.';
+  @override
+  String get authDemoAccess => 'Acces Demo';
+  @override
+  String get authTogglePasswordVisibility =>
+      'Afficher ou masquer le mot de passe';
+  @override
+  String get commonRequired => 'Requis';
+  @override
+  String get partnerpageApplyerrorprefix => 'Erreur lors de la candidature : ';
+  @override
+  String get partnerpageCommissionsEmpty => 'Aucune commission enregistrée.';
+  @override
+  String get partnerpageCommissionsTitle => 'Dernières commissions';
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'Suivez vos conversions et vos commissions Leopardo RH — statut partenaire actif.';
+  @override
+  String get partnerpageDashboardTitle => 'Dashboard Partenaire';
+  @override
+  String get partnerpageLoading => 'Chargement de votre espace...';
+  @override
+  String get partnerpageMetricsConversions => 'Conversions';
+  @override
+  String get partnerpageMetricsPending => 'En attente';
+  @override
+  String get partnerpageMetricsTotalearned => 'Gains totaux';
+  @override
+  String get partnerpageMetricsWithdrawable => 'Solde retirable';
+  @override
+  String get partnerpageNotappliedAgency => 'Postuler en tant qu\'Agence';
+  @override
+  String get partnerpageNotappliedIndividual =>
+      'Postuler en tant qu\'Individuel';
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'Rejoignez l\'écosystème Leopardo RH et gagnez des commissions sur chaque entreprise que vous parrainez. Jusqu\'à 20 % de commission récurrente.';
+  @override
+  String get partnerpageNotappliedTitle => 'Devenir Partenaire';
+  @override
+  String get partnerpagePayoutBody =>
+      'Vos commissions sont payées une fois le seuil atteint. Vérifiez que vos coordonnées bancaires sont à jour.';
+  @override
+  String get partnerpagePayoutErrorprefix =>
+      'Erreur lors de la demande de virement : ';
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'Solde insuffisant pour demander un virement (minimum 100,00 €).';
+  @override
+  String get partnerpagePayoutRequest => 'Demander un virement';
+  @override
+  String get partnerpagePayoutSending => 'Envoi...';
+  @override
+  String get partnerpagePayoutSuccess =>
+      'Demande de virement envoyée avec succès.';
+  @override
+  String get partnerpagePayoutTitle => 'Paiement';
+  @override
+  String get partnerpagePendingBody =>
+      'Votre demande est en cours de validation par notre équipe commerciale. Vous recevrez un email dès que votre accès sera activé.';
+  @override
+  String get partnerpagePendingTitle => 'Candidature en cours';
+  @override
+  String get partnerpageReferralCopied => 'Copié !';
+  @override
+  String get partnerpageReferralCopy => 'Copier mon lien';
+  @override
+  String get partnerpageReferralCopyerror =>
+      'Impossible de copier le lien. Copiez-le manuellement.';
+  @override
+  String get partnerpageReferralTitle => 'Lien de parrainage';
+  @override
+  String get partnerpageReferralUnavailable => 'Lien indisponible';
+  @override
+  String get partnerpageTableAmount => 'Montant';
+  @override
+  String get partnerpageTableDate => 'Date';
+  @override
+  String get partnerpageTableStatus => 'Statut';
+  @override
+  String get partnerpageTableStatuspaid => 'Payée';
+  @override
+  String get partnerpageTableStatuspending => 'En attente';
+  @override
+  String get partnerpageTableTenantid => 'Tenant ID';
+  @override
+  String get settingspageCancel => 'Annuler';
+  @override
+  String get settingspageConfirmpassword => 'Confirmer le mot de passe';
+  @override
+  String get settingspageCurrentpassword => 'Mot de passe actuel';
+  @override
+  String get settingspageDisable2fa => 'Désactiver le 2FA';
+  @override
+  String get settingspageDisabled => 'Désactivé';
+  @override
+  String get settingspageEmail => 'Adresse email';
+  @override
+  String get settingspageEnable2fa => 'Activer le 2FA';
+  @override
+  String get settingspageEnabled => 'Activé';
+  @override
+  String get settingspageEntercodestep =>
+      '2. Entrez le code à 6 chiffres généré';
+  @override
+  String get settingspageFullname => 'Nom complet';
+  @override
+  String get settingspageGeneratesecret => 'Générer un secret 2FA';
+  @override
+  String get settingspageGeneratesecrethint =>
+      'Générez un secret et scannez-le avec une application d\'authentification (Google Authenticator, Authy, 1Password...).';
+  @override
+  String get settingspageManualsecret => 'Secret manuel :';
+  @override
+  String get settingspageMinlengthhint => 'Minimum 8 caractères.';
+  @override
+  String get settingspageNewpassword => 'Nouveau mot de passe';
+  @override
+  String get settingspagePassword => 'Mot de passe';
+  @override
+  String get settingspagePasswordsmismatch =>
+      'Les mots de passe ne correspondent pas.';
+  @override
+  String get settingspagePasswordsubtitle =>
+      'Changer votre mot de passe déconnectera automatiquement toutes vos autres sessions actives.';
+  @override
+  String get settingspagePasswordtitle => 'Mot de passe';
+  @override
+  String get settingspagePasswordupdated =>
+      'Mot de passe mis à jour avec succès.';
+  @override
+  String get settingspageProfilesubtitle =>
+      'Nom et adresse email utilisés pour vous connecter.';
+  @override
+  String get settingspageProfiletitle => 'Informations du profil';
+  @override
+  String get settingspageProfileupdated => 'Profil mis à jour avec succès.';
+  @override
+  String get settingspageSavechanges => 'Enregistrer les modifications';
+  @override
+  String get settingspageScanstep =>
+      '1. Scannez ce lien / secret dans votre application 2FA :';
+  @override
+  String get settingspageSubtitle =>
+      'Gérez vos informations, votre mot de passe et la sécurité de votre compte super-administrateur.';
+  @override
+  String get settingspageTitle => 'Mon compte';
+  @override
+  String get settingspageTwofactoractivehint =>
+      'Le 2FA est actif. Pour le désactiver, confirmez votre mot de passe.';
+  @override
+  String get settingspageTwofactordisabled => '2FA désactivé.';
+  @override
+  String get settingspageTwofactorenabled => '2FA activé avec succès.';
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'Ajoutez une couche de sécurité supplémentaire à votre compte de super-administrateur.';
+  @override
+  String get settingspageTwofactortitle =>
+      'Authentification à deux facteurs (2FA)';
+  @override
+  String get settingspageUpdatepassword => 'Mettre à jour le mot de passe';
+  @override
+  String get systempageApierror => 'Erreur : :error';
+  @override
+  String get systempageApioperational => 'API opérationnelle';
+  @override
+  String get systempageApioperationaldb => 'API opérationnelle — DB :ms ms';
+  @override
+  String get systempageApiservices => 'Services API';
+  @override
+  String get systempageApiunavailable => 'Non disponible — GET /health/live';
+  @override
+  String get systempageDatabase => 'Base de Données';
+  @override
+  String get systempageDberror => 'Erreur : :error';
+  @override
+  String get systempageDblatency => 'Latence : :ms ms';
+  @override
+  String get systempageDbunavailable =>
+      'Non disponible — lancez un Health Check.';
+  @override
+  String get systempageDbunreachable => 'base injoignable';
+  @override
+  String get systempageGlobalerror =>
+      'Sonde agrégée : base de données injoignable.';
+  @override
+  String get systempageGlobalhealthy =>
+      'Sonde agrégée DB + Redis opérationnelle.';
+  @override
+  String get systempageGlobalstatus => 'Statut Global';
+  @override
+  String get systempageGlobalunavailable =>
+      'Non disponible — GET /admin/dashboard/stats';
+  @override
+  String get systempageGlobalwarning => 'Sonde agrégée : dégradation détectée.';
+  @override
+  String get systempageHealthcheck => 'Health Check';
+  @override
+  String get systempageHealthcheckrunning => 'Analyse...';
+  @override
+  String get systempageHealtherror =>
+      'Health check terminé — base de données en erreur';
+  @override
+  String get systempageHealthliveunreachable =>
+      'Sonde /health/live injoignable.';
+  @override
+  String get systempageHealthok =>
+      'Health check terminé — base de données opérationnelle';
+  @override
+  String get systempageHealthunreachable =>
+      'Health check terminé — base de données injoignable';
+  @override
+  String get systempageInfradetails =>
+      ':active compagnies actives · PHP :php · queue :queue';
+  @override
+  String get systempageInfrastructure => 'Infrastructure';
+  @override
+  String get systempageInfraunavailable =>
+      'Non disponible — GET /platform/metrics/overview';
+  @override
+  String get systempageMetricsloaderror =>
+      'Erreur lors du chargement des métriques plateforme';
+  @override
+  String get systempageNotifobsloaderror =>
+      'Erreur lors du chargement de l\'observabilité des notifications';
+  @override
+  String get systempageQueueobsloaderror =>
+      'Erreur lors du chargement de l\'observabilité des jobs';
+  @override
+  String get systempageRetry => 'Réessayer';
+  @override
+  String get systempageServiceunreachable => 'service injoignable';
+  @override
+  String get systempageStatsloaderror =>
+      'Erreur lors du chargement des stats système';
+  @override
+  String get systempageSubtitle =>
+      'Monitoring, configuration et automatisation de la plateforme Leopardo RH.';
+  @override
+  String get systempageTitle => 'Administration Système';
+  @override
+  String get userAuthAlreadyAccount => 'Deja un compte ? Se connecter';
+  @override
+  String get userAuthBackToHome => 'À l\'accueil';
+  @override
+  String get userAuthCity => 'Ville';
+  @override
+  String get userAuthCompanyEmail => 'Email entreprise';
+  @override
+  String get userAuthCompanyName => 'Nom de l\'entreprise';
+  @override
+  String get userAuthCompanyRequestBody =>
+      'Un administrateur examinera votre demande. Vous recevrez une notification dès qu\'elle sera traitée.';
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'Remplissez les informations de votre entreprise. Un administrateur validera votre demande.';
+  @override
+  String get userAuthCompanyRequestTitle => 'Demande soumise !';
+  @override
+  String get userAuthCountry => 'Pays';
+  @override
+  String get userAuthCreateCompany => 'Créer une entreprise';
+  @override
+  String get userAuthDescription => 'Description';
+  @override
+  String get userAuthFirstName => 'Prenom';
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'Erreur Google : $error';
+  }
+
+  @override
+  String get userAuthLastName => 'Nom';
+  @override
+  String get userAuthLoginSubtitle =>
+      'Retrouvez votre espace, vos documents et vos demandes.';
+  @override
+  String get userAuthNoAccount => 'Pas encore de compte ? S\'inscrire';
+  @override
+  String get userAuthPersonalLogin => 'Connexion personnelle';
+  @override
+  String get userAuthPhone => 'Téléphone';
+  @override
+  String get userAuthPhoneOptional => 'Telephone (optionnel)';
+  @override
+  String get userAuthRegisterButton => 'Creer mon compte';
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'Accedez a votre espace personnel et organisez vos documents.';
+  @override
+  String get userAuthRegisterTitle => 'Creer mon compte';
+  @override
+  String get userAuthSector => 'Secteur d\'activité';
+  @override
+  String get userAuthSubmitError => 'Erreur lors de la soumission';
+  @override
+  String get userAuthSubmitRequest => 'Soumettre la demande';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_fr.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -109,6 +108,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authTwoFactorRequired => 'Le code 2FA est requis.';
 
   @override
+  String get authDemoAccess => 'Acces Demo';
+
+  @override
+  String get authTogglePasswordVisibility =>
+      'Afficher ou masquer le mot de passe';
+
+  @override
   String get commonLanguageLabel => 'Langue';
 
   @override
@@ -200,6 +206,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get commonCountriesUs => 'États-Unis';
+
+  @override
+  String get commonRequired => 'Requis';
 
   @override
   String get modulesAttendance => 'Pointage';
@@ -2690,6 +2699,454 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get employeesEmptyList => 'Aucun employé visible pour ce compte.';
+
+  @override
+  String get userAuthCompanyRequestTitle => 'Demande soumise !';
+
+  @override
+  String get userAuthCompanyRequestBody =>
+      'Un administrateur examinera votre demande. Vous recevrez une notification dès qu\'elle sera traitée.';
+
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'Remplissez les informations de votre entreprise. Un administrateur validera votre demande.';
+
+  @override
+  String get userAuthBackToHome => 'À l\'accueil';
+
+  @override
+  String get userAuthCreateCompany => 'Créer une entreprise';
+
+  @override
+  String get userAuthCompanyName => 'Nom de l\'entreprise';
+
+  @override
+  String get userAuthCompanyEmail => 'Email entreprise';
+
+  @override
+  String get userAuthSector => 'Secteur d\'activité';
+
+  @override
+  String get userAuthCountry => 'Pays';
+
+  @override
+  String get userAuthCity => 'Ville';
+
+  @override
+  String get userAuthPhone => 'Téléphone';
+
+  @override
+  String get userAuthDescription => 'Description';
+
+  @override
+  String get userAuthSubmitRequest => 'Soumettre la demande';
+
+  @override
+  String get userAuthSubmitError => 'Erreur lors de la soumission';
+
+  @override
+  String get userAuthAlreadyAccount => 'Deja un compte ? Se connecter';
+
+  @override
+  String get userAuthFirstName => 'Prenom';
+
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'Erreur Google : $error';
+  }
+
+  @override
+  String get userAuthLastName => 'Nom';
+
+  @override
+  String get userAuthLoginSubtitle =>
+      'Retrouvez votre espace, vos documents et vos demandes.';
+
+  @override
+  String get userAuthNoAccount => 'Pas encore de compte ? S\'inscrire';
+
+  @override
+  String get userAuthPersonalLogin => 'Connexion personnelle';
+
+  @override
+  String get userAuthPhoneOptional => 'Telephone (optionnel)';
+
+  @override
+  String get userAuthRegisterButton => 'Creer mon compte';
+
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'Accedez a votre espace personnel et organisez vos documents.';
+
+  @override
+  String get userAuthRegisterTitle => 'Creer mon compte';
+
+  @override
+  String get partnerpageLoading => 'Chargement de votre espace...';
+
+  @override
+  String get partnerpageApplyerrorprefix => 'Erreur lors de la candidature : ';
+
+  @override
+  String get partnerpageNotappliedTitle => 'Devenir Partenaire';
+
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'Rejoignez l\'écosystème Leopardo RH et gagnez des commissions sur chaque entreprise que vous parrainez. Jusqu\'à 20 % de commission récurrente.';
+
+  @override
+  String get partnerpageNotappliedIndividual =>
+      'Postuler en tant qu\'Individuel';
+
+  @override
+  String get partnerpageNotappliedAgency => 'Postuler en tant qu\'Agence';
+
+  @override
+  String get partnerpagePendingTitle => 'Candidature en cours';
+
+  @override
+  String get partnerpagePendingBody =>
+      'Votre demande est en cours de validation par notre équipe commerciale. Vous recevrez un email dès que votre accès sera activé.';
+
+  @override
+  String get partnerpageDashboardTitle => 'Dashboard Partenaire';
+
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'Suivez vos conversions et vos commissions Leopardo RH — statut partenaire actif.';
+
+  @override
+  String get partnerpageMetricsConversions => 'Conversions';
+
+  @override
+  String get partnerpageMetricsTotalearned => 'Gains totaux';
+
+  @override
+  String get partnerpageMetricsPending => 'En attente';
+
+  @override
+  String get partnerpageMetricsWithdrawable => 'Solde retirable';
+
+  @override
+  String get partnerpageCommissionsTitle => 'Dernières commissions';
+
+  @override
+  String get partnerpageCommissionsEmpty => 'Aucune commission enregistrée.';
+
+  @override
+  String get partnerpageTableTenantid => 'Tenant ID';
+
+  @override
+  String get partnerpageTableDate => 'Date';
+
+  @override
+  String get partnerpageTableStatus => 'Statut';
+
+  @override
+  String get partnerpageTableAmount => 'Montant';
+
+  @override
+  String get partnerpageTableStatuspaid => 'Payée';
+
+  @override
+  String get partnerpageTableStatuspending => 'En attente';
+
+  @override
+  String get partnerpagePayoutTitle => 'Paiement';
+
+  @override
+  String get partnerpagePayoutBody =>
+      'Vos commissions sont payées une fois le seuil atteint. Vérifiez que vos coordonnées bancaires sont à jour.';
+
+  @override
+  String get partnerpagePayoutRequest => 'Demander un virement';
+
+  @override
+  String get partnerpagePayoutSending => 'Envoi...';
+
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'Solde insuffisant pour demander un virement (minimum 100,00 €).';
+
+  @override
+  String get partnerpagePayoutSuccess =>
+      'Demande de virement envoyée avec succès.';
+
+  @override
+  String get partnerpagePayoutErrorprefix =>
+      'Erreur lors de la demande de virement : ';
+
+  @override
+  String get partnerpageReferralTitle => 'Lien de parrainage';
+
+  @override
+  String get partnerpageReferralUnavailable => 'Lien indisponible';
+
+  @override
+  String get partnerpageReferralCopy => 'Copier mon lien';
+
+  @override
+  String get partnerpageReferralCopied => 'Copié !';
+
+  @override
+  String get partnerpageReferralCopyerror =>
+      'Impossible de copier le lien. Copiez-le manuellement.';
+
+  @override
+  String get apiSessionexpired => 'Session expirée. Reconnexion en cours...';
+
+  @override
+  String get apiAccessdenied =>
+      'Accès refusé sur :endpoint. Permissions insuffisantes.';
+
+  @override
+  String get apiNotfound => 'Ressource introuvable : :endpoint';
+
+  @override
+  String get apiToomanyrequests =>
+      'Trop de requêtes. Veuillez patienter quelques secondes.';
+
+  @override
+  String get apiServererror => 'Erreur serveur sur :endpoint. :detail';
+
+  @override
+  String get apiServererrorretry => 'Réessayez plus tard.';
+
+  @override
+  String get apiServerunavailable =>
+      'Le serveur est temporairement indisponible (:status). Réessayez dans quelques instants.';
+
+  @override
+  String get apiGenericerror => 'Erreur :status sur :endpoint.';
+
+  @override
+  String get apiInvaliddata => 'Données invalides.';
+
+  @override
+  String get apiConnectionerror =>
+      'Erreur de connexion. Vérifiez votre connexion internet.';
+
+  @override
+  String get settingspageCancel => 'Annuler';
+
+  @override
+  String get settingspageConfirmpassword => 'Confirmer le mot de passe';
+
+  @override
+  String get settingspageCurrentpassword => 'Mot de passe actuel';
+
+  @override
+  String get settingspageDisable2fa => 'Désactiver le 2FA';
+
+  @override
+  String get settingspageDisabled => 'Désactivé';
+
+  @override
+  String get settingspageEmail => 'Adresse email';
+
+  @override
+  String get settingspageEnable2fa => 'Activer le 2FA';
+
+  @override
+  String get settingspageEnabled => 'Activé';
+
+  @override
+  String get settingspageEntercodestep =>
+      '2. Entrez le code à 6 chiffres généré';
+
+  @override
+  String get settingspageFullname => 'Nom complet';
+
+  @override
+  String get settingspageGeneratesecret => 'Générer un secret 2FA';
+
+  @override
+  String get settingspageGeneratesecrethint =>
+      'Générez un secret et scannez-le avec une application d\'authentification (Google Authenticator, Authy, 1Password...).';
+
+  @override
+  String get settingspageManualsecret => 'Secret manuel :';
+
+  @override
+  String get settingspageMinlengthhint => 'Minimum 8 caractères.';
+
+  @override
+  String get settingspageNewpassword => 'Nouveau mot de passe';
+
+  @override
+  String get settingspagePassword => 'Mot de passe';
+
+  @override
+  String get settingspagePasswordsubtitle =>
+      'Changer votre mot de passe déconnectera automatiquement toutes vos autres sessions actives.';
+
+  @override
+  String get settingspagePasswordtitle => 'Mot de passe';
+
+  @override
+  String get settingspagePasswordupdated =>
+      'Mot de passe mis à jour avec succès.';
+
+  @override
+  String get settingspagePasswordsmismatch =>
+      'Les mots de passe ne correspondent pas.';
+
+  @override
+  String get settingspageProfilesubtitle =>
+      'Nom et adresse email utilisés pour vous connecter.';
+
+  @override
+  String get settingspageProfiletitle => 'Informations du profil';
+
+  @override
+  String get settingspageProfileupdated => 'Profil mis à jour avec succès.';
+
+  @override
+  String get settingspageSavechanges => 'Enregistrer les modifications';
+
+  @override
+  String get settingspageScanstep =>
+      '1. Scannez ce lien / secret dans votre application 2FA :';
+
+  @override
+  String get settingspageSubtitle =>
+      'Gérez vos informations, votre mot de passe et la sécurité de votre compte super-administrateur.';
+
+  @override
+  String get settingspageTitle => 'Mon compte';
+
+  @override
+  String get settingspageTwofactoractivehint =>
+      'Le 2FA est actif. Pour le désactiver, confirmez votre mot de passe.';
+
+  @override
+  String get settingspageTwofactordisabled => '2FA désactivé.';
+
+  @override
+  String get settingspageTwofactorenabled => '2FA activé avec succès.';
+
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'Ajoutez une couche de sécurité supplémentaire à votre compte de super-administrateur.';
+
+  @override
+  String get settingspageTwofactortitle =>
+      'Authentification à deux facteurs (2FA)';
+
+  @override
+  String get settingspageUpdatepassword => 'Mettre à jour le mot de passe';
+
+  @override
+  String get systempageApierror => 'Erreur : :error';
+
+  @override
+  String get systempageApioperational => 'API opérationnelle';
+
+  @override
+  String get systempageApioperationaldb => 'API opérationnelle — DB :ms ms';
+
+  @override
+  String get systempageApiservices => 'Services API';
+
+  @override
+  String get systempageApiunavailable => 'Non disponible — GET /health/live';
+
+  @override
+  String get systempageDatabase => 'Base de Données';
+
+  @override
+  String get systempageDberror => 'Erreur : :error';
+
+  @override
+  String get systempageDblatency => 'Latence : :ms ms';
+
+  @override
+  String get systempageDbunavailable =>
+      'Non disponible — lancez un Health Check.';
+
+  @override
+  String get systempageDbunreachable => 'base injoignable';
+
+  @override
+  String get systempageGlobalerror =>
+      'Sonde agrégée : base de données injoignable.';
+
+  @override
+  String get systempageGlobalhealthy =>
+      'Sonde agrégée DB + Redis opérationnelle.';
+
+  @override
+  String get systempageGlobalstatus => 'Statut Global';
+
+  @override
+  String get systempageGlobalunavailable =>
+      'Non disponible — GET /admin/dashboard/stats';
+
+  @override
+  String get systempageGlobalwarning => 'Sonde agrégée : dégradation détectée.';
+
+  @override
+  String get systempageHealthcheck => 'Health Check';
+
+  @override
+  String get systempageHealthcheckrunning => 'Analyse...';
+
+  @override
+  String get systempageHealtherror =>
+      'Health check terminé — base de données en erreur';
+
+  @override
+  String get systempageHealthliveunreachable =>
+      'Sonde /health/live injoignable.';
+
+  @override
+  String get systempageHealthok =>
+      'Health check terminé — base de données opérationnelle';
+
+  @override
+  String get systempageHealthunreachable =>
+      'Health check terminé — base de données injoignable';
+
+  @override
+  String get systempageInfradetails =>
+      ':active compagnies actives · PHP :php · queue :queue';
+
+  @override
+  String get systempageInfraunavailable =>
+      'Non disponible — GET /platform/metrics/overview';
+
+  @override
+  String get systempageInfrastructure => 'Infrastructure';
+
+  @override
+  String get systempageMetricsloaderror =>
+      'Erreur lors du chargement des métriques plateforme';
+
+  @override
+  String get systempageNotifobsloaderror =>
+      'Erreur lors du chargement de l\'observabilité des notifications';
+
+  @override
+  String get systempageQueueobsloaderror =>
+      'Erreur lors du chargement de l\'observabilité des jobs';
+
+  @override
+  String get systempageRetry => 'Réessayer';
+
+  @override
+  String get systempageServiceunreachable => 'service injoignable';
+
+  @override
+  String get systempageStatsloaderror =>
+      'Erreur lors du chargement des stats système';
+
+  @override
+  String get systempageSubtitle =>
+      'Monitoring, configuration et automatisation de la plateforme Leopardo RH.';
+
+  @override
+  String get systempageTitle => 'Administration Système';
+
   @override
   String get retry => 'Réessayer';
 
@@ -2962,327 +3419,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get orgChartExpand => 'Développer';
-  @override
-  String get errorUnexpected => 'Une erreur est survenue';
-  @override
-  String get apiAccessdenied =>
-      'Accès refusé sur :endpoint. Permissions insuffisantes.';
-  @override
-  String get apiConnectionerror =>
-      'Erreur de connexion. Vérifiez votre connexion internet.';
-  @override
-  String get apiGenericerror => 'Erreur :status sur :endpoint.';
-  @override
-  String get apiInvaliddata => 'Données invalides.';
-  @override
-  String get apiNotfound => 'Ressource introuvable : :endpoint';
-  @override
-  String get apiServererror => 'Erreur serveur sur :endpoint. :detail';
-  @override
-  String get apiServererrorretry => 'Réessayez plus tard.';
-  @override
-  String get apiServerunavailable =>
-      'Le serveur est temporairement indisponible (:status). Réessayez dans quelques instants.';
-  @override
-  String get apiSessionexpired => 'Session expirée. Reconnexion en cours...';
-  @override
-  String get apiToomanyrequests =>
-      'Trop de requêtes. Veuillez patienter quelques secondes.';
-  @override
-  String get authDemoAccess => 'Acces Demo';
-  @override
-  String get authTogglePasswordVisibility =>
-      'Afficher ou masquer le mot de passe';
-  @override
-  String get commonRequired => 'Requis';
-  @override
-  String get partnerpageApplyerrorprefix => 'Erreur lors de la candidature : ';
-  @override
-  String get partnerpageCommissionsEmpty => 'Aucune commission enregistrée.';
-  @override
-  String get partnerpageCommissionsTitle => 'Dernières commissions';
-  @override
-  String get partnerpageDashboardSubtitle =>
-      'Suivez vos conversions et vos commissions Leopardo RH — statut partenaire actif.';
-  @override
-  String get partnerpageDashboardTitle => 'Dashboard Partenaire';
-  @override
-  String get partnerpageLoading => 'Chargement de votre espace...';
-  @override
-  String get partnerpageMetricsConversions => 'Conversions';
-  @override
-  String get partnerpageMetricsPending => 'En attente';
-  @override
-  String get partnerpageMetricsTotalearned => 'Gains totaux';
-  @override
-  String get partnerpageMetricsWithdrawable => 'Solde retirable';
-  @override
-  String get partnerpageNotappliedAgency => 'Postuler en tant qu\'Agence';
-  @override
-  String get partnerpageNotappliedIndividual =>
-      'Postuler en tant qu\'Individuel';
-  @override
-  String get partnerpageNotappliedSubtitle =>
-      'Rejoignez l\'écosystème Leopardo RH et gagnez des commissions sur chaque entreprise que vous parrainez. Jusqu\'à 20 % de commission récurrente.';
-  @override
-  String get partnerpageNotappliedTitle => 'Devenir Partenaire';
-  @override
-  String get partnerpagePayoutBody =>
-      'Vos commissions sont payées une fois le seuil atteint. Vérifiez que vos coordonnées bancaires sont à jour.';
-  @override
-  String get partnerpagePayoutErrorprefix =>
-      'Erreur lors de la demande de virement : ';
-  @override
-  String get partnerpagePayoutInsufficient =>
-      'Solde insuffisant pour demander un virement (minimum 100,00 €).';
-  @override
-  String get partnerpagePayoutRequest => 'Demander un virement';
-  @override
-  String get partnerpagePayoutSending => 'Envoi...';
-  @override
-  String get partnerpagePayoutSuccess =>
-      'Demande de virement envoyée avec succès.';
-  @override
-  String get partnerpagePayoutTitle => 'Paiement';
-  @override
-  String get partnerpagePendingBody =>
-      'Votre demande est en cours de validation par notre équipe commerciale. Vous recevrez un email dès que votre accès sera activé.';
-  @override
-  String get partnerpagePendingTitle => 'Candidature en cours';
-  @override
-  String get partnerpageReferralCopied => 'Copié !';
-  @override
-  String get partnerpageReferralCopy => 'Copier mon lien';
-  @override
-  String get partnerpageReferralCopyerror =>
-      'Impossible de copier le lien. Copiez-le manuellement.';
-  @override
-  String get partnerpageReferralTitle => 'Lien de parrainage';
-  @override
-  String get partnerpageReferralUnavailable => 'Lien indisponible';
-  @override
-  String get partnerpageTableAmount => 'Montant';
-  @override
-  String get partnerpageTableDate => 'Date';
-  @override
-  String get partnerpageTableStatus => 'Statut';
-  @override
-  String get partnerpageTableStatuspaid => 'Payée';
-  @override
-  String get partnerpageTableStatuspending => 'En attente';
-  @override
-  String get partnerpageTableTenantid => 'Tenant ID';
-  @override
-  String get settingspageCancel => 'Annuler';
-  @override
-  String get settingspageConfirmpassword => 'Confirmer le mot de passe';
-  @override
-  String get settingspageCurrentpassword => 'Mot de passe actuel';
-  @override
-  String get settingspageDisable2fa => 'Désactiver le 2FA';
-  @override
-  String get settingspageDisabled => 'Désactivé';
-  @override
-  String get settingspageEmail => 'Adresse email';
-  @override
-  String get settingspageEnable2fa => 'Activer le 2FA';
-  @override
-  String get settingspageEnabled => 'Activé';
-  @override
-  String get settingspageEntercodestep =>
-      '2. Entrez le code à 6 chiffres généré';
-  @override
-  String get settingspageFullname => 'Nom complet';
-  @override
-  String get settingspageGeneratesecret => 'Générer un secret 2FA';
-  @override
-  String get settingspageGeneratesecrethint =>
-      'Générez un secret et scannez-le avec une application d\'authentification (Google Authenticator, Authy, 1Password...).';
-  @override
-  String get settingspageManualsecret => 'Secret manuel :';
-  @override
-  String get settingspageMinlengthhint => 'Minimum 8 caractères.';
-  @override
-  String get settingspageNewpassword => 'Nouveau mot de passe';
-  @override
-  String get settingspagePassword => 'Mot de passe';
-  @override
-  String get settingspagePasswordsmismatch =>
-      'Les mots de passe ne correspondent pas.';
-  @override
-  String get settingspagePasswordsubtitle =>
-      'Changer votre mot de passe déconnectera automatiquement toutes vos autres sessions actives.';
-  @override
-  String get settingspagePasswordtitle => 'Mot de passe';
-  @override
-  String get settingspagePasswordupdated =>
-      'Mot de passe mis à jour avec succès.';
-  @override
-  String get settingspageProfilesubtitle =>
-      'Nom et adresse email utilisés pour vous connecter.';
-  @override
-  String get settingspageProfiletitle => 'Informations du profil';
-  @override
-  String get settingspageProfileupdated => 'Profil mis à jour avec succès.';
-  @override
-  String get settingspageSavechanges => 'Enregistrer les modifications';
-  @override
-  String get settingspageScanstep =>
-      '1. Scannez ce lien / secret dans votre application 2FA :';
-  @override
-  String get settingspageSubtitle =>
-      'Gérez vos informations, votre mot de passe et la sécurité de votre compte super-administrateur.';
-  @override
-  String get settingspageTitle => 'Mon compte';
-  @override
-  String get settingspageTwofactoractivehint =>
-      'Le 2FA est actif. Pour le désactiver, confirmez votre mot de passe.';
-  @override
-  String get settingspageTwofactordisabled => '2FA désactivé.';
-  @override
-  String get settingspageTwofactorenabled => '2FA activé avec succès.';
-  @override
-  String get settingspageTwofactorsubtitle =>
-      'Ajoutez une couche de sécurité supplémentaire à votre compte de super-administrateur.';
-  @override
-  String get settingspageTwofactortitle =>
-      'Authentification à deux facteurs (2FA)';
-  @override
-  String get settingspageUpdatepassword => 'Mettre à jour le mot de passe';
-  @override
-  String get systempageApierror => 'Erreur : :error';
-  @override
-  String get systempageApioperational => 'API opérationnelle';
-  @override
-  String get systempageApioperationaldb => 'API opérationnelle — DB :ms ms';
-  @override
-  String get systempageApiservices => 'Services API';
-  @override
-  String get systempageApiunavailable => 'Non disponible — GET /health/live';
-  @override
-  String get systempageDatabase => 'Base de Données';
-  @override
-  String get systempageDberror => 'Erreur : :error';
-  @override
-  String get systempageDblatency => 'Latence : :ms ms';
-  @override
-  String get systempageDbunavailable =>
-      'Non disponible — lancez un Health Check.';
-  @override
-  String get systempageDbunreachable => 'base injoignable';
-  @override
-  String get systempageGlobalerror =>
-      'Sonde agrégée : base de données injoignable.';
-  @override
-  String get systempageGlobalhealthy =>
-      'Sonde agrégée DB + Redis opérationnelle.';
-  @override
-  String get systempageGlobalstatus => 'Statut Global';
-  @override
-  String get systempageGlobalunavailable =>
-      'Non disponible — GET /admin/dashboard/stats';
-  @override
-  String get systempageGlobalwarning => 'Sonde agrégée : dégradation détectée.';
-  @override
-  String get systempageHealthcheck => 'Health Check';
-  @override
-  String get systempageHealthcheckrunning => 'Analyse...';
-  @override
-  String get systempageHealtherror =>
-      'Health check terminé — base de données en erreur';
-  @override
-  String get systempageHealthliveunreachable =>
-      'Sonde /health/live injoignable.';
-  @override
-  String get systempageHealthok =>
-      'Health check terminé — base de données opérationnelle';
-  @override
-  String get systempageHealthunreachable =>
-      'Health check terminé — base de données injoignable';
-  @override
-  String get systempageInfradetails =>
-      ':active compagnies actives · PHP :php · queue :queue';
-  @override
-  String get systempageInfrastructure => 'Infrastructure';
-  @override
-  String get systempageInfraunavailable =>
-      'Non disponible — GET /platform/metrics/overview';
-  @override
-  String get systempageMetricsloaderror =>
-      'Erreur lors du chargement des métriques plateforme';
-  @override
-  String get systempageNotifobsloaderror =>
-      'Erreur lors du chargement de l\'observabilité des notifications';
-  @override
-  String get systempageQueueobsloaderror =>
-      'Erreur lors du chargement de l\'observabilité des jobs';
-  @override
-  String get systempageRetry => 'Réessayer';
-  @override
-  String get systempageServiceunreachable => 'service injoignable';
-  @override
-  String get systempageStatsloaderror =>
-      'Erreur lors du chargement des stats système';
-  @override
-  String get systempageSubtitle =>
-      'Monitoring, configuration et automatisation de la plateforme Leopardo RH.';
-  @override
-  String get systempageTitle => 'Administration Système';
-  @override
-  String get userAuthAlreadyAccount => 'Deja un compte ? Se connecter';
-  @override
-  String get userAuthBackToHome => 'À l\'accueil';
-  @override
-  String get userAuthCity => 'Ville';
-  @override
-  String get userAuthCompanyEmail => 'Email entreprise';
-  @override
-  String get userAuthCompanyName => 'Nom de l\'entreprise';
-  @override
-  String get userAuthCompanyRequestBody =>
-      'Un administrateur examinera votre demande. Vous recevrez une notification dès qu\'elle sera traitée.';
-  @override
-  String get userAuthCompanyRequestInfo =>
-      'Remplissez les informations de votre entreprise. Un administrateur validera votre demande.';
-  @override
-  String get userAuthCompanyRequestTitle => 'Demande soumise !';
-  @override
-  String get userAuthCountry => 'Pays';
-  @override
-  String get userAuthCreateCompany => 'Créer une entreprise';
-  @override
-  String get userAuthDescription => 'Description';
-  @override
-  String get userAuthFirstName => 'Prenom';
-  @override
-  String userAuthGoogleError(Object error) {
-    return 'Erreur Google : $error';
-  }
 
   @override
-  String get userAuthLastName => 'Nom';
+  String get errorUnexpected => 'Une erreur est survenue';
+
   @override
-  String get userAuthLoginSubtitle =>
-      'Retrouvez votre espace, vos documents et vos demandes.';
+  String get approvalApproved => 'Demande approuvée';
+
   @override
-  String get userAuthNoAccount => 'Pas encore de compte ? S\'inscrire';
-  @override
-  String get userAuthPersonalLogin => 'Connexion personnelle';
-  @override
-  String get userAuthPhone => 'Téléphone';
-  @override
-  String get userAuthPhoneOptional => 'Telephone (optionnel)';
-  @override
-  String get userAuthRegisterButton => 'Creer mon compte';
-  @override
-  String get userAuthRegisterSubtitleAlt =>
-      'Accedez a votre espace personnel et organisez vos documents.';
-  @override
-  String get userAuthRegisterTitle => 'Creer mon compte';
-  @override
-  String get userAuthSector => 'Secteur d\'activité';
-  @override
-  String get userAuthSubmitError => 'Erreur lors de la soumission';
-  @override
-  String get userAuthSubmitRequest => 'Soumettre la demande';
+  String get approvalRejected => 'Demande refusée';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -105,6 +104,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authTwoFactorRequired => '2FA kodu gereklidir.';
 
   @override
+  String get authDemoAccess => 'Demo erisimi';
+
+  @override
+  String get authTogglePasswordVisibility => 'Sifreyi goster veya gizle';
+
+  @override
   String get commonLanguageLabel => 'Dil';
 
   @override
@@ -197,6 +202,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get commonCountriesUs => 'Amerika Birleşik Devletleri';
+
+  @override
+  String get commonRequired => 'Gerekli';
 
   @override
   String get modulesAttendance => 'Puantaj';
@@ -2653,6 +2661,449 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get employeesEmptyList => 'Bu hesap için görünür çalışan yok.';
+
+  @override
+  String get userAuthCompanyRequestTitle => 'Talep gönderildi!';
+
+  @override
+  String get userAuthCompanyRequestBody =>
+      'Bir yönetici talebinizi inceleyecek. İşlendiğinde bir bildirim alacaksınız.';
+
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'Şirket bilgilerinizi doldurun. Bir yönetici talebinizi onaylayacak.';
+
+  @override
+  String get userAuthBackToHome => 'Ana sayfaya dön';
+
+  @override
+  String get userAuthCreateCompany => 'Şirket oluştur';
+
+  @override
+  String get userAuthCompanyName => 'Şirket adı';
+
+  @override
+  String get userAuthCompanyEmail => 'Şirket e-postası';
+
+  @override
+  String get userAuthSector => 'İş sektörü';
+
+  @override
+  String get userAuthCountry => 'Ülke';
+
+  @override
+  String get userAuthCity => 'Şehir';
+
+  @override
+  String get userAuthPhone => 'Telefon';
+
+  @override
+  String get userAuthDescription => 'Açıklama';
+
+  @override
+  String get userAuthSubmitRequest => 'Talep gönder';
+
+  @override
+  String get userAuthSubmitError => 'Talep gönderme hatası';
+
+  @override
+  String get userAuthAlreadyAccount => 'Zaten hesabiniz var mi? Giris yapin';
+
+  @override
+  String get userAuthFirstName => 'Ad';
+
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'Google hatasi: $error';
+  }
+
+  @override
+  String get userAuthLastName => 'Soyad';
+
+  @override
+  String get userAuthLoginSubtitle =>
+      'Alanınıza, belgelerinize ve taleplerinize erisin.';
+
+  @override
+  String get userAuthNoAccount => 'Henuz hesabınız yok mu? Kayit olun';
+
+  @override
+  String get userAuthPersonalLogin => 'Kisisel giris';
+
+  @override
+  String get userAuthPhoneOptional => 'Telefon (opsiyonel)';
+
+  @override
+  String get userAuthRegisterButton => 'Hesabimi olustur';
+
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'Kisisel alanınıza erisin ve belgelerinizi duzenleyin.';
+
+  @override
+  String get userAuthRegisterTitle => 'Hesabimi olustur';
+
+  @override
+  String get partnerpageLoading => 'Alanınız yükleniyor...';
+
+  @override
+  String get partnerpageApplyerrorprefix => 'Başvuru sırasında hata: ';
+
+  @override
+  String get partnerpageNotappliedTitle => 'Partner Olun';
+
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'Leopardo RH ekosistemine katılın ve yönlendirdiğiniz her şirket için komisyon kazanın. %20\'ye varan düzenli komisyon.';
+
+  @override
+  String get partnerpageNotappliedIndividual => 'Bireysel olarak başvurun';
+
+  @override
+  String get partnerpageNotappliedAgency => 'Ajans olarak başvurun';
+
+  @override
+  String get partnerpagePendingTitle => 'Başvuru inceleniyor';
+
+  @override
+  String get partnerpagePendingBody =>
+      'Başvurunuz satış ekibimiz tarafından doğrulanıyor. Erişiminiz etkinleştirilir etkinleştirilmez bir e-posta alacaksınız.';
+
+  @override
+  String get partnerpageDashboardTitle => 'Partner Paneli';
+
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'Leopardo RH dönüşümlerinizi ve komisyonlarınızı takip edin — aktif partner durumu.';
+
+  @override
+  String get partnerpageMetricsConversions => 'Dönüşümler';
+
+  @override
+  String get partnerpageMetricsTotalearned => 'Toplam kazanç';
+
+  @override
+  String get partnerpageMetricsPending => 'Beklemede';
+
+  @override
+  String get partnerpageMetricsWithdrawable => 'Çekilebilir bakiye';
+
+  @override
+  String get partnerpageCommissionsTitle => 'Son komisyonlar';
+
+  @override
+  String get partnerpageCommissionsEmpty => 'Kayıtlı komisyon yok.';
+
+  @override
+  String get partnerpageTableTenantid => 'Tenant Kimliği';
+
+  @override
+  String get partnerpageTableDate => 'Tarih';
+
+  @override
+  String get partnerpageTableStatus => 'Durum';
+
+  @override
+  String get partnerpageTableAmount => 'Tutar';
+
+  @override
+  String get partnerpageTableStatuspaid => 'Ödendi';
+
+  @override
+  String get partnerpageTableStatuspending => 'Beklemede';
+
+  @override
+  String get partnerpagePayoutTitle => 'Ödeme';
+
+  @override
+  String get partnerpagePayoutBody =>
+      'Komisyonlarınız eşiğe ulaşıldığında ödenir. Banka bilgilerinizin güncel olduğundan emin olun.';
+
+  @override
+  String get partnerpagePayoutRequest => 'Havale talep et';
+
+  @override
+  String get partnerpagePayoutSending => 'Gönderiliyor...';
+
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'Havale talep etmek için bakiye yetersiz (minimum 100,00 €).';
+
+  @override
+  String get partnerpagePayoutSuccess => 'Havale talebi başarıyla gönderildi.';
+
+  @override
+  String get partnerpagePayoutErrorprefix => 'Havale talebi sırasında hata: ';
+
+  @override
+  String get partnerpageReferralTitle => 'Referans bağlantısı';
+
+  @override
+  String get partnerpageReferralUnavailable => 'Bağlantı kullanılamıyor';
+
+  @override
+  String get partnerpageReferralCopy => 'Bağlantımı kopyala';
+
+  @override
+  String get partnerpageReferralCopied => 'Kopyalandı!';
+
+  @override
+  String get partnerpageReferralCopyerror =>
+      'Bağlantı kopyalanamadı. Lütfen elle kopyalayın.';
+
+  @override
+  String get apiSessionexpired =>
+      'Oturum süresi doldu. Yeniden bağlanılıyor...';
+
+  @override
+  String get apiAccessdenied =>
+      ':endpoint üzerinde erişim reddedildi. Yetersiz izinler.';
+
+  @override
+  String get apiNotfound => 'Kaynak bulunamadı: :endpoint';
+
+  @override
+  String get apiToomanyrequests =>
+      'Çok fazla istek. Lütfen birkaç saniye bekleyin.';
+
+  @override
+  String get apiServererror => ':endpoint üzerinde sunucu hatası. :detail';
+
+  @override
+  String get apiServererrorretry => 'Daha sonra tekrar deneyin.';
+
+  @override
+  String get apiServerunavailable =>
+      'Sunucu geçici olarak kullanılamıyor (:status). Lütfen kısa süre sonra tekrar deneyin.';
+
+  @override
+  String get apiGenericerror => ':endpoint üzerinde :status hatası.';
+
+  @override
+  String get apiInvaliddata => 'Geçersiz veri.';
+
+  @override
+  String get apiConnectionerror =>
+      'Bağlantı hatası. İnternet bağlantınızı kontrol edin.';
+
+  @override
+  String get settingspageCancel => 'İptal';
+
+  @override
+  String get settingspageConfirmpassword => 'Parolayı doğrula';
+
+  @override
+  String get settingspageCurrentpassword => 'Mevcut parola';
+
+  @override
+  String get settingspageDisable2fa => '2FA\'yı devre dışı bırak';
+
+  @override
+  String get settingspageDisabled => 'Devre dışı';
+
+  @override
+  String get settingspageEmail => 'E-posta adresi';
+
+  @override
+  String get settingspageEnable2fa => '2FA\'yı etkinleştir';
+
+  @override
+  String get settingspageEnabled => 'Etkin';
+
+  @override
+  String get settingspageEntercodestep => '2. Üretilen 6 haneli kodu girin';
+
+  @override
+  String get settingspageFullname => 'Ad soyad';
+
+  @override
+  String get settingspageGeneratesecret => '2FA sırrı oluştur';
+
+  @override
+  String get settingspageGeneratesecrethint =>
+      'Bir sır üretin ve bir kimlik doğrulama uygulamasıyla (Google Authenticator, Authy, 1Password...) tarayın.';
+
+  @override
+  String get settingspageManualsecret => 'Manuel sır:';
+
+  @override
+  String get settingspageMinlengthhint => 'En az 8 karakter.';
+
+  @override
+  String get settingspageNewpassword => 'Yeni parola';
+
+  @override
+  String get settingspagePassword => 'Parola';
+
+  @override
+  String get settingspagePasswordsubtitle =>
+      'Parolanızı değiştirmek, diğer tüm aktif oturumlarınızı otomatik olarak sonlandırır.';
+
+  @override
+  String get settingspagePasswordtitle => 'Parola';
+
+  @override
+  String get settingspagePasswordupdated => 'Parola başarıyla güncellendi.';
+
+  @override
+  String get settingspagePasswordsmismatch => 'Parolalar eşleşmiyor.';
+
+  @override
+  String get settingspageProfilesubtitle =>
+      'Oturum açmak için kullanılan ad ve e-posta adresi.';
+
+  @override
+  String get settingspageProfiletitle => 'Profil bilgileri';
+
+  @override
+  String get settingspageProfileupdated => 'Profil başarıyla güncellendi.';
+
+  @override
+  String get settingspageSavechanges => 'Değişiklikleri kaydet';
+
+  @override
+  String get settingspageScanstep =>
+      '1. Bu bağlantıyı / sırrı 2FA uygulamanızda tarayın:';
+
+  @override
+  String get settingspageSubtitle =>
+      'Bilgilerinizi, parolanızı ve süper yönetici hesabınızın güvenliğini yönetin.';
+
+  @override
+  String get settingspageTitle => 'Hesabım';
+
+  @override
+  String get settingspageTwofactoractivehint =>
+      '2FA etkin. Devre dışı bırakmak için parolanızı doğrulayın.';
+
+  @override
+  String get settingspageTwofactordisabled => '2FA devre dışı bırakıldı.';
+
+  @override
+  String get settingspageTwofactorenabled => '2FA başarıyla etkinleştirildi.';
+
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'Süper yönetici hesabınıza ek bir güvenlik katmanı ekleyin.';
+
+  @override
+  String get settingspageTwofactortitle =>
+      'İki faktörlü kimlik doğrulama (2FA)';
+
+  @override
+  String get settingspageUpdatepassword => 'Parolayı güncelle';
+
+  @override
+  String get systempageApierror => 'Hata: :error';
+
+  @override
+  String get systempageApioperational => 'API çalışıyor';
+
+  @override
+  String get systempageApioperationaldb => 'API çalışıyor — DB :ms ms';
+
+  @override
+  String get systempageApiservices => 'API Hizmetleri';
+
+  @override
+  String get systempageApiunavailable => 'Kullanılamıyor — GET /health/live';
+
+  @override
+  String get systempageDatabase => 'Veritabanı';
+
+  @override
+  String get systempageDberror => 'Hata: :error';
+
+  @override
+  String get systempageDblatency => 'Gecikme: :ms ms';
+
+  @override
+  String get systempageDbunavailable =>
+      'Kullanılamıyor — bir Sağlık Kontrolü çalıştırın.';
+
+  @override
+  String get systempageDbunreachable => 'veritabanına ulaşılamıyor';
+
+  @override
+  String get systempageGlobalerror =>
+      'Birleşik sonda: veritabanına ulaşılamıyor.';
+
+  @override
+  String get systempageGlobalhealthy =>
+      'Birleşik DB + Redis sondası çalışıyor.';
+
+  @override
+  String get systempageGlobalstatus => 'Genel Durum';
+
+  @override
+  String get systempageGlobalunavailable =>
+      'Kullanılamıyor — GET /admin/dashboard/stats';
+
+  @override
+  String get systempageGlobalwarning => 'Birleşik sonda: bozulma algılandı.';
+
+  @override
+  String get systempageHealthcheck => 'Sağlık Kontrolü';
+
+  @override
+  String get systempageHealthcheckrunning => 'Kontrol ediliyor...';
+
+  @override
+  String get systempageHealtherror =>
+      'Sağlık kontrolü tamamlandı — veritabanında hata';
+
+  @override
+  String get systempageHealthliveunreachable =>
+      '/health/live sondasına ulaşılamıyor.';
+
+  @override
+  String get systempageHealthok =>
+      'Sağlık kontrolü tamamlandı — veritabanı çalışıyor';
+
+  @override
+  String get systempageHealthunreachable =>
+      'Sağlık kontrolü tamamlandı — veritabanına ulaşılamıyor';
+
+  @override
+  String get systempageInfradetails =>
+      ':active aktif şirket · PHP :php · kuyruk :queue';
+
+  @override
+  String get systempageInfraunavailable =>
+      'Kullanılamıyor — GET /platform/metrics/overview';
+
+  @override
+  String get systempageInfrastructure => 'Altyapı';
+
+  @override
+  String get systempageMetricsloaderror =>
+      'Platform metrikleri yüklenirken hata oluştu';
+
+  @override
+  String get systempageNotifobsloaderror =>
+      'Bildirim gözlemlenebilirliği yüklenirken hata oluştu';
+
+  @override
+  String get systempageQueueobsloaderror =>
+      'İş gözlemlenebilirliği yüklenirken hata oluştu';
+
+  @override
+  String get systempageRetry => 'Yeniden dene';
+
+  @override
+  String get systempageServiceunreachable => 'hizmete ulaşılamıyor';
+
+  @override
+  String get systempageStatsloaderror =>
+      'Sistem istatistikleri yüklenirken hata oluştu';
+
+  @override
+  String get systempageSubtitle =>
+      'Leopardo RH platformunun izlenmesi, yapılandırılması ve otomasyonu.';
+
+  @override
+  String get systempageTitle => 'Sistem Yönetimi';
+
   @override
   String get retry => 'Yeniden dene';
 
@@ -2922,321 +3373,13 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get orgChartExpand => 'Genişlet';
-  @override
-  String get errorUnexpected => 'Bir hata oluştu';
-  @override
-  String get apiAccessdenied =>
-      ':endpoint üzerinde erişim reddedildi. Yetersiz izinler.';
-  @override
-  String get apiConnectionerror =>
-      'Bağlantı hatası. İnternet bağlantınızı kontrol edin.';
-  @override
-  String get apiGenericerror => ':endpoint üzerinde :status hatası.';
-  @override
-  String get apiInvaliddata => 'Geçersiz veri.';
-  @override
-  String get apiNotfound => 'Kaynak bulunamadı: :endpoint';
-  @override
-  String get apiServererror => ':endpoint üzerinde sunucu hatası. :detail';
-  @override
-  String get apiServererrorretry => 'Daha sonra tekrar deneyin.';
-  @override
-  String get apiServerunavailable =>
-      'Sunucu geçici olarak kullanılamıyor (:status). Lütfen kısa süre sonra tekrar deneyin.';
-  @override
-  String get apiSessionexpired =>
-      'Oturum süresi doldu. Yeniden bağlanılıyor...';
-  @override
-  String get apiToomanyrequests =>
-      'Çok fazla istek. Lütfen birkaç saniye bekleyin.';
-  @override
-  String get authDemoAccess => 'Demo erisimi';
-  @override
-  String get authTogglePasswordVisibility => 'Sifreyi goster veya gizle';
-  @override
-  String get commonRequired => 'Gerekli';
-  @override
-  String get partnerpageApplyerrorprefix => 'Başvuru sırasında hata: ';
-  @override
-  String get partnerpageCommissionsEmpty => 'Kayıtlı komisyon yok.';
-  @override
-  String get partnerpageCommissionsTitle => 'Son komisyonlar';
-  @override
-  String get partnerpageDashboardSubtitle =>
-      'Leopardo RH dönüşümlerinizi ve komisyonlarınızı takip edin — aktif partner durumu.';
-  @override
-  String get partnerpageDashboardTitle => 'Partner Paneli';
-  @override
-  String get partnerpageLoading => 'Alanınız yükleniyor...';
-  @override
-  String get partnerpageMetricsConversions => 'Dönüşümler';
-  @override
-  String get partnerpageMetricsPending => 'Beklemede';
-  @override
-  String get partnerpageMetricsTotalearned => 'Toplam kazanç';
-  @override
-  String get partnerpageMetricsWithdrawable => 'Çekilebilir bakiye';
-  @override
-  String get partnerpageNotappliedAgency => 'Ajans olarak başvurun';
-  @override
-  String get partnerpageNotappliedIndividual => 'Bireysel olarak başvurun';
-  @override
-  String get partnerpageNotappliedSubtitle =>
-      'Leopardo RH ekosistemine katılın ve yönlendirdiğiniz her şirket için komisyon kazanın. %20\'ye varan düzenli komisyon.';
-  @override
-  String get partnerpageNotappliedTitle => 'Partner Olun';
-  @override
-  String get partnerpagePayoutBody =>
-      'Komisyonlarınız eşiğe ulaşıldığında ödenir. Banka bilgilerinizin güncel olduğundan emin olun.';
-  @override
-  String get partnerpagePayoutErrorprefix => 'Havale talebi sırasında hata: ';
-  @override
-  String get partnerpagePayoutInsufficient =>
-      'Havale talep etmek için bakiye yetersiz (minimum 100,00 €).';
-  @override
-  String get partnerpagePayoutRequest => 'Havale talep et';
-  @override
-  String get partnerpagePayoutSending => 'Gönderiliyor...';
-  @override
-  String get partnerpagePayoutSuccess => 'Havale talebi başarıyla gönderildi.';
-  @override
-  String get partnerpagePayoutTitle => 'Ödeme';
-  @override
-  String get partnerpagePendingBody =>
-      'Başvurunuz satış ekibimiz tarafından doğrulanıyor. Erişiminiz etkinleştirilir etkinleştirilmez bir e-posta alacaksınız.';
-  @override
-  String get partnerpagePendingTitle => 'Başvuru inceleniyor';
-  @override
-  String get partnerpageReferralCopied => 'Kopyalandı!';
-  @override
-  String get partnerpageReferralCopy => 'Bağlantımı kopyala';
-  @override
-  String get partnerpageReferralCopyerror =>
-      'Bağlantı kopyalanamadı. Lütfen elle kopyalayın.';
-  @override
-  String get partnerpageReferralTitle => 'Referans bağlantısı';
-  @override
-  String get partnerpageReferralUnavailable => 'Bağlantı kullanılamıyor';
-  @override
-  String get partnerpageTableAmount => 'Tutar';
-  @override
-  String get partnerpageTableDate => 'Tarih';
-  @override
-  String get partnerpageTableStatus => 'Durum';
-  @override
-  String get partnerpageTableStatuspaid => 'Ödendi';
-  @override
-  String get partnerpageTableStatuspending => 'Beklemede';
-  @override
-  String get partnerpageTableTenantid => 'Tenant Kimliği';
-  @override
-  String get settingspageCancel => 'İptal';
-  @override
-  String get settingspageConfirmpassword => 'Parolayı doğrula';
-  @override
-  String get settingspageCurrentpassword => 'Mevcut parola';
-  @override
-  String get settingspageDisable2fa => '2FA\'yı devre dışı bırak';
-  @override
-  String get settingspageDisabled => 'Devre dışı';
-  @override
-  String get settingspageEmail => 'E-posta adresi';
-  @override
-  String get settingspageEnable2fa => '2FA\'yı etkinleştir';
-  @override
-  String get settingspageEnabled => 'Etkin';
-  @override
-  String get settingspageEntercodestep => '2. Üretilen 6 haneli kodu girin';
-  @override
-  String get settingspageFullname => 'Ad soyad';
-  @override
-  String get settingspageGeneratesecret => '2FA sırrı oluştur';
-  @override
-  String get settingspageGeneratesecrethint =>
-      'Bir sır üretin ve bir kimlik doğrulama uygulamasıyla (Google Authenticator, Authy, 1Password...) tarayın.';
-  @override
-  String get settingspageManualsecret => 'Manuel sır:';
-  @override
-  String get settingspageMinlengthhint => 'En az 8 karakter.';
-  @override
-  String get settingspageNewpassword => 'Yeni parola';
-  @override
-  String get settingspagePassword => 'Parola';
-  @override
-  String get settingspagePasswordsmismatch => 'Parolalar eşleşmiyor.';
-  @override
-  String get settingspagePasswordsubtitle =>
-      'Parolanızı değiştirmek, diğer tüm aktif oturumlarınızı otomatik olarak sonlandırır.';
-  @override
-  String get settingspagePasswordtitle => 'Parola';
-  @override
-  String get settingspagePasswordupdated => 'Parola başarıyla güncellendi.';
-  @override
-  String get settingspageProfilesubtitle =>
-      'Oturum açmak için kullanılan ad ve e-posta adresi.';
-  @override
-  String get settingspageProfiletitle => 'Profil bilgileri';
-  @override
-  String get settingspageProfileupdated => 'Profil başarıyla güncellendi.';
-  @override
-  String get settingspageSavechanges => 'Değişiklikleri kaydet';
-  @override
-  String get settingspageScanstep =>
-      '1. Bu bağlantıyı / sırrı 2FA uygulamanızda tarayın:';
-  @override
-  String get settingspageSubtitle =>
-      'Bilgilerinizi, parolanızı ve süper yönetici hesabınızın güvenliğini yönetin.';
-  @override
-  String get settingspageTitle => 'Hesabım';
-  @override
-  String get settingspageTwofactoractivehint =>
-      '2FA etkin. Devre dışı bırakmak için parolanızı doğrulayın.';
-  @override
-  String get settingspageTwofactordisabled => '2FA devre dışı bırakıldı.';
-  @override
-  String get settingspageTwofactorenabled => '2FA başarıyla etkinleştirildi.';
-  @override
-  String get settingspageTwofactorsubtitle =>
-      'Süper yönetici hesabınıza ek bir güvenlik katmanı ekleyin.';
-  @override
-  String get settingspageTwofactortitle =>
-      'İki faktörlü kimlik doğrulama (2FA)';
-  @override
-  String get settingspageUpdatepassword => 'Parolayı güncelle';
-  @override
-  String get systempageApierror => 'Hata: :error';
-  @override
-  String get systempageApioperational => 'API çalışıyor';
-  @override
-  String get systempageApioperationaldb => 'API çalışıyor — DB :ms ms';
-  @override
-  String get systempageApiservices => 'API Hizmetleri';
-  @override
-  String get systempageApiunavailable => 'Kullanılamıyor — GET /health/live';
-  @override
-  String get systempageDatabase => 'Veritabanı';
-  @override
-  String get systempageDberror => 'Hata: :error';
-  @override
-  String get systempageDblatency => 'Gecikme: :ms ms';
-  @override
-  String get systempageDbunavailable =>
-      'Kullanılamıyor — bir Sağlık Kontrolü çalıştırın.';
-  @override
-  String get systempageDbunreachable => 'veritabanına ulaşılamıyor';
-  @override
-  String get systempageGlobalerror =>
-      'Birleşik sonda: veritabanına ulaşılamıyor.';
-  @override
-  String get systempageGlobalhealthy =>
-      'Birleşik DB + Redis sondası çalışıyor.';
-  @override
-  String get systempageGlobalstatus => 'Genel Durum';
-  @override
-  String get systempageGlobalunavailable =>
-      'Kullanılamıyor — GET /admin/dashboard/stats';
-  @override
-  String get systempageGlobalwarning => 'Birleşik sonda: bozulma algılandı.';
-  @override
-  String get systempageHealthcheck => 'Sağlık Kontrolü';
-  @override
-  String get systempageHealthcheckrunning => 'Kontrol ediliyor...';
-  @override
-  String get systempageHealtherror =>
-      'Sağlık kontrolü tamamlandı — veritabanında hata';
-  @override
-  String get systempageHealthliveunreachable =>
-      '/health/live sondasına ulaşılamıyor.';
-  @override
-  String get systempageHealthok =>
-      'Sağlık kontrolü tamamlandı — veritabanı çalışıyor';
-  @override
-  String get systempageHealthunreachable =>
-      'Sağlık kontrolü tamamlandı — veritabanına ulaşılamıyor';
-  @override
-  String get systempageInfradetails =>
-      ':active aktif şirket · PHP :php · kuyruk :queue';
-  @override
-  String get systempageInfrastructure => 'Altyapı';
-  @override
-  String get systempageInfraunavailable =>
-      'Kullanılamıyor — GET /platform/metrics/overview';
-  @override
-  String get systempageMetricsloaderror =>
-      'Platform metrikleri yüklenirken hata oluştu';
-  @override
-  String get systempageNotifobsloaderror =>
-      'Bildirim gözlemlenebilirliği yüklenirken hata oluştu';
-  @override
-  String get systempageQueueobsloaderror =>
-      'İş gözlemlenebilirliği yüklenirken hata oluştu';
-  @override
-  String get systempageRetry => 'Yeniden dene';
-  @override
-  String get systempageServiceunreachable => 'hizmete ulaşılamıyor';
-  @override
-  String get systempageStatsloaderror =>
-      'Sistem istatistikleri yüklenirken hata oluştu';
-  @override
-  String get systempageSubtitle =>
-      'Leopardo RH platformunun izlenmesi, yapılandırılması ve otomasyonu.';
-  @override
-  String get systempageTitle => 'Sistem Yönetimi';
-  @override
-  String get userAuthAlreadyAccount => 'Zaten hesabiniz var mi? Giris yapin';
-  @override
-  String get userAuthBackToHome => 'Ana sayfaya dön';
-  @override
-  String get userAuthCity => 'Şehir';
-  @override
-  String get userAuthCompanyEmail => 'Şirket e-postası';
-  @override
-  String get userAuthCompanyName => 'Şirket adı';
-  @override
-  String get userAuthCompanyRequestBody =>
-      'Bir yönetici talebinizi inceleyecek. İşlendiğinde bir bildirim alacaksınız.';
-  @override
-  String get userAuthCompanyRequestInfo =>
-      'Şirket bilgilerinizi doldurun. Bir yönetici talebinizi onaylayacak.';
-  @override
-  String get userAuthCompanyRequestTitle => 'Talep gönderildi!';
-  @override
-  String get userAuthCountry => 'Ülke';
-  @override
-  String get userAuthCreateCompany => 'Şirket oluştur';
-  @override
-  String get userAuthDescription => 'Açıklama';
-  @override
-  String get userAuthFirstName => 'Ad';
-  @override
-  String userAuthGoogleError(Object error) {
-    return 'Google hatasi: $error';
-  }
 
   @override
-  String get userAuthLastName => 'Soyad';
+  String get errorUnexpected => 'Bir hata oluştu';
+
   @override
-  String get userAuthLoginSubtitle =>
-      'Alanınıza, belgelerinize ve taleplerinize erisin.';
+  String get approvalApproved => 'Talep onaylandı';
+
   @override
-  String get userAuthNoAccount => 'Henuz hesabınız yok mu? Kayit olun';
-  @override
-  String get userAuthPersonalLogin => 'Kisisel giris';
-  @override
-  String get userAuthPhone => 'Telefon';
-  @override
-  String get userAuthPhoneOptional => 'Telefon (opsiyonel)';
-  @override
-  String get userAuthRegisterButton => 'Hesabimi olustur';
-  @override
-  String get userAuthRegisterSubtitleAlt =>
-      'Kisisel alanınıza erisin ve belgelerinizi duzenleyin.';
-  @override
-  String get userAuthRegisterTitle => 'Hesabimi olustur';
-  @override
-  String get userAuthSector => 'İş sektörü';
-  @override
-  String get userAuthSubmitError => 'Talep gönderme hatası';
-  @override
-  String get userAuthSubmitRequest => 'Talep gönder';
+  String get approvalRejected => 'Talep reddedildi';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2711,7 +2712,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String evaluationPeriod(String period) {
-    return 'Dönem: \$period';
+    return 'Dönem: $period';
   }
 
   @override
@@ -2731,7 +2732,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String attendanceTimeRange(String from, String to) {
-    return '\$from - \$to';
+    return '$from - $to';
   }
 
   @override
@@ -2741,8 +2742,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get attendanceHoursWorked => 'çalışılan saatler';
 
   @override
-  String attendanceDaySummary(String date, String status, String range, String hours) {
-    return '\$date günü, durum \$status, \$range, \$hours.';
+  String attendanceDaySummary(
+    String date,
+    String status,
+    String range,
+    String hours,
+  ) {
+    return '$date günü, durum $status, $range, $hours.';
   }
 
   @override
@@ -2762,12 +2768,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String employeeNumber(String id) {
-    return 'Çalışan #\$id';
+    return 'Çalışan #$id';
   }
 
   @override
   String sessionEntryAt(String time) {
-    return 'Giriş: \$time';
+    return 'Giriş: $time';
   }
 
   @override
@@ -2775,7 +2781,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String errorPrefix(String message) {
-    return 'Hata: \$message';
+    return 'Hata: $message';
   }
 
   @override
@@ -2798,7 +2804,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String saPresenceInProgress(String time) {
-    return '\$time itibarıyla devam eden katılım';
+    return '$time itibarıyla devam eden katılım';
   }
 
   @override
@@ -2837,7 +2843,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String saConfigLoadError(String error) {
-    return 'Yapılandırma yüklenemedi.\n\$error';
+    return 'Yapılandırma yüklenemedi.\n$error';
   }
 
   @override
@@ -2918,4 +2924,319 @@ class AppLocalizationsTr extends AppLocalizations {
   String get orgChartExpand => 'Genişlet';
   @override
   String get errorUnexpected => 'Bir hata oluştu';
+  @override
+  String get apiAccessdenied =>
+      ':endpoint üzerinde erişim reddedildi. Yetersiz izinler.';
+  @override
+  String get apiConnectionerror =>
+      'Bağlantı hatası. İnternet bağlantınızı kontrol edin.';
+  @override
+  String get apiGenericerror => ':endpoint üzerinde :status hatası.';
+  @override
+  String get apiInvaliddata => 'Geçersiz veri.';
+  @override
+  String get apiNotfound => 'Kaynak bulunamadı: :endpoint';
+  @override
+  String get apiServererror => ':endpoint üzerinde sunucu hatası. :detail';
+  @override
+  String get apiServererrorretry => 'Daha sonra tekrar deneyin.';
+  @override
+  String get apiServerunavailable =>
+      'Sunucu geçici olarak kullanılamıyor (:status). Lütfen kısa süre sonra tekrar deneyin.';
+  @override
+  String get apiSessionexpired =>
+      'Oturum süresi doldu. Yeniden bağlanılıyor...';
+  @override
+  String get apiToomanyrequests =>
+      'Çok fazla istek. Lütfen birkaç saniye bekleyin.';
+  @override
+  String get authDemoAccess => 'Demo erisimi';
+  @override
+  String get authTogglePasswordVisibility => 'Sifreyi goster veya gizle';
+  @override
+  String get commonRequired => 'Gerekli';
+  @override
+  String get partnerpageApplyerrorprefix => 'Başvuru sırasında hata: ';
+  @override
+  String get partnerpageCommissionsEmpty => 'Kayıtlı komisyon yok.';
+  @override
+  String get partnerpageCommissionsTitle => 'Son komisyonlar';
+  @override
+  String get partnerpageDashboardSubtitle =>
+      'Leopardo RH dönüşümlerinizi ve komisyonlarınızı takip edin — aktif partner durumu.';
+  @override
+  String get partnerpageDashboardTitle => 'Partner Paneli';
+  @override
+  String get partnerpageLoading => 'Alanınız yükleniyor...';
+  @override
+  String get partnerpageMetricsConversions => 'Dönüşümler';
+  @override
+  String get partnerpageMetricsPending => 'Beklemede';
+  @override
+  String get partnerpageMetricsTotalearned => 'Toplam kazanç';
+  @override
+  String get partnerpageMetricsWithdrawable => 'Çekilebilir bakiye';
+  @override
+  String get partnerpageNotappliedAgency => 'Ajans olarak başvurun';
+  @override
+  String get partnerpageNotappliedIndividual => 'Bireysel olarak başvurun';
+  @override
+  String get partnerpageNotappliedSubtitle =>
+      'Leopardo RH ekosistemine katılın ve yönlendirdiğiniz her şirket için komisyon kazanın. %20\'ye varan düzenli komisyon.';
+  @override
+  String get partnerpageNotappliedTitle => 'Partner Olun';
+  @override
+  String get partnerpagePayoutBody =>
+      'Komisyonlarınız eşiğe ulaşıldığında ödenir. Banka bilgilerinizin güncel olduğundan emin olun.';
+  @override
+  String get partnerpagePayoutErrorprefix => 'Havale talebi sırasında hata: ';
+  @override
+  String get partnerpagePayoutInsufficient =>
+      'Havale talep etmek için bakiye yetersiz (minimum 100,00 €).';
+  @override
+  String get partnerpagePayoutRequest => 'Havale talep et';
+  @override
+  String get partnerpagePayoutSending => 'Gönderiliyor...';
+  @override
+  String get partnerpagePayoutSuccess => 'Havale talebi başarıyla gönderildi.';
+  @override
+  String get partnerpagePayoutTitle => 'Ödeme';
+  @override
+  String get partnerpagePendingBody =>
+      'Başvurunuz satış ekibimiz tarafından doğrulanıyor. Erişiminiz etkinleştirilir etkinleştirilmez bir e-posta alacaksınız.';
+  @override
+  String get partnerpagePendingTitle => 'Başvuru inceleniyor';
+  @override
+  String get partnerpageReferralCopied => 'Kopyalandı!';
+  @override
+  String get partnerpageReferralCopy => 'Bağlantımı kopyala';
+  @override
+  String get partnerpageReferralCopyerror =>
+      'Bağlantı kopyalanamadı. Lütfen elle kopyalayın.';
+  @override
+  String get partnerpageReferralTitle => 'Referans bağlantısı';
+  @override
+  String get partnerpageReferralUnavailable => 'Bağlantı kullanılamıyor';
+  @override
+  String get partnerpageTableAmount => 'Tutar';
+  @override
+  String get partnerpageTableDate => 'Tarih';
+  @override
+  String get partnerpageTableStatus => 'Durum';
+  @override
+  String get partnerpageTableStatuspaid => 'Ödendi';
+  @override
+  String get partnerpageTableStatuspending => 'Beklemede';
+  @override
+  String get partnerpageTableTenantid => 'Tenant Kimliği';
+  @override
+  String get settingspageCancel => 'İptal';
+  @override
+  String get settingspageConfirmpassword => 'Parolayı doğrula';
+  @override
+  String get settingspageCurrentpassword => 'Mevcut parola';
+  @override
+  String get settingspageDisable2fa => '2FA\'yı devre dışı bırak';
+  @override
+  String get settingspageDisabled => 'Devre dışı';
+  @override
+  String get settingspageEmail => 'E-posta adresi';
+  @override
+  String get settingspageEnable2fa => '2FA\'yı etkinleştir';
+  @override
+  String get settingspageEnabled => 'Etkin';
+  @override
+  String get settingspageEntercodestep => '2. Üretilen 6 haneli kodu girin';
+  @override
+  String get settingspageFullname => 'Ad soyad';
+  @override
+  String get settingspageGeneratesecret => '2FA sırrı oluştur';
+  @override
+  String get settingspageGeneratesecrethint =>
+      'Bir sır üretin ve bir kimlik doğrulama uygulamasıyla (Google Authenticator, Authy, 1Password...) tarayın.';
+  @override
+  String get settingspageManualsecret => 'Manuel sır:';
+  @override
+  String get settingspageMinlengthhint => 'En az 8 karakter.';
+  @override
+  String get settingspageNewpassword => 'Yeni parola';
+  @override
+  String get settingspagePassword => 'Parola';
+  @override
+  String get settingspagePasswordsmismatch => 'Parolalar eşleşmiyor.';
+  @override
+  String get settingspagePasswordsubtitle =>
+      'Parolanızı değiştirmek, diğer tüm aktif oturumlarınızı otomatik olarak sonlandırır.';
+  @override
+  String get settingspagePasswordtitle => 'Parola';
+  @override
+  String get settingspagePasswordupdated => 'Parola başarıyla güncellendi.';
+  @override
+  String get settingspageProfilesubtitle =>
+      'Oturum açmak için kullanılan ad ve e-posta adresi.';
+  @override
+  String get settingspageProfiletitle => 'Profil bilgileri';
+  @override
+  String get settingspageProfileupdated => 'Profil başarıyla güncellendi.';
+  @override
+  String get settingspageSavechanges => 'Değişiklikleri kaydet';
+  @override
+  String get settingspageScanstep =>
+      '1. Bu bağlantıyı / sırrı 2FA uygulamanızda tarayın:';
+  @override
+  String get settingspageSubtitle =>
+      'Bilgilerinizi, parolanızı ve süper yönetici hesabınızın güvenliğini yönetin.';
+  @override
+  String get settingspageTitle => 'Hesabım';
+  @override
+  String get settingspageTwofactoractivehint =>
+      '2FA etkin. Devre dışı bırakmak için parolanızı doğrulayın.';
+  @override
+  String get settingspageTwofactordisabled => '2FA devre dışı bırakıldı.';
+  @override
+  String get settingspageTwofactorenabled => '2FA başarıyla etkinleştirildi.';
+  @override
+  String get settingspageTwofactorsubtitle =>
+      'Süper yönetici hesabınıza ek bir güvenlik katmanı ekleyin.';
+  @override
+  String get settingspageTwofactortitle =>
+      'İki faktörlü kimlik doğrulama (2FA)';
+  @override
+  String get settingspageUpdatepassword => 'Parolayı güncelle';
+  @override
+  String get systempageApierror => 'Hata: :error';
+  @override
+  String get systempageApioperational => 'API çalışıyor';
+  @override
+  String get systempageApioperationaldb => 'API çalışıyor — DB :ms ms';
+  @override
+  String get systempageApiservices => 'API Hizmetleri';
+  @override
+  String get systempageApiunavailable => 'Kullanılamıyor — GET /health/live';
+  @override
+  String get systempageDatabase => 'Veritabanı';
+  @override
+  String get systempageDberror => 'Hata: :error';
+  @override
+  String get systempageDblatency => 'Gecikme: :ms ms';
+  @override
+  String get systempageDbunavailable =>
+      'Kullanılamıyor — bir Sağlık Kontrolü çalıştırın.';
+  @override
+  String get systempageDbunreachable => 'veritabanına ulaşılamıyor';
+  @override
+  String get systempageGlobalerror =>
+      'Birleşik sonda: veritabanına ulaşılamıyor.';
+  @override
+  String get systempageGlobalhealthy =>
+      'Birleşik DB + Redis sondası çalışıyor.';
+  @override
+  String get systempageGlobalstatus => 'Genel Durum';
+  @override
+  String get systempageGlobalunavailable =>
+      'Kullanılamıyor — GET /admin/dashboard/stats';
+  @override
+  String get systempageGlobalwarning => 'Birleşik sonda: bozulma algılandı.';
+  @override
+  String get systempageHealthcheck => 'Sağlık Kontrolü';
+  @override
+  String get systempageHealthcheckrunning => 'Kontrol ediliyor...';
+  @override
+  String get systempageHealtherror =>
+      'Sağlık kontrolü tamamlandı — veritabanında hata';
+  @override
+  String get systempageHealthliveunreachable =>
+      '/health/live sondasına ulaşılamıyor.';
+  @override
+  String get systempageHealthok =>
+      'Sağlık kontrolü tamamlandı — veritabanı çalışıyor';
+  @override
+  String get systempageHealthunreachable =>
+      'Sağlık kontrolü tamamlandı — veritabanına ulaşılamıyor';
+  @override
+  String get systempageInfradetails =>
+      ':active aktif şirket · PHP :php · kuyruk :queue';
+  @override
+  String get systempageInfrastructure => 'Altyapı';
+  @override
+  String get systempageInfraunavailable =>
+      'Kullanılamıyor — GET /platform/metrics/overview';
+  @override
+  String get systempageMetricsloaderror =>
+      'Platform metrikleri yüklenirken hata oluştu';
+  @override
+  String get systempageNotifobsloaderror =>
+      'Bildirim gözlemlenebilirliği yüklenirken hata oluştu';
+  @override
+  String get systempageQueueobsloaderror =>
+      'İş gözlemlenebilirliği yüklenirken hata oluştu';
+  @override
+  String get systempageRetry => 'Yeniden dene';
+  @override
+  String get systempageServiceunreachable => 'hizmete ulaşılamıyor';
+  @override
+  String get systempageStatsloaderror =>
+      'Sistem istatistikleri yüklenirken hata oluştu';
+  @override
+  String get systempageSubtitle =>
+      'Leopardo RH platformunun izlenmesi, yapılandırılması ve otomasyonu.';
+  @override
+  String get systempageTitle => 'Sistem Yönetimi';
+  @override
+  String get userAuthAlreadyAccount => 'Zaten hesabiniz var mi? Giris yapin';
+  @override
+  String get userAuthBackToHome => 'Ana sayfaya dön';
+  @override
+  String get userAuthCity => 'Şehir';
+  @override
+  String get userAuthCompanyEmail => 'Şirket e-postası';
+  @override
+  String get userAuthCompanyName => 'Şirket adı';
+  @override
+  String get userAuthCompanyRequestBody =>
+      'Bir yönetici talebinizi inceleyecek. İşlendiğinde bir bildirim alacaksınız.';
+  @override
+  String get userAuthCompanyRequestInfo =>
+      'Şirket bilgilerinizi doldurun. Bir yönetici talebinizi onaylayacak.';
+  @override
+  String get userAuthCompanyRequestTitle => 'Talep gönderildi!';
+  @override
+  String get userAuthCountry => 'Ülke';
+  @override
+  String get userAuthCreateCompany => 'Şirket oluştur';
+  @override
+  String get userAuthDescription => 'Açıklama';
+  @override
+  String get userAuthFirstName => 'Ad';
+  @override
+  String userAuthGoogleError(Object error) {
+    return 'Google hatasi: $error';
+  }
+
+  @override
+  String get userAuthLastName => 'Soyad';
+  @override
+  String get userAuthLoginSubtitle =>
+      'Alanınıza, belgelerinize ve taleplerinize erisin.';
+  @override
+  String get userAuthNoAccount => 'Henuz hesabınız yok mu? Kayit olun';
+  @override
+  String get userAuthPersonalLogin => 'Kisisel giris';
+  @override
+  String get userAuthPhone => 'Telefon';
+  @override
+  String get userAuthPhoneOptional => 'Telefon (opsiyonel)';
+  @override
+  String get userAuthRegisterButton => 'Hesabimi olustur';
+  @override
+  String get userAuthRegisterSubtitleAlt =>
+      'Kisisel alanınıza erisin ve belgelerinizi duzenleyin.';
+  @override
+  String get userAuthRegisterTitle => 'Hesabimi olustur';
+  @override
+  String get userAuthSector => 'İş sektörü';
+  @override
+  String get userAuthSubmitError => 'Talep gönderme hatası';
+  @override
+  String get userAuthSubmitRequest => 'Talep gönder';
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
+++ b/front/mobile_apps/leopardo_core/lib/l10n/generated/app_localizations_tr.dart
@@ -3194,11 +3194,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String attendanceDaySummary(
-    String date,
-    String status,
-    String range,
-    String hours,
-  ) {
+      String date, String status, String range, String hours) {
     return '$date günü, durum $status, $range, $hours.';
   }
 

--- a/front/mobile_apps/leopardo_employee/lib/features/auth/screens/register_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/auth/screens/register_screen.dart
@@ -160,7 +160,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                       ElevatedButton(
                         onPressed: authState.isLoading ? null : _submit,
                         child: authState.isLoading
-                            ? const SizedBox(
+                            ? SizedBox(
                                 height: 20,
                                 width: 20,
                                 child: CircularProgressIndicator(

--- a/front/mobile_apps/leopardo_employee/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/cabinet/screens/cabinet_screen.dart
@@ -340,6 +340,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 if (!mounted) return;
                 final url = result['share_url'] ?? '';
                 await Clipboard.setData(ClipboardData(text: url));
+                if (!mounted) return;
                 ScaffoldMessenger.of(context)
                     .showSnackBar(SnackBar(content: Text('Lien copié : $url')));
               },

--- a/front/mobile_apps/leopardo_employee/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/cabinet/screens/cabinet_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
@@ -132,8 +133,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
           EmptyState(
             icon: Icons.door_sliding_outlined,
             title: 'Placard vide',
-            description:
-                'Ajoutez des dossiers et documents pour organiser votre espace.',
+            description: 'Ajoutez des dossiers et documents pour organiser votre espace.',
           ),
         ],
       );
@@ -260,10 +260,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
               if (name.isEmpty) return;
               Navigator.pop(ctx);
               final repo = ref.read(cabinetRepositoryProvider);
-              await repo.createFolder(
-                name: name,
-                parentId: widget.folderId,
-              );
+              await repo.createFolder(name: name, parentId: widget.folderId);
               ref.invalidate(cabinetFoldersProvider(widget.folderId));
             },
             child: const Text('Creer'),
@@ -278,9 +275,8 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
     if (picked == null) return;
 
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('Envoi en cours...')));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Envoi en cours...')));
 
     final repo = ref.read(cabinetRepositoryProvider);
     try {
@@ -302,7 +298,9 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
       // le snackbar affiché pour toujours et perdait l'image sélectionnée.
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Echec de l\'envoi du document. Reessayez.')),
+        const SnackBar(
+          content: Text('Echec de l\'envoi du document. Reessayez.'),
+        ),
       );
     }
   }
@@ -341,9 +339,9 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 );
                 if (!mounted) return;
                 final url = result['share_url'] ?? '';
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Lien copie : $url')),
-                );
+                await Clipboard.setData(ClipboardData(text: url));
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('Lien copié : $url')));
               },
             ),
             const Divider(),
@@ -401,9 +399,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
             child: const Text('Annuler'),
           ),
           FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.danger,
-            ),
+            style: FilledButton.styleFrom(backgroundColor: AppColors.danger),
             onPressed: () async {
               Navigator.pop(ctx);
               final repo = ref.read(cabinetRepositoryProvider);
@@ -439,10 +435,8 @@ class _FolderTile extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         child: InkWell(
           borderRadius: BorderRadius.circular(16),
-          onTap: () => context.push(
-            '/cabinet/folder/${folder.id}',
-            extra: folder.name,
-          ),
+          onTap: () =>
+              context.push('/cabinet/folder/${folder.id}', extra: folder.name),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
             decoration: BoxDecoration(

--- a/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/smart_attendance/screens/smart_attendance_screen.dart
@@ -7,7 +7,6 @@ import 'package:leopardo_core/core/theme/app_colors.dart';
 import 'package:leopardo_employee/features/smart_attendance/data/models/geo_attendance_session.dart';
 import 'package:leopardo_employee/features/smart_attendance/data/models/smart_attendance_config.dart';
 import 'package:leopardo_employee/features/smart_attendance/providers/smart_attendance_provider.dart';
-import 'package:leopardo_employee/features/smart_attendance/screens/attendance_mode_picker_screen.dart';
 import 'package:leopardo_core/l10n/l10n.dart';
 
 /// Écran principal du module Pointage Intelligent.
@@ -503,7 +502,7 @@ class _GpsZoneStatusCard extends StatelessWidget {
                   color: AppColors.mobileAccentOrange.withValues(alpha: 0.3),
                 ),
               ),
-              child: const Row(
+              child: Row(
                 children: [
                   Icon(
                     Icons.warning_amber_rounded,
@@ -597,7 +596,7 @@ class _SessionCard extends StatelessWidget {
     }
   }
 
-  String get _statusLabel {
+  String _statusLabel(BuildContext context) {
     switch (session.status) {
       case 'approved':
         return context.l10n.saStatusApproved;
@@ -669,7 +668,7 @@ class _SessionCard extends StatelessWidget {
                         borderRadius: BorderRadius.circular(20),
                       ),
                       child: Text(
-                        _statusLabel,
+                        _statusLabel(context),
                         style: TextStyle(
                           color: _statusColor,
                           fontSize: 11,

--- a/front/mobile_apps/leopardo_hr/lib/app.dart
+++ b/front/mobile_apps/leopardo_hr/lib/app.dart
@@ -73,7 +73,10 @@ final routerProvider = Provider<GoRouter>((ref) {
               const SizedBox(height: 12),
               Text(
                 context.l10n.errorUnexpected,
-                style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
               const SizedBox(height: 8),
               Text(context.l10n.pageNotFound, textAlign: TextAlign.center),
@@ -108,7 +111,8 @@ final routerProvider = Provider<GoRouter>((ref) {
         '/access-denied',
       };
       final onPublic = publicRoutes.contains(location);
-      final isAuthorized = isAuth && authState.employee!.isHr;
+      final isAuthorized =
+          isAuth && (authState.employee!.isManager || authState.employee!.isHr);
 
       if (!isAuth && !onPublic) return '/welcome';
       if (isAuth && !isAuthorized) {

--- a/front/mobile_apps/leopardo_hr/lib/features/auth/screens/register_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/auth/screens/register_screen.dart
@@ -160,7 +160,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                       ElevatedButton(
                         onPressed: authState.isLoading ? null : _submit,
                         child: authState.isLoading
-                            ? const SizedBox(
+                            ? SizedBox(
                                 height: 20,
                                 width: 20,
                                 child: CircularProgressIndicator(

--- a/front/mobile_apps/leopardo_hr/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/cabinet/screens/cabinet_screen.dart
@@ -340,6 +340,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 if (!mounted) return;
                 final url = result['share_url'] ?? '';
                 await Clipboard.setData(ClipboardData(text: url));
+                if (!mounted) return;
                 ScaffoldMessenger.of(context)
                     .showSnackBar(SnackBar(content: Text('Lien copié : $url')));
               },

--- a/front/mobile_apps/leopardo_hr/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile_apps/leopardo_hr/lib/features/cabinet/screens/cabinet_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
@@ -132,8 +133,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
           EmptyState(
             icon: Icons.door_sliding_outlined,
             title: 'Placard vide',
-            description:
-                'Ajoutez des dossiers et documents pour organiser votre espace.',
+            description: 'Ajoutez des dossiers et documents pour organiser votre espace.',
           ),
         ],
       );
@@ -260,10 +260,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
               if (name.isEmpty) return;
               Navigator.pop(ctx);
               final repo = ref.read(cabinetRepositoryProvider);
-              await repo.createFolder(
-                name: name,
-                parentId: widget.folderId,
-              );
+              await repo.createFolder(name: name, parentId: widget.folderId);
               ref.invalidate(cabinetFoldersProvider(widget.folderId));
             },
             child: const Text('Creer'),
@@ -278,9 +275,8 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
     if (picked == null) return;
 
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('Envoi en cours...')));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Envoi en cours...')));
 
     final repo = ref.read(cabinetRepositoryProvider);
     try {
@@ -302,7 +298,9 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
       // le snackbar affiché pour toujours et perdait l'image sélectionnée.
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Echec de l\'envoi du document. Reessayez.')),
+        const SnackBar(
+          content: Text('Echec de l\'envoi du document. Reessayez.'),
+        ),
       );
     }
   }
@@ -341,9 +339,9 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 );
                 if (!mounted) return;
                 final url = result['share_url'] ?? '';
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Lien copie : $url')),
-                );
+                await Clipboard.setData(ClipboardData(text: url));
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('Lien copié : $url')));
               },
             ),
             const Divider(),
@@ -401,9 +399,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
             child: const Text('Annuler'),
           ),
           FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.danger,
-            ),
+            style: FilledButton.styleFrom(backgroundColor: AppColors.danger),
             onPressed: () async {
               Navigator.pop(ctx);
               final repo = ref.read(cabinetRepositoryProvider);
@@ -439,10 +435,8 @@ class _FolderTile extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         child: InkWell(
           borderRadius: BorderRadius.circular(16),
-          onTap: () => context.push(
-            '/cabinet/folder/${folder.id}',
-            extra: folder.name,
-          ),
+          onTap: () =>
+              context.push('/cabinet/folder/${folder.id}', extra: folder.name),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
             decoration: BoxDecoration(

--- a/front/mobile_apps/leopardo_hr/test/navigation/go_router_guard_test.dart
+++ b/front/mobile_apps/leopardo_hr/test/navigation/go_router_guard_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leopardo_hr/features/auth/screens/access_denied_screen.dart';
 import 'package:leopardo_hr/features/auth/screens/welcome_screen.dart';
 import 'package:leopardo_hr/features/home/screens/home_screen.dart';
 
@@ -28,5 +29,37 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(HomeScreen), findsOneWidget);
+  });
+
+  testWidgets('manager principal (managerRole=principal) accède à l app RH', (
+    tester,
+  ) async {
+    // #4960 : le guard n'acceptait que manager_role == 'rh' — le manager
+    // principal (rôle attendu par le README et les écrans team/approvals)
+    // était bloqué sur /access-denied, contrairement à l'app Manager.
+    await tester.pumpWidget(
+      appRouterHarness(
+        overrides: [
+          authOverride(testEmployee(role: 'manager', managerRole: 'principal')),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(find.byType(AccessDeniedScreen), findsNothing);
+  });
+
+  testWidgets('employé simple est redirigé vers /access-denied', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      appRouterHarness(
+        overrides: [authOverride(testEmployee(role: 'employee'))],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AccessDeniedScreen), findsOneWidget);
   });
 }

--- a/front/mobile_apps/leopardo_manager/lib/features/approvals/screens/approval_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/approvals/screens/approval_screen.dart
@@ -19,6 +19,7 @@ class ApprovalScreen extends ConsumerStatefulWidget {
 
 class _ApprovalScreenState extends ConsumerState<ApprovalScreen> {
   final _commentController = TextEditingController();
+  bool _approving = false;
 
   @override
   void dispose() {
@@ -27,9 +28,15 @@ class _ApprovalScreenState extends ConsumerState<ApprovalScreen> {
   }
 
   Future<void> _approve(int id) async {
+    // #4960 : double-tap = double POST sans confirmation ni état busy.
+    if (_approving) return;
+    setState(() => _approving = true);
     try {
       await ref.read(approvalRepositoryProvider).approve(id);
       ref.invalidate(pendingApprovalsProvider);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(context.l10n.approvalApproved)));
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -39,6 +46,8 @@ class _ApprovalScreenState extends ConsumerState<ApprovalScreen> {
           ),
         );
       }
+    } finally {
+      if (mounted) setState(() => _approving = false);
     }
   }
 
@@ -46,64 +55,80 @@ class _ApprovalScreenState extends ConsumerState<ApprovalScreen> {
     _commentController.clear();
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: MobileSurface.card,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: Text(
-          'Motif du refus',
-          style: AppTypography.subtitle.copyWith(
-            color: MobileSurface.text,
-            fontWeight: FontWeight.w600,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          backgroundColor: MobileSurface.card,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
           ),
-        ),
-        content: TextField(
-          controller: _commentController,
-          style: AppTypography.body.copyWith(color: MobileSurface.text),
-          maxLines: 3,
-          decoration: InputDecoration(
-            hintText: 'Expliquez la raison...',
-            hintStyle: AppTypography.body.copyWith(color: MobileSurface.muted),
-            enabledBorder: OutlineInputBorder(
-              borderSide: BorderSide(color: MobileSurface.border),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderSide: const BorderSide(color: AppColors.rh),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            filled: true,
-            fillColor: MobileSurface.surface,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(
-              'Annuler',
-              style: AppTypography.body.copyWith(color: MobileSurface.text),
+          title: Text(
+            'Motif du refus',
+            style: AppTypography.subtitle.copyWith(
+              color: MobileSurface.text,
+              fontWeight: FontWeight.w600,
             ),
           ),
-          ElevatedButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: AppColors.danger,
-              foregroundColor: Colors.white,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(8),
+          content: TextField(
+            controller: _commentController,
+            style: AppTypography.body.copyWith(color: MobileSurface.text),
+            maxLines: 3,
+            onChanged: (_) => setDialogState(() {}),
+            decoration: InputDecoration(
+              hintText: 'Expliquez la raison...',
+              hintStyle: AppTypography.body.copyWith(
+                color: MobileSurface.muted,
               ),
-              elevation: 0,
+              enabledBorder: OutlineInputBorder(
+                borderSide: BorderSide(color: MobileSurface.border),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderSide: const BorderSide(color: AppColors.rh),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              filled: true,
+              fillColor: MobileSurface.surface,
             ),
-            child: const Text('Refuser'),
           ),
-        ],
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(
+                'Annuler',
+                style: AppTypography.body.copyWith(color: MobileSurface.text),
+              ),
+            ),
+            ElevatedButton(
+              // #4960 : le refus était silencieux si le commentaire était
+              // vide (dialog fermé, aucune action) — le bouton reste
+              // désactivé tant que le motif n'est pas renseigné.
+              onPressed: _commentController.text.trim().isEmpty
+                  ? null
+                  : () => Navigator.pop(ctx, true),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.danger,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                elevation: 0,
+              ),
+              child: const Text('Refuser'),
+            ),
+          ],
+        ),
       ),
     );
-    if (confirmed == true && _commentController.text.isNotEmpty) {
+    if (confirmed == true) {
       try {
         await ref
             .read(approvalRepositoryProvider)
             .reject(id, comment: _commentController.text);
         ref.invalidate(pendingApprovalsProvider);
+        if (!mounted) return;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(context.l10n.approvalRejected)));
       } catch (e) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/front/mobile_apps/leopardo_manager/lib/features/auth/screens/register_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/auth/screens/register_screen.dart
@@ -160,7 +160,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                       ElevatedButton(
                         onPressed: authState.isLoading ? null : _submit,
                         child: authState.isLoading
-                            ? const SizedBox(
+                            ? SizedBox(
                                 height: 20,
                                 width: 20,
                                 child: CircularProgressIndicator(

--- a/front/mobile_apps/leopardo_manager/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/cabinet/screens/cabinet_screen.dart
@@ -340,6 +340,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 if (!mounted) return;
                 final url = result['share_url'] ?? '';
                 await Clipboard.setData(ClipboardData(text: url));
+                if (!mounted) return;
                 ScaffoldMessenger.of(context)
                     .showSnackBar(SnackBar(content: Text('Lien copié : $url')));
               },

--- a/front/mobile_apps/leopardo_manager/lib/features/cabinet/screens/cabinet_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/cabinet/screens/cabinet_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
@@ -132,8 +133,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
           EmptyState(
             icon: Icons.door_sliding_outlined,
             title: 'Placard vide',
-            description:
-                'Ajoutez des dossiers et documents pour organiser votre espace.',
+            description: 'Ajoutez des dossiers et documents pour organiser votre espace.',
           ),
         ],
       );
@@ -260,10 +260,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
               if (name.isEmpty) return;
               Navigator.pop(ctx);
               final repo = ref.read(cabinetRepositoryProvider);
-              await repo.createFolder(
-                name: name,
-                parentId: widget.folderId,
-              );
+              await repo.createFolder(name: name, parentId: widget.folderId);
               ref.invalidate(cabinetFoldersProvider(widget.folderId));
             },
             child: const Text('Creer'),
@@ -278,9 +275,8 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
     if (picked == null) return;
 
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('Envoi en cours...')));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Envoi en cours...')));
 
     final repo = ref.read(cabinetRepositoryProvider);
     try {
@@ -302,7 +298,9 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
       // le snackbar affiché pour toujours et perdait l'image sélectionnée.
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Echec de l\'envoi du document. Reessayez.')),
+        const SnackBar(
+          content: Text('Echec de l\'envoi du document. Reessayez.'),
+        ),
       );
     }
   }
@@ -341,9 +339,9 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
                 );
                 if (!mounted) return;
                 final url = result['share_url'] ?? '';
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Lien copie : $url')),
-                );
+                await Clipboard.setData(ClipboardData(text: url));
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('Lien copié : $url')));
               },
             ),
             const Divider(),
@@ -401,9 +399,7 @@ class _CabinetScreenState extends ConsumerState<CabinetScreen> {
             child: const Text('Annuler'),
           ),
           FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.danger,
-            ),
+            style: FilledButton.styleFrom(backgroundColor: AppColors.danger),
             onPressed: () async {
               Navigator.pop(ctx);
               final repo = ref.read(cabinetRepositoryProvider);
@@ -439,10 +435,8 @@ class _FolderTile extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         child: InkWell(
           borderRadius: BorderRadius.circular(16),
-          onTap: () => context.push(
-            '/cabinet/folder/${folder.id}',
-            extra: folder.name,
-          ),
+          onTap: () =>
+              context.push('/cabinet/folder/${folder.id}', extra: folder.name),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
             decoration: BoxDecoration(

--- a/front/mobile_apps/leopardo_manager/lib/features/schedules/screens/schedule_list_screen.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/schedules/screens/schedule_list_screen.dart
@@ -51,8 +51,7 @@ class ScheduleListScreen extends ConsumerWidget {
                   EmptyState(
                     icon: Icons.schedule_outlined,
                     title: 'Aucune regle entreprise',
-                    description:
-                        'Creez la premiere regle pour cadrer horaires, repos, conges, pauses et heures supplementaires.',
+                    description: 'Creez la premiere regle pour cadrer horaires, repos, conges, pauses et heures supplementaires.',
                   ),
                 ],
               );
@@ -320,9 +319,8 @@ class _ScheduleAssignSheetState extends ConsumerState<_ScheduleAssignSheet> {
       );
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Echec : $error')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Echec : $error')));
     } finally {
       if (mounted) setState(() => _submitting = false);
     }
@@ -465,10 +463,11 @@ class _ScheduleFormSheetState extends ConsumerState<_ScheduleFormSheet> {
       text: (schedule?.overtimeThresholdWeekly ?? 40).toStringAsFixed(0),
     );
     _leaveDaysCtrl = TextEditingController(
-      text: (schedule?.leaveRules.isNotEmpty == true
-              ? schedule!.leaveRules.first.daysPerYear ?? 21
-              : 21)
-          .toStringAsFixed(0),
+      text:
+          (schedule?.leaveRules.isNotEmpty == true
+                  ? schedule!.leaveRules.first.daysPerYear ?? 21
+                  : 21)
+              .toStringAsFixed(0),
     );
     _notesCtrl = TextEditingController(text: schedule?.assignmentNotes ?? '');
     _startTime = _parseTime(schedule?.startTime ?? '08:00');
@@ -666,8 +665,7 @@ class _ScheduleFormSheetState extends ConsumerState<_ScheduleFormSheet> {
                 style: AppTypography.body.copyWith(color: MobileSurface.text),
                 decoration: InputDecoration(
                   labelText: 'Regles internes',
-                  hintText:
-                      'Repos, consignes de pause, conges, exceptions terrain...',
+                  hintText: 'Repos, consignes de pause, conges, exceptions terrain...',
                   prefixIcon: const Icon(
                     Icons.rule_folder_outlined,
                     color: MobileSurface.secondary,
@@ -744,14 +742,12 @@ class _ScheduleFormSheetState extends ConsumerState<_ScheduleFormSheet> {
       ref.invalidate(schedulesProvider);
       if (!mounted) return;
       Navigator.of(context).pop();
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Horaire enregistre.')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Horaire enregistre.')));
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Echec : $error')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Echec : $error')));
     } finally {
       if (mounted) setState(() => _submitting = false);
     }
@@ -761,20 +757,47 @@ class _ScheduleFormSheetState extends ConsumerState<_ScheduleFormSheet> {
     final schedule = widget.schedule;
     if (schedule == null || schedule.isDefault) return;
 
+    // #4960 : suppression sans confirmation — un appui sur la corbeille
+    // effaçait directement le planning de toute l'équipe affectée.
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: MobileSurface.card,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text('Supprimer cet horaire ?'),
+        content: const Text(
+          'Les employés affectés perdront cet horaire. Cette action est irréversible.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Annuler'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.danger,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Supprimer'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
     setState(() => _submitting = true);
     try {
       await ref.read(scheduleRepositoryProvider).delete(schedule.id);
       ref.invalidate(schedulesProvider);
       if (!mounted) return;
       Navigator.of(context).pop();
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Horaire supprime.')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Horaire supprime.')));
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Echec : $error')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Echec : $error')));
     } finally {
       if (mounted) setState(() => _submitting = false);
     }
@@ -925,4 +948,3 @@ class _TimeButton extends StatelessWidget {
     );
   }
 }
-

--- a/front/mobile_apps/leopardo_manager/lib/features/user_auth/data/user_auth_repository.dart
+++ b/front/mobile_apps/leopardo_manager/lib/features/user_auth/data/user_auth_repository.dart
@@ -20,7 +20,8 @@ class UserAuthRepository {
   }) async {
     final response = await apiClient.requestWithRetry(
       '/user/register',
-      method: 'POST', maxRetriesOverride: 0,
+      method: 'POST',
+      maxRetriesOverride: 0,
       isLoginRequest: true,
       data: {
         'first_name': firstName,
@@ -45,7 +46,8 @@ class UserAuthRepository {
   }) async {
     final response = await apiClient.requestWithRetry(
       '/user/login',
-      method: 'POST', maxRetriesOverride: 0,
+      method: 'POST',
+      maxRetriesOverride: 0,
       isLoginRequest: true,
       data: {'email': email, 'password': password, 'device_name': 'Mobile App'},
     );
@@ -61,7 +63,8 @@ class UserAuthRepository {
   Future<Map<String, dynamic>> googleSignIn({required String idToken}) async {
     final response = await apiClient.requestWithRetry(
       '/user/google-signin',
-      method: 'POST', maxRetriesOverride: 0,
+      method: 'POST',
+      maxRetriesOverride: 0,
       isLoginRequest: true,
       data: {'id_token': idToken},
     );
@@ -96,7 +99,8 @@ class UserAuthRepository {
     try {
       await apiClient.requestWithRetry(
         '/user/logout',
-        method: 'POST', maxRetriesOverride: 0,
+        method: 'POST',
+        maxRetriesOverride: 0,
         useUserSession: true,
         timeoutOverride: const Duration(seconds: 8),
       );
@@ -118,7 +122,8 @@ class UserAuthRepository {
   }) async {
     final response = await apiClient.requestWithRetry(
       '/user/company-requests',
-      method: 'POST', maxRetriesOverride: 0,
+      method: 'POST',
+      maxRetriesOverride: 0,
       useUserSession: true,
       timeoutOverride: const Duration(seconds: 15),
       data: {
@@ -156,7 +161,7 @@ class UserAuthRepository {
     final user = AppUser.fromJson(_userPayload(extractDataMap(response.data)));
 
     // Persiste la nouvelle locale localement pour que le header Accept-Language
-    // et le Locale Flutter soient mis Ã  jour sans nÃ©cessiter un re-login.
+    // et le Locale Flutter soient mis à jour sans nécessiter un re-login.
     if (preferredLanguage != null) {
       final lang = user.preferredLanguage.isNotEmpty
           ? user.preferredLanguage


### PR DESCRIPTION
## Problème
Récurrence de #4762 : la CI mobile de `main` est **rouge** — le job `Analyze leopardo_employee` échoue sur `flutter analyze`. Cause : **137 clés ARB de `leopardo_core` absentes des localizations générées** (`generated/`), dont **28 référencées par le code de l'app employé** (`userAuth*`, `authDemoAccess`, `commonRequired`…) → erreur de compile.

## Contenu
Cette PR (reconstruite sur la chaîne #4973, qui livre la régénération canonique `flutter gen-l10n` des 137 clés + les erreurs d'analyze préexistantes de main) apporte le reste du correctif :

1. **Garde CI anti-récurrence** : `dev-hub/tools/check-mobile-l10n-sync.sh`, branchée sur le job `mobile-apps-guard` de `mobile-apps-ci.yml` (+ filtres de chemins). Toute clé ARB absente des générés fait échouer le pipeline — le scénario #4762 redevient impossible.
2. La régénération elle-même (137 clés, membres triés alphabétiquement, doc comments, interpolation non échappée) est couverte par les fichiers générés canoniques portés par la chaîne #4973.

## Validation
- `flutter analyze` : 0 issue sur core/employee/manager/hr (Flutter 3.47.0).
- `check-mobile-l10n-sync.sh` : OK (0 clé manquante sur les 4 locales).
- Test négatif vérifié : une clé ARB renommée → le script échoue.
