### PR TITLE
test(api): paquet B — 5 tests kiosk/biométrie/web sur vraies migrations (F-13 #4972)

### DIFF
--- a/api/tests/Feature/BiometricWorkflowTest.php
+++ b/api/tests/Feature/BiometricWorkflowTest.php
@@ -7,24 +7,12 @@ use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Attendance\Domain\Models\BiometricEnrollmentRequest;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 class BiometricWorkflowTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_employee_biometric_request_requires_manager_approval_before_activation(): void
     {

--- a/api/tests/Feature/KioskMultiEventPunchTest.php
+++ b/api/tests/Feature/KioskMultiEventPunchTest.php
@@ -12,7 +12,7 @@ use App\Modules\HR\Domain\Contracts\OnboardingQrInterface;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -25,19 +25,7 @@ use Tests\TestCase;
  */
 class KioskMultiEventPunchTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_kiosk_punch_records_the_requested_work_type(): void
     {

--- a/api/tests/Feature/KioskSyncSkippedEventsTest.php
+++ b/api/tests/Feature/KioskSyncSkippedEventsTest.php
@@ -9,7 +9,7 @@ use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -25,19 +25,7 @@ use Tests\TestCase;
  */
 class KioskSyncSkippedEventsTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_sync_reports_skipped_events_with_reasons(): void
     {

--- a/api/tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php
+++ b/api/tests/Feature/Web/AttendanceCorrectionAdminPagesTest.php
@@ -7,24 +7,12 @@ use App\Core\Tenant\Domain\Models\Company;
 use App\Core\Auth\Domain\Models\Employee;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 class AttendanceCorrectionAdminPagesTest extends TestCase
 {
-    use CreatesMvpSchema;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
-    }
+    use RefreshTenantDatabase;
 
     public function test_manager_can_list_and_approve_pending_correction_from_web(): void
     {

--- a/api/tests/Feature/WebKioskSessionGateTest.php
+++ b/api/tests/Feature/WebKioskSessionGateTest.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -22,21 +22,14 @@ use Tests\TestCase;
  */
 class WebKioskSessionGateTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
         // La route web est protégée par CSRF ; le test du gate de session
         // n'a pas vocation à re-tester le CSRF (couvert par ailleurs).
         $this->withoutMiddleware(VerifyCsrfToken::class);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
## F-13 (#4972) — Paquet B : 5 tests kiosk/biométrie/web sur vraies migrations

BiometricWorkflowTest, KioskMultiEventPunchTest, KioskSyncSkippedEventsTest, WebKioskSessionGateTest, Web/AttendanceCorrectionAdminPagesTest → `RefreshTenantDatabase`.

Fixtures déjà alignées (first_name/last_name fournis partout, tables kiosks/biometric/attendance réelles). Le garde `Schema::hasTable` des schémas inline reste inoffensif (tables existantes).