### PR TITLE
fix(api): export_history.employee_id INTEGER (22P02) + Retry-After sur 429 + test stale (Closes #5034)

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ExportController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/ExportController.php
@@ -241,7 +241,7 @@ class ExportController extends Controller
             'created_at',
         ]);
 
-        return $this->exportResponse($request, $records, 'vehicles_export');
+        return $this->exportResponse($request, $records, 'vehicles_export', 'vehicles');
     }
 
     public function history(Request $request): JsonResponse
@@ -455,8 +455,12 @@ class ExportController extends Controller
     /**
      * @param  Collection<int, \stdClass>  $records
      */
-    private function exportResponse(Request $request, Collection $records, string $filenamePrefix): JsonResponse
+    private function exportResponse(Request $request, Collection $records, string $filenamePrefix, ?string $type = null): JsonResponse
     {
+        // Le type d'historisation (#2199) est distinct du préfixe de fichier :
+        // convention établie `employees` → `employees_export_*.csv` (#5034).
+        $type ??= $filenamePrefix;
+
         $validated = $request->validate([
             'format' => 'nullable|in:json,csv,xlsx',
         ]);
@@ -467,7 +471,7 @@ class ExportController extends Controller
         $format = $validated['format'] ?? 'json';
         if ($format === 'csv' || $format === 'xlsx') {
             $filename = $filenamePrefix.'_'.now()->format('Y-m-d').'.csv';
-            $this->recordExport($request, $user, $filenamePrefix, 'csv', $records->count(), $filename);
+            $this->recordExport($request, $user, $type, 'csv', $records->count(), $filename);
 
             return response()->json([
                 'data' => [
@@ -479,7 +483,7 @@ class ExportController extends Controller
             ]);
         }
 
-        $this->recordExport($request, $user, $filenamePrefix, 'json', $records->count());
+        $this->recordExport($request, $user, $type, 'json', $records->count());
 
         return response()->json([
             'data' => [

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -172,11 +172,20 @@ return Application::configure(basePath: dirname(__DIR__))
                 return null;
             }
 
-            return new JsonResponse([
+            $response = new JsonResponse([
                 'error' => 'TOO_MANY_REQUESTS',
                 'message' => 'TOO_MANY_REQUESTS',
                 'localized_message' => __('errors.TOO_MANY_REQUESTS'),
             ], 429);
+
+            // Issue #1774 / #5034 : préserver les headers du throttling
+            // (Retry-After, X-RateLimit-*) posés par ThrottleRequestsException —
+            // sans eux, le 429 est inexploitable côté client (retry).
+            foreach ($exception->getHeaders() as $headerName => $headerValue) {
+                $response->headers->set($headerName, $headerValue);
+            }
+
+            return $response;
         });
 
         // Handle oversized file uploads gracefully (PHP rejects them before Laravel

--- a/api/database/migrations/tenant/2026_08_15_000003_create_export_history_table.php
+++ b/api/database/migrations/tenant/2026_08_15_000003_create_export_history_table.php
@@ -30,7 +30,7 @@ return new class extends Migration
             // Tenant : UUID du propriétaire (index (company_id, created_at)
             // couvre la requête paginée de /export/history).
             $table->uuid('company_id');
-            $table->uuid('employee_id')->nullable();
+            $table->unsignedInteger('employee_id')->nullable(); // employees.id est INTEGER (increments) — le type uuid cassait l'insert (22P02, #5034)
             // Type d'export : employees | attendance | pay_slips | absences |
             // training | contracts | vehicles | payroll_journal |
             // payroll_ledger | accounting_od.

--- a/api/database/migrations/tenant/2026_08_17_000001_fix_export_history_employee_id_type.php
+++ b/api/database/migrations/tenant/2026_08_17_000001_fix_export_history_employee_id_type.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #5034 — `export_history.employee_id` était typé `uuid` alors que
+ * `employees.id` est un INTEGER (`increments`, migration 000101) : tout
+ * INSERT historisant un export échouait en 22P02 (invalid input syntax for
+ * type uuid) → l'historisation #2199 n'a jamais fonctionné en prod, et en
+ * environnement de test l'erreur avalée laissait la transaction PG abortée
+ * (25P02) → 500 sur GET /export/*.
+ *
+ * Corrige les bases ayant déjà exécuté 2026_08_15_000003 : ALTER du type de
+ * colonne. La table étant vide (tous les inserts échouaient), la conversion
+ * est sans risque.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! schemaTableExists('export_history')) {
+            return;
+        }
+
+        $schema = resolveTableSchema('export_history');
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            // `uuid::integer` n'est pas un cast valide en PostgreSQL (42846) —
+            // USING NULL : la table est vide (l'historisation #2199 échouait
+            // systématiquement), aucune donnée n'est perdue.
+            DB::statement(
+                "ALTER TABLE \"{$schema}\".\"export_history\" ALTER COLUMN employee_id TYPE integer USING NULL"
+            );
+        }
+        // SQLite/local : le schéma est recréé par les tests, pas de correctif.
+    }
+
+    public function down(): void
+    {
+        // Pas de retour arrière : le type `uuid` d'origine était un bug.
+    }
+};

--- a/api/tests/Feature/Security/HttpErrorLocalizedMessageTest.php
+++ b/api/tests/Feature/Security/HttpErrorLocalizedMessageTest.php
@@ -56,10 +56,13 @@ class HttpErrorLocalizedMessageTest extends TestCase
 
     public function test_429_response_has_localized_message(): void
     {
+        // #4955 : tout 429 (y compris abort(429)) sert désormais le code
+        // stable TOO_MANY_REQUESTS + message localisé — le message brut
+        // « Too Many Requests. » n'est plus exposé.
         $this->getJson('/api/_test/err-429')
             ->assertStatus(429)
-            ->assertJsonPath('error', 'Too Many Requests')
-            ->assertJsonPath('message', 'Too Many Requests')
+            ->assertJsonPath('error', 'TOO_MANY_REQUESTS')
+            ->assertJsonPath('message', 'TOO_MANY_REQUESTS')
             ->assertJsonPath('localized_message', __('errors.TOO_MANY_REQUESTS'));
     }
 


### PR DESCRIPTION
## Contexte
Issue #5034 (QA 2026-08-17) : la suite `tests/Feature/HR/` était rouge. Après les fixes mergés (#4979, #5014, #5065), 3 classes restaient en échec. Cause racine principale trouvée et corrigée ici.

## Changements
1. **`export_history.employee_id` typé `uuid` au lieu d'INTEGER** (migration 2026_08_15_000003) — `employees.id` est un INTEGER (`increments`) : tout INSERT d'historisation échouait en **22P02** → la feature #2199 (historisation des exports) n'a JAMAIS fonctionné, et en test l'erreur avalée laissait la transaction PG abortée (**25P02**) → 500 sur GET /export/*.
   - Migration d'origine corrigée + **migration corrective** `2026_08_17_000001` (ALTER TYPE integer USING NULL — table vide, `uuid::integer` n'est pas un cast PG valide).
   - **Vérifié live local** : `/export/employees` → 200 et `/export/history` renvoie enfin l'historisation réelle.
2. **`ExportController::exportResponse()`** : le type d'historisation est désormais distinct du préfixe de fichier (`vehicles` vs `vehicles_export_*.csv`) — convention établie (`employees` vs `employees_export_*`).
3. **Renderer 429 (`ThrottleRequestsException`)** : les headers **Retry-After / X-RateLimit-*** sont maintenant copiés sur la réponse (le renderer dédié, enregistré avant le générique, les perdait → `RateLimiterResilienceTest` rouge).
4. **Test stale mis à jour** : `HttpErrorLocalizedMessageTest::test_429...` attendait le message brut « Too Many Requests » — depuis #4955, tout 429 sert `TOO_MANY_REQUESTS` stable + localisé.

## Vérifié (local)
- `tests/Feature/HR/` **44/44** · `RateLimiterResilienceTest` **3/3** · `HttpErrorLocalizedMessageTest` **5/5** · `ExportHistoryTest` **4/4**.
- Migration corrective appliquée sur la DB dev (type integer).

## Reste (hors périmètre, suivi #4978)
- `TrialSignupSlugRaceTest` (retry 23505 × transaction de test RefreshDatabase — à valider en CI PG16).
- Contamination d'ordre entre suites (Organigramme) — flakiness transitoire.