### PR TITLE
test(leave): align pending reservation with working days

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,7 +6,8 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context.
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context; per-employee failures are also surfaced in console output instead of being silent.
+
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 
 ### Security

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,7 +6,7 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` or `search_path` context; per-employee failures are surfaced in console output and rethrown in the test environment for actionable CI diagnostics.
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` or `search_path` context; per-employee failures are surfaced in console output and rethrown in the test environment for actionable CI diagnostics, including explicit policy/balance visibility checks for the test harness.
 
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,7 +6,7 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context; per-employee failures are also surfaced in console output instead of being silent.
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context; per-employee failures are surfaced in console output and rethrown in the test environment for actionable CI diagnostics.
 
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -5,6 +5,9 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
+
 ### Security
 - **Constant-time comparison and hashed storage for `edge_token`** — `EdgeNodeController` now hashes the Edge node authentication token at rest (`hash('sha256', $token)`) instead of storing it in cleartext, and verifies incoming tokens with `hash_equals()` instead of a plain string comparison
   - Removes a timing side-channel that could let an attacker recover a valid `edge_token` byte-by-byte via response-time measurements

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,8 +6,9 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` or `search_path` context; per-employee failures are surfaced in console output and rethrown in the test environment for actionable CI diagnostics, including explicit policy/balance visibility checks for the test harness.
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` or `search_path` context; per-employee failures remain isolated and logged without poisoning the command transaction.
 
+- **Leave carry-forward assertions are tenant-independent.** The regression test reads generated accruals and balances without reapplying the current-company global scope after the global console command runs.
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 
 ### Security

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,7 +6,7 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, and accrual expiration queries while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context.
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context.
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 
 ### Security

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,7 +6,7 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context; per-employee failures are surfaced in console output and rethrown in the test environment for actionable CI diagnostics.
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, accrual expiration queries, and write builders while retaining explicit company filters, so console execution cannot inherit a stale `current_company` or `search_path` context; per-employee failures are surfaced in console output and rethrown in the test environment for actionable CI diagnostics.
 
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,7 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
+- **LeaveCarryForward processes all tenants explicitly.** The annual carry-forward command now disables tenant global scopes for policies, balances, and accrual expiration queries while retaining explicit company filters, so console execution cannot inherit a stale `current_company` context.
 - **Leave pending reservation fixture aligned with working-day semantics.** The regression test now reserves two distinct one-day working-day absences against a one-day balance, verifying pending-day reservation without relying on the legacy calendar-day calculation.
 
 ### Security

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -39,9 +39,6 @@ class LeaveCarryForward extends Command
             ->where('carry_forward', true)
             ->get();
 
-        if (app()->environment('testing') && $policies->isEmpty()) {
-            throw new \RuntimeException('LeaveCarryForward found no active carry-forward policies on search_path '.DB::selectOne('select current_schema()')->current_schema.'.');
-        }
 
         $carried = 0;
         $expired = 0;
@@ -53,9 +50,6 @@ class LeaveCarryForward extends Command
                 ->where('year', $fromYear)
                 ->get();
 
-            if (app()->environment('testing') && $balances->isEmpty()) {
-                throw new \RuntimeException("LeaveCarryForward found no balance for policy {$policy->id}, company {$policy->company_id}, year {$fromYear}.");
-            }
 
             foreach ($balances as $oldBalance) {
                 try {
@@ -99,11 +93,7 @@ class LeaveCarryForward extends Command
                     });
                 } catch (\Throwable $e) {
                     Log::warning("Carry-forward failed for employee {$oldBalance->employee_id}: {$e->getMessage()}");
-                    $this->warn("Carry-forward failed for employee {$oldBalance->employee_id}: {$e->getMessage()}");
 
-                    if (app()->environment('testing')) {
-                        throw $e;
-                    }
                 }
             }
         }

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -39,6 +39,10 @@ class LeaveCarryForward extends Command
             ->where('carry_forward', true)
             ->get();
 
+        if (app()->environment('testing') && $policies->isEmpty()) {
+            throw new \RuntimeException('LeaveCarryForward found no active carry-forward policies on search_path '.DB::selectOne('select current_schema()')->current_schema.'.');
+        }
+
         $carried = 0;
         $expired = 0;
 

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -85,6 +85,10 @@ class LeaveCarryForward extends Command
                 } catch (\Throwable $e) {
                     Log::warning("Carry-forward failed for employee {$oldBalance->employee_id}: {$e->getMessage()}");
                     $this->warn("Carry-forward failed for employee {$oldBalance->employee_id}: {$e->getMessage()}");
+
+                    if (app()->environment('testing')) {
+                        throw $e;
+                    }
                 }
             }
         }

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -84,6 +84,7 @@ class LeaveCarryForward extends Command
                     });
                 } catch (\Throwable $e) {
                     Log::warning("Carry-forward failed for employee {$oldBalance->employee_id}: {$e->getMessage()}");
+                    $this->warn("Carry-forward failed for employee {$oldBalance->employee_id}: {$e->getMessage()}");
                 }
             }
         }

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -19,6 +19,13 @@ class LeaveCarryForward extends Command
 
     public function handle(): int
     {
+        // Les commandes console peuvent être invoquées depuis un worker ayant
+        // laissé un search_path public ou tenant spécifique. Cette commande
+        // globale lit et écrit dans le schéma tenant partagé canonique.
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('SET search_path TO shared_tenants, public');
+        }
+
         $fromYear = (int) ($this->option('year') ?? (now()->year - 1));
         $toYear = $fromYear + 1;
 

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -24,7 +24,11 @@ class LeaveCarryForward extends Command
 
         $this->info("Processing carry-forward from {$fromYear} to {$toYear}...");
 
-        $policies = LeavePolicy::where('active', true)
+        // Commande globale : elle traite tous les tenants et ne doit pas
+        // hériter d’un `current_company` éventuellement présent dans le
+        // processus de test/worker.
+        $policies = LeavePolicy::withoutGlobalScopes()
+            ->where('active', true)
             ->where('carry_forward', true)
             ->get();
 
@@ -32,7 +36,8 @@ class LeaveCarryForward extends Command
         $expired = 0;
 
         foreach ($policies as $policy) {
-            $balances = LeaveBalance::where('company_id', $policy->company_id)
+            $balances = LeaveBalance::withoutGlobalScopes()
+                ->where('company_id', $policy->company_id)
                 ->where('absence_type_id', $policy->absence_type_id)
                 ->where('year', $fromYear)
                 ->get();
@@ -92,7 +97,8 @@ class LeaveCarryForward extends Command
 
     private function expireOldCarryForwards(int $currentYear, int &$expired): void
     {
-        $policies = LeavePolicy::where('active', true)
+        $policies = LeavePolicy::withoutGlobalScopes()
+            ->where('active', true)
             ->where('carry_forward', true)
             ->whereNotNull('carry_forward_expiry_days')
             ->where('carry_forward_expiry_days', '>', 0)
@@ -105,14 +111,16 @@ class LeaveCarryForward extends Command
                 continue;
             }
 
-            $carryForwards = LeaveAccrual::where('leave_policy_id', $policy->id)
+            $carryForwards = LeaveAccrual::withoutGlobalScopes()
+                ->where('leave_policy_id', $policy->id)
                 ->where('type', 'carry_forward')
                 ->where('effective_date', now()->startOfYear()->toDateString())
                 ->whereNull('expired_at')
                 ->get();
 
             foreach ($carryForwards as $accrual) {
-                $balance = LeaveBalance::where('company_id', $accrual->company_id)
+                $balance = LeaveBalance::withoutGlobalScopes()
+                    ->where('company_id', $accrual->company_id)
                     ->where('employee_id', $accrual->employee_id)
                     ->where('absence_type_id', $policy->absence_type_id)
                     ->where('year', $currentYear)

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -53,6 +53,10 @@ class LeaveCarryForward extends Command
                 ->where('year', $fromYear)
                 ->get();
 
+            if (app()->environment('testing') && $balances->isEmpty()) {
+                throw new \RuntimeException("LeaveCarryForward found no balance for policy {$policy->id}, company {$policy->company_id}, year {$fromYear}.");
+            }
+
             foreach ($balances as $oldBalance) {
                 try {
                     DB::transaction(function () use ($policy, $oldBalance, $toYear, &$carried): void {

--- a/api/app/Console/Commands/LeaveCarryForward.php
+++ b/api/app/Console/Commands/LeaveCarryForward.php
@@ -58,7 +58,7 @@ class LeaveCarryForward extends Command
                         $maxCarry = $policy->carry_forward_max ?? $unused;
                         $carryAmount = min($unused, $maxCarry);
 
-                        $newBalance = LeaveBalance::firstOrCreate(
+                        $newBalance = LeaveBalance::withoutGlobalScopes()->firstOrCreate(
                             [
                                 'company_id' => $policy->company_id,
                                 'employee_id' => $oldBalance->employee_id,
@@ -70,7 +70,7 @@ class LeaveCarryForward extends Command
 
                         $newBalance->increment('balance', $carryAmount);
 
-                        LeaveAccrual::create([
+                        LeaveAccrual::withoutGlobalScopes()->create([
                             'company_id' => $policy->company_id,
                             'employee_id' => $oldBalance->employee_id,
                             'leave_policy_id' => $policy->id,

--- a/api/tests/Feature/Leave/LeavePendingReservationTest.php
+++ b/api/tests/Feature/Leave/LeavePendingReservationTest.php
@@ -129,7 +129,7 @@ class LeavePendingReservationTest extends TestCase
             'company_id' => $company->id,
             'employee_id' => $employee->id,
             'absence_type_id' => $type->id,
-            'balance' => 20,
+            'balance' => 1,
             'used' => 0,
             'pending' => 0,
             'year' => now()->year,
@@ -137,18 +137,21 @@ class LeavePendingReservationTest extends TestCase
 
         \Laravel\Sanctum\Sanctum::actingAs($employee);
 
-        // Première demande : 15 j → pending = 15.
+        $firstDate = now()->addMonths(2)->nextWeekday();
+        $secondDate = $firstDate->copy()->addWeekday();
+
+        // Première demande : 1 jour ouvré → pending = 1.
         $this->postJson('/api/v1/absences', [
             'absence_type_id' => $type->id,
-            'start_date' => now()->addDays(1)->format('Y-m-d'),
-            'end_date' => now()->addDays(15)->format('Y-m-d'),
+            'start_date' => $firstDate->format('Y-m-d'),
+            'end_date' => $firstDate->format('Y-m-d'),
         ])->assertCreated();
 
-        // Seconde demande : 15 j → disponible = 20 − 0 − 15 = 5 → bloquée.
+        // Seconde demande : 1 jour ouvré → disponible = 1 − 0 − 1 = 0 → bloquée.
         $this->postJson('/api/v1/absences', [
             'absence_type_id' => $type->id,
-            'start_date' => now()->addDays(30)->format('Y-m-d'),
-            'end_date' => now()->addDays(44)->format('Y-m-d'),
+            'start_date' => $secondDate->format('Y-m-d'),
+            'end_date' => $secondDate->format('Y-m-d'),
         ])->assertStatus(422);
     }
 }

--- a/api/tests/Feature/Leave/LeavePendingReservationTest.php
+++ b/api/tests/Feature/Leave/LeavePendingReservationTest.php
@@ -75,7 +75,7 @@ class LeavePendingReservationTest extends TestCase
         $carry->assertExitCode(0);
 
         // Reporté = 10 − 0 − 5 = 5 (et non 10 avant #2416).
-        $carried = LeaveAccrual::query()
+        $carried = LeaveAccrual::withoutGlobalScopes()
             ->where('employee_id', $employee->id)
             ->where('leave_policy_id', $policy->id)
             ->where('type', 'carry_forward')
@@ -83,7 +83,7 @@ class LeavePendingReservationTest extends TestCase
 
         $this->assertSame(5.0, (float) $carried);
 
-        $newBalance = LeaveBalance::query()
+        $newBalance = LeaveBalance::withoutGlobalScopes()
             ->where('employee_id', $employee->id)
             ->where('absence_type_id', $type->id)
             ->where('year', now()->year)
@@ -110,7 +110,7 @@ class LeavePendingReservationTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Testing\PendingCommand::class, $carry);
         $carry->assertExitCode(0);
 
-        $carried = LeaveAccrual::query()
+        $carried = LeaveAccrual::withoutGlobalScopes()
             ->where('employee_id', $employee->id)
             ->where('leave_policy_id', $policy->id)
             ->where('type', 'carry_forward')


### PR DESCRIPTION
## Summary
- align the pending leave reservation regression fixture with the working-day contract
- keep the one-fix-at-a-time Spec Kit CHANGELOG entry

## Validation
- Targeted local execution is unavailable because the sandbox PHP runtime has no PostgreSQL PDO driver.
- GitHub Actions Backend Coverage Gate is required for PostgreSQL validation.