### PR TITLE
docs(spec-kit): kiosque punch-methods — spec + tasks (Epic #5119)

### DIFF
--- a/.specify/features/5119-kiosk-punch-methods/spec.md
+++ b/.specify/features/5119-kiosk-punch-methods/spec.md
@@ -1,0 +1,73 @@
+# Feature Specification: Kiosque — méthodes de pointage configurables par tenant (Epic #5119)
+
+**Feature Branch**: `fix/5119-kiosk-punch-methods`
+**Issues**: #5119 (epic) · #5120 (API data-model) · #5121 (enforcement) · #5122 (employé badge/enrollment) · #5123 (kiosk web UI) · #5124 (spec-kit/docs)
+**Presets**: `leopardo-multitenancy` (table + endpoint API)
+
+## Contexte
+
+Le kiosque (ZKTeco + `front/zkteco-kiosk` + `POST /zkteco/sync-attendance/{serialNumber}`) accepte
+aujourd'hui tous les types de pointage sans distinction. `ZktecoDevice` expose déjà
+`fingerprint_capacity`/`face_capacity`, et l'employé a `biometric_fingerprint_enabled` /
+`biometric_face_enabled` (garde `BIOMETRIC_NOT_APPROVED` dans `KioskAttendanceService`).
+Le `punch_type` (0-5) décrit l'événement (entrée/sortie/pause…), **pas** la méthode biométrique.
+
+Le tenant doit pouvoir **paramétrer, depuis l'API de configuration des kiosques
+(`/api/v1/zkteco/devices`), les méthodes de pointage autorisées** : `fingerprint` (doigt),
+`face` (visage), `card` (carte/badge) — par device, avec un défaut entreprise optionnel.
+
+## User Stories
+
+### US1 — Configurer les méthodes par kiosque (P1)
+En tant que manager RH, je paramètre chaque kiosque avec les méthodes autorisées
+(empreinte, visage, carte) depuis l'API devices, et je vois la config en lecture.
+
+**Acceptance Scenarios**:
+1. Given un device existant, When `PUT /zkteco/devices/{id}` avec `punch_methods: ["face","card"]`, Then la config est persistée et visible en `GET`.
+2. Given `punch_methods` absent, When store/update, Then `null` (toutes méthodes, rétro-compat).
+3. Given une valeur invalide (`"retina"`), When update, Then 422 (validation `in:fingerprint,face,card`).
+4. Given un autre tenant, When GET/PUT le device, Then 404 (isolation inchangée).
+
+### US2 — Enforcement à la sync (P1)
+En tant que kiosque, je n'envoie que des pointages dont la méthode est autorisée ; sinon le backend refuse proprement, avec un message localisé.
+
+**Acceptance Scenarios**:
+1. Given un device autorisant `["face","card"]`, When sync d'un record `method: "fingerprint"`, Then refus du record (`PUNCH_METHOD_NOT_ALLOWED`).
+2. Given méthode autorisée mais employé non enrôlé (ex. `card` sans `badge_number`), When sync, Then refus (`EMPLOYEE_METHOD_NOT_ENROLLED`).
+3. Given payload sans `method`, When sync, Then comportement actuel (empreinte) — rétro-compat.
+4. Given refus, Then entrée sur le canal log `audit` (device, employé, méthode, IP).
+
+### US3 — Employé : badge + statut d'enrôlement (P2)
+En tant que manager RH, je renseigne le badge/carte d'un employé et je vois pour chacun quelles méthodes sont enrôlées.
+
+**Acceptance Scenarios**:
+1. Given `PATCH /employees/{id}` avec `badge_number: "A-1042"`, Then champ persisté, unique dans le tenant.
+2. Given badge vide, Then exposé absent ; Given renseigné, Then `enrollment.card: true` dans `EmployeeResource`.
+3. Given un badge existant, When sync `method: "card"` + `badge_number`, Then l'employé est résolu (en plus de `zkteco_id`/`matricule`).
+
+### US4 — Kiosk web piloté par la config (P2)
+En tant qu'employé devant le kiosque, je ne vois que les méthodes autorisées, et je peux pointer par carte (saisie du badge).
+
+**Acceptance Scenarios**:
+1. Given config `["card"]`, When ouverture du kiosk, Then seul le flux carte est proposé.
+2. Given flux carte, When saisie du badge, Then pointage envoyé avec `method: "card"` + `badge_number`.
+3. Given aucune méthode autorisée, Then état « méthode non disponible » (pas de crash).
+4. Given libellés, Then affichés en fr/en/tr/ar (`i18n.js`).
+
+## Requirements
+
+- **FR-001** (`#5120` API) : `ZktecoDevice.punch_methods` jsonb nullable (`fingerprint|face|card`), fillable + cast array, validation `array|in|distinct`, exposition index/show, défaut entreprise via `company_settings` (`kiosk.punch_methods.default`).
+- **FR-002** (`#5121` enforcement) : helper `methodAllowed(device, method)` ; mapping enrollment employé (`fingerprint`→`biometric_fingerprint_enabled`, `face`→`biometric_face_enabled`, `card`→`badge_number` non vide) ; codes `PUNCH_METHOD_NOT_ALLOWED` / `EMPLOYEE_METHOD_NOT_ENROLLED` ×4 locales ; log audit ; rétro-compat sans `method`.
+- **FR-003** (`#5122` employé) : `employees.badge_number` nullable unique scoped company (migration additive + index partiel) ; PATCH validé ; bloc `enrollment: {fingerprint, face, card}` dans `EmployeeResource` ; lookup kiosk incluant `badge_number`.
+- **FR-004** (`#5123` kiosk web) : chargement de `punch_methods` au boot (config/bridge) ; sélecteur filtré + état vide ; flux carte (saisie badge) ; payload `method` ajouté au POST punch local et à la sync ; i18n ×4.
+- **FR-005** (`#5124` docs) : `.specify/features/5119-kiosk-punch-methods/{spec.md,tasks.md}` ; MAJ `docs/dossierdeConception/` (multitenancy/kiosque) + guide device ; CHANGELOG à la livraison.
+
+## Decisions
+
+- **Rétro-compatibilité** : `punch_methods` absent/null ⇒ toutes méthodes ; payload `method` absent ⇒ `fingerprint` (comportement actuel). Aucun retrait de champ.
+- **Portée** : config par **device** (chaque kiosque peut différer) + défaut entreprise optionnel. Pas de scope mobile (smart-attendance) dans cette épic.
+- **Carte** : le badge est un champ employé formel (`badge_number`) ; le fallback `matricule` actuel reste en secours.
+
+## Success Criteria
+
+- CRUD `punch_methods` testé (API) ; enforcement testé (records refusés + codes ×4) ; badge + `enrollment` exposés et testés ; kiosk web filtré + flux carte ; `flutter analyze`/CI kiosk verts ; docs + spec mergées.

--- a/.specify/features/5119-kiosk-punch-methods/tasks.md
+++ b/.specify/features/5119-kiosk-punch-methods/tasks.md
@@ -1,0 +1,46 @@
+# Tasks — Kiosque punch-methods (Epic #5119)
+
+> Référence croisée des issues filles. Ordre d'exécution : T5 (spec/docs) → T1 (API) → T2 (enforcement) → T3 (employé) → T4 (kiosk web).
+
+## T1 — API data-model `punch_methods` (#5120)
+- [ ] Migration : `punch_methods` jsonb nullable sur `zkteco_devices`.
+- [ ] Modèle `ZktecoDevice` : `$fillable` + cast `array` + constantes `PUNCH_METHOD_FINGERPRINT/FACE/CARD`.
+- [ ] Règle de validation (store/update) : `array` + `in:fingerprint,face,card` + `distinct` (champ optionnel).
+- [ ] Exposition dans `index`/`show` (ressource device).
+- [ ] Défaut entreprise : lecture `company_settings` `kiosk.punch_methods.default` (helper de résolution).
+- [ ] Tests Feature : CRUD valide/invalide/absent, isolation tenant.
+
+## T2 — Enforcement sync-attendance (#5121)
+- [ ] Helper `methodAllowed(ZktecoDevice $device, string $method): bool` (config device → défaut entreprise → toutes).
+- [ ] Mapping enrollment employé : `fingerprint`→`biometric_fingerprint_enabled`, `face`→`biometric_face_enabled`, `card`→`badge_number` non vide.
+- [ ] Intégration dans `KioskAttendanceService::syncPunches` / `ZktecoIntegrationService` : refus record (`skip`) ou lot selon la gravité.
+- [ ] Codes erreur `PUNCH_METHOD_NOT_ALLOWED` / `EMPLOYEE_METHOD_NOT_ENROLLED` ×4 catalogues `errors.*` (fr/en/tr/ar) + `localized_message`.
+- [ ] Log canal `audit` pour chaque refus.
+- [ ] Rétro-compat : payload sans `method` ⇒ `fingerprint`.
+- [ ] Tests Feature : méthode non autorisée, employé non enrôlé, rétro-compat.
+
+## T3 — Employé badge + enrollment (#5122)
+- [ ] Migration additive `badge_number` nullable + index unique partiel scoped company.
+- [ ] `Employee` : fillable + validation PATCH (`nullable|string|max:50`, unicité scoped company).
+- [ ] `EmployeeResource` : `badge_number` (si non vide) + bloc `enrollment: {fingerprint, face, card}`.
+- [ ] Lookup kiosk : `badge_number` ajouté à la résolution employé (à côté de `zkteco_id`/`matricule`).
+- [ ] Tests Feature : PATCH badge, unicité, exposition enrollment, lookup.
+
+## T4 — Kiosk web (#5123)
+- [ ] Chargement de `punch_methods` au boot (bridge/config endpoint).
+- [ ] Filtrage du sélecteur de méthode (`biometricType`) + état « aucune méthode ».
+- [ ] Écran/flux carte : saisie badge → POST punch local avec `method: 'card'` + `badge_number`.
+- [ ] Payload `method` pour empreinte/visage (`fingerprint`/`face`).
+- [ ] i18n ×4 dans `front/zkteco-kiosk/i18n.js` (3 méthodes + écran carte + erreurs).
+- [ ] Vérification manuelle documentée / tests unitaires si le setup le permet.
+
+## T5 — Spec-kit + docs (#5124)
+- [ ] `.specify/features/5119-kiosk-punch-methods/spec.md` (livré).
+- [ ] `.specify/features/5119-kiosk-punch-methods/tasks.md` (livré).
+- [ ] MAJ `docs/dossierdeConception/` (multitenancy ou section kiosque) : méthodes par tenant.
+- [ ] MAJ guide device / `docs/kiosk/` : paramétrage `punch_methods` + flux carte.
+- [ ] CHANGELOG à la livraison (gouvernance).
+
+## Ordre et dépendances
+1. **T5** (spec livrée, les issues #5120-#5124 existent déjà).
+2. **T1** (data-model) → **T3** (badge/enrollment, indépendant mais requis pour `card`) → **T2** (enforcement, dépend de T1+T3) → **T4** (UI kiosk, dépend de T1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Versioning : Semantic Versioning (semver.org) 
 
 ## [Unreleased]
+- **docs(spec-kit): kiosque — méthodes de pointage configurables par tenant (Epic #5119).** Spec + tasks livrées (`.specify/features/5119-kiosk-punch-methods/`) : config `punch_methods` (fingerprint/face/card) par device + défaut entreprise, enforcement sync-attendance, badge employé + statut d'enrôlement, UI kiosk pilotée par la config. Issues filles #5120-#5124.
 - **fix(api/security): EdgeNode/EdgeLicense — credentials plus jamais sérialisés en clair (Closes #4687).** `$hidden = ['license_key','metadata']` sur `EdgeNode` (le metadata contient le hash SHA-256 de l'edge_token) et `$hidden = ['license_key','signed_payload']` sur `EdgeLicense` : les réponses list/show ne fuient plus les secrets. Les endpoints d'émission (`POST /api/v1/edge` et `POST /api/v1/edge/{id}/license`) ré-exposent explicitement via `makeVisible()` — le contrat d'enregistrement `license: {license_key, signed_payload}` est préservé (test dédié `EdgeCredentialVisibilityTest`).
 ## [Unreleased]
 - **fix(admin): résiduel i18n FR — Support/CRM/Edge/NotFound localisés ×4 (Closes #4840).** SupportTicketsView (« Aucun ticket », sélection, erreur de chargement), CrmPipelineView (10 libellés pipeline), EdgeNodesView (table + stats + sync), NotFoundView (liens utiles, système) passent aux catalogues fr/en/ar/tr (clés support.*, crm.*, edge.*, notFound.*). Toast script via le helper `translate` (pattern #4781), plus de chaînes FR/EN en dur dans ces 4 vues.


### PR DESCRIPTION
**Épic** : #5119 — kiosque : méthodes de pointage configurables par tenant.

Livraison du Spec Kit (T5/#5124) :
- `.specify/features/5119-kiosk-punch-methods/spec.md` — user stories US1-US4, FR-001→005, décisions (rétro-compat, scope device, badge).
- `.specify/features/5119-kiosk-punch-methods/tasks.md` — T1-T5 avec ordre et dépendances.

Les issues filles existent : #5120 (API punch_methods), #5121 (enforcement sync), #5122 (badge + enrollment employé), #5123 (UI kiosk), #5124 (docs).

Prochaine étape : implémenter T1 → T3 → T2 → T4.