### PR TITLE
test(api): paquet A — 6 tests HR sur vraies migrations (F-13 #4972)

### DIFF
--- a/api/tests/Feature/HR/ApiTokenControllerTest.php
+++ b/api/tests/Feature/HR/ApiTokenControllerTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\HR;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -16,14 +16,13 @@ use Tests\TestCase;
  */
 class ApiTokenControllerTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected Company $company;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
         /** @var Company $company */
         $company = Company::factory()->create();
         $this->company = $company;

--- a/api/tests/Feature/HR/EmployeeImportRaceTest.php
+++ b/api/tests/Feature/HR/EmployeeImportRaceTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -24,19 +24,7 @@ use Tests\TestCase;
  */
 class EmployeeImportRaceTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     private function makeCompany(): Company
     {
@@ -46,6 +34,8 @@ class EmployeeImportRaceTest extends TestCase
     private function makeManager(Company $company): Employee
     {
         $sensitiveEmployee1 = new Employee([
+            'first_name' => 'Manager',
+            'last_name' => 'Import',
             'email' => 'manager-'.uniqid().'@test.local',
         ]);
         $sensitiveEmployee1->forceFill(['password_hash' => Hash::make('password123')])->save();
@@ -151,6 +141,8 @@ class EmployeeImportRaceTest extends TestCase
 
         $conflictEmail = 'existing-'.uniqid().'@example.com';
         $sensitiveEmployee0 = new Employee([
+            'first_name' => 'Employe',
+            'last_name' => 'Import',
             'email' => $conflictEmail,
         ]);
         $sensitiveEmployee0->forceFill(['password_hash' => Hash::make('x')])->save();

--- a/api/tests/Feature/HR/EmployeeMailResilienceTest.php
+++ b/api/tests/Feature/HR/EmployeeMailResilienceTest.php
@@ -132,7 +132,6 @@ class EmployeeMailResilienceTest extends TestCase
         ]);
         $invitation->save();
 
-
         $this->postJson("/api/v1/invitations/{$invitation->id}/resend")
             ->assertOk()
             ->assertJsonPath('data.email', 'resend@example.dz');

--- a/api/tests/Feature/HR/EmployeePasswordProvisioningTest.php
+++ b/api/tests/Feature/HR/EmployeePasswordProvisioningTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -25,19 +25,7 @@ use Tests\TestCase;
  */
 class EmployeePasswordProvisioningTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_employee_can_login_with_password_provided_at_creation(): void
     {

--- a/api/tests/Feature/HR/EmployeeSensitiveFillableTest.php
+++ b/api/tests/Feature/HR/EmployeeSensitiveFillableTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\HR;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\Hash;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -18,19 +18,7 @@ use Tests\TestCase;
  */
 class EmployeeSensitiveFillableTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_sensitive_fields_are_not_written_by_mass_assignment(): void
     {

--- a/api/tests/Feature/HR/EmployeeServiceCreateFillableTest.php
+++ b/api/tests/Feature/HR/EmployeeServiceCreateFillableTest.php
@@ -9,7 +9,7 @@ use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -24,19 +24,7 @@ use Tests\TestCase;
  */
 class EmployeeServiceCreateFillableTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_create_persists_salary_base_role_manager_role_and_company(): void
     {

--- a/api/tests/Feature/HR/EmployeeTenantIsolationTest.php
+++ b/api/tests/Feature/HR/EmployeeTenantIsolationTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\HR;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\Hash;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -29,19 +29,7 @@ use Tests\TestCase;
  */
 class EmployeeTenantIsolationTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     private function makeCompany(string $slug, string $email): Company
     {
@@ -61,6 +49,8 @@ class EmployeeTenantIsolationTest extends TestCase
     private function makeManager(Company $company, string $email, string $managerRole): Employee
     {
         $sensitiveEmployee1 = new Employee([
+            'first_name' => 'Manager',
+            'last_name' => ucfirst(str_replace('-', ' ', $slug)),
             'email' => $email,
         ]);
         $sensitiveEmployee1->forceFill(['password_hash' => Hash::make('password123')])->save();
@@ -76,6 +66,8 @@ class EmployeeTenantIsolationTest extends TestCase
     private function makeEmployee(Company $company, string $email): Employee
     {
         $sensitiveEmployee0 = new Employee([
+            'first_name' => 'Employe',
+            'last_name' => ucfirst(str_replace('-', ' ', $slug)),
             'email' => $email,
         ]);
         $sensitiveEmployee0->forceFill(['password_hash' => Hash::make('password123')])->save();


### PR DESCRIPTION
## F-13 (#4972) — Paquet A : 6 tests Feature HR sur vraies migrations

`RefreshTenantDatabase` (vraies migrations) remplace le schéma manuel `CreatesMvpSchema` pour 6 fichiers :

- ApiTokenControllerTest, EmployeeImportRaceTest, EmployeePasswordProvisioningTest, EmployeeSensitiveFillableTest, EmployeeServiceCreateFillableTest, EmployeeTenantIsolationTest.

Fixtures alignées sur la migration réelle : `first_name`/`last_name` NOT NULL (le schéma Mvp avait `default ''`) ajoutés aux créations brutes (makeManager/makeEmployee de TenantIsolation, makeManager/conflict d'ImportRace). EmployeeSensitiveFillableTest garde le fix city (#5034).

Paquets B (kiosk/biométrie/web) et C (leave/payroll/security) à suivre.