### PR TITLE
test(hr): 6 fichiers Feature → RefreshTenantDatabase (F-13, #4972)

### DIFF
--- a/api/tests/Feature/HR/ApiTokenControllerTest.php
+++ b/api/tests/Feature/HR/ApiTokenControllerTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\HR;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -16,14 +16,13 @@ use Tests\TestCase;
  */
 class ApiTokenControllerTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected Company $company;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
         /** @var Company $company */
         $company = Company::factory()->create();
         $this->company = $company;

--- a/api/tests/Feature/HR/EmployeeImportRaceTest.php
+++ b/api/tests/Feature/HR/EmployeeImportRaceTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -24,18 +24,11 @@ use Tests\TestCase;
  */
 class EmployeeImportRaceTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
     }
 
     private function makeCompany(): Company

--- a/api/tests/Feature/HR/EmployeePasswordProvisioningTest.php
+++ b/api/tests/Feature/HR/EmployeePasswordProvisioningTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -25,18 +25,11 @@ use Tests\TestCase;
  */
 class EmployeePasswordProvisioningTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
     }
 
     public function test_employee_can_login_with_password_provided_at_creation(): void

--- a/api/tests/Feature/HR/EmployeeSensitiveFillableTest.php
+++ b/api/tests/Feature/HR/EmployeeSensitiveFillableTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\HR;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\Hash;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -18,18 +18,11 @@ use Tests\TestCase;
  */
 class EmployeeSensitiveFillableTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
     }
 
     public function test_sensitive_fields_are_not_written_by_mass_assignment(): void

--- a/api/tests/Feature/HR/EmployeeServiceCreateFillableTest.php
+++ b/api/tests/Feature/HR/EmployeeServiceCreateFillableTest.php
@@ -9,7 +9,7 @@ use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Laravel\Sanctum\Sanctum;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -24,18 +24,11 @@ use Tests\TestCase;
  */
 class EmployeeServiceCreateFillableTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
     }
 
     public function test_create_persists_salary_base_role_manager_role_and_company(): void

--- a/api/tests/Feature/HR/EmployeeTenantIsolationTest.php
+++ b/api/tests/Feature/HR/EmployeeTenantIsolationTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\HR;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use Illuminate\Support\Facades\Hash;
-use Tests\Support\CreatesMvpSchema;
+use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
 /**
@@ -29,18 +29,11 @@ use Tests\TestCase;
  */
 class EmployeeTenantIsolationTest extends TestCase
 {
-    use CreatesMvpSchema;
+    use RefreshTenantDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setUpMvpSchema();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownMvpSchema();
-        parent::tearDown();
     }
 
     private function makeCompany(string $slug, string $email): Company


### PR DESCRIPTION
Migration F-13 hors noyau strict : HR ×6 (ApiTokenController, EmployeeImportRace, EmployeePasswordProvisioning, EmployeeSensitiveFillable, EmployeeServiceCreateFillable, EmployeeTenantIsolation) de `CreatesMvpSchema` vers `RefreshTenantDatabase` (migrations réelles, pattern #1635/#1644/#1713). Fixtures déjà alignées (#5034). CI = retour requis (pas de migration à l'aveugle).