### PR TITLE
fix(routes): accounting.php reconstruit — débloque les checks backend (Fixes #5401)

### DIFF
--- a/api/routes/modules/accounting.php
+++ b/api/routes/modules/accounting.php
@@ -53,20 +53,15 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 't
             Route::post('/documents/{document}/credit-note', [AccountingDocumentController::class, 'creditNote'])->whereNumber('document');
         });
     });
+/**
  * Routes API du module Comptabilité — trésorerie : paiements, rapprochement,
- * relances (issue #5229) + contacts client/fournisseur (issue #5222).
- *
- * APV L.08 — Un module = un route group Laravel. Toutes les routes sont
- * exposées sous le préfixe /api/v1 (groupe porté par api.php).
+ * relances (issue #5229).
  *
  * RBAC : `api.manager:principal,comptable` — la trésorerie est réservée à la
- * direction et aux comptables (aucun accès RH/marketing) ; contacts —
- * `comptable` (CRUD complet), `principal` (lecture + paramétrage).
+ * direction et aux comptables (aucun accès RH/marketing).
  */
 
-use App\Modules\Accounting\Interfaces\Api\V1\AccountingContactController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingPaymentController;
-use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth:sanctum', 'token.refresh', 'tenant', 'api.manager:principal,comptable'])->group(function (): void {
     Route::get('accounting/payments', [AccountingPaymentController::class, 'index']);
@@ -74,17 +69,3 @@ Route::middleware(['auth:sanctum', 'token.refresh', 'tenant', 'api.manager:princ
     Route::post('accounting/payments/{payment}/reconcile', [AccountingPaymentController::class, 'reconcile']);
     Route::post('accounting/reminders/run', [AccountingPaymentController::class, 'runReminders']);
 });
-
-Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])
-    ->prefix('accounting')
-    ->group(function (): void {
-
-        // ── Contacts client/fournisseur (RBAC comptable + principal) ────────
-        Route::middleware('api.manager:comptable,principal')->group(function (): void {
-            Route::get('/contacts', [AccountingContactController::class, 'index']);
-            Route::post('/contacts', [AccountingContactController::class, 'store']);
-            Route::get('/contacts/{contact}', [AccountingContactController::class, 'show'])->whereNumber('contact');
-            Route::put('/contacts/{contact}', [AccountingContactController::class, 'update'])->whereNumber('contact');
-            Route::delete('/contacts/{contact}', [AccountingContactController::class, 'destroy'])->whereNumber('contact');
-        });
-    });


### PR DESCRIPTION
## Contexte

Fixes #5401 — **régression sur main** : `api/routes/modules/accounting.php` ne parse plus (PHP Parse error ligne 56, docblock orphelin + groupe contacts dupliqué introduits par la reconstruction `161c882e` #5229). Tout `artisan` échoue → **tous les checks backend de toutes les PR ouvertes sont rouges** (constaté sur #5394 et #5397).

## Changement (fix minimal, zéro changement de contrat)

- Bloc principal conservé tel quel : contacts + settings + rapports + documents (middlewares d'origine, `throttle` + `api.manager`).
- Routes **trésorerie #5229** conservées (`accounting/payments`, `payments/{id}/reconcile`, `reminders/run`, `documents/{id}/payments`) avec leur middleware d'origine.
- Supprimés : docblock orphelin (lignes 56-65) + groupe contacts **dupliqué** (lignes 78-90) + doublon de `use`.

## Validation

- `php -l` vert.
- `artisan route:list --path=accounting` boote : contacts, documents, settings, rapports, paiements, rapprochement, relances — routes complètes.

## Anti-collision (protocole #2400)

5 PR ouvertes touchent ce fichier (#5357/#5363/#5377/#5388/#5395). Ce fix ne réécrit **aucune route** : suppression pure de doublons. Merge rapide recommandé pour débloquer la CI.

Fixes #5401
