### PR TITLE
test(web/e2e): couvrir le flux Google OAuth — bouton, proxy, callback — Closes #5174

### DIFF
--- a/front/web/e2e/google-oauth.spec.ts
+++ b/front/web/e2e/google-oauth.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Issue #5174 — zéro couverture e2e du flux Google OAuth (bouton + proxy).
+ *
+ * Le flux dépend de 3 points fragiles (issue #5174) :
+ *   1. href du bouton same-origin (`/api/v1/auth/google`, fix #2277) ;
+ *   2. proxy catch-all (302 transmis) ;
+ *   3. callback (échange de code + cookie `leopardo_token`) — couvert par le
+ *      test d'intégration hermétique `callback/__tests__/route.test.ts`.
+ *
+ * Le smoke « proxy répond 3xx » est réservé à la CI contre la prod
+ * (GOOGLE_OAUTH_PROXY_SMOKE=1, env Render GOOGLE_* requis — issue #5170) :
+ * en local/web-ci le backend de prod n'est pas fiable pour ce test.
+ */
+test.describe('Google OAuth — vitrine (bouton + proxy same-origin)', () => {
+  test('bouton « Continue with Google » : href same-origin /api/v1/auth/google (#2277)', async ({ page }) => {
+    await page.goto('/auth/login');
+
+    const googleButton = page.locator('a[href="/api/v1/auth/google"]');
+    await expect(googleButton.first()).toBeVisible();
+    await expect(googleButton.first()).toHaveAttribute('href', '/api/v1/auth/google');
+  });
+
+  test('aucune URL backend Render directe dans le DOM de la page login', async ({ page }) => {
+    await page.goto('/auth/login');
+
+    const hrefs = await page.locator('a[href]').evaluateAll((els) =>
+      els.map((el) => el.getAttribute('href') ?? '')
+    );
+    for (const href of hrefs) {
+      expect(href).not.toContain('onrender.com');
+    }
+
+    const bodyHtml = await page.locator('body').innerHTML();
+    expect(bodyHtml).not.toContain('gestionemployerbackend.onrender.com');
+  });
+
+  test('proxy same-origin : GET /api/v1/auth/google répond 3xx (smoke prod)', async ({ request }) => {
+    test.skip(
+      !process.env.GOOGLE_OAUTH_PROXY_SMOKE,
+      'smoke prod uniquement : activer avec GOOGLE_OAUTH_PROXY_SMOKE=1 (env Render GOOGLE_* requis, issue #5170)'
+    );
+
+    const response = await request.get('/api/v1/auth/google', { maxRedirects: 0 });
+    // 302 vers accounts.google.com attendu ; un 500 (env GOOGLE_* absent)
+    // fait échouer le smoke — c'est exactement le but (détection #5170).
+    expect(response.status()).toBeGreaterThanOrEqual(300);
+    expect(response.status()).toBeLessThan(400);
+  });
+});

--- a/front/web/e2e/staging-smoke.spec.ts
+++ b/front/web/e2e/staging-smoke.spec.ts
@@ -43,4 +43,25 @@ test.describe('Web vitrine staging smoke', () => {
     await expect(page.locator('input[type="email"]').first()).toHaveAttribute('placeholder', /email/i);
     await expect(page.locator('form button[type="submit"]').first()).toContainText(/Tester|Try|Dene|جرّب/i);
   });
+
+  test('Google OAuth : bouton same-origin + proxy 3xx en prod (#5174/#5170)', async ({ page, request }) => {
+    await open(page, '/auth/login');
+
+    // 1. Bouton same-origin (fix #2277) — jamais d'URL Render directe.
+    const googleButton = page.locator('a[href="/api/v1/auth/google"]');
+    await expect(googleButton.first()).toBeVisible();
+    const hrefs = await page.locator('a[href]').evaluateAll((els) =>
+      els.map((el) => el.getAttribute('href') ?? '')
+    );
+    for (const href of hrefs) {
+      expect(href).not.toContain('onrender.com');
+    }
+
+    // 2. Smoke prod : GET /api/v1/auth/google doit répondre 3xx (redirection
+    //    Google). Un 500 (env GOOGLE_CLIENT_ID/SECRET/REDIRECT_URL absents sur
+    //    Render, issue #5170) fait échouer ce test — détection voulue (#5174).
+    const response = await request.get('/api/v1/auth/google', { maxRedirects: 0 });
+    expect(response.status()).toBeGreaterThanOrEqual(300);
+    expect(response.status()).toBeLessThan(400);
+  });
 });

--- a/front/web/src/app/api/v1/auth/google/callback/__tests__/route.test.ts
+++ b/front/web/src/app/api/v1/auth/google/callback/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+/**
+ * Issue #5174 — test d'intégration du callback Google OAuth côté vitrine
+ * (`.specify/features/web-google-oauth-proxy`, fix #2277).
+ *
+ * La mécanique testée ici est le cœur du flux :
+ *   code valide → cookie `leopardo_token` (httpOnly) + redirect /dashboard
+ *   code invalide (backend ≥ 400) → redirect ?error=google_auth_failed
+ *   backend injoignable → redirect ?error=google_network
+ *   payload sans token → redirect ?error=google_no_account
+ *   code absent → redirect ?error=google
+ *
+ * Le fetch backend est mocké : le test est hermétique (aucune dépendance
+ * réseau / aucun Socialite réel).
+ */
+
+jest.mock('@/lib/backend-url', () => ({
+  resolveBackendBaseUrl: jest.fn(() => 'https://backend.example.com/api/v1'),
+}));
+
+const mockCookieStore = {
+  set: jest.fn(),
+  get: jest.fn(() => undefined),
+};
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => mockCookieStore),
+}));
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = mockFetch as unknown as typeof fetch;
+  mockCookieStore.set.mockClear();
+  mockCookieStore.get.mockClear();
+});
+
+function callbackRequest(code?: string): NextRequest {
+  const url = code
+    ? `http://localhost:3000/api/v1/auth/google/callback?code=${code}`
+    : 'http://localhost:3000/api/v1/auth/google/callback';
+  return new NextRequest(url);
+}
+
+describe('GET /api/v1/auth/google/callback', () => {
+  it('redirige vers ?error=google quand le code est absent', async () => {
+    const response = await GET(callbackRequest());
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/login?error=google');
+    expect(mockCookieStore.set).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('pose le cookie httpOnly et redirige vers /dashboard pour un code valide', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ token: 'valid-token-123' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const response = await GET(callbackRequest('valid-code'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/dashboard');
+    expect(mockCookieStore.set).toHaveBeenCalledWith(
+      'leopardo_token',
+      'valid-token-123',
+      expect.objectContaining({ httpOnly: true, path: '/' })
+    );
+    // Le fetch cible bien le backend, pas une URL Render en dur.
+    const backendUrl = mockFetch.mock.calls[0]?.[0] as string;
+    expect(backendUrl).toContain('https://backend.example.com/api/v1/auth/google/callback');
+  });
+
+  it('redirige vers ?error=google_auth_failed quand le backend répond ≥ 400', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'UNKNOWN_ACCOUNT' }), { status: 401 })
+    );
+
+    const response = await GET(callbackRequest('revoked-code'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/login?error=google_auth_failed');
+    expect(mockCookieStore.set).not.toHaveBeenCalled();
+  });
+
+  it('redirige vers ?error=google_network quand le backend est injoignable', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const response = await GET(callbackRequest('any-code'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/login?error=google_network');
+  });
+
+  it('redirige vers ?error=google_no_account quand le payload ne contient pas de token', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false }), { status: 200 })
+    );
+
+    const response = await GET(callbackRequest('unlinked-code'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/login?error=google_no_account');
+    expect(mockCookieStore.set).not.toHaveBeenCalled();
+  });
+});

--- a/front/web/src/modules/vitrine/data/__tests__/case-study-detail-i18n.test.ts
+++ b/front/web/src/modules/vitrine/data/__tests__/case-study-detail-i18n.test.ts
@@ -39,7 +39,7 @@ describe('case study detail i18n (#4703)', () => {
       .filter((l: string) => !l.trim().startsWith('//'))
       .join('\n')
     const frLines = code.split('\n').filter((l: string) => {
-      const matches = l.match(/(['"])[^'"]*[àâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ][^'"]*\1/g)
+      const matches = l.match(/(['"])[^'"]*[àâäéèêëîïôöùûüçÀ\u00C2\u00C4ÉÈÊËÎÏÔÖÙÛÜÇ][^'"]*\1/g)
       return (matches ?? []).length > 0
     })
     expect(frLines).toEqual([])

--- a/front/web/src/modules/vitrine/lib/__tests__/module-content-i18n.test.ts
+++ b/front/web/src/modules/vitrine/lib/__tests__/module-content-i18n.test.ts
@@ -107,7 +107,7 @@ describe('module page sections i18n (#4702)', () => {
         .filter((l: string) => !l.trim().startsWith('//'))
         .join('\n')
       const frLines = code.split('\n').filter((l: string) => {
-        const matches = l.match(/(['"])[^'"]*[àâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ][^'"]*\1/g)
+        const matches = l.match(/(['"])[^'"]*[àâäéèêëîïôöùûüçÀ\u00C2\u00C4ÉÈÊËÎÏÔÖÙÛÜÇ][^'"]*\1/g)
         return (matches ?? []).length > 0
       })
       expect(frLines).toEqual([])


### PR DESCRIPTION
## Issue
**Closes #5174** — [P2][QA][testing] Zéro couverture e2e du flux Google OAuth.

## Changements
- `e2e/google-oauth.spec.ts` : href same-origin du bouton (#2277), aucune URL Render directe dans le DOM, smoke proxy 3xx (activé par `GOOGLE_OAUTH_PROXY_SMOKE=1` en CI prod — détecte le 500 #5170) ;
- test d'intégration hermétique du callback (`route.test.ts`, 5 cas) : code valide → cookie `leopardo_token` httpOnly + /dashboard ; ≥ 400 → `?error=google_auth_failed` ; réseau → `?error=google_network` ; payload sans token → `?error=google_no_account` ; code absent → `?error=google` ;
- `staging-smoke.spec.ts` : smoke prod Google — rouge tant que l'env Render GOOGLE_* n'est pas posé (#5170), c'est le but.

## Vérifications
- `jest route.test.ts` : 5/5 ✅ · `tsc --noEmit` ✅ · `eslint` ✅
- Réf : rapport QA 2026-08-20 (F1/F6).