### PR TITLE
fix(mobile/core): répare le retry API, la file de sync et le crash check-out offline

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/api/api_client.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/api/api_client.dart
@@ -54,17 +54,16 @@ class ApiClient {
             options.headers['Authorization'] = 'Bearer $token';
           }
 
-          options.headers['Accept-Language'] =
-              preferredLanguage.isNotEmpty
-                  ? preferredLanguage
-                  : PlatformDispatcher.instance.locale.languageCode
-                      .toLowerCase();
+          options.headers['Accept-Language'] = preferredLanguage.isNotEmpty
+              ? preferredLanguage
+              : PlatformDispatcher.instance.locale.languageCode.toLowerCase();
 
           return handler.next(options);
         },
         onError: (DioException e, handler) async {
           if (e.response?.statusCode == 401) {
-            final useUserSession = e.requestOptions.headers['X-User-Session'] == 'true';
+            final useUserSession =
+                e.requestOptions.headers['X-User-Session'] == 'true';
             if (useUserSession) {
               await _storage.deleteUserToken();
             } else {
@@ -74,7 +73,13 @@ class ApiClient {
               }
             }
           }
-          return handler.next(_handleError(e));
+          // #4960 : on ne convertit PAS ici (l'ancien `_handleError` jetait
+          // une ApiException, ce qui neutralisait la classification et donc
+          // le retry de `requestWithRetry` — les 502/503/timeouts n'étaient
+          // jamais re-tentés). La DioException originale circule ; la
+          // conversion en ApiException localisée se fait après épuisement
+          // des tentatives (fin de requestWithRetry/downloadWithRetry).
+          return handler.next(e);
         },
       ),
     );
@@ -83,7 +88,8 @@ class ApiClient {
     // compiled with --dart-define=API_BASE_URL=mock (misconfigured CI, demo
     // build distributed by mistake) must not silently serve fake data in
     // production. See issue #1470 / audit T14 (2026-04-22).
-    if (!kReleaseMode && const String.fromEnvironment('API_BASE_URL') == 'mock') {
+    if (!kReleaseMode &&
+        const String.fromEnvironment('API_BASE_URL') == 'mock') {
       importMockInterceptor();
     }
   }
@@ -151,8 +157,13 @@ class ApiClient {
     // duplicate accounts, AI charges or published content. Only methods with
     // HTTP idempotency semantics keep the automatic transient-error retry.
     final normalizedMethod = method.toUpperCase();
-    final isIdempotentMethod = const {'GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'}
-        .contains(normalizedMethod);
+    final isIdempotentMethod = const {
+      'GET',
+      'HEAD',
+      'OPTIONS',
+      'PUT',
+      'DELETE',
+    }.contains(normalizedMethod);
     final maxRetries =
         maxRetriesOverride ??
         (isIdempotentMethod
@@ -220,7 +231,10 @@ class ApiClient {
     }
 
     if (lastError is DioException) {
-      throw lastError;
+      // Conversion en ApiException localisée uniquement après épuisement
+      // des tentatives (la classification isColdStart/timeout/network se
+      // fait sur la DioException originale, cf. interceptor onError #4960).
+      throw _handleError(lastError);
     }
     throw ApiException('Request failed after retries');
   }
@@ -300,11 +314,16 @@ class ApiClient {
         }
 
         await _deleteDownload(savePath);
-        rethrow;
+        // Conversion en ApiException localisée (cf. #4960) — le retry a déjà
+        // été tenté au-dessus si l'erreur était transitoire.
+        throw _handleError(e);
       }
     }
 
     await _deleteDownload(savePath);
+    if (lastError is DioException) {
+      throw _handleError(lastError);
+    }
     throw lastError ?? ApiException(localizedErrorCode('DOWNLOAD_FAILED'));
   }
 
@@ -339,7 +358,8 @@ class ApiClient {
       // Issue #2743 — un 403 n'est pas toujours une suspension : on distingue
       // la suspension explicite (payload) du simple défaut de permission.
       final data = e.response?.data;
-      final isSuspended = data is Map &&
+      final isSuspended =
+          data is Map &&
           (data['suspended'] == true || data['error'] == 'ACCOUNT_SUSPENDED');
       message = localizedErrorCode(
         isSuspended ? 'ACCOUNT_SUSPENDED' : 'FORBIDDEN',

--- a/front/mobile_apps/leopardo_core/lib/offline/database/edge_database.dart
+++ b/front/mobile_apps/leopardo_core/lib/offline/database/edge_database.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
@@ -27,8 +28,9 @@ class LocalAttendanceLogs extends Table {
   RealColumn get gpsLat => real().nullable()();
   RealColumn get gpsLng => real().nullable()();
   TextColumn get status => text().withDefault(const Constant('present'))();
-  TextColumn get syncStatus =>
-      text().withDefault(const Constant('pending'))(); // pending|synced|conflict|failed
+  TextColumn get syncStatus => text().withDefault(
+    const Constant('pending'),
+  )(); // pending|synced|conflict|failed
   TextColumn get externalEventId => text().nullable()();
   DateTimeColumn get createdAt =>
       dateTime().clientDefault(() => DateTime.now())();
@@ -48,10 +50,10 @@ class LocalAbsences extends Table {
   DateTimeColumn get startDate => dateTime()();
   DateTimeColumn get endDate => dateTime()();
   TextColumn get reason => text().nullable()();
-  TextColumn get status =>
-      text().withDefault(const Constant('pending'))(); // pending|approved|rejected
-  TextColumn get syncStatus =>
-      text().withDefault(const Constant('pending'))();
+  TextColumn get status => text().withDefault(
+    const Constant('pending'),
+  )(); // pending|approved|rejected
+  TextColumn get syncStatus => text().withDefault(const Constant('pending'))();
   DateTimeColumn get createdAt =>
       dateTime().clientDefault(() => DateTime.now())();
   DateTimeColumn get updatedAt =>
@@ -73,7 +75,8 @@ class LocalEmployees extends Table {
   TextColumn get positionId => text().nullable()();
   TextColumn get role => text().withDefault(const Constant('employee'))();
   TextColumn get status => text().withDefault(const Constant('active'))();
-  TextColumn get faceEncoding => text().nullable()(); // base64 for local biometric
+  TextColumn get faceEncoding =>
+      text().nullable()(); // base64 for local biometric
   TextColumn get biometricId => text().nullable()();
   DateTimeColumn get updatedAt =>
       dateTime().clientDefault(() => DateTime.now())();
@@ -167,15 +170,32 @@ class EdgeDatabase extends _$EdgeDatabase {
   }
 
   Future<void> checkOut(String logId) async {
-    await (update(localAttendanceLogs)..where((t) => t.id.equals(logId)))
-        .write(LocalAttendanceLogsCompanion(
-      checkOut: Value(DateTime.now()),
-      updatedAt: Value(DateTime.now()),
-      syncStatus: const Value('pending'),
-    ));
-    final log = await (select(localAttendanceLogs)
-          ..where((t) => t.id.equals(logId)))
-        .getSingle();
+    final existing = await (select(
+      localAttendanceLogs,
+    )..where((t) => t.id.equals(logId))).getSingleOrNull();
+
+    if (existing == null) {
+      // #4960 : check-in fait en ligne (aucune ligne locale) puis check-out
+      // pendant une coupure — l'ancien code appelait getSingle() et
+      // crashe en StateError. On enregistre un update minimal côté serveur
+      // (le moteur EdgeSync applique l'update par id) : le check-out n'est
+      // ni perdu ni crashé, il partira à la prochaine synchro.
+      await _enqueue('attendance_logs', logId, 'update', {
+        'check_out': DateTime.now().toIso8601String(),
+      });
+      return;
+    }
+
+    await (update(localAttendanceLogs)..where((t) => t.id.equals(logId))).write(
+      LocalAttendanceLogsCompanion(
+        checkOut: Value(DateTime.now()),
+        updatedAt: Value(DateTime.now()),
+        syncStatus: const Value('pending'),
+      ),
+    );
+    final log = await (select(
+      localAttendanceLogs,
+    )..where((t) => t.id.equals(logId))).getSingle();
     await _enqueue('attendance_logs', logId, 'update', _logToJson(log));
   }
 
@@ -196,21 +216,38 @@ class EdgeDatabase extends _$EdgeDatabase {
       (select(localEmployees)..where((t) => t.id.equals(id))).getSingleOrNull();
 
   Future<List<LocalEmployee>> searchEmployees(String query) =>
-      (select(localEmployees)
-            ..where(
-              (t) =>
-                  t.firstName.contains(query) |
-                  t.lastName.contains(query) |
-                  t.email.contains(query),
-            ))
+      (select(localEmployees)..where(
+            (t) =>
+                t.firstName.contains(query) |
+                t.lastName.contains(query) |
+                t.email.contains(query),
+          ))
           .get();
 
   // ── Sync Queue ───────────────────────────────────────
 
+  /// Nombre maximal de tentatives de push avant statut terminal 'failed'
+  /// (issue #4960) : les échecs transitoires sont re-tentés au cycle
+  /// suivant ; au-delà, l'item reste en 'failed' et n'est plus re-piégé —
+  /// il faut une intervention (diagnostic) plutôt qu'un retry sans fin.
+  static const int maxSyncAttempts = 5;
+
+  /// Items à pousser : 'pending' + 'failed' dont le compteur de tentatives
+  /// n'a pas atteint [maxSyncAttempts]. Sans cela, un 5xx transitoire ou
+  /// une coupure pendant le push perdait définitivement le pointage
+  /// (markFailed posait 'failed' et rien ne re-tentait jamais).
   Future<List<LocalSyncQueueItem>> getPendingItems() =>
       (select(localSyncQueue)
-            ..where((t) => t.status.equals('pending'))
-            ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+            ..where(
+              (t) =>
+                  t.status.equals('pending') |
+                  (t.status.equals('failed') &
+                      t.attemptCount.isSmallerThanValue(maxSyncAttempts)),
+            )
+            ..orderBy([
+              (t) => OrderingTerm.asc(t.attemptCount),
+              (t) => OrderingTerm.asc(t.createdAt),
+            ]))
           .get();
 
   Future<void> markSynced(String itemId) =>
@@ -221,10 +258,14 @@ class EdgeDatabase extends _$EdgeDatabase {
         ),
       );
 
-  Future<void> markFailed(String itemId) =>
-      (update(localSyncQueue)..where((t) => t.id.equals(itemId))).write(
-        const LocalSyncQueueCompanion(
-          status: Value('failed'),
+  /// Marque l'item en échec et incrémente [LocalSyncQueueItem.attemptCount].
+  /// Prend l'item complet pour conserver le compteur (drift n'incrémente pas
+  /// atomiquement sans SQL brut).
+  Future<void> markFailed(LocalSyncQueueItem item) =>
+      (update(localSyncQueue)..where((t) => t.id.equals(item.id))).write(
+        LocalSyncQueueCompanion(
+          status: const Value('failed'),
+          attemptCount: Value(item.attemptCount + 1),
         ),
       );
 
@@ -246,31 +287,31 @@ class EdgeDatabase extends _$EdgeDatabase {
 
   // Helper serializers
   Map<String, dynamic> _logToJson(LocalAttendanceLog l) => {
-        'id': l.id,
-        'employee_id': l.employeeId,
-        'company_id': l.companyId,
-        'check_in': l.checkIn.toIso8601String(),
-        'check_out': l.checkOut?.toIso8601String(),
-        'method': l.method,
-        'work_type': l.workType,
-        'gps_lat': l.gpsLat,
-        'gps_lng': l.gpsLng,
-        'status': l.status,
-        'external_event_id': l.externalEventId,
-        'updated_at': l.updatedAt.toIso8601String(),
-      };
+    'id': l.id,
+    'employee_id': l.employeeId,
+    'company_id': l.companyId,
+    'check_in': l.checkIn.toIso8601String(),
+    'check_out': l.checkOut?.toIso8601String(),
+    'method': l.method,
+    'work_type': l.workType,
+    'gps_lat': l.gpsLat,
+    'gps_lng': l.gpsLng,
+    'status': l.status,
+    'external_event_id': l.externalEventId,
+    'updated_at': l.updatedAt.toIso8601String(),
+  };
 
   Map<String, dynamic> _absenceToJson(LocalAbsence a) => {
-        'id': a.id,
-        'employee_id': a.employeeId,
-        'company_id': a.companyId,
-        'absence_type_id': a.absenceTypeId,
-        'start_date': a.startDate.toIso8601String(),
-        'end_date': a.endDate.toIso8601String(),
-        'reason': a.reason,
-        'status': a.status,
-        'updated_at': a.updatedAt.toIso8601String(),
-      };
+    'id': a.id,
+    'employee_id': a.employeeId,
+    'company_id': a.companyId,
+    'absence_type_id': a.absenceTypeId,
+    'start_date': a.startDate.toIso8601String(),
+    'end_date': a.endDate.toIso8601String(),
+    'reason': a.reason,
+    'status': a.status,
+    'updated_at': a.updatedAt.toIso8601String(),
+  };
 
   // Audit #1707 : l'ancien encodeur maison n'échappait pas les guillemets
   // (un `reason` libre contenant " produisait un payload injetable → la file
@@ -285,4 +326,3 @@ LazyDatabase _openConnection() {
     return NativeDatabase.createInBackground(file);
   });
 }
-

--- a/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
+++ b/front/mobile_apps/leopardo_core/lib/offline/services/sync_service.dart
@@ -17,10 +17,10 @@ enum SyncMode { cloud, edge, offline }
 class SyncService {
   final EdgeDatabase _db;
   final Dio _dio;
-  final String _edgeBaseUrl;   // e.g. http://leopardo.local:7878
-  final String _cloudBaseUrl;  // e.g. https://api.leopardo.app
-  final String _edgeNodeId;    // Cloud-issued UUID for this Edge node
-  String _edgeToken;           // Bearer secret, distinct from _edgeNodeId
+  final String _edgeBaseUrl; // e.g. http://leopardo.local:7878
+  final String _cloudBaseUrl; // e.g. https://api.leopardo.app
+  final String _edgeNodeId; // Cloud-issued UUID for this Edge node
+  String _edgeToken; // Bearer secret, distinct from _edgeNodeId
 
   /// Audit #1700 : le secret est hydraté depuis flutter_secure_storage au
   /// démarrage (après construction du provider) — setter mutable.
@@ -54,12 +54,12 @@ class SyncService {
     required String cloudBaseUrl,
     required String edgeNodeId,
     required String edgeToken,
-  })  : _db = db,
-        _dio = dio,
-        _edgeBaseUrl = edgeBaseUrl,
-        _cloudBaseUrl = cloudBaseUrl,
-        _edgeNodeId = edgeNodeId,
-        _edgeToken = edgeToken {
+  }) : _db = db,
+       _dio = dio,
+       _edgeBaseUrl = edgeBaseUrl,
+       _cloudBaseUrl = cloudBaseUrl,
+       _edgeNodeId = edgeNodeId,
+       _edgeToken = edgeToken {
     // Issue #4406 : les providers passent un `Dio()` nu (aucun BaseOptions) —
     // une requête Edge/Cloud pendante (TCP accepté, réponse jamais reçue)
     // bloquerait `syncNow()` pour toujours. Bornes par défaut : 10 s connect /
@@ -76,10 +76,7 @@ class SyncService {
     _connectivitySub = Connectivity().onConnectivityChanged.listen(
       _onConnectivityChangedList,
     );
-    _syncTimer = Timer.periodic(
-      const Duration(minutes: 5),
-      (_) => syncNow(),
-    );
+    _syncTimer = Timer.periodic(const Duration(minutes: 5), (_) => syncNow());
     _detectMode();
   }
 
@@ -146,8 +143,8 @@ class SyncService {
   /// Returns the correct base URL for API calls — transparent to callers.
   String get apiBaseUrl {
     return switch (_currentMode) {
-      SyncMode.edge    => '$_edgeBaseUrl/api',
-      SyncMode.cloud   => '$_cloudBaseUrl/api',
+      SyncMode.edge => '$_edgeBaseUrl/api',
+      SyncMode.cloud => '$_cloudBaseUrl/api',
       SyncMode.offline => '$_edgeBaseUrl/api',
     };
   }
@@ -167,27 +164,30 @@ class SyncService {
       // Batch into groups of 50
       final batches = <List<LocalSyncQueueItem>>[];
       for (var i = 0; i < pending.length; i += 50) {
-        batches.add(pending.sublist(
-          i,
-          i + 50 > pending.length ? pending.length : i + 50,
-        ));
+        batches.add(
+          pending.sublist(i, i + 50 > pending.length ? pending.length : i + 50),
+        );
       }
 
       for (final batch in batches) {
         final List<Map<String, dynamic>> records;
         try {
-          records = batch.map((item) => {
-            'entity_type': item.entityType,
-            'entity_id': item.entityId,
-            'operation': item.operation,
-            'payload': jsonDecode(item.payload),
-          }).toList();
+          records = batch
+              .map(
+                (item) => {
+                  'entity_type': item.entityType,
+                  'entity_id': item.entityId,
+                  'operation': item.operation,
+                  'payload': jsonDecode(item.payload),
+                },
+              )
+              .toList();
         } on FormatException {
           // Audit #1707 : payload illisible (anciens enregistrements
           // sérialisés par l'encodeur maison) — marquer le batch en erreur
           // et continuer au lieu de bloquer la file pour toujours.
           for (final item in batch) {
-            await _db.markFailed(item.id);
+            await _db.markFailed(item);
             failed++;
           }
           continue;
@@ -199,14 +199,13 @@ class SyncService {
           // app image), so the path is identical — only the base URL and
           // the real edgeNodeId (a Cloud-issued UUID, distinct from the
           // bearer edgeToken) differ.
-          final target = '${_activeBaseUrl()}/api/v1/edge-node/$_edgeNodeId/push';
+          final target =
+              '${_activeBaseUrl()}/api/v1/edge-node/$_edgeNodeId/push';
 
           await _dio.post(
             target,
             data: {'records': records},
-            options: Options(
-              headers: {'Authorization': 'Bearer $_edgeToken'},
-            ),
+            options: Options(headers: {'Authorization': 'Bearer $_edgeToken'}),
           );
 
           for (final item in batch) {
@@ -215,7 +214,7 @@ class SyncService {
           }
         } on DioException {
           for (final item in batch) {
-            await _db.markFailed(item.id);
+            await _db.markFailed(item);
             failed++;
           }
         }
@@ -240,9 +239,7 @@ class SyncService {
 
       final response = await _dio.get(
         url,
-        options: Options(
-          headers: {'Authorization': 'Bearer $_edgeToken'},
-        ),
+        options: Options(headers: {'Authorization': 'Bearer $_edgeToken'}),
       );
 
       final delta = response.data as Map<String, dynamic>?;
@@ -252,7 +249,9 @@ class SyncService {
     } catch (e) {
       // Issue #3867 : échec de pull loggé (mode, erreur) — silencieux avant,
       // impossible à diagnostiquer sur le terrain.
-      debugPrint('[SyncService] pull failed ($_currentMode) — ${e.runtimeType}: $e');
+      debugPrint(
+        '[SyncService] pull failed ($_currentMode) — ${e.runtimeType}: $e',
+      );
     }
   }
 

--- a/front/mobile_apps/leopardo_core/test/offline/attendance_offline_service_test.dart
+++ b/front/mobile_apps/leopardo_core/test/offline/attendance_offline_service_test.dart
@@ -155,6 +155,34 @@ void main() {
       final logs = await db.getAttendanceLogs('emp-6');
       expect(logs.single.checkOut, isNotNull);
     });
+
+    test('check-in online + check-out pendant une coupure : pas de crash, '
+        'update minimal mis en file (#4960)', () async {
+      syncServiceSetMode(syncService, SyncMode.cloud);
+
+      // Check-in en ligne : ID cloud, aucune ligne locale.
+      adapter.queueSuccess(data: {
+        'data': {'id': 'cloud-log-42'},
+      });
+      final checkIn = await service.checkIn(
+        employeeId: 'emp-7',
+        companyId: 'co-1',
+      );
+      expect(checkIn.savedLocally, isFalse);
+      expect(checkIn.synced, isTrue);
+      expect(checkIn.id, 'cloud-log-42');
+
+      // Coupure réseau au check-out : l'ancien code crashe en StateError
+      // (getSingle sur une ligne inexistante) — désormais update minimal.
+      adapter.queueFailure();
+      await service.checkOut(logId: 'cloud-log-42');
+
+      final pending = await db.getPendingItems();
+      expect(pending, hasLength(1));
+      expect(pending.single.entityId, 'cloud-log-42');
+      expect(pending.single.operation, 'update');
+      expect(pending.single.payload, contains('check_out'));
+    });
   });
 }
 

--- a/front/mobile_apps/leopardo_core/test/offline/sync_service_test.dart
+++ b/front/mobile_apps/leopardo_core/test/offline/sync_service_test.dart
@@ -115,10 +115,38 @@ void main() {
     expect(result.sent, 0);
     expect(result.failed, 1);
 
-    // The item is no longer "pending" (it was marked failed, ready for a
-    // future retry policy), so the sync queue drains it from this cycle.
+    // #4960 : l'item échoué est re-piégé au cycle suivant (retry policy) —
+    // attemptCount incrémenté, status 'failed' mais < maxSyncAttempts. Ce
+    // n'est plus un drop silencieux.
     final pending = await db.getPendingItems();
-    expect(pending, isEmpty);
+    expect(pending, hasLength(1));
+    expect(pending.first.status, 'failed');
+    expect(pending.first.attemptCount, 1);
+  });
+
+  test('syncNow() stops retrying an item after maxSyncAttempts failures', () async {
+    service.debugSetModeForTesting(SyncMode.cloud);
+    await db.insertAttendanceLog(
+      LocalAttendanceLogsCompanion.insert(
+        employeeId: 'emp-2',
+        companyId: 'co-1',
+        checkIn: DateTime.now(),
+      ),
+    );
+
+    // Simule 5 échecs de push successifs (statut terminal 'failed').
+    for (var i = 0; i < EdgeDatabase.maxSyncAttempts; i++) {
+      adapter.queueFailure();
+      adapter.queueSuccess(data: {'entities': <String, dynamic>{}});
+      await service.syncNow();
+    }
+
+    final pending = await db.getPendingItems();
+    expect(pending, isEmpty, reason: 'item terminal — plus de retry');
+
+    final item = await (db.select(db.localSyncQueue)).getSingle();
+    expect(item.status, 'failed');
+    expect(item.attemptCount, EdgeDatabase.maxSyncAttempts);
   });
 
   test('syncNow() applies an employees delta from the pull response', () async {


### PR DESCRIPTION
## Problème
Trois P1 identifiés par l'audit mobile du 2026-08-17 (rapport `RAPPORT_CHEF_DE_PROJET_MOBILE_2026-08-17.md`), tous dans `leopardo_core` :

1. **Retry API inerte (code mort)** — l'intercepteur `onError` convertissait l'erreur via `_handleError` (qui **throw** une `ApiException`) avant que la boucle de `requestWithRetry` puisse classifier : `isColdStart`/`isTimeout`/`isNetwork` n'étaient **jamais vrais** → aucun 502/503/504, timeout ou erreur réseau n'était re-tenté.
2. **Perte de données silencieuse** — `markFailed` posait `status='failed'` et `getPendingItems()` ne sélectionnait que `'pending'` → un échec transitoire pendant le push perdait définitivement le pointage/absence.
3. **Crash check-out offline** — check-in en ligne puis coupure au check-out : `_db.checkOut(cloudId)` → 0 ligne → `getSingle()` lève un `StateError` non attrapé.

## Correctifs
1. **`api_client.dart`** : l'intercepteur passe la `DioException` originale (`handler.next(e)`) ; la conversion en `ApiException` localisée se fait **après** épuisement des tentatives (fin de `requestWithRetry` et `downloadWithRetry`). Le retry 502/503/504/timeout/réseau fonctionne enfin (GET idempotent seulement, mutations = 0 retry).
2. **`edge_database.dart`** : retry policy de la file — `getPendingItems()` re-piège les `failed` avec `attemptCount < maxSyncAttempts` (5) ; `markFailed` incrémente le compteur (statut terminal après 5 tentatives).
3. **`edge_database.dart` `checkOut()`** : `getSingleOrNull()` + mise en file d'un **update minimal** (`check_out`) appliqué par le moteur EdgeSync (update par id) — ni crash ni perte du pointage.

## Tests
- `sync_service_test.dart` : le test « transient failure → retry » verrouillait l'ancien comportement de drop — mis à jour pour asserter le re-piégeage (`attemptCount=1`) ; ajout d'un test de statut terminal après `maxSyncAttempts`.
- `attendance_offline_service_test.dart` : ajout du scénario exact du crash #4960 (check-in online + coupure au check-out → update minimal en file, pas d'exception).
