### PR TITLE
fix(ci/mobile): guard localisation — marker dans le core (répare CI main, progrès #5279)

### DIFF
--- a/dev-hub/tools/validate-mobile-location-readiness.ps1
+++ b/dev-hub/tools/validate-mobile-location-readiness.ps1
@@ -43,8 +43,12 @@ foreach ($app in $apps) {
     $iosPlist = Read-RepoFile "front/mobile_apps/leopardo_$app/ios/Runner/Info.plist"
     Assert-Contains $iosPlist "NSLocationWhenInUseUsageDescription" "$app Info.plist"
 
+    # #5279 (dé-duplication mobile) : attendanceLocationServiceProvider vit
+    # dans leopardo_core depuis le lot 1 — les apps le re-exportent.
+    $coreProviders = Read-RepoFile "front/mobile_apps/leopardo_core/lib/core/providers/core_providers.dart"
+    Assert-Contains $coreProviders "attendanceLocationServiceProvider" "core providers"
     $providers = Read-RepoFile "front/mobile_apps/leopardo_$app/lib/core/providers/core_providers.dart"
-    Assert-Contains $providers "attendanceLocationServiceProvider" "$app providers"
+    Assert-Contains $providers "package:leopardo_core/core/providers/core_providers.dart" "$app providers re-export"
 
     $attendanceProvider = Read-RepoFile "front/mobile_apps/leopardo_$app/lib/features/attendance/providers/attendance_provider.dart"
     Assert-Contains $attendanceProvider "currentForAttendance" "$app attendance provider"


### PR DESCRIPTION
## Fix CI main (rouge depuis le lot 1 #5370)

Le guard `validate-mobile-location-readiness.ps1` vérifiait que `attendanceLocationServiceProvider` apparaissait dans le `core_providers.dart` de chaque app. Depuis le lot 1, ce provider vit dans `leopardo_core` et les apps le re-exportent (import+export) → le marker n'apparaît plus dans les apps → **échec des runs mobile-apps-ci post-merge 21:53 et 03:59**.

**Fix** : le guard vérifie désormais le marker dans le core + la présence du re-export dans chaque app (cohérent avec l'architecture #5279).

Aucun impact runtime. `git diff --check` OK.