### PR TITLE
fix(api): sweeper auto-réparation des provisionings de démo bloqués (Closes #4948)

### DIFF
--- a/api/app/Console/Commands/CheckStalledTrialProvisionings.php
+++ b/api/app/Console/Commands/CheckStalledTrialProvisionings.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Jobs\ProvisionDemoTenantJob;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Issue #4948 — self-healing des provisionings de démo jamais partis.
+ *
+ * Constat prod : avec le worker de queue down (épic #3765/#3766), une ligne
+ * `trial_provisionings` reste `pending` indéfiniment — GET /trial/status
+ * répond `pending` pendant des heures, aucun magic link n'est envoyé, et le
+ * funnel d'acquisition est à l'arrêt (promesse « sandbox < 30 s » non tenue).
+ *
+ * Ce sweeper (toutes les 15 min, voir bootstrap/app.php) :
+ *  1. repère les lignes `pending` plus vieilles que STALLED_AFTER_MINUTES
+ *     (le job normal passe à ready/failed en < 10 min, retries comprises —
+ *     une ligne pendante au-delà est définitivement orpheline) ;
+ *  2. tente jusqu'à MAX_ATTEMPTS re-dispatches du job avec les arguments
+ *     d'origine (company_name/country stockés depuis la migration
+ *     2026_08_18_000001 — les lignes antérieures non reconstructibles sont
+ *     simplement passées en failed) ;
+ *  3. au-delà, passe la ligne en `failed` avec un message explicite et lève
+ *     une alerte Log::error (monitoring) — le statut ne ment plus, et le
+ *     prochain signup (l'anti-doublon #3951 ne réutilise que les lignes
+ *     `pending`) peut repartir proprement.
+ */
+class CheckStalledTrialProvisionings extends Command
+{
+    protected $signature = 'trial:provisioning-sweep';
+
+    protected $description = 'Re-dispatch or fail trial provisionings stuck in pending (worker stalled)';
+
+    private const STALLED_AFTER_MINUTES = 30;
+
+    private const MAX_ATTEMPTS = 3;
+
+    public function handle(): int
+    {
+        $stalled = DB::table('trial_provisionings')
+            ->where('status', 'pending')
+            ->where('created_at', '<', now()->subMinutes(self::STALLED_AFTER_MINUTES))
+            ->orderBy('created_at')
+            ->get();
+
+        if ($stalled->isEmpty()) {
+            $this->info('No stalled trial provisioning.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($stalled as $row) {
+            $this->recover($row);
+        }
+
+        $this->info("Processed {$stalled->count()} stalled trial provisioning(s).");
+
+        return self::SUCCESS;
+    }
+
+    private function recover(object $row): void
+    {
+        // Ligne non reconstructible (créée avant la migration 000001) : pas
+        // d'arguments pour re-dispatcher — fail immédiat, l'alerte est loggée.
+        if (! is_string($row->company_name) || $row->company_name === '' || ! is_string($row->country)) {
+            $this->failPermanently($row, 'sweeper:company_context_missing');
+
+            return;
+        }
+
+        if ((int) $row->attempts >= self::MAX_ATTEMPTS) {
+            $this->failPermanently($row, 'sweeper:worker_stalled_after_'.self::MAX_ATTEMPTS.'_attempts');
+
+            return;
+        }
+
+        DB::table('trial_provisionings')
+            ->where('provisioning_token', $row->provisioning_token)
+            ->increment('attempts');
+
+        ProvisionDemoTenantJob::dispatch($row->email, $row->company_name, $row->country, $row->provisioning_token);
+
+        Log::warning('trial.provisioning_redispatch', [
+            'email' => $row->email,
+            'token' => $row->provisioning_token,
+            'attempts' => (int) $row->attempts + 1,
+            'reason' => 'stalled_pending_'.self::STALLED_AFTER_MINUTES.'_min',
+        ]);
+
+        $this->warn("Re-dispatched {$row->email} (attempt ".(int) $row->attempts + 1 .').');
+    }
+
+    private function failPermanently(object $row, string $reason): void
+    {
+        DB::table('trial_provisionings')
+            ->where('provisioning_token', $row->provisioning_token)
+            ->update([
+                'status' => 'failed',
+                'error' => $reason,
+                'updated_at' => now(),
+            ]);
+
+        Log::error('trial.provisioning_failed_sweeper', [
+            'email' => $row->email,
+            'token' => $row->provisioning_token,
+            'attempts' => (int) $row->attempts,
+            'reason' => $reason,
+        ]);
+
+        $this->error("Failed {$row->email}: {$reason}");
+    }
+}

--- a/api/database/migrations/public/2026_08_18_000001_add_recovery_columns_to_trial_provisionings.php
+++ b/api/database/migrations/public/2026_08_18_000001_add_recovery_columns_to_trial_provisionings.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #4948 — colonnes de reprise du self-healing.
+ *
+ * Contexte : si le worker de queue est down (épic #3765/#3766), les lignes
+ * `trial_provisionings` restent `pending` indéfiniment (statut pollé par
+ * GET /trial/status, jamais `ready` ni `failed` — funnel d'acquisition KO).
+ *
+ * Ces colonnes permettent au sweeper `trial:provisioning-sweep` de :
+ * - reconstruire le job (company_name + country) pour un re-dispatch, et
+ * - borner les tentatives (attempts) avant de passer la ligne en `failed`.
+ *
+ * Sans company_name/country stockés, un re-dispatch serait impossible (le
+ * job exige ces arguments) — d'où cette migration, complémentaire du
+ * sweeper lui-même.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! schemaTableExists('trial_provisionings')) {
+            return;
+        }
+
+        Schema::table('public.trial_provisionings', function (Blueprint $table): void {
+            if (! Schema::hasColumn('public.trial_provisionings', 'company_name')) {
+                $table->string('company_name', 120)->nullable()->after('provisioning_token');
+            }
+            if (! Schema::hasColumn('public.trial_provisionings', 'country')) {
+                $table->string('country', 2)->nullable()->after('company_name');
+            }
+            if (! Schema::hasColumn('public.trial_provisionings', 'attempts')) {
+                $table->unsignedSmallInteger('attempts')->default(0)->after('country');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (schemaTableExists('trial_provisionings')
+            && Schema::hasColumn('public.trial_provisionings', 'company_name')) {
+            Schema::table('public.trial_provisionings', function (Blueprint $table): void {
+                $table->dropColumn(['company_name', 'country', 'attempts']);
+            });
+        }
+    }
+};

--- a/api/tests/Feature/Billing/TrialProvisioningSweepTest.php
+++ b/api/tests/Feature/Billing/TrialProvisioningSweepTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Billing;
+
+use App\Jobs\ProvisionDemoTenantJob;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #4948 — sweeper `trial:provisioning-sweep`.
+ *
+ * Couvre les 3 branches du self-healing des provisionings restés `pending`
+ * (worker de queue down, épic #3765/#3766) :
+ *  1. ligne reconstructible → re-dispatch borné du job (attempts + 1) ;
+ *  2. attempts épuisés → passage en `failed` + aucun re-dispatch ;
+ *  3. ligne antérieure à la migration 000001 (company_name/country absents)
+ *     → passage en `failed` sans re-dispatch.
+ *
+ * `trial_provisionings` vit dans le schéma `public` — RefreshTenantDatabase
+ * couvre ce cas (mêmes prérequis que TrialSignupSlugRaceTest).
+ */
+class TrialProvisioningSweepTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private function insertStalledRow(array $overrides = []): int
+    {
+        return DB::table('trial_provisionings')->insertGetId(array_merge([
+            'email' => 'prospect@example.com',
+            'provisioning_token' => 'tok_'.str()->random(32),
+            'company_name' => 'Acme Test SARL',
+            'country' => 'DZ',
+            'attempts' => 0,
+            'status' => 'pending',
+            'created_at' => now()->subHours(2),
+            'updated_at' => now()->subHours(2),
+        ], $overrides));
+    }
+
+    public function test_stalled_pending_row_is_redispatched_with_original_arguments(): void
+    {
+        Queue::fake();
+        $token = 'tok_redispatched';
+        $this->insertStalledRow(['provisioning_token' => $token]);
+
+        $this->artisan('trial:provisioning-sweep')->assertExitCode(0);
+
+        Queue::assertPushed(ProvisionDemoTenantJob::class, function (ProvisionDemoTenantJob $job) use ($token): bool {
+            return $job->email === 'prospect@example.com'
+                && $job->companyName === 'Acme Test SARL'
+                && $job->country === 'DZ'
+                && $job->provisioningToken === $token;
+        });
+
+        $this->assertSame(
+            1,
+            (int) DB::table('trial_provisionings')->where('provisioning_token', $token)->value('attempts'),
+            'attempts doit être incrémenté à 1 après le premier re-dispatch.',
+        );
+        $this->assertSame('pending', DB::table('trial_provisionings')->where('provisioning_token', $token)->value('status'));
+    }
+
+    public function test_row_after_max_attempts_is_failed_and_not_redispatched(): void
+    {
+        Queue::fake();
+        $token = 'tok_exhausted';
+        $this->insertStalledRow(['provisioning_token' => $token, 'attempts' => 3]);
+
+        $this->artisan('trial:provisioning-sweep')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProvisionDemoTenantJob::class);
+
+        $row = DB::table('trial_provisionings')->where('provisioning_token', $token)->first();
+        $this->assertSame('failed', $row->status);
+        $this->assertSame('sweeper:worker_stalled_after_3_attempts', $row->error);
+    }
+
+    public function test_row_without_recovery_columns_is_failed_without_redispatch(): void
+    {
+        Queue::fake();
+        $token = 'tok_legacy';
+        // Ligne « antérieure » à la migration 000001 : company_name/country NULL.
+        $this->insertStalledRow(['provisioning_token' => $token, 'company_name' => null, 'country' => null]);
+
+        $this->artisan('trial:provisioning-sweep')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProvisionDemoTenantJob::class);
+
+        $row = DB::table('trial_provisionings')->where('provisioning_token', $token)->first();
+        $this->assertSame('failed', $row->status);
+        $this->assertSame('sweeper:company_context_missing', $row->error);
+    }
+
+    public function test_fresh_pending_row_is_left_untouched(): void
+    {
+        Queue::fake();
+        $token = 'tok_fresh';
+        $this->insertStalledRow(['provisioning_token' => $token, 'created_at' => now()->subMinutes(5)]);
+
+        $this->artisan('trial:provisioning-sweep')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProvisionDemoTenantJob::class);
+        $this->assertSame('pending', DB::table('trial_provisionings')->where('provisioning_token', $token)->value('status'));
+    }
+}


### PR DESCRIPTION
## Problème
Worker de queue down (épic #3765/#3766) ⇒ les lignes `trial_provisionings` restent `pending` indéfiniment : GET /trial/status répond pending >2h (jamais ready ni failed), aucun magic link, funnel d'acquisition à l'arrêt (promesse « sandbox < 30 s » non tenue).

## Correctif (code — ne dépend pas de l'accès Render)
1. **Migration additive** `2026_08_18_000001` : `company_name`, `country`, `attempts` (default 0) sur `trial_provisionings` — rend le re-dispatch possible (le job exige ces arguments).
2. **`trial:provisioning-sweep`** (planifié toutes les 15 min, withoutOverlapping) : pending > 30 min ⇒ re-dispatch borné (3 tentatives) ; au-delà ⇒ `failed` + alerte Log::error (monitoring). Lignes antérieures non reconstructibles ⇒ `failed` (`sweeper:company_context_missing`).
3. Signup : stocke company_name/country (l'anti-doublon #3951 ne réutilise que les lignes `pending` ⇒ après le fail, le prochain signup repart proprement).

## Tests
`TrialProvisioningSweepTest` : re-dispatch avec args d'origine + attempts, exhaustion → failed sans re-dispatch, ligne legacy → failed, ligne fraîche intouchée. (php -l OK ×5 ; CI requis pour l'exécution PHPUnit.)

## Note
Le point « vérifier/relancer le worker Render » reste ops (#4948 point 1-2) — ce correctif rend le système auto-cicatrisant et alerte le monitoring.