### PR TITLE
docs(ops): DEPLOYMENT_URLS.md — URLs de déploiement actives (progrès #3765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 - **fix(ci/tests): follow-up #4978 après merge #5092.** Le retour structuré de `SenegalPayrollRules::calculateSocialChargesWithCategory()` satisfait PHPStan Strict, et `TenantIsolationTest` force la persistance de `password_hash` dans sa fixture Employee afin de respecter PostgreSQL.
+- **docs(ops): DEPLOYMENT_URLS.md — URLs de déploiement actives documentées (progrès #3765)** — surfaces live (Render API, Vercel vitrine, Cloudflare Pages admin), services, hooks de déploiement, health endpoints, procédure de vérification v4.24.0+.
 - **fix(web): NEXT_PUBLIC_ENABLE_BLOG activé par défaut (Closes #2906).** env.ts : enableBlog bascule de `=== true` à `!== false` — blog actif par défaut, désactivable explicitement via `=false`. .env.local.example documenté. Sitemap test commenté.
 - **feat(mobile/i18n): dette #4194 vague 4 — 41 clés team ×4 locales + team_screen manager/hr migrés (Refs #4194 #2755).** 41 clés teamTitle/teamAdd/teamViewProfile/teamMakeHr/teamArchive… ×4 locales + générés Dart. team_screen.dart ×2 apps : 34 chaînes chacun → context.l10n.*.
 - **feat(mobile/i18n): dette #4194 vague 3 — 59 clés settings + 3 param ×4 locales ; manager/hr settings migrés (Refs #4194 #2755).** 62 nouvelles clés ARB (settingsMyProfile, settingsFirstName, settingsBiometric*, settingsJourney*, settingsPassword*, settingsLanguageSaved…) ×4 locales + générés Dart. Settings screens leopardo_manager/hr : 36+20 chaînes migrées. Salary advance screens leopardo_manager/hr : 26 chaînes chacun.

--- a/docs/ops/DEPLOYMENT_URLS.md
+++ b/docs/ops/DEPLOYMENT_URLS.md
@@ -1,0 +1,60 @@
+# DEPLOYMENT_URLS.md — URLs de déploiement actives (source : registre DOMAINS.md)
+
+> Livrable de l'épic #3765 (stabilisation production). Documente les URLs
+> **réellement actives** (services gratuits Render/Vercel/Cloudflare Pages),
+> les endpoints de santé et la procédure de déploiement.
+> Source de vérité des domaines : `docs/ops/DOMAINS.md` (garde
+> `check-canonical-domains.sh`).
+
+## Surfaces actives (live)
+
+| Surface | URL | Service | Vérifié |
+|---|---|---|---|
+| API Laravel (base `/api/v1`) | `https://gestionemployerbackend.onrender.com` | Render (gratuit) | HTTP 200 2026-08-15 |
+| Santé API | `https://gestionemployerbackend.onrender.com/api/v1/health` | Render | — |
+| Vitrine / portail web | `https://gestionemployer-backend.vercel.app` | Vercel (gratuit) | HTTP 200 2026-08-15 |
+| Admin plateforme (super-admin) | `https://leo-admin.pages.dev` | Cloudflare Pages | CORS/Sanctum de référence (#3766) |
+
+## Services Render (backend)
+
+- **API + Web** : `gestionemployerbackend` — déployé via webhook
+  `RENDER_DEPLOY_HOOK_URL` (secret GitHub, workflow `deploy-main.yml`).
+- **Queue worker** : service séparé attendu (voir #4948 — `leopardo-queue-worker`).
+- **Staging** : `RENDER_STAGING_DEPLOY_HOOK_URL` (fallback hook prod si absent) ;
+  URL d'health-check staging : `STAGING_API_URL`
+  (défaut `https://gestionemployerbackend.onrender.com`).
+- **Rollback** : `RENDER_ROLLBACK_HOOK_URL` (déclenché en cas d'échec de deploy prod).
+
+## Déclenchement d'un déploiement
+
+```bash
+# Déploiement API/Web (Render) — via le hook secret (depuis GitHub Actions)
+curl -X POST "$RENDER_DEPLOY_HOOK_URL"
+
+# Vérification post-déploiement
+curl -s https://gestionemployerbackend.onrender.com/api/v1/health
+curl -s https://gestionemployerbackend.onrender.com/api/v1/health/ready
+```
+
+La version API attendue sur main : `APP_VERSION` = **4.24.0+**
+(`api/config/app.php`, défaut `env('APP_VERSION', '4.24.0')`).
+Critère de succès #3765 : `/api/v1/health` retourne v4.24.0+.
+
+## Variables d'environnement liées au déploiement
+
+| Variable | Usage | Valeur de référence |
+|---|---|---|
+| `RENDER_DEPLOY_HOOK_URL` | Webhook deploy prod | secret GitHub |
+| `RENDER_STAGING_DEPLOY_HOOK_URL` | Webhook deploy staging | secret GitHub (fallback prod) |
+| `RENDER_ROLLBACK_HOOK_URL` | Webhook rollback prod | secret GitHub |
+| `STAGING_API_URL` | Health-check staging / lien `environment.url` | `https://gestionemployerbackend.onrender.com` |
+| `LEOPARDO_API_URL` | Base API utilisée par la vitrine Next.js | résolue via `resolveBackendBaseUrl()` (défaut Render) |
+| `FRONTEND_URL` / `APP_URL` | URLs canoniques CORS/Sanctum | `https://gestionemployer-backend.vercel.app` / `https://gestionemployerbackend.onrender.com` |
+| `NEXT_PUBLIC_ENABLE_BLOG` | Activation du blog vitrine (#2906) | `true` (contenu prêt, activé 2026-08-18) |
+
+## Domaines réservés (NXDOMAIN — NE PAS utiliser en default de build)
+
+`leopardo-rh.com`, `www.leopardo-rh.com`, `app.leopardo-rh.com`,
+`admin.leopardo-rh.com`, `api.leopardo-rh.com`, `docs.leopardo-rh.com`,
+`api.leopardo.app`, `proxy.leopardo-rh.com`, `demo.leopardo-rh.com`…
+→ voir `docs/ops/DOMAINS.md` (registre complet) et #3452 (provisionnement DNS).


### PR DESCRIPTION
## Livrable épic #3765 (stabilisation production)

Documente les **URLs de déploiement réellement actives** (services gratuits Render/Vercel/Cloudflare Pages) :
- Surfaces live : API `gestionemployerbackend.onrender.com`, vitrine `gestionemployer-backend.vercel.app`, admin `leo-admin.pages.dev`
- Health endpoints : `/api/v1/health`, `/health/live`, `/health/ready`
- Hooks de déploiement : `RENDER_DEPLOY_HOOK_URL`, `RENDER_STAGING_DEPLOY_HOOK_URL`, `RENDER_ROLLBACK_HOOK_URL`
- Procédure de vérification post-déploiement (critère #3765 : `/api/v1/health` → v4.24.0+)
- Rappel des domaines réservés NXDOMAIN à ne pas utiliser comme defaults (#3452)

Source : registre canonique `docs/ops/DOMAINS.md` — garde `check-canonical-domains.sh` vérifiée (aucune référence hors registre).

## Reste (accès humain/infra, pas de code)

- Déclencher le déploiement Render manuel vers v4.24.0+ (webhook ou console Render)
- Provisionner le DNS #3452 quand décidé