### PR TITLE
fix(i18n): ARB mobile resynchronisés — débloque validate-and-sync sur toutes les PRs

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_ar.arb
@@ -319,6 +319,9 @@
   "dashboardClientRequests": "طلبات العملاء",
   "dashboardTenantsAtRisk": "مستأجرون معرضون للخطر",
   "dashboardPlatformDashboardHint": "متاح في لوحة تحكم المنصة.",
+  "dashboardSearchplaceholder": "بحث...",
+  "dashboardModulesactivesentence": "{active} وحدة نشطة، و{locked} لتفعيلها حسب خطتك.",
+  "dashboardYourcompany": "شركتك",
   "marketingOauthNavTitle": "تسويق OAuth",
   "marketingOauthTitle": "إعدادات OAuth التسويق",
   "marketingOauthSubtitle": "اربط حسابات وسائل التواصل الاجتماعي عبر Ayrshare",
@@ -338,6 +341,8 @@
   "marketingOauthFieldsPlaceholderId": "معرف العميل الخاص بك",
   "marketingOauthFieldsPlaceholderSecret": "سر جديد (اختياري)",
   "marketingOauthFieldsPlaceholderUri": "https://example.com/oauth/callback",
+  "marketingSocialexampleplaceholder": "مثال: Leopardo RH — وسائل التواصل الاجتماعي",
+  "marketingPostcontentplaceholder": "محتوى المنشور...",
   "attendanceSendingToServer": "جار إرسال {label} إلى الخادم...",
   "attendanceRetryAfterFailure": "{label}. حاول مرة أخرى.",
   "holidaysPageTitle": "الأعياد الرسمية حسب البلد",
@@ -905,6 +910,10 @@
   "apiGenericerror": "خطأ :status على :endpoint.",
   "apiInvaliddata": "بيانات غير صالحة.",
   "apiConnectionerror": "خطأ في الاتصال. تحقق من اتصالك بالإنترنت.",
+  "apiLoginInvalidJson": "نص الطلب غير صالح.",
+  "apiLoginTimeout": "يستغرق الخادم وقتاً طويلاً للرد. يرجى المحاولة مرة أخرى بعد قليل.",
+  "apiLoginNetworkError": "تعذر الوصول إلى الخادم.",
+  "apiLoginBackendError": "استجابة خادم غير متوقعة.",
   "settingspageCancel": "إلغاء",
   "settingspageConfirmpassword": "تأكيد كلمة المرور",
   "settingspageCurrentpassword": "كلمة المرور الحالية",
@@ -970,152 +979,18 @@
   "systempageStatsloaderror": "خطأ أثناء تحميل إحصائيات النظام",
   "systempageSubtitle": "مراقبة منصة Leopardo RH وتكوينها وأتمتتها.",
   "systempageTitle": "إدارة النظام",
-  "retry": "إعادة المحاولة",
-  "featureComingSoon": "الميزة قريبًا",
-  "backToHome": "العودة إلى الرئيسية",
-  "pageNotFound": "الصفحة المطلوبة غير موجودة أو فشل التنقل.",
-  "registerCreateAccount": "أنشئ حسابك",
-  "registerFirstName": "الاسم الأول",
-  "registerRequired": "مطلوب",
-  "registerPassword": "كلمة المرور",
-  "registerMinChars": "8 أحرف على الأقل",
-  "registerCreating": "جارٍ إنشاء الحساب...",
-  "registerSubmit": "أنشئ حسابي",
-  "accessDeniedTitle": "تم رفض الوصول",
-  "accessDeniedBody": "لا يملك حسابك دور المدير المطلوب لهذا التطبيق. استخدم التطبيق المطابق لدورك (موظف، موارد بشرية…) أو تواصل مع المسؤول.",
-  "accessDeniedLogout": "تسجيل الخروج",
-  "accessDeniedBodyHr": "لا يملك حسابك دور الموارد البشرية المطلوب لهذا التطبيق. استخدم التطبيق المطابق لدورك (موظف، مدير…) أو تواصل مع المسؤول.",
-  "evaluationsTitle": "تقييماتي",
-  "evaluationsEmpty": "لا توجد تقييمات",
-  "evaluationsEmptyHint": "ليس لديك أي تقييم مسجل بعد.",
-  "evaluationPeriod": "الفترة: {period}",
-  "@evaluationPeriod": {
-    "placeholders": {
-      "period": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceOnTime": "في الموعد",
-  "attendanceLate": "متأخر",
-  "attendanceAbsent": "غائب",
-  "attendanceInProgress": "قيد التقدم",
-  "attendanceNoClock": "لا يوجد تسجيل حضور",
-  "attendanceTimeRange": "من {from} إلى {to}",
-  "@attendanceTimeRange": {
-    "placeholders": {
-      "from": {
-        "type": "String"
-      },
-      "to": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceHourWorked": "ساعة عمل",
-  "attendanceHoursWorked": "ساعات عمل",
-  "attendanceDaySummary": "يوم {date}، الحالة {status}، {range}، {hours}.",
-  "@attendanceDaySummary": {
-    "placeholders": {
-      "date": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      },
-      "range": {
-        "type": "String"
-      },
-      "hours": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionApproved": "تمت الموافقة على الجلسة ✓",
-  "sessionRejected": "تم رفض الجلسة",
-  "pendingSessionsToValidate": "للموافقة",
-  "pendingSessionsUpToDate": "كل شيء محدث",
-  "pendingSessionsEmpty": "لا توجد جلسة GPS بانتظار الموافقة.",
-  "employeeNumber": "الموظف #{id}",
-  "@employeeNumber": {
-    "placeholders": {
-      "id": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionEntryAt": "الدخول: {time}",
-  "@sessionEntryAt": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionsToValidate": "جلسات للموافقة",
-  "errorPrefix": "خطأ: {message}",
-  "@errorPrefix": {
-    "placeholders": {
-      "message": {
-        "type": "String"
-      }
-    }
-  },
-  "saDashboardTitle": "حضور GPS — لوحة تحكم الفريق",
-  "saDetected": "تم الكشف",
-  "saApproved": "تمت الموافقة",
-  "saRejected": "مرفوضة",
-  "saRecentSessions": "الجلسات الأخيرة",
-  "saForced": "مفروض",
-  "saPresenceInProgress": "حضور قيد التقدم منذ {time}",
-  "@saPresenceInProgress": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "saGpsZoneNotConfigured": "لم يتم إعداد منطقة GPS لشركتك بعد.",
-  "saDisableAutoGps": "تعطيل GPS التلقائي",
-  "saStatusApproved": "تمت الموافقة",
-  "saStatusDetected": "تم الكشف",
-  "saStatusRejected": "مرفوضة",
-  "saStatusCancelled": "ملغاة",
-  "saStatusPending": "قيد التحقق",
-  "saEnableAutoGps": "تفعيل GPS التلقائي",
-  "attendanceOvertime": "ساعات إضافية",
-  "approvalsUpToDate": "كل شيء محدث",
-  "approvalsEmpty": "لا توجد موافقات معلقة.",
-  "saConfigLoadError": "تعذر تحميل الإعدادات.\n{error}",
-  "@saConfigLoadError": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "ampAutoDetectDesc": "يتم اكتشاف حضورك تلقائيًا عند دخولك منطقة الشركة. لا حاجة لأي إجراء منك.",
-  "ampRecommended": "موصى به",
-  "ampQrScanDesc": "امسح رمز QR المعروض عند مدخل الشركة لتسجيل دخولك وخروجك.",
-  "ampManualDesc": "سجل يدويًا بالضغط على زرّي الوصول والمغادرة في شاشة الحضور.",
-  "ampSaveError": "تعذر حفظ تفضيلاتك. تحقق من اتصالك.",
-  "ampTitle": "اختر كيف تريد تسجيل حضورك كل يوم.",
-  "ampModeTitle": "وضع التسجيل",
-  "back": "رجوع",
-  "refresh": "تحديث",
-  "saSessionsLoadError": "تعذر تحميل جلسات GPS. تحقق من اتصالك.",
-  "saStartMonitoringError": "تعذر بدء مراقبة GPS. تحقق من أذونات الموقع وأعد المحاولة.",
-  "shellTeam": "الفريق",
-  "shellSettings": "الإعدادات",
-  "homeCompleteOnboarding": "إكمال تأهيلي",
-  "homeOnboardingHint": "هيئ مساحة عملك في بضع خطوات.",
-  "welcomeMyTeam": "فريقي",
-  "welcomePresences": "الحضور",
-  "welcomeTasks": "المهام",
-  "welcomeLeaves": "الإجازات",
-  "monthlySummaryLoading": "جارٍ تحميل الملخص الشهري...",
-  "orgChartEmpty": "سيتوفر الهيكل التنظيمي بمجرد إعداد الموظفين.",
-  "orgChartCollapse": "طي",
-  "orgChartExpand": "توسيع",
-  "errorUnexpected": "حدث خطأ"
+  "billingCancelSubscriptionConfirm": "هل تريد إلغاء اشتراكك؟ ستفقد الوصول إلى الوحدات المميزة في نهاية الفترة الحالية.",
+  "billingNoActivePeriod": "لا توجد فترة نشطة",
+  "billingNoActiveSubscription": "لا يوجد اشتراك نشط",
+  "billingPeriodLabel": "الفترة",
+  "billingCheckoutSandboxMessage": "دفع محاكى (وضع الاختبار). لن يتم خصم أي بطاقة.",
+  "billingCheckoutUnavailable": "الدفع عبر الإنترنت غير متاح مؤقتاً. تواصل مع الدعم على support@leopardo-rh.com.",
+  "billingCheckoutFailed": "تعذر إنشاء جلسة الدفع.",
+  "contractsListSubtitle": "إدارة عقود الموظفين: تتبع الحالات والاستحقاقات وتصدير PDF، مرتبطة مباشرة بواجهة برمجة تطبيقات الموارد البشرية.",
+  "contractsSearchplaceholder": "ابحث عن موظف أو نوع عقد...",
+  "contractsAllstatuses": "كل الحالات",
+  "trainingTitleplaceholder": "العنوان *",
+  "trainingDurationplaceholder": "المدة (ساعة)",
+  "trainingMaxparticipantsplaceholder": "الحد الأقصى للمشاركين",
+  "trainingOnline": "عبر الإنترنت"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_en.arb
@@ -319,6 +319,9 @@
   "dashboardClientRequests": "Client requests",
   "dashboardTenantsAtRisk": "Tenants at risk",
   "dashboardPlatformDashboardHint": "Available in the platform dashboard.",
+  "dashboardSearchplaceholder": "Search...",
+  "dashboardModulesactivesentence": "{active} modules active, {locked} to activate based on your plan.",
+  "dashboardYourcompany": "Your company",
   "marketingOauthNavTitle": "Marketing OAuth",
   "marketingOauthTitle": "Marketing OAuth Settings",
   "marketingOauthSubtitle": "Connect your social media accounts via Ayrshare",
@@ -338,6 +341,8 @@
   "marketingOauthFieldsPlaceholderId": "Your Client ID",
   "marketingOauthFieldsPlaceholderSecret": "New secret (optional)",
   "marketingOauthFieldsPlaceholderUri": "https://example.com/oauth/callback",
+  "marketingSocialexampleplaceholder": "Ex: Leopardo RH — Social media",
+  "marketingPostcontentplaceholder": "Post content...",
   "attendanceSendingToServer": "Sending {label} to the server...",
   "attendanceRetryAfterFailure": "{label}. Please try again.",
   "holidaysPageTitle": "Public holidays by country",
@@ -905,6 +910,10 @@
   "apiGenericerror": "Error :status on :endpoint.",
   "apiInvaliddata": "Invalid data.",
   "apiConnectionerror": "Connection error. Check your internet connection.",
+  "apiLoginInvalidJson": "Invalid request body.",
+  "apiLoginTimeout": "The server is taking too long to respond. Please try again shortly.",
+  "apiLoginNetworkError": "Unable to reach the server.",
+  "apiLoginBackendError": "Unexpected server response.",
   "settingspageCancel": "Cancel",
   "settingspageConfirmpassword": "Confirm password",
   "settingspageCurrentpassword": "Current password",
@@ -970,152 +979,18 @@
   "systempageStatsloaderror": "Error loading system stats",
   "systempageSubtitle": "Monitoring, configuration and automation of the Leopardo RH platform.",
   "systempageTitle": "System Administration",
-  "retry": "Retry",
-  "featureComingSoon": "Feature coming soon",
-  "backToHome": "Back to home",
-  "pageNotFound": "The requested page was not found or the navigation failed.",
-  "registerCreateAccount": "Create your account",
-  "registerFirstName": "First name",
-  "registerRequired": "Required",
-  "registerPassword": "Password",
-  "registerMinChars": "8 characters minimum",
-  "registerCreating": "Creating your account...",
-  "registerSubmit": "Create my account",
-  "accessDeniedTitle": "Access denied",
-  "accessDeniedBody": "Your account does not have the required Manager role for this application. Use the application matching your role (Employee, HR…) or contact your administrator.",
-  "accessDeniedLogout": "Log out",
-  "accessDeniedBodyHr": "Your account does not have the required HR role for this application. Use the application matching your role (Employee, Manager…) or contact your administrator.",
-  "evaluationsTitle": "My Evaluations",
-  "evaluationsEmpty": "No evaluations",
-  "evaluationsEmptyHint": "You don't have any recorded evaluation yet.",
-  "evaluationPeriod": "Period: {period}",
-  "@evaluationPeriod": {
-    "placeholders": {
-      "period": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceOnTime": "on time",
-  "attendanceLate": "late",
-  "attendanceAbsent": "absent",
-  "attendanceInProgress": "in progress",
-  "attendanceNoClock": "no clock-in",
-  "attendanceTimeRange": "from {from} to {to}",
-  "@attendanceTimeRange": {
-    "placeholders": {
-      "from": {
-        "type": "String"
-      },
-      "to": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceHourWorked": "hour worked",
-  "attendanceHoursWorked": "hours worked",
-  "attendanceDaySummary": "Day of {date}, status {status}, {range}, {hours}.",
-  "@attendanceDaySummary": {
-    "placeholders": {
-      "date": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      },
-      "range": {
-        "type": "String"
-      },
-      "hours": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionApproved": "Session approved ✓",
-  "sessionRejected": "Session rejected",
-  "pendingSessionsToValidate": "To validate",
-  "pendingSessionsUpToDate": "All up to date",
-  "pendingSessionsEmpty": "No GPS session waiting for validation.",
-  "employeeNumber": "Employee #{id}",
-  "@employeeNumber": {
-    "placeholders": {
-      "id": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionEntryAt": "Entry: {time}",
-  "@sessionEntryAt": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionsToValidate": "Sessions to validate",
-  "errorPrefix": "Error: {message}",
-  "@errorPrefix": {
-    "placeholders": {
-      "message": {
-        "type": "String"
-      }
-    }
-  },
-  "saDashboardTitle": "GPS attendance — team dashboard",
-  "saDetected": "Detected",
-  "saApproved": "Approved",
-  "saRejected": "Rejected",
-  "saRecentSessions": "Recent sessions",
-  "saForced": "Enforced",
-  "saPresenceInProgress": "Presence in progress since {time}",
-  "@saPresenceInProgress": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "saGpsZoneNotConfigured": "Your company's GPS zone is not configured yet.",
-  "saDisableAutoGps": "Disable automatic GPS",
-  "saStatusApproved": "Approved",
-  "saStatusDetected": "Detected",
-  "saStatusRejected": "Rejected",
-  "saStatusCancelled": "Cancelled",
-  "saStatusPending": "Pending validation",
-  "saEnableAutoGps": "Enable automatic GPS",
-  "attendanceOvertime": "Overtime hours",
-  "approvalsUpToDate": "All up to date",
-  "approvalsEmpty": "No pending approvals.",
-  "saConfigLoadError": "Unable to load the configuration.\n{error}",
-  "@saConfigLoadError": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "ampAutoDetectDesc": "Your presence is detected automatically as soon as you enter the company zone. No action required from you.",
-  "ampRecommended": "Recommended",
-  "ampQrScanDesc": "Scan the QR Code displayed at the company entrance to clock in and out.",
-  "ampManualDesc": "Clock in manually using the Arrival and Departure buttons in the attendance screen.",
-  "ampSaveError": "Unable to save your preference. Check your connection.",
-  "ampTitle": "Choose how you want to clock your presence every day.",
-  "ampModeTitle": "Attendance mode",
-  "back": "Back",
-  "refresh": "Refresh",
-  "saSessionsLoadError": "Unable to load GPS sessions. Check your connection.",
-  "saStartMonitoringError": "Unable to start GPS monitoring. Check location permissions and try again.",
-  "shellTeam": "Team",
-  "shellSettings": "Settings",
-  "homeCompleteOnboarding": "Complete my onboarding",
-  "homeOnboardingHint": "Set up your workspace in a few steps.",
-  "welcomeMyTeam": "My team",
-  "welcomePresences": "Attendance",
-  "welcomeTasks": "Tasks",
-  "welcomeLeaves": "Leave",
-  "monthlySummaryLoading": "Loading monthly summary...",
-  "orgChartEmpty": "The org chart will be available once employees are configured.",
-  "orgChartCollapse": "Collapse",
-  "orgChartExpand": "Expand",
-  "errorUnexpected": "An error occurred"
+  "billingCancelSubscriptionConfirm": "Cancel your subscription? You will lose access to premium modules at the end of the current period.",
+  "billingNoActivePeriod": "No active period",
+  "billingNoActiveSubscription": "No active subscription",
+  "billingPeriodLabel": "Period",
+  "billingCheckoutSandboxMessage": "Simulated payment (sandbox mode). No card is charged.",
+  "billingCheckoutUnavailable": "Online payment is temporarily unavailable. Contact support at support@leopardo-rh.com.",
+  "billingCheckoutFailed": "Unable to create the payment session.",
+  "contractsListSubtitle": "Employee contract management: status tracking, expirations and PDF export, wired directly to the HR API.",
+  "contractsSearchplaceholder": "Search for an employee or contract type...",
+  "contractsAllstatuses": "All statuses",
+  "trainingTitleplaceholder": "Title *",
+  "trainingDurationplaceholder": "Duration (h)",
+  "trainingMaxparticipantsplaceholder": "Max participants",
+  "trainingOnline": "Online"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_fr.arb
@@ -319,6 +319,9 @@
   "dashboardClientRequests": "Demandes clients",
   "dashboardTenantsAtRisk": "Tenants à risque",
   "dashboardPlatformDashboardHint": "Disponible dans le dashboard plateforme.",
+  "dashboardSearchplaceholder": "Rechercher...",
+  "dashboardModulesactivesentence": "{active} modules actifs, {locked} a activer selon votre plan.",
+  "dashboardYourcompany": "Votre entreprise",
   "marketingOauthNavTitle": "Marketing OAuth",
   "marketingOauthTitle": "Paramètres OAuth Marketing",
   "marketingOauthSubtitle": "Connectez vos comptes réseaux sociaux via Ayrshare",
@@ -338,6 +341,8 @@
   "marketingOauthFieldsPlaceholderId": "Votre Client ID",
   "marketingOauthFieldsPlaceholderSecret": "Nouveau secret (optionnel)",
   "marketingOauthFieldsPlaceholderUri": "https://example.com/oauth/callback",
+  "marketingSocialexampleplaceholder": "Ex: Leopardo RH — Reseaux sociaux",
+  "marketingPostcontentplaceholder": "Contenu de la publication...",
   "attendanceSendingToServer": "{label} vers le serveur...",
   "attendanceRetryAfterFailure": "{label}. Reessayez.",
   "holidaysPageTitle": "Jours fériés par pays",
@@ -905,6 +910,10 @@
   "apiGenericerror": "Erreur :status sur :endpoint.",
   "apiInvaliddata": "Données invalides.",
   "apiConnectionerror": "Erreur de connexion. Vérifiez votre connexion internet.",
+  "apiLoginInvalidJson": "Corps de requête invalide.",
+  "apiLoginTimeout": "Le serveur met trop de temps à répondre. Réessayez dans quelques instants.",
+  "apiLoginNetworkError": "Impossible de contacter le serveur.",
+  "apiLoginBackendError": "Réponse serveur inattendue.",
   "settingspageCancel": "Annuler",
   "settingspageConfirmpassword": "Confirmer le mot de passe",
   "settingspageCurrentpassword": "Mot de passe actuel",
@@ -970,152 +979,18 @@
   "systempageStatsloaderror": "Erreur lors du chargement des stats système",
   "systempageSubtitle": "Monitoring, configuration et automatisation de la plateforme Leopardo RH.",
   "systempageTitle": "Administration Système",
-  "retry": "Réessayer",
-  "featureComingSoon": "Fonction bientôt disponible",
-  "backToHome": "Retour à l'accueil",
-  "pageNotFound": "La page demandée est introuvable ou la navigation a échoué.",
-  "registerCreateAccount": "Créer votre compte",
-  "registerFirstName": "Prénom",
-  "registerRequired": "Obligatoire",
-  "registerPassword": "Mot de passe",
-  "registerMinChars": "8 caractères minimum",
-  "registerCreating": "Création de compte en cours...",
-  "registerSubmit": "Créer mon compte",
-  "accessDeniedTitle": "Accès refusé",
-  "accessDeniedBody": "Votre compte n'a pas le rôle Manager requis pour cette application. Utilisez l'application correspondant à votre rôle (Employee, RH…) ou contactez votre administrateur.",
-  "accessDeniedLogout": "Se déconnecter",
-  "accessDeniedBodyHr": "Votre compte n'a pas le rôle RH requis pour cette application. Utilisez l'application correspondant à votre rôle (Employee, Manager…) ou contactez votre administrateur.",
-  "evaluationsTitle": "Mes Évaluations",
-  "evaluationsEmpty": "Aucune évaluation",
-  "evaluationsEmptyHint": "Vous n'avez pas encore d'évaluation enregistrée.",
-  "evaluationPeriod": "Période : {period}",
-  "@evaluationPeriod": {
-    "placeholders": {
-      "period": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceOnTime": "à l'heure",
-  "attendanceLate": "en retard",
-  "attendanceAbsent": "absent",
-  "attendanceInProgress": "en cours",
-  "attendanceNoClock": "pas de pointage",
-  "attendanceTimeRange": "de {from} à {to}",
-  "@attendanceTimeRange": {
-    "placeholders": {
-      "from": {
-        "type": "String"
-      },
-      "to": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceHourWorked": "heure travaillée",
-  "attendanceHoursWorked": "heures travaillées",
-  "attendanceDaySummary": "Journée du {date}, statut {status}, {range}, {hours}.",
-  "@attendanceDaySummary": {
-    "placeholders": {
-      "date": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      },
-      "range": {
-        "type": "String"
-      },
-      "hours": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionApproved": "Session approuvée ✓",
-  "sessionRejected": "Session rejetée",
-  "pendingSessionsToValidate": "À valider",
-  "pendingSessionsUpToDate": "Tout est à jour",
-  "pendingSessionsEmpty": "Aucune session GPS en attente de validation.",
-  "employeeNumber": "Employé #{id}",
-  "@employeeNumber": {
-    "placeholders": {
-      "id": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionEntryAt": "Entrée : {time}",
-  "@sessionEntryAt": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionsToValidate": "Sessions à valider",
-  "errorPrefix": "Erreur : {message}",
-  "@errorPrefix": {
-    "placeholders": {
-      "message": {
-        "type": "String"
-      }
-    }
-  },
-  "saDashboardTitle": "Pointage GPS — tableau de bord équipe",
-  "saDetected": "Détectées",
-  "saApproved": "Approuvées",
-  "saRejected": "Rejetées",
-  "saRecentSessions": "Sessions récentes",
-  "saForced": "Imposé",
-  "saPresenceInProgress": "Présence en cours depuis {time}",
-  "@saPresenceInProgress": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "saGpsZoneNotConfigured": "La zone GPS de votre entreprise n'est pas encore configurée.",
-  "saDisableAutoGps": "Désactiver le GPS automatique",
-  "saStatusApproved": "Approuvée",
-  "saStatusDetected": "Détectée",
-  "saStatusRejected": "Rejetée",
-  "saStatusCancelled": "Annulée",
-  "saStatusPending": "En validation",
-  "saEnableAutoGps": "Activer le GPS automatique",
-  "attendanceOvertime": "Heures supplémentaires",
-  "approvalsUpToDate": "Tout est à jour",
-  "approvalsEmpty": "Aucune approbation en attente.",
-  "saConfigLoadError": "Impossible de charger la configuration.\n{error}",
-  "@saConfigLoadError": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "ampAutoDetectDesc": "Votre présence est détectée automatiquement dès que vous entrez dans la zone de l'entreprise. Aucune action requise de votre part.",
-  "ampRecommended": "Recommandé",
-  "ampQrScanDesc": "Scannez le QR Code affiché à l'entrée de l'entreprise pour pointer votre arrivée et votre départ.",
-  "ampManualDesc": "Pointez manuellement en appuyant sur les boutons Arrivée et Départ dans l'écran de présence.",
-  "ampSaveError": "Impossible de sauvegarder votre préférence. Vérifiez votre connexion.",
-  "ampTitle": "Choisissez comment vous souhaitez pointer votre présence chaque jour.",
-  "ampModeTitle": "Mode de pointage",
-  "back": "Retour",
-  "refresh": "Actualiser",
-  "saSessionsLoadError": "Impossible de charger les sessions GPS. Vérifiez votre connexion.",
-  "saStartMonitoringError": "Impossible de démarrer la surveillance GPS. Vérifiez les permissions de localisation et réessayez.",
-  "shellTeam": "Équipe",
-  "shellSettings": "Réglages",
-  "homeCompleteOnboarding": "Compléter mon onboarding",
-  "homeOnboardingHint": "Configurez votre espace en quelques étapes.",
-  "welcomeMyTeam": "Mon équipe",
-  "welcomePresences": "Présences",
-  "welcomeTasks": "Tâches",
-  "welcomeLeaves": "Congés",
-  "monthlySummaryLoading": "Chargement du résumé mensuel...",
-  "orgChartEmpty": "L'organigramme sera disponible une fois les employés configurés.",
-  "orgChartCollapse": "Réduire",
-  "orgChartExpand": "Développer",
-  "errorUnexpected": "Une erreur est survenue"
+  "billingCancelSubscriptionConfirm": "Annuler votre abonnement ? Vous perdrez l'accès aux modules premium à la fin de la période en cours.",
+  "billingNoActivePeriod": "Aucune période active",
+  "billingNoActiveSubscription": "Aucun abonnement active",
+  "billingPeriodLabel": "Période",
+  "billingCheckoutSandboxMessage": "Paiement simulé (mode sandbox). Aucune carte débitée.",
+  "billingCheckoutUnavailable": "Le paiement en ligne est temporairement indisponible. Contactez le support à support@leopardo-rh.com.",
+  "billingCheckoutFailed": "Impossible de créer la session de paiement.",
+  "contractsListSubtitle": "Gestion des contrats employés : suivi des statuts, échéances et export PDF, branchée directement sur l'API RH.",
+  "contractsSearchplaceholder": "Rechercher un employe ou un type de contrat...",
+  "contractsAllstatuses": "Tous les statuts",
+  "trainingTitleplaceholder": "Titre *",
+  "trainingDurationplaceholder": "Duree (h)",
+  "trainingMaxparticipantsplaceholder": "Participants max",
+  "trainingOnline": "En ligne"
 }

--- a/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
+++ b/front/mobile_apps/leopardo_core/lib/l10n/app_tr.arb
@@ -319,6 +319,9 @@
   "dashboardClientRequests": "Müşteri talepleri",
   "dashboardTenantsAtRisk": "Risk altındaki kiracılar",
   "dashboardPlatformDashboardHint": "Platform panelinde mevcuttur.",
+  "dashboardSearchplaceholder": "Ara...",
+  "dashboardModulesactivesentence": "{active} aktif modül, planınıza göre {locked} etkinleştirilecek.",
+  "dashboardYourcompany": "Şirketiniz",
   "marketingOauthNavTitle": "Pazarlama OAuth",
   "marketingOauthTitle": "Pazarlama OAuth Ayarları",
   "marketingOauthSubtitle": "Ayrshare aracılığıyla sosyal medya hesaplarınızı bağlayın",
@@ -338,6 +341,8 @@
   "marketingOauthFieldsPlaceholderId": "İstemci Kimliğiniz",
   "marketingOauthFieldsPlaceholderSecret": "Yeni sır (isteğe bağlı)",
   "marketingOauthFieldsPlaceholderUri": "https://example.com/oauth/callback",
+  "marketingSocialexampleplaceholder": "Örn: Leopardo RH — Sosyal medya",
+  "marketingPostcontentplaceholder": "Gönderi içeriği...",
   "attendanceSendingToServer": "{label} sunucuya gönderiliyor...",
   "attendanceRetryAfterFailure": "{label}. Lütfen tekrar deneyin.",
   "holidaysPageTitle": "Ülkeye göre resmî tatiller",
@@ -905,6 +910,10 @@
   "apiGenericerror": ":endpoint üzerinde :status hatası.",
   "apiInvaliddata": "Geçersiz veri.",
   "apiConnectionerror": "Bağlantı hatası. İnternet bağlantınızı kontrol edin.",
+  "apiLoginInvalidJson": "Geçersiz istek gövdesi.",
+  "apiLoginTimeout": "Sunucu yanıt vermekte çok yavaş. Lütfen kısa süre sonra tekrar deneyin.",
+  "apiLoginNetworkError": "Sunucuya ulaşılamıyor.",
+  "apiLoginBackendError": "Beklenmeyen sunucu yanıtı.",
   "settingspageCancel": "İptal",
   "settingspageConfirmpassword": "Parolayı doğrula",
   "settingspageCurrentpassword": "Mevcut parola",
@@ -970,152 +979,18 @@
   "systempageStatsloaderror": "Sistem istatistikleri yüklenirken hata oluştu",
   "systempageSubtitle": "Leopardo RH platformunun izlenmesi, yapılandırılması ve otomasyonu.",
   "systempageTitle": "Sistem Yönetimi",
-  "retry": "Yeniden dene",
-  "featureComingSoon": "Özellik yakında",
-  "backToHome": "Ana sayfaya dön",
-  "pageNotFound": "İstenen sayfa bulunamadı veya gezinme başarısız oldu.",
-  "registerCreateAccount": "Hesabınızı oluşturun",
-  "registerFirstName": "Ad",
-  "registerRequired": "Zorunlu",
-  "registerPassword": "Şifre",
-  "registerMinChars": "En az 8 karakter",
-  "registerCreating": "Hesap oluşturuluyor...",
-  "registerSubmit": "Hesabımı oluştur",
-  "accessDeniedTitle": "Erişim reddedildi",
-  "accessDeniedBody": "Hesabınız bu uygulama için gerekli Yönetici rolüne sahip değil. Rolünüze uygun uygulamayı kullanın (Çalışan, İK…) veya yöneticinizle iletişime geçin.",
-  "accessDeniedLogout": "Çıkış yap",
-  "accessDeniedBodyHr": "Hesabınız bu uygulama için gerekli İK rolüne sahip değil. Rolünüze uygun uygulamayı kullanın (Çalışan, Yönetici…) veya yöneticinizle iletişime geçin.",
-  "evaluationsTitle": "Değerlendirmelerim",
-  "evaluationsEmpty": "Değerlendirme yok",
-  "evaluationsEmptyHint": "Henüz kayıtlı bir değerlendirmeniz yok.",
-  "evaluationPeriod": "Dönem: {period}",
-  "@evaluationPeriod": {
-    "placeholders": {
-      "period": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceOnTime": "zamanında",
-  "attendanceLate": "geç",
-  "attendanceAbsent": "yok",
-  "attendanceInProgress": "devam ediyor",
-  "attendanceNoClock": "kayıt yok",
-  "attendanceTimeRange": "{from} - {to}",
-  "@attendanceTimeRange": {
-    "placeholders": {
-      "from": {
-        "type": "String"
-      },
-      "to": {
-        "type": "String"
-      }
-    }
-  },
-  "attendanceHourWorked": "çalışılan saat",
-  "attendanceHoursWorked": "çalışılan saatler",
-  "attendanceDaySummary": "{date} günü, durum {status}, {range}, {hours}.",
-  "@attendanceDaySummary": {
-    "placeholders": {
-      "date": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      },
-      "range": {
-        "type": "String"
-      },
-      "hours": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionApproved": "Oturum onaylandı ✓",
-  "sessionRejected": "Oturum reddedildi",
-  "pendingSessionsToValidate": "Onaylanacak",
-  "pendingSessionsUpToDate": "Her şey güncel",
-  "pendingSessionsEmpty": "Onay bekleyen GPS oturumu yok.",
-  "employeeNumber": "Çalışan #{id}",
-  "@employeeNumber": {
-    "placeholders": {
-      "id": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionEntryAt": "Giriş: {time}",
-  "@sessionEntryAt": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "sessionsToValidate": "Onaylanacak oturumlar",
-  "errorPrefix": "Hata: {message}",
-  "@errorPrefix": {
-    "placeholders": {
-      "message": {
-        "type": "String"
-      }
-    }
-  },
-  "saDashboardTitle": "GPS yoklama — ekip paneli",
-  "saDetected": "Algılanan",
-  "saApproved": "Onaylanan",
-  "saRejected": "Reddedilen",
-  "saRecentSessions": "Son oturumlar",
-  "saForced": "Zorunlu",
-  "saPresenceInProgress": "{time} itibarıyla devam eden katılım",
-  "@saPresenceInProgress": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "saGpsZoneNotConfigured": "Şirketinizin GPS bölgesi henüz yapılandırılmadı.",
-  "saDisableAutoGps": "Otomatik GPS'i kapat",
-  "saStatusApproved": "Onaylandı",
-  "saStatusDetected": "Algılandı",
-  "saStatusRejected": "Reddedildi",
-  "saStatusCancelled": "İptal edildi",
-  "saStatusPending": "Onay bekleniyor",
-  "saEnableAutoGps": "Otomatik GPS'i aç",
-  "attendanceOvertime": "Fazla mesai",
-  "approvalsUpToDate": "Her şey güncel",
-  "approvalsEmpty": "Bekleyen onay yok.",
-  "saConfigLoadError": "Yapılandırma yüklenemedi.\n{error}",
-  "@saConfigLoadError": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "ampAutoDetectDesc": "Şirket bölgesine girdiğinizde varlığınız otomatik algılanır. Sizden hiçbir işlem gerekmez.",
-  "ampRecommended": "Önerilen",
-  "ampQrScanDesc": "Şirket girişinde gösterilen QR Kodu tarayarak giriş ve çıkışınızı yapın.",
-  "ampManualDesc": "Yoklama ekranındaki Giriş ve Çıkış butonlarına basarak manuel kayıt yapın.",
-  "ampSaveError": "Tercihiniz kaydedilemedi. Bağlantınızı kontrol edin.",
-  "ampTitle": "Her gün katılımınızı nasıl kaydetmek istediğinizi seçin.",
-  "ampModeTitle": "Kayıt modu",
-  "back": "Geri",
-  "refresh": "Yenile",
-  "saSessionsLoadError": "GPS oturumları yüklenemedi. Bağlantınızı kontrol edin.",
-  "saStartMonitoringError": "GPS izleme başlatılamadı. Konum izinlerini kontrol edip tekrar deneyin.",
-  "shellTeam": "Ekip",
-  "shellSettings": "Ayarlar",
-  "homeCompleteOnboarding": "İşe alıştırmamı tamamla",
-  "homeOnboardingHint": "Çalışma alanınızı birkaç adımda kurun.",
-  "welcomeMyTeam": "Ekibim",
-  "welcomePresences": "Yoklamalar",
-  "welcomeTasks": "Görevler",
-  "welcomeLeaves": "İzinler",
-  "monthlySummaryLoading": "Aylık özet yükleniyor...",
-  "orgChartEmpty": "Çalışanlar yapılandırıldığında organizasyon şeması kullanılabilir olacak.",
-  "orgChartCollapse": "Daralt",
-  "orgChartExpand": "Genişlet",
-  "errorUnexpected": "Bir hata oluştu"
+  "billingCancelSubscriptionConfirm": "Aboneliğinizi iptal etmek istiyor musunuz? Premium modüllere erişiminizi mevcut dönem sonunda kaybedersiniz.",
+  "billingNoActivePeriod": "Aktif dönem yok",
+  "billingNoActiveSubscription": "Aktif abonelik yok",
+  "billingPeriodLabel": "Dönem",
+  "billingCheckoutSandboxMessage": "Simüle edilmiş ödeme (sandbox modu). Karttan ücret alınmaz.",
+  "billingCheckoutUnavailable": "Çevrimiçi ödeme geçici olarak kullanılamıyor. support@leopardo-rh.com adresinden destek ile iletişime geçin.",
+  "billingCheckoutFailed": "Ödeme oturumu oluşturulamadı.",
+  "contractsListSubtitle": "Çalışan sözleşme yönetimi: durum takibi, son tarihler ve PDF dışa aktarma, doğrudan İK API'sine bağlı.",
+  "contractsSearchplaceholder": "Çalışan veya sözleşme türü ara...",
+  "contractsAllstatuses": "Tüm durumlar",
+  "trainingTitleplaceholder": "Başlık *",
+  "trainingDurationplaceholder": "Süre (saat)",
+  "trainingMaxparticipantsplaceholder": "Maks. katılımcı",
+  "trainingOnline": "Çevrimiçi"
 }


### PR DESCRIPTION
## Contexte
Le check `validate-and-sync` échoue sur toutes les PRs basées sur main (vérifié : diff identique sur origin/main sans toucher aux ARB — état stale pré-existant, cf. surveillance CI 17/08).

## Fix
Résultat idempotent de `sync-mobile.js` committé (I18N_SYNC_MOBILE_OK) : −596 clés legacy prunées, +96 clés nouvelles (apiLogin*, dashboard*, marketing*…) sur les 4 ARB `leopardo_core` (fr/en/tr/ar).

## Impact
Remet `validate-and-sync` vert sur main → débloque la CI des PRs en file (dont #4964-#4967, #4983-#4986).