### PR TITLE
fix(api/tests): suite HR — 9 échecs pré-existants corrigés (Closes #5034)

### DIFF
--- a/api/app/Http/Middleware/ResilientThrottleRequests.php
+++ b/api/app/Http/Middleware/ResilientThrottleRequests.php
@@ -25,7 +25,10 @@ use Symfony\Component\HttpFoundation\Response;
  * Comportement :
  *  - échec du stockage pendant la PHASE LIMITER (lecture/écriture du compteur)
  *    → `report()` (Sentry/logs) + **429 dégradé** avec `Retry-After` (au lieu
- *    d'un 500). La requête n'atteint pas le contrôleur.
+ *    d'un 500) pour les limiters NOMÉS (politiques métier fail-closed) ;
+ *    → fail-open (pass-through, 200) pour les limites ANONYMES `throttle:X,Y`
+ *    (anti-abus générique best-effort, ex. /health — les sondes doivent
+ *    répondre 200/503 même pendant la panne du compteur, cf. #1774/#5034).
  *  - échec pendant la pose des headers `X-RateLimit-*` (phase post-`$next()`)
  *    → `report()` non bloquant, la réponse du contrôleur est conservée.
  *  - dépassement réel du quota → 429 normal (`ThrottleRequestsException`
@@ -83,6 +86,26 @@ class ResilientThrottleRequests extends ThrottleRequests
         } catch (\Throwable $e) {
             report($e);
 
+            // Panne du stockage du compteur sur une limite ANONYME (throttle:X,Y
+            // générique, ex. /health) : fail-open — la politique ne peut de toute
+            // façon pas être appliquée, et 429-er les sondes/probes amplifierait
+            // la panne (déploiements Render, supervision externe). Les limiters
+            // NOMÉS (auth-sensitive, payroll-sensitive, platform-sensitive...)
+            // restent fail-closed : 429 dégradé (voir #1774/#4955).
+            $namedOnly = true;
+            foreach ($limits as $limit) {
+                if (! $limit->named) {
+                    $namedOnly = false;
+                    break;
+                }
+            }
+
+            if (! $namedOnly) {
+                $response = $next($request);
+
+                return $response;
+            }
+
             return $this->degradedTooManyRequestsResponse($request);
         }
 
@@ -137,6 +160,8 @@ class ResilientThrottleRequests extends ThrottleRequests
                 key: $prefix.$this->resolveRequestSignature($request),
                 maxAttempts: (int) $this->resolveMaxAttempts($request, $maxAttempts),
                 decaySeconds: 60 * $decayMinutes,
+                // Limite anonyme (throttle:X,Y) : anti-abus générique best-effort.
+                named: false,
             ),
         ];
     }
@@ -174,6 +199,7 @@ class ResilientThrottleRequests extends ThrottleRequests
                 decaySeconds: (int) $limit->decaySeconds,
                 afterCallback: $limit->afterCallback instanceof Closure ? $limit->afterCallback : null,
                 responseCallback: $limit->responseCallback instanceof Closure ? $limit->responseCallback : null,
+                named: true,
             );
         }
 

--- a/api/app/Http/Middleware/ThrottleLimitConfig.php
+++ b/api/app/Http/Middleware/ThrottleLimitConfig.php
@@ -25,5 +25,6 @@ final class ThrottleLimitConfig
         public readonly int $decaySeconds,
         public readonly ?Closure $afterCallback = null,
         public readonly ?Closure $responseCallback = null,
+        public readonly bool $named = false,
     ) {}
 }

--- a/api/tests/Feature/HR/EmployeeSensitiveFillableTest.php
+++ b/api/tests/Feature/HR/EmployeeSensitiveFillableTest.php
@@ -39,6 +39,7 @@ class EmployeeSensitiveFillableTest extends TestCase
             'slug' => 'sensitive-qa',
             'sector' => 'tech',
             'country' => 'DZ',
+            'city' => 'Alger', // NOT NULL — durcissement #3677 : fixtures hors mass-assign
         ]);
 
         $employee = new Employee([
@@ -68,6 +69,7 @@ class EmployeeSensitiveFillableTest extends TestCase
             'slug' => 'explicit-qa',
             'sector' => 'tech',
             'country' => 'DZ',
+            'city' => 'Alger', // NOT NULL
         ]);
 
         $employee = Employee::query()->create([

--- a/api/tests/Feature/HR/OrganigrammeTest.php
+++ b/api/tests/Feature/HR/OrganigrammeTest.php
@@ -42,16 +42,20 @@ class OrganigrammeTest extends TestCase
             'role' => 'employee',
             'status' => 'active',
             'department_id' => $department->id,
+            'manager_id' => $manager->id, // rattaché au manager → enfant dans l'arbre
         ]);
         $this->assertInstanceOf(Employee::class, $employee);
 
         $response = $this->actingAs($manager, 'sanctum')
             ->getJson("/api/v1/departments/{$department->id}/hierarchy");
 
+        // L'endpoint renvoie un ARBRE (spec mobile #2633, même forme que
+        // /org-chart) : data = liste des racines, manager du département en
+        // racine, employés du département en enfants (#5034 : le test
+        // attendait une forme {department, employee_count, employees}).
         $response->assertStatus(200)
-            ->assertJsonPath('data.department.id', $department->id)
-            ->assertJsonPath('data.employee_count', 1)
-            ->assertJsonPath('data.employees.0.id', $employee->id);
+            ->assertJsonPath('data.0.id', $manager->id)
+            ->assertJsonPath('data.0.children.0.id', $employee->id);
     }
 
     public function test_hierarchy_returns_empty_tree_for_department_without_employees(): void
@@ -74,10 +78,12 @@ class OrganigrammeTest extends TestCase
         $department->company_id = $company->id;
         $department->save();
 
+        // Arbre sans employé : la racine (manager) est présente sans enfants.
         $this->actingAs($manager, 'sanctum')
             ->getJson("/api/v1/departments/{$department->id}/hierarchy")
             ->assertStatus(200)
-            ->assertJsonPath('data.employee_count', 0);
+            ->assertJsonPath('data.0.id', $manager->id)
+            ->assertJsonPath('data.0.children', []);
     }
 
     public function test_hierarchy_is_scoped_to_tenant(): void

--- a/api/tests/Feature/HR/UserEmployeeLinkCrossTenantTest.php
+++ b/api/tests/Feature/HR/UserEmployeeLinkCrossTenantTest.php
@@ -28,6 +28,7 @@ class UserEmployeeLinkCrossTenantTest extends TestCase
         $employeeB = Employee::factory()->create(['company_id' => $companyB->id]);
 
         $user = User::query()->forceCreate([
+            'first_name' => 'John', // NOT NULL users.first_name (#5034)
             'email' => 'john.doe@example.com',
             'password_hash' => Hash::make('password123'),
         ]);
@@ -61,6 +62,7 @@ class UserEmployeeLinkCrossTenantTest extends TestCase
         $employee = Employee::factory()->create(['company_id' => $company->id]);
 
         $user = User::query()->forceCreate([
+            'first_name' => 'Jane', // NOT NULL users.first_name (#5034)
             'email' => 'jane.doe@example.com',
             'password_hash' => Hash::make('password123'),
         ]);

--- a/api/tests/Feature/WebhookRouteDedupTest.php
+++ b/api/tests/Feature/WebhookRouteDedupTest.php
@@ -20,7 +20,9 @@ class WebhookRouteDedupTest extends TestCase
             $uri = $route->uri();
             $methods = $route->methods();
 
-            return str_ends_with($uri, 'webhooks/{webhookEndpoint}/test')
+            // URI exacte : le variant super-admin /admin/webhooks/... existe
+            // aussi (surface distincte, #2634) et terminait pareil (#5034).
+            return $uri === 'api/v1/webhooks/{webhookEndpoint}/test'
                 && in_array('POST', $methods, true);
         });
 


### PR DESCRIPTION
## #5034 — Suite HR : 9 échecs pré-existants (fixtures NOT NULL + forme endpoint)\n\nCorrections vérifiées sur les logs CI réels (run 32081198888, main f64bed34 — erreurs SQLSTATE exactes) :\n\n1. **EmployeeSensitiveFillableTest** (2) :  sans  → 23502 NOT NULL (durcissement #3677).\n2. **UserEmployeeLinkCrossTenantTest** (2) :  sans  → 23502 NOT NULL.\n3. **OrganigrammeTest** (3) : le test attendait  — l'endpoint renvoie un ARBRE (spec mobile #2633, même forme que /org-chart ; consommé par ). Assertions alignées sur la forme réelle (racine = manager, employé = enfant) — **c'est le test qui était faux, pas l'endpoint**.\n4. **WebhookRouteDedupTest** (1) : filtre  matchait aussi  (surface super-admin #2634) → URI exacte.\n5. **ResilientThrottleRequests** (1) : panne du stockage du compteur sur limite ANONYME (, ex. /health) → fail-open pass-through ; limiters NOMÉS (auth/payroll/platform) → 429 dégradé conservé. Concilie #1774 (sondes /health 200 pendant panne) et #3241 (throttle /health conservé).\n\nLes 2 échecs HrAppRoutesTest (password_hash NOT NULL) sont déjà corrigés par #5030 (EmployeeService).\n\nCloses #5034