### PR TITLE
docs(pilotes): carnet feedback pilotes DZ (template + 3 carnets) — Closes #5152

### DIFF
--- a/docs/pilotes/CARNET_TEMPLATE.md
+++ b/docs/pilotes/CARNET_TEMPLATE.md
@@ -1,0 +1,66 @@
+# 📓 CARNET PILOTE — Template (issue #5152)
+
+**Version** : 1.0 · **Date** : 2026-08-20 · **Lié** : `docs/ops/SUIVI_PILOTES.md`
+(usage mesuré), `docs/ops/SLA_PILOTES.md` (bugs bloquants), `docs/pilotes/RETRO_<date>.md`.
+
+> Un carnet par pilote, mis à jour **chaque semaine** (rituel QA du jeudi +
+> bilan du vendredi). C'est la matière première du gate J60 (rétro pilotes,
+> bilan 60 jours) : factuel, sourcé, sans opinion.
+
+---
+
+## 1. Identité
+
+| Champ | Valeur |
+|---|---|
+| Pilote | Pilote 1 / 2 / 3 |
+| Société | *(à la signature)* |
+| Contact | *(email / tel — à la signature)* |
+| Pays | DZ |
+| Taille (employés) | *(à la signature)* |
+| Secteur | *(à la signature)* |
+| Signature | *(date — objectif Phase 2)* |
+| Carnet créé | *(date)* |
+
+## 2. Usage hebdo (mesuré — `php artisan pilot:report --company=<slug>`)
+
+| Semaine | Logins | Pointages | Runs paie | Employés actifs | Dernière activité | Bloquants ouverts |
+|---|---|---|---|---|---|---|
+| *(date)* | | | | | | |
+| *(date)* | | | | | | |
+
+Cible : **2 pilotes actifs / semaine** (gate J60). Une semaine sans aucune
+activité = relance (action humaine).
+
+## 3. Top 3 douleurs (ce qui fait mal)
+
+1. *(ex. : la saisie des absences CP est trop longue)* — date, contexte
+2. *(à remplir)*
+3. *(à remplir)*
+
+## 4. Top 3 manques (ce qui manque)
+
+1. *(ex. : export CSV des pointages)* — date, contexte
+2. *(à remplir)*
+3. *(à remplir)*
+
+## 5. Promesses non tenues
+
+| Promesse | Date | Statut | Issue de suivi |
+|---|---|---|---|
+| *(ex. : paie conforme DZ avant fin août)* | | ouverte / tenue / décalée | #… |
+
+## 6. Bugs bloquants (SLA < 24 h — issue #5155)
+
+| Date | Issue | Impact (paie/pointage/login) | Ouvert | Résolu (deploy) | Délai |
+|---|---|---|---|---|---|
+| | | | | | |
+
+## 7. Décisions prises
+
+| Date | Décision | Par qui | Contexte |
+|---|---|---|---|
+| | | | |
+
+---
+*Rituel : mise à jour hebdo (QA jeudi + bilan vendredi). Template issue #5152.*


### PR DESCRIPTION
## Issue
**Closes #5152** — [P2][docs] Carnet de feedback pilotes DZ : template + création des 3 carnets.

## Changements
- `docs/pilotes/CARNET_TEMPLATE.md` : identité, usage hebdo mesuré (pilot:report #5156), top 3 douleurs/manques, promesses non tenues, bugs bloquants (SLA #5155), décisions ;
- 3 issues créées pré-remplies : **#5186** (Pilote 1), **#5187** (Pilote 2), **#5188** (Pilote 3) ;
- rituel : mise à jour QA jeudi + bilan vendredi.