### PR TITLE
ci: e2e-staging/owasp-zap — skip les parents cancelled au niveau job (#5032)

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -48,6 +48,12 @@ concurrency:
 
 jobs:
   should-run:
+    # #5032 : un parent CANCELLED/skipped (déploiement supersédé par un push
+    # plus récent) ne doit pas consommer de runner juste pour laisser le
+    # deploy-gate le dire. On ne filtre QUE ces conclusions : un parent failed
+    # reste traité (le gate vérifie deploy-api précisément — un échec mobile
+    # ne doit pas bloquer le smoke API).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     timeout-minutes: 45
     name: Check deployment status
     runs-on: ubuntu-latest

--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -32,6 +32,12 @@ concurrency:
 
 jobs:
   should-run:
+    # #5032 : un parent CANCELLED/skipped (déploiement supersédé par un push
+    # plus récent) ne doit pas consommer de runner juste pour laisser le
+    # deploy-gate le dire. On ne filtre QUE ces conclusions : un parent failed
+    # reste traité (le gate vérifie deploy-api précisément — un échec mobile
+    # ne doit pas bloquer le smoke API).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     timeout-minutes: 45
     name: Check deployment status
     runs-on: ubuntu-latest


### PR DESCRIPTION
## CI saturation — e2e-staging/owasp-zap ne démarrent plus sur parents cancelled

`workflow_run types:[completed]` émet aussi pour les déploiements CANCELLED (supersédés par un push plus récent) : le job `should-run` démarrait (runner + checkout consommés) avant que le deploy-gate ne décide de skipper.

**Changement** : `if` au niveau job — ne démarre que pour dispatch manuel ou parent `success`/`failure`. Les parents `cancelled`/`skipped`/`timed_out` ne consomment plus de runner → moins de churn dans la file saturée (#5032).

La spécificité du gate (`deploy-api` check — un échec mobile ne bloque pas le smoke API) est préservée pour les parents `failure`.