### PR TITLE
fix(ci): gate de déploiement AVANT le checkout privilégié — CodeQL cache-poisoning (alert #30)

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -43,6 +43,17 @@ jobs:
       web_changed: ${{ steps.final.outputs.web_changed }}
       app_version: ${{ steps.final.outputs.app_version }}
     steps:
+      # The gate runs before the full deployment checkout. This sparse,
+      # credential-free checkout contains only the trusted local action so
+      # GitHub can resolve it without exposing the deployment tree first.
+      - name: Checkout trusted deploy gate action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          sparse-checkout: .github/actions/verify-deploy-workflows
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Guard PROD_API_BASE_URL (#4524)
         shell: bash
         run: |

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -116,8 +116,67 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout deployment SHA
+      - name: Resolve changed areas via API (before privileged checkout)
         if: steps.context.outputs.should_deploy == 'pending-validation'
+        id: changes_api
+        # CodeQL actions/cache-poisoning/poisonable-step (alerte #30) : le
+        # checkout privilégié ne doit JAMAIS utiliser un SHA non vérifié.
+        # On calcule ici web_changed via l'API (compare des fichiers entre le
+        # parent et le SHA) pour permettre au gate de tourner AVANT le
+        # checkout — même logique que le filtre `web` de .github/paths-filters.yml.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = `${{ steps.context.outputs.sha }}`;
+            const isWebPath = (p) =>
+              p.startsWith('front/admin-dashboard/') ||
+              p === '.github/workflows/web-ci.yml' ||
+              p === '.github/workflows/deploy-main.yml' ||
+              p === 'docs/GESTION_PROJET/SCENARIOS_TEST_WEB_ADMIN_GITHUB_ACTIONS.md' ||
+              p === 'docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md';
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+              const parent = commit.parents[0]?.sha;
+              let webChanged = true; // conservateur : parent inconnu => web requise
+              if (parent) {
+                const { data: cmp } = await github.rest.repos.compareCommitsWithBasehead({
+                  owner,
+                  repo,
+                  basehead: `${parent}...${sha}`,
+                });
+                webChanged = (cmp.files ?? []).some((f) => isWebPath(f.filename));
+              }
+              core.setOutput('web_changed', webChanged ? 'true' : 'false');
+              core.setOutput('parent_sha', parent ?? '');
+            } catch (err) {
+              core.warning(`resolve changes via API failed: ${err.message} — web_changed conservateur (true).`);
+              core.setOutput('web_changed', 'true');
+              core.setOutput('parent_sha', '');
+            }
+
+      - name: Verify required workflow conclusions for deployment SHA
+        if: steps.context.outputs.should_deploy == 'pending-validation'
+        id: workflow_gate
+        # Issue #4723 : logique de gate partagée avec l'autre workflow de
+        # déploiement via l'action composite verify-deploy-workflows.
+        # CodeQL cache-poisoning (alerte #30) : ce gate 100 % API tourne AVANT
+        # le checkout privilégié ; web_changed provient de changes_api (API),
+        # pas d'un diff local post-checkout.
+        uses: ./.github/actions/verify-deploy-workflows
+        with:
+          sha: ${{ steps.context.outputs.sha }}
+          required_workflows: '["Tests - Leopardo RH","Web CI - Leopardo Admin"]'
+          web_changed: ${{ steps.changes_api.outputs.web_changed == 'true' }}
+      - name: Finalize deployment decision
+        if: steps.context.outputs.should_deploy == 'pending-validation'
+        id: decision
+        shell: bash
+        run: |
+          echo "should_deploy=${{ steps.workflow_gate.outputs.should_deploy }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout deployment SHA
+        if: steps.context.outputs.should_deploy == 'pending-validation' && steps.decision.outputs.should_deploy == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           lfs: true
@@ -126,7 +185,7 @@ jobs:
           persist-credentials: false
 
       - name: Resolve parent commit for change detection
-        if: steps.context.outputs.should_deploy == 'pending-validation'
+        if: steps.context.outputs.should_deploy == 'pending-validation' && steps.decision.outputs.should_deploy == 'true'
         id: parent
         shell: bash
         run: |
@@ -136,7 +195,7 @@ jobs:
           echo "sha=${parent:-${sha}}" >> "$GITHUB_OUTPUT"
 
       - name: Detect changed areas for deployment gating
-        if: steps.context.outputs.should_deploy == 'pending-validation'
+        if: steps.context.outputs.should_deploy == 'pending-validation' && steps.decision.outputs.should_deploy == 'true'
         id: changes
         # Audit §3.3 / Plan P2: now shares .github/paths-filters.yml with
         # tests.yml's detect-changes job instead of a second hand-rolled
@@ -147,13 +206,13 @@ jobs:
           base: ${{ steps.parent.outputs.sha }}
 
       - name: Export web_changed output
-        if: steps.context.outputs.should_deploy == 'pending-validation'
+        if: steps.context.outputs.should_deploy == 'pending-validation' && steps.decision.outputs.should_deploy == 'true'
         shell: bash
         run: |
           echo "web_changed=${{ steps.changes.outputs.web }}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve program version for deploy metadata
-        if: steps.context.outputs.should_deploy == 'pending-validation'
+        if: steps.context.outputs.should_deploy == 'pending-validation' && steps.decision.outputs.should_deploy == 'true'
         id: version
         shell: bash
         run: |
@@ -166,25 +225,8 @@ jobs:
           echo "app_version=${program_version}" >> "$GITHUB_OUTPUT"
           echo "Deploy APP_VERSION=${program_version}"
 
-      - name: Verify required workflow conclusions for deployment SHA
-        if: steps.context.outputs.should_deploy == 'pending-validation'
-        id: workflow_gate
-        # Issue #4723 : logique de gate partagée avec l'autre workflow de
-        # déploiement via l'action composite verify-deploy-workflows.
-        uses: ./.github/actions/verify-deploy-workflows
-        with:
-          sha: ${{ steps.context.outputs.sha }}
-          required_workflows: '["Tests - Leopardo RH","Web CI - Leopardo Admin"]'
-          web_changed: ${{ steps.changes.outputs.web == 'true' }}
-      - name: Finalize deployment decision
-        if: steps.context.outputs.should_deploy == 'pending-validation'
-        id: decision
-        shell: bash
-        run: |
-          echo "should_deploy=${{ steps.workflow_gate.outputs.should_deploy }}" >> "$GITHUB_OUTPUT"
-
       - name: Expose validated deployment decision
-        if: steps.context.outputs.should_deploy == 'pending-validation'
+        if: steps.context.outputs.should_deploy == 'pending-validation' && steps.decision.outputs.should_deploy == 'true'
         shell: bash
         run: |
           echo "Deployment gate resolved for ${{ steps.context.outputs.sha }}."


### PR DESCRIPTION
## Contexte
Alerte CodeQL **actions/cache-poisoning/poisonable-step (high, #30)** : le checkout privilégié (`ref: ${{ steps.context.outputs.sha }}`) tournait **avant** la vérification API des conclusions CI — le SHA (issu de l'event) n'était pas vérifié au moment du checkout.

## Correctif (recommandation AUDIT_GLOBAL_2026-07-26 §2.1)
Restructure du job `prepare` de `deploy-main.yml` :
1. **Nouvelle étape `changes_api`** : `web_changed` résolu via l'API GitHub (`compare parent...sha`), même logique que le filtre `web` de `.github/paths-filters.yml` — aucun checkout requis.
2. **Gate `verify-deploy-workflows` (100 % API) + décision déplacés AVANT le checkout**.
3. **Checkout conditionné** à `decision.should_deploy == 'true'` : un SHA non vérifié n'est jamais checkouté (fail-closed). Les étapes post-checkout (parent, changes, version) héritent de la même garde.

## Validation
- YAML parsé (structure, IDs uniques) ; comportement du gate inchangé (polling borné 30 min, anti-stale).
- Déclencheurs `push: main` + `workflow_dispatch` inchangés ; sorties du job `prepare` inchangées (`should_deploy`, `sha`, `web_changed`, `app_version`).
- L'action composite `verify-deploy-workflows` est purement API (github-script) : aucune dépendance au working tree.

À valider par actionlint + re-scan CodeQL sur la PR.

Closes #4824
