### PR TITLE
fix(accounting): main v2 — provider/routes enfin corrects + bugs rapprochement bancaire #5435

### DIFF
--- a/api/app/Modules/Accounting/Infrastructure/Services/BankReconciliationService.php
+++ b/api/app/Modules/Accounting/Infrastructure/Services/BankReconciliationService.php
@@ -250,10 +250,16 @@ final class BankReconciliationService
     {
         $total = $statement->lines()->count();
         $matched = $statement->matchedLines()->count();
+        // Les propositions (matching approximatif) passent aussi le relevé en
+        // `reconciling` : une action manuelle est attendue (#5435).
+        $proposed = $statement->pendingLines()
+            ->get()
+            ->filter(static fn (BankStatementLine $line): bool => isset(((array) $line->metadata)['proposed_payment_id']))
+            ->count();
 
         $status = $total > 0 && $matched === $total
             ? BankStatementStatus::Reconciled
-            : ($matched > 0 ? BankStatementStatus::Reconciling : BankStatementStatus::Imported);
+            : ($matched > 0 || $proposed > 0 ? BankStatementStatus::Reconciling : BankStatementStatus::Imported);
 
         $statement->forceFill(['status' => $status->value])->save();
     }

--- a/api/app/Modules/Accounting/Infrastructure/Services/BankStatementImportService.php
+++ b/api/app/Modules/Accounting/Infrastructure/Services/BankStatementImportService.php
@@ -287,6 +287,17 @@ final class BankStatementImportService
             return null;
         }
 
+        if (! $date instanceof Carbon) {
+            return null;
+        }
+
+        // Strict : `2026-13-99` déborde silencieusement chez Carbon (mois 13 →
+        // année suivante) — un round-trip garantit que la valeur saisie est une
+        // date réelle du calendrier (#5435, jamais vérifié par CI avant).
+        if ($date->format($this->dateFormat()) !== $value) {
+            return null;
+        }
+
         return $date;
     }
 

--- a/api/app/Modules/Accounting/Infrastructure/Services/JournalPostingService.php
+++ b/api/app/Modules/Accounting/Infrastructure/Services/JournalPostingService.php
@@ -62,6 +62,9 @@ final class JournalPostingService
         'bank_transfer' => self::ACCOUNT_BANK,
         'check' => self::ACCOUNT_BANK,
         'card' => self::ACCOUNT_BANK,
+        // #5272 (ADR-0017) — paiement en ligne : trésorerie banque.
+        'online_chargily' => self::ACCOUNT_BANK,
+        'online_stripe' => self::ACCOUNT_BANK,
         'other' => self::ACCOUNT_BANK,
     ];
 

--- a/api/app/Modules/Accounting/Infrastructure/Services/PaymentRegistrationService.php
+++ b/api/app/Modules/Accounting/Infrastructure/Services/PaymentRegistrationService.php
@@ -58,6 +58,9 @@ final class PaymentRegistrationService
         return DB::transaction(function () use ($document, $amount, $method, $reference, $receivedAt, $gatewayPaymentId): AccountingPayment {
             /** @var AccountingPayment $payment */
             $payment = AccountingPayment::create([
+                // company_id dérivé du document — indépendant du contexte
+                // tenant (API, console, tests) : jamais null (NOT NULL).
+                'company_id' => $document->company_id,
                 'document_id' => $document->id,
                 'amount' => $amount,
                 'method' => $method,

--- a/api/app/Modules/Accounting/Interfaces/Api/V1/BankStatementController.php
+++ b/api/app/Modules/Accounting/Interfaces/Api/V1/BankStatementController.php
@@ -80,8 +80,10 @@ final class BankStatementController extends Controller
     /**
      * GET /api/v1/accounting/bank-statements/{statement}
      */
-    public function show(BankStatement $statement): JsonResponse
+    public function show(Request $request, BankStatement $statement): JsonResponse
     {
+        $this->assertTenantScope($request, $statement);
+
         return response()->json([
             'data' => $this->serializeStatement($statement),
         ]);
@@ -90,8 +92,10 @@ final class BankStatementController extends Controller
     /**
      * POST /api/v1/accounting/bank-statements/{statement}/reconcile
      */
-    public function reconcile(BankStatement $statement): JsonResponse
+    public function reconcile(Request $request, BankStatement $statement): JsonResponse
     {
+        $this->assertTenantScope($request, $statement);
+
         $result = $this->reconciliationService->autoReconcile($statement);
 
         return response()->json([
@@ -102,9 +106,11 @@ final class BankStatementController extends Controller
     /**
      * POST /api/v1/accounting/bank-statement-lines/{line}/match
      */
-    public function match(BankStatementLine $line, MatchBankStatementLineRequest $request): JsonResponse
+    public function match(Request $request, BankStatementLine $line, MatchBankStatementLineRequest $matchRequest): JsonResponse
     {
-        $paymentId = $request->validated('payment_id');
+        $this->assertTenantLineScope($request, $line);
+
+        $paymentId = $matchRequest->validated('payment_id');
         /** @var AccountingPayment $payment */
         $payment = AccountingPayment::query()->findOrFail(is_numeric($paymentId) ? (int) $paymentId : 0);
 
@@ -125,8 +131,10 @@ final class BankStatementController extends Controller
     /**
      * GET /api/v1/accounting/bank-statements/{statement}/status
      */
-    public function status(BankStatement $statement): JsonResponse
+    public function status(Request $request, BankStatement $statement): JsonResponse
     {
+        $this->assertTenantScope($request, $statement);
+
         return response()->json([
             'data' => $this->reconciliationService->status($statement),
         ]);
@@ -160,5 +168,29 @@ final class BankStatementController extends Controller
                     'confidence' => $line->confidence,
                 ])->values(),
         ];
+    }
+
+    /**
+     * Garde d'isolation tenant (fail-closed #3727) : le scope global du trait
+     * BelongsToCompany ne s'applique PAS au route-model binding implicite —
+     * sans garde explicite, un relevé d'un autre tenant répondait 200
+     * (fuite cross-tenant, tests #5435).
+     */
+    private function assertTenantLineScope(Request $request, BankStatementLine $line): void
+    {
+        $companyId = $request->user()?->getAttribute('company_id');
+
+        if ($companyId !== null && (string) $line->company_id !== (string) $companyId) {
+            abort(404);
+        }
+    }
+
+    private function assertTenantScope(Request $request, BankStatement $statement): void
+    {
+        $companyId = $request->user()?->getAttribute('company_id');
+
+        if ($companyId !== null && (string) $statement->company_id !== (string) $companyId) {
+            abort(404);
+        }
     }
 }

--- a/api/app/Modules/Accounting/Providers/AccountingServiceProvider.php
+++ b/api/app/Modules/Accounting/Providers/AccountingServiceProvider.php
@@ -10,10 +10,34 @@ use App\Modules\Accounting\Domain\Contracts\DocumentNumberingInterface;
 use App\Modules\Accounting\Domain\Contracts\PdfRendererInterface;
 use App\Modules\Accounting\Infrastructure\Services\DocumentNumberingService;
 use App\Modules\Accounting\Infrastructure\Services\DocumentPdfRenderer;
+use App\Modules\Accounting\Interfaces\Console\SeedAccountingDemoCommand;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Module Comptabilité — 19ᵉ module DDD (COMPTABILITE_CONCEPTION.md §3).
+ *
+ * Les bindings de domaine sont enregistrés par les issues qui fournissent les
+ * implémentations d'infrastructure : DocumentNumberingInterface (#5223),
+ * PdfRendererInterface (#5224).
+ */
+class AccountingServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(PdfRendererInterface::class, DocumentPdfRenderer::class);
+        // #5223 — numérotation paramétrable des documents comptables.
+        $this->app->bind(
+            DocumentNumberingInterface::class,
+            DocumentNumberingService::class,
+        );
+
+        // #5224 — rendu PDF (fr + ar RTL) fourni par l'issue #5224.
         // Issue #5274 — démo exploitable en 1 clic (données vitrine, jamais réelles).
         $this->commands([
             SeedAccountingDemoCommand::class,
-        ]);    }
+        ]);
+    }
 
     public function boot(): void
     {

--- a/api/database/migrations/tenant/2026_08_25_000003_5435_create_bank_statement_tables.php
+++ b/api/database/migrations/tenant/2026_08_25_000003_5435_create_bank_statement_tables.php
@@ -52,7 +52,9 @@ return new class extends Migration
                 $table->string('external_reference', 120)->nullable();
                 $table->string('category', 60)->nullable();
                 $table->string('status', 20)->default('pending'); // pending|matched
-                $table->uuid('matched_payment_id')->nullable()->index();
+                // #5435 — FK vers accounting_payments.id (bigint) : le type doit
+                // correspondre (uuid cassait le matching, jamais vérifié par CI).
+                $table->unsignedBigInteger('matched_payment_id')->nullable()->index();
                 $table->unsignedSmallInteger('confidence')->nullable(); // score 0-100
                 $table->text('metadata')->nullable();
                 $table->timestamps();

--- a/api/lang/ar/accounting.php
+++ b/api/lang/ar/accounting.php
@@ -61,15 +61,15 @@ return [
         'amount_min' => 'يجب أن يكون المبلغ موجباً تماماً.',
         'method_invalid' => 'طريقة دفع غير صالحة (cash, bank_transfer, check, card, other).',
         'series_unknown' => 'سلسلة غير معروفة: « :key » ليست نوع مستند (:allowed).',
-    ],
-
         'bank_file_required' => 'ملف CSV مطلوب.',
         'bank_file_mimes' => 'يجب أن يكون الملف بصيغة CSV.',
-        'bank_period_required' => 'فترة الكشف مطلوبة (YYYY-MM).',
+        'bank_period_required' => 'فترة كشف الحساب مطلوبة (YYYY-MM).',
         'bank_period_format' => 'يجب أن تكون الفترة بصيغة YYYY-MM.',
         'bank_reference_required' => 'مرجع الاستيراد مطلوب.',
         'bank_payment_required' => 'الدفعة المراد مطابقتها مطلوبة.',
         'bank_payment_exists' => 'الدفعة المحددة غير موجودة.',
+    ],
+
     'errors' => [
         'gateway_checkout_failed' => 'بوابة الدفع غير متاحة مؤقتًا. يرجى المحاولة لاحقًا.',
         'payment_amount_positive' => 'يجب أن يكون مبلغ الدفع موجباً تماماً.',

--- a/api/lang/ar/errors.php
+++ b/api/lang/ar/errors.php
@@ -2,7 +2,7 @@
 
 return [
     // Auth
-        'UNKNOWN_ACCOUNT' => 'لا يوجد حساب Leopardo RH مرتبط ببريد Google هذا. اطلب دعوة من المسؤول.',
+    'UNKNOWN_ACCOUNT' => 'لا يوجد حساب Leopardo RH مرتبط ببريد Google هذا. اطلب دعوة من المسؤول.',
     'INVALID_CREDENTIALS' => 'البريد الإلكتروني أو كلمة المرور غير صحيحة.',
     'ACCOUNT_SUSPENDED' => 'تم تعليق حسابك. تواصل مع المسؤول.',
     'ACCOUNT_ARCHIVED' => 'هذا الحساب مؤرشف.',
@@ -255,8 +255,9 @@ return [
     'TWO_FACTOR_REQUIRED' => 'التحقق المزدوج إلزامي لهذا الحساب. فعّله قبل تسجيل الدخول.',
     'TWO_FACTOR_ALREADY_ENABLED' => 'التحقق المزدوج مفعّل بالفعل على هذا الحساب.',
     'TWO_FACTOR_CHALLENGE_EXPIRED' => 'انتهت جلسة التحقق المزدوج. سجّل الدخول مجددًا.',
+    'ALREADY_SEEDED' => 'تم بالفعل تحميل البيانات التجريبية.',
     'DOCUMENT_SHARE_NOT_FOUND' => 'رابط المشاركة غير موجود أو منتهي الصلاحية.',
     'DOCUMENT_PDF_NOT_READY' => 'ملف PDF للمستند غير متوفر بعد.',
     'BANK_STATEMENT_DUPLICATE_IMPORT' => 'تم استيراد هذا الكشف البنكي بالفعل لهذه الفترة.',
     'BANK_STATEMENT_LINE_ALREADY_MATCHED' => 'هذا السطر أو الدفعة مطابق بالفعل.',
-    'BANK_STATEMENT_IMPORT_FORMAT' => 'تنسيق ملف الكشف غير صالح.',];
+    'BANK_STATEMENT_IMPORT_FORMAT' => 'تنسيق ملف الكشف غير صالح.', ];

--- a/api/lang/en/accounting.php
+++ b/api/lang/en/accounting.php
@@ -61,8 +61,6 @@ return [
         'amount_min' => 'The amount must be strictly positive.',
         'method_invalid' => 'Invalid payment method (cash, bank_transfer, check, card, other).',
         'series_unknown' => 'Unknown series: « :key » is not a document type (:allowed).',
-    ],
-
         'bank_file_required' => 'The CSV file is required.',
         'bank_file_mimes' => 'The file must be CSV.',
         'bank_period_required' => 'The statement period is required (YYYY-MM).',
@@ -70,6 +68,8 @@ return [
         'bank_reference_required' => 'The import reference is required.',
         'bank_payment_required' => 'The payment to reconcile is required.',
         'bank_payment_exists' => 'The selected payment does not exist.',
+    ],
+
     'errors' => [
         'gateway_checkout_failed' => 'The payment gateway is temporarily unavailable. Please try again later.',
         'payment_amount_positive' => 'The payment amount must be strictly positive.',

--- a/api/lang/en/errors.php
+++ b/api/lang/en/errors.php
@@ -2,7 +2,7 @@
 
 return [
     // Auth
-        'UNKNOWN_ACCOUNT' => 'No Leopardo RH account is linked to this Google email. Ask your administrator for an invitation.',
+    'UNKNOWN_ACCOUNT' => 'No Leopardo RH account is linked to this Google email. Ask your administrator for an invitation.',
     'INVALID_CREDENTIALS' => 'Invalid email or password.',
     'ACCOUNT_SUSPENDED' => 'Your account has been suspended. Contact your manager.',
     'ACCOUNT_ARCHIVED' => 'This account is archived.',
@@ -258,6 +258,7 @@ return [
     'DOCUMENT_NOT_FULLY_PAID' => 'The document cannot be marked paid until the full amount is settled.',
     'INVALID_DOCUMENT_TRANSITION' => 'Status transition not allowed for this document.',
     'DOCUMENT_PDF_NOT_READY' => 'The document PDF is not ready yet.',
+    'ALREADY_SEEDED' => 'Demo data has already been seeded.',
     'DOCUMENT_SHARE_NOT_FOUND' => 'Share link not found or expired.',
     'ACCOUNTING_VAT_PERIOD_INVALID' => 'Invalid period. Use the YYYY-MM format.',
     'TWO_FACTOR_INVALID' => 'Invalid or expired two-factor authentication code.',

--- a/api/lang/fr/accounting.php
+++ b/api/lang/fr/accounting.php
@@ -65,9 +65,9 @@ return [
         'bank_file_mimes' => 'Le fichier doit être au format CSV.',
         'bank_period_required' => 'La période du relevé est requise (format AAAA-MM).',
         'bank_period_format' => 'La période doit être au format AAAA-MM.',
-        'bank_reference_required' => 'La référence d'import est requise.',
+        'bank_reference_required' => 'La référence d\'import est requise.',
         'bank_payment_required' => 'Le paiement à rapprocher est requis.',
-        'bank_payment_exists' => 'Le paiement sélectionné n'existe pas.',
+        'bank_payment_exists' => 'Le paiement sélectionné n\'existe pas.',
     ],
 
     // Erreurs métier (issue #5227)

--- a/api/lang/fr/errors.php
+++ b/api/lang/fr/errors.php
@@ -2,7 +2,7 @@
 
 return [
     // Auth
-        'UNKNOWN_ACCOUNT' => "Aucun compte Leopardo RH n\'est associé à cet email Google. Demandez une invitation à votre administrateur.",
+    'UNKNOWN_ACCOUNT' => "Aucun compte Leopardo RH n\'est associé à cet email Google. Demandez une invitation à votre administrateur.",
     'INVALID_CREDENTIALS' => 'Email ou mot de passe incorrect.',
     'ACCOUNT_SUSPENDED' => 'Votre compte a été suspendu. Contactez votre responsable.',
     'ACCOUNT_ARCHIVED' => 'Ce compte est archivé.',
@@ -252,6 +252,7 @@ return [
     'DOCUMENT_NOT_FULLY_PAID' => 'Le document ne peut pas être marqué payé tant que le montant total n\'est pas réglé.',
     'INVALID_DOCUMENT_TRANSITION' => 'Transition de statut non autorisée pour ce document.',
     'DOCUMENT_PDF_NOT_READY' => 'Le PDF du document n\'est pas encore prêt.',
+    'ALREADY_SEEDED' => 'Les données de démonstration sont déjà présentes.',
     'DOCUMENT_SHARE_NOT_FOUND' => 'Lien de partage introuvable ou expiré.',
     'ACCOUNTING_VAT_PERIOD_INVALID' => 'Période invalide. Utilisez le format AAAA-MM.',
     'TWO_FACTOR_INVALID' => 'Code de double authentification invalide ou expiré.',

--- a/api/lang/tr/accounting.php
+++ b/api/lang/tr/accounting.php
@@ -61,15 +61,15 @@ return [
         'amount_min' => 'Tutar kesinlikle pozitif olmalıdır.',
         'method_invalid' => 'Geçersiz ödeme yöntemi (cash, bank_transfer, check, card, other).',
         'series_unknown' => 'Bilinmeyen seri: « :key » bir belge türü değil (:allowed).',
-    ],
-
         'bank_file_required' => 'CSV dosyası zorunludur.',
         'bank_file_mimes' => 'Dosya CSV formatında olmalıdır.',
-        'bank_period_required' => 'Dönem zorunludur (YYYY-MM).',
-        'bank_period_format' => 'Dönem YYYY-MM formatında olmalıdır.',
+        'bank_period_required' => 'Hesap dönemi zorunludur (YYYY-AA).',
+        'bank_period_format' => 'Dönem YYYY-AA formatında olmalıdır.',
         'bank_reference_required' => 'İçe aktarma referansı zorunludur.',
-        'bank_payment_required' => 'Eşleştirilecek ödeme zorunludur.',
-        'bank_payment_exists' => 'Seçilen ödeme mevcut değil.',
+        'bank_payment_required' => 'Mutabakatı yapılacak ödeme zorunludur.',
+        'bank_payment_exists' => 'Seçilen ödeme bulunamadı.',
+    ],
+
     'errors' => [
         'gateway_checkout_failed' => 'Ödeme sağlayıcısı geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin.',
         'payment_amount_positive' => 'Ödeme tutarı kesinlikle pozitif olmalıdır.',

--- a/api/lang/tr/errors.php
+++ b/api/lang/tr/errors.php
@@ -2,7 +2,7 @@
 
 return [
     // Auth
-        'UNKNOWN_ACCOUNT' => 'Bu Google e-postasıyla ilişkili bir Leopardo RH hesabı yok. Yöneticinizden davet isteyin.',
+    'UNKNOWN_ACCOUNT' => 'Bu Google e-postasıyla ilişkili bir Leopardo RH hesabı yok. Yöneticinizden davet isteyin.',
     'INVALID_CREDENTIALS' => 'E-posta veya şifre hatalı.',
     'ACCOUNT_SUSPENDED' => 'Hesabınız askıya alındı. Yöneticinizle iletişime geçin.',
     'ACCOUNT_ARCHIVED' => 'Bu hesap arşivlenmiş.',
@@ -251,6 +251,7 @@ return [
     'DOCUMENT_NOT_FULLY_PAID' => 'Toplam tutar ödenmeden belge ödendi olarak işaretlenemez.',
     'INVALID_DOCUMENT_TRANSITION' => 'Bu belge için durum geçişine izin verilmiyor.',
     'DOCUMENT_PDF_NOT_READY' => 'Belgenin PDF\'i henüz hazır değil.',
+    'ALREADY_SEEDED' => 'Demo verileri zaten yüklendi.',
     'DOCUMENT_SHARE_NOT_FOUND' => 'Paylaşım bağlantısı bulunamadı veya süresi doldu.',
     'ACCOUNTING_VAT_PERIOD_INVALID' => 'Geçersiz dönem. AAAA-AA biçimini kullanın.',
     'TWO_FACTOR_INVALID' => 'Geçersiz veya süresi dolmuş iki faktörlü doğrulama kodu.',

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -20343,286 +20343,127 @@ paths:
           description: "Entretien supprimé"
         "401":
           $ref: "#/components/responses/Error401"
-  /smart-attendance/mode-settings:
+  /accounting/activation:
     get:
-      tags: ["SmartAttendance"]
-      summary: "Parametres du mode de pointage de l'entreprise"
-      deprecated: true
+      tags: ["Accounting"]
+      summary: "Etat d'activation du module Comptabilite (check-list du wizard)"
+      description: |
+        Retourne la check-list d'activation du tenant courant : parametrage
+        complet, contact de demonstration cree, facture d'exemple creee.
+        Lecture seule, aucune ecriture. Idempotent.
       responses:
         "200":
-          description: "Configuration (forced_mode, punch_photo_mode, gps_enabled, latitude, longitude, radius_meters, allow_employee_override)"
-        "401":
-          $ref: "#/components/responses/Error401"
-    put:
-      tags: ["SmartAttendance"]
-      summary: "Configurer le mode de pointage (principal)"
-      deprecated: true
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                forced_mode:
-                  type: string
-                  enum: [gps_auto, qr, manual, mixed]
-                punch_photo_mode:
-                  type: string
-                  enum: [kiosk, photo_required]
-                gps_enabled:
-                  type: boolean
-                latitude:
-                  type: number
-                  minimum: -90
-                  maximum: 90
-                longitude:
-                  type: number
-                  minimum: -180
-                  maximum: 180
-                radius_meters:
-                  type: integer
-                  minimum: 10
-                  maximum: 5000
-                allow_employee_override:
-                  type: boolean
-      responses:
-        "200":
-          description: "Configuration mise a jour"
-        "401":
-          $ref: "#/components/responses/Error401"
-  /smart-attendance/config:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Lire la configuration de mode active pour l'employe connecte"
-      deprecated: true
-      description: "Resout le mode de pointage effectif (GPS/QR/manuel) et indique si une photo de pointage est obligatoire (punch_photo_mode=photo_required)."
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Configuration de mode active"
+          description: "Etat d'activation (etapes + apercus contact/facture)"
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   data:
-                    type: object
-                    properties:
-                      mode: { type: string, enum: [manual, gps_auto, qr, mixed] }
-                      can_override: { type: boolean }
-                      gps_enabled: { type: boolean }
-                      geofence:
-                        type: object
-                        nullable: true
-                        properties:
-                          latitude: { type: number, nullable: true }
-                          longitude: { type: number, nullable: true }
-                          radius_meters: { type: integer, nullable: true }
-                      requires_consent: { type: boolean }
-                      requires_punch_photo:
-                        type: boolean
-                        description: "true si l'entreprise impose une photo a chaque pointage mobile (arrivee/depart)."
-        "401":
-          $ref: "#/components/responses/Error401"
-  /smart-attendance/preferences:
-    put:
-      tags: ["SmartAttendance"]
-      summary: "Mettre à jour les préférences de pointage"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [preferred_mode]
-              properties:
-                preferred_mode:
-                  type: string
-                  enum: [gps_auto, qr, manual]
-                gps_consent_given:
-                  type: boolean
-                revoke_consent:
-                  type: boolean
-      responses:
-        "200":
-          description: "Préférences mises à jour"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                  data:
-                    $ref: "#/components/schemas/EmployeeAttendancePreference"
+                    $ref: "#/components/schemas/AccountingActivation"
         "403":
-          $ref: "#/components/responses/Error403"
-        "422":
-          $ref: "#/components/responses/Validation422"
-  /smart-attendance/geo-events:
+          $ref: "#/components/responses/Error401"
     post:
-      tags: ["SmartAttendance"]
-      summary: "Envoyer un événement géographique (entrée/sortie de zone)"
-      deprecated: true
-      security:
-        - BearerAuth: []
+      tags: ["Accounting"]
+      summary: "Executer l'activation guidee du module Comptabilite (wizard)"
+      description: |
+        Idempotent : persiste le parametrage (defauts pays si champ absent),
+        cree un contact de demonstration et une facture d'exemple jetable
+        (marquee EXEMPLE, statut brouillon) si absents. Un second appel ne
+        cree jamais de doublon. Payload identique a PUT /accounting/settings
+        (champs optionnels).
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GeoEventRequest"
+              $ref: "#/components/schemas/AccountingSettingsPayload"
       responses:
         "200":
-          description: "Événement enregistré"
+          description: "Activation executee (etat final)"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AccountingActivation"
         "422":
           $ref: "#/components/responses/Validation422"
-  /smart-attendance/sessions:
+        "403":
+          $ref: "#/components/responses/Error401"
+
+  /accounting/dashboard:
     get:
-      tags: ["SmartAttendance"]
-      summary: "Lister les sessions GPS"
-      deprecated: true
-      security:
-        - BearerAuth: []
+      tags: ["Accounting"]
+      summary: "Tableau de bord comptable — factures emises, encaissements, impayes, depenses"
+      description: |
+        Synthese de pilotage du tenant courant (issue #5230) : factures emises
+        (ventes, hors brouillons/annules), encaissements (paiements recus),
+        impayes (aging par retard d'echeance 0-30/31-60/61-90/90+ jours) et
+        depenses fournisseurs (documents lies a un contact fournisseur).
+        Periode par defaut : mois courant. Lecture seule.
       parameters:
-        - name: status
+        - name: from
           in: query
+          description: "Debut de periode (YYYY-MM-DD)."
           schema:
             type: string
-            enum: [detected, pending_validation, approved, rejected, cancelled]
-        - name: per_page
+            format: date
+        - name: to
           in: query
+          description: "Fin de periode (YYYY-MM-DD)."
           schema:
-            type: integer
-            default: 20
+            type: string
+            format: date
       responses:
         "200":
-          description: "Liste paginée des sessions GPS"
+          description: "Synthese du tableau de bord"
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   data:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/GeoAttendanceSession"
-  /smart-attendance/sessions/{id}:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Détail d'une session GPS"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: "Session GPS"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: "#/components/schemas/GeoAttendanceSession"
-        "404":
-          $ref: "#/components/responses/Error404"
-  /smart-attendance/sessions/{id}/approve:
-    post:
-      tags: ["SmartAttendance"]
-      summary: "Approuver une session GPS (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: "Session mise à jour"
-        "401":
+                    $ref: "#/components/schemas/AccountingDashboard"
+        "422":
+          $ref: "#/components/responses/Validation422"
+        "403":
           $ref: "#/components/responses/Error401"
-        "404":
-          $ref: "#/components/responses/Error404"
-  /smart-attendance/sessions/{id}/reject:
-    post:
-      tags: ["SmartAttendance"]
-      summary: "Rejeter une session GPS (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: "Session mise à jour"
-        "401":
-          $ref: "#/components/responses/Error401"
-        "404":
-          $ref: "#/components/responses/Error404"
-  /smart-attendance/dashboard:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Statistiques du jour — Smart Attendance (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Statistiques du jour"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SmartAttendanceDashboard"
 
-  # --- ZKTeco (pointeuses biometriques) ---
-  /smart-attendance/my-sessions:
+  /accounting/dashboard/export:
     get:
-      tags: ["SmartAttendance"]
-      summary: "Sessions GPS de l'employé courant"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Sessions de l'employé"
-        "401":
-          $ref: "#/components/responses/Error401"
-  /smart-attendance/employees/{employeeId}/preference:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Préférence mode géolocalisation d'un employé (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
+      tags: ["Accounting"]
+      summary: "Export CSV de la liste des impayes"
+      description: |
+        Export CSV (UTF-8) de la liste des impayes du tenant courant (issue
+        #5230) : numero, contact, dates, retard, total TTC, paye, reste du,
+        statut. Fichier : accounting-dashboard-outstanding-<from>_<to>.csv.
       parameters:
-        - name: employeeId
-          in: path
-          required: true
+        - name: from
+          in: query
+          description: "Debut de periode (YYYY-MM-DD)."
           schema:
-            type: integer
+            type: string
+            format: date
+        - name: to
+          in: query
+          description: "Fin de periode (YYYY-MM-DD)."
+          schema:
+            type: string
+            format: date
       responses:
         "200":
-          description: "Préférence de l'employé"
-        "401":
+          description: "Fichier CSV (text/csv)"
+          content:
+            text/csv:
+              schema:
+                type: string
+        "422":
+          $ref: "#/components/responses/Validation422"
+        "403":
           $ref: "#/components/responses/Error401"
+
   /accounting/journal:
     get:
       tags: ["Accounting"]
@@ -20743,75 +20584,6 @@ paths:
         "422":
           description: "Periode cloturee (PERIOD_CLOSED) — aucun posting possible."
 components:
-
-  TwoFactorStatusResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          enabled:
-            type: boolean
-          mfa_required:
-            type: boolean
-
-  TwoFactorEnrollResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          secret:
-            type: string
-          qr_url:
-            type: string
-
-  TwoFactorConfirmResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          recovery_codes:
-            type: array
-            items:
-              type: string
-
-  TwoFactorVerifyRequest:
-    type: object
-    required: [challenge_token]
-    properties:
-      challenge_token:
-        type: string
-      code:
-        type: string
-        description: "Code TOTP (ou recovery_code)"
-      recovery_code:
-        type: string
-      device_name:
-        type: string
-        nullable: true
-      remember_device:
-        type: boolean
-
-  TwoFactorVerifyResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          id:
-            type: integer
-          email:
-            type: string
-      token:
-        type: string
-      token_type:
-        type: string
-      token_expires_at:
-        type: string
-        nullable: true
-
   securitySchemes:
     BearerAuth:
       type: http
@@ -20967,6 +20739,8 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    Error409:
+      description: "Conflit (ex. import duplique)"
     Error422:
       description: "Erreur de validation"
       content:
@@ -20981,6 +20755,74 @@ components:
             $ref: "#/components/schemas/ValidationErrorResponse"
 
   schemas:
+    TwoFactorStatusResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            mfa_required:
+              type: boolean
+
+    TwoFactorEnrollResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            secret:
+              type: string
+            qr_url:
+              type: string
+
+    TwoFactorConfirmResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            recovery_codes:
+              type: array
+              items:
+                type: string
+
+    TwoFactorVerifyRequest:
+      type: object
+      required: [challenge_token]
+      properties:
+        challenge_token:
+          type: string
+        code:
+          type: string
+          description: "Code TOTP (ou recovery_code)"
+        recovery_code:
+          type: string
+        device_name:
+          type: string
+          nullable: true
+        remember_device:
+          type: boolean
+
+    TwoFactorVerifyResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: integer
+            email:
+              type: string
+        token:
+          type: string
+        token_type:
+          type: string
+        token_expires_at:
+          type: string
+          nullable: true
+
     # ── Attendance schemas (v4.18.0) ──
     AttendanceModeSettings:
       type: object
@@ -24255,6 +24097,152 @@ components:
           type: string
           maxLength: 500
 
+    AccountingDashboard:
+      type: object
+      description: "Synthese du tableau de bord comptable (issue #5230)."
+      properties:
+        period:
+          type: object
+          properties:
+            from:
+              type: string
+              format: date
+            to:
+              type: string
+              format: date
+        invoices:
+          type: object
+          description: "Factures emises (ventes, hors brouillons/annules) sur la periode."
+          properties:
+            count:
+              type: integer
+            total_ttc:
+              type: number
+              nullable: true
+        collections:
+          type: object
+          description: "Encaissements (paiements recus) sur la periode."
+          properties:
+            count:
+              type: integer
+            total:
+              type: number
+              nullable: true
+        expenses:
+          type: object
+          description: "Depenses fournisseurs (documents lies a un contact fournisseur) sur la periode."
+          properties:
+            count:
+              type: integer
+            total_ttc:
+              type: number
+              nullable: true
+        outstanding:
+          type: object
+          description: "Impayes : documents emis non soldes + aging par retard d'echeance."
+          properties:
+            count:
+              type: integer
+            total_due:
+              type: number
+            aging:
+              type: array
+              description: "Buckets 0_30 / 31_60 / 61_90 / 90_plus (documents en retard)."
+              items:
+                type: object
+                properties:
+                  bucket:
+                    type: string
+                  count:
+                    type: integer
+                  total_due:
+                    type: number
+            list:
+              type: array
+              description: "100 impayes les plus anciens (tri echeance ASC)."
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  number:
+                    type: string
+                  contact:
+                    type: string
+                  issue_date:
+                    type: string
+                    format: date
+                    nullable: true
+                  due_date:
+                    type: string
+                    format: date
+                    nullable: true
+                  days_late:
+                    type: integer
+                  total_ttc:
+                    type: number
+                  paid_amount:
+                    type: number
+                  due_amount:
+                    type: number
+                  status:
+                    type: string
+
+    AccountingActivation:
+      type: object
+      description: "Etat d'activation du module Comptabilite (issue #5288) — check-list du wizard."
+      properties:
+        completed:
+          type: boolean
+          description: "true quand les trois etapes sont satisfaites."
+        steps:
+          type: object
+          properties:
+            settings:
+              type: boolean
+              description: "Parametrage comptable persiste et complet."
+            contact:
+              type: boolean
+              description: "Contact de demonstration present (metadata.is_sample)."
+            example_invoice:
+              type: boolean
+              description: "Facture d'exemple presente (metadata.is_example)."
+        contact:
+          type: object
+          nullable: true
+          description: "Apercu du contact de demonstration, ou null."
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            email:
+              type: string
+              nullable: true
+            type:
+              type: string
+        example_invoice:
+          type: object
+          nullable: true
+          description: "Apercu de la facture d'exemple, ou null."
+          properties:
+            id:
+              type: integer
+            number:
+              type: string
+            status:
+              type: string
+            total_ttc:
+              type: number
+              nullable: true
+            currency:
+              type: string
+              nullable: true
+            issue_date:
+              type: string
+              format: date
+              nullable: true
+
     AccountingContact:
       type: object
       properties:
@@ -24438,6 +24426,24 @@ components:
             type: string
 
     AccountingCheckout:
+      type: object
+      description: "Session de paiement en ligne creee (issue #5272)."
+      required:
+        - checkout_url
+        - expires_at
+        - gateway
+      properties:
+        checkout_url:
+          type: string
+          format: uri
+          description: "URL de paiement hebergee par la passerelle (Chargily / Stripe)."
+        expires_at:
+          type: string
+          format: date-time
+          description: "Expiration de la session de paiement."
+        gateway:
+          type: string
+          enum: [chargily, stripe]
     BankStatementLine:
       type: object
       description: "Ligne de relevé bancaire (issue #5435)."
@@ -24466,24 +24472,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BankStatementLine"
-      type: object
-      description: "Session de paiement en ligne creee (issue #5272)."
-      required:
-        - checkout_url
-        - expires_at
-        - gateway
-      properties:
-        checkout_url:
-          type: string
-          format: uri
-          description: "URL de paiement hebergee par la passerelle (Chargily / Stripe)."
-        expires_at:
-          type: string
-          format: date-time
-          description: "Expiration de la session de paiement."
-        gateway:
-          type: string
-          enum: [chargily, stripe]
 
     AccountingCheckoutPayload:
       type: object
@@ -24497,6 +24485,7 @@ components:
           type: string
           format: uri
           nullable: true
+
 
     VatDeclaration:
       type: object

--- a/api/routes/modules/accounting.php
+++ b/api/routes/modules/accounting.php
@@ -3,31 +3,50 @@
 declare(strict_types=1);
 
 /**
- * Routes Module Comptabilité — issue #5222 (CRUD contacts) et #5223 (documents).
+ * Routes Module Comptabilité — #5222 contacts, #5223 documents, #5225
+ * partages publics, #5229 trésorerie, #5232 settings, #5234 journal,
+ * #5230 tableaux de bord, #5270 multi-devises, #5271 TVA, #5272 checkout,
+ * #5273 audit trail, #5288 activation guidée (wizard), #5435 rapprochement
+ * bancaire.
  *
- * RBAC (matrice comptabilité) : contacts client/fournisseur —
- * `comptable` (CRUD complet), `principal` (lecture + paramétrage) ;
- * documents (Phase A, #5223) — `principal`/`comptable`.
- * Toutes les routes exigent un employé manager du tenant courant
- * (middleware api.manager) ; l'isolation tenant est portée par le trait
- * BelongsToCompany (scope global fail-closed #3727).
+ * RBAC (matrice comptabilité, COMPTABILITE_CONCEPTION.md §5) :
+ *  - contacts/settings/TVA/convert/dashboard/activation : `comptable` (CRUD) +
+ *    `principal` (lecture + paramétrage) ;
+ *  - documents + journal + audit : `principal`/`comptable` ;
+ *  - trésorerie + rapprochement bancaire : `principal`/`comptable`.
+ * Toutes les routes exigent un employé manager du tenant courant (middleware
+ * api.manager) ; l'isolation tenant est portée par le trait BelongsToCompany
+ * (scope global fail-closed #3727).
  */
 
+use App\Modules\Accounting\Interfaces\Api\V1\AccountingActivationController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingAuditController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingCheckoutController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingContactController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingCurrencyController;
+use App\Modules\Accounting\Interfaces\Api\V1\AccountingDashboardController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingDocumentController;
+use App\Modules\Accounting\Interfaces\Api\V1\AccountingJournalController;
+use App\Modules\Accounting\Interfaces\Api\V1\AccountingPaymentController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingReportController;
 use App\Modules\Accounting\Interfaces\Api\V1\AccountingSettingsController;
+use App\Modules\Accounting\Interfaces\Api\V1\BankStatementController;
 use App\Modules\Accounting\Interfaces\Api\V1\PublicDocumentShareController;
 use Illuminate\Support\Facades\Route;
+
+// Public: consultation + téléchargement d'un document partagé (token + throttle).
+// Issue #5225 — le token de partage est la credential (pas d'auth Sanctum),
+// accès RGPD limité au document partagé (pattern CabinetShare #1817).
+Route::get('/accounting/documents/shared/{token}', [PublicDocumentShareController::class, 'info'])
+    ->middleware('throttle:60,1');
+Route::get('/accounting/documents/shared/{token}/download', [PublicDocumentShareController::class, 'download'])
+    ->middleware('throttle:60,1');
 
 Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])
     ->prefix('accounting')
     ->group(function (): void {
 
-        // ── Contacts client/fournisseur (RBAC comptable + principal) ────────
+        // ── Contacts / settings / TVA / convert / activation / dashboard ────
         Route::middleware('api.manager:comptable,principal')->group(function (): void {
             Route::get('/contacts', [AccountingContactController::class, 'index']);
             Route::post('/contacts', [AccountingContactController::class, 'store']);
@@ -35,15 +54,28 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 't
             Route::put('/contacts/{contact}', [AccountingContactController::class, 'update'])->whereNumber('contact');
             Route::delete('/contacts/{contact}', [AccountingContactController::class, 'destroy'])->whereNumber('contact');
 
-            // ── Paramétrage comptable (issue #5232) — une ligne par entreprise
-            // GET  : settings persistés ou défauts pays (CountryDefaults) ;
-            // PUT  : upsert avec validation (devise, TVA, séries, mentions).
+            // Paramétrage comptable (issue #5232) — une ligne par entreprise.
             Route::get('/settings', [AccountingSettingsController::class, 'show']);
             Route::put('/settings', [AccountingSettingsController::class, 'update']);
 
+            // Déclaration TVA par période (issue #5271).
+            Route::get('/reports/vat-declaration', [AccountingReportController::class, 'vatDeclaration']);
+
+            // Conversion multi-devises (issue #5270) — calcul pur, aucun état
+            // persistant : HT/TVA/TTC entre devise de document et devise de
+            // référence. Taux manuel requis dès que les devises diffèrent.
+            Route::post('/currency/convert', [AccountingCurrencyController::class, 'convert']);
+
+            // Activation guidée du module (issue #5288) — wizard comptable/principal.
+            Route::get('/activation', [AccountingActivationController::class, 'show']);
+            Route::post('/activation', [AccountingActivationController::class, 'complete']);
+
+            // Tableaux de bord comptables (issue #5230) — rapports manager/comptable.
+            Route::get('/dashboard', [AccountingDashboardController::class, 'show']);
+            Route::get('/dashboard/export', [AccountingDashboardController::class, 'export']);
         });
 
-        // ── Documents (Phase A, #5223) — RBAC principal/comptable ───────────
+        // ── Documents (Phase A, #5223) + audit trail (#5273) ───────────────
         Route::middleware('api.manager:principal,comptable')->group(function (): void {
             Route::get('/documents', [AccountingDocumentController::class, 'index']);
             Route::post('/documents', [AccountingDocumentController::class, 'store']);
@@ -59,51 +91,29 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 't
             // #5273 — audit trail du module (qui/quoi/quand) — RBAC principal/comptable.
             Route::get('/audit-logs', [AccountingAuditController::class, 'index']);
         });
-<<<<<<< HEAD
-=======
 
+        // ── Journal des écritures (issue #5234) — débit/crédit + clôture ────
+        Route::middleware('api.manager:principal,comptable')->group(function (): void {
+            Route::get('/journal', [AccountingJournalController::class, 'index']);
+            Route::get('/journal/export.csv', [AccountingJournalController::class, 'export']);
+            Route::post('/journal/periods/{period}/close', [AccountingJournalController::class, 'closePeriod']);
+            Route::post('/documents/{document}/journal', [AccountingJournalController::class, 'postDocument'])->whereNumber('document');
+        });
 
-            // ── Rapports (issue #5271) — déclaration TVA par période.
-            Route::get('/reports/vat-declaration', [AccountingReportController::class, 'vatDeclaration']);
+        // ── Trésorerie (issue #5229) + rapprochement bancaire (#5435) ───────
+        Route::middleware('api.manager:principal,comptable')->group(function (): void {
+            Route::get('/payments', [AccountingPaymentController::class, 'index']);
+            Route::post('/documents/{document}/payments', [AccountingPaymentController::class, 'store'])->whereNumber('document');
+            Route::post('/payments/{payment}/reconcile', [AccountingPaymentController::class, 'reconcile'])->whereNumber('payment');
+            Route::post('/reminders/run', [AccountingPaymentController::class, 'runReminders']);
 
-            // ── Conversion multi-devises (issue #5270) — calcul pur, aucun
-            // état persistant : HT/TVA/TTC entre devise de document et devise
-            // de référence. Taux manuel requis dès que les devises diffèrent.
-            Route::post('/currency/convert', [AccountingCurrencyController::class, 'convert']);
-
->>>>>>> origin/main
+            // #5435 — rapprochement bancaire Phase D : import de relevé, matching
+            // auto/manuel, état. Même RBAC que la trésorerie (comptable/principal).
+            Route::get('/bank-statements', [BankStatementController::class, 'index']);
+            Route::post('/bank-statements/import', [BankStatementController::class, 'import']);
+            Route::get('/bank-statements/{statement}', [BankStatementController::class, 'show']);
+            Route::post('/bank-statements/{statement}/reconcile', [BankStatementController::class, 'reconcile']);
+            Route::get('/bank-statements/{statement}/status', [BankStatementController::class, 'status']);
+            Route::post('/bank-statement-lines/{line}/match', [BankStatementController::class, 'match']);
+        });
     });
-/**
- * Routes API du module Comptabilité — trésorerie : paiements, rapprochement,
- * relances (issue #5229).
- *
- * RBAC : `api.manager:principal,comptable` — la trésorerie est réservée à la
- * direction et aux comptables (aucun accès RH/marketing).
- */
-
-use App\Modules\Accounting\Interfaces\Api\V1\AccountingPaymentController;
-<<<<<<< HEAD
-=======
-use App\Modules\Accounting\Interfaces\Api\V1\BankStatementController;
->>>>>>> origin/main
-
-Route::middleware(['auth:sanctum', 'token.refresh', 'tenant', 'api.manager:principal,comptable'])->group(function (): void {
-    Route::get('accounting/payments', [AccountingPaymentController::class, 'index']);
-    Route::post('accounting/documents/{document}/payments', [AccountingPaymentController::class, 'store']);
-    Route::post('accounting/payments/{payment}/reconcile', [AccountingPaymentController::class, 'reconcile']);
-    Route::post('accounting/reminders/run', [AccountingPaymentController::class, 'runReminders']);
-<<<<<<< HEAD
-});
-=======
-    // #5435 — rapprochement bancaire Phase D : import de relevé, matching
-    // auto/manuel, état. Même RBAC que la trésorerie (comptable/principal).
-    Route::get('accounting/bank-statements', [BankStatementController::class, 'index']);
-    Route::post('accounting/bank-statements/import', [BankStatementController::class, 'import']);
-    Route::get('accounting/bank-statements/{statement}', [BankStatementController::class, 'show']);
-    Route::post('accounting/bank-statements/{statement}/reconcile', [BankStatementController::class, 'reconcile']);
-    Route::get('accounting/bank-statements/{statement}/status', [BankStatementController::class, 'status']);
-    Route::post('accounting/bank-statement-lines/{line}/match', [BankStatementController::class, 'match']);
-});
-
-
->>>>>>> origin/main

--- a/dev-hub/openapi/v1.yaml
+++ b/dev-hub/openapi/v1.yaml
@@ -20354,286 +20354,127 @@ paths:
           description: "Entretien supprimé"
         "401":
           $ref: "#/components/responses/Error401"
-  /smart-attendance/mode-settings:
+  /accounting/activation:
     get:
-      tags: ["SmartAttendance"]
-      summary: "Parametres du mode de pointage de l'entreprise"
-      deprecated: true
+      tags: ["Accounting"]
+      summary: "Etat d'activation du module Comptabilite (check-list du wizard)"
+      description: |
+        Retourne la check-list d'activation du tenant courant : parametrage
+        complet, contact de demonstration cree, facture d'exemple creee.
+        Lecture seule, aucune ecriture. Idempotent.
       responses:
         "200":
-          description: "Configuration (forced_mode, punch_photo_mode, gps_enabled, latitude, longitude, radius_meters, allow_employee_override)"
-        "401":
-          $ref: "#/components/responses/Error401"
-    put:
-      tags: ["SmartAttendance"]
-      summary: "Configurer le mode de pointage (principal)"
-      deprecated: true
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                forced_mode:
-                  type: string
-                  enum: [gps_auto, qr, manual, mixed]
-                punch_photo_mode:
-                  type: string
-                  enum: [kiosk, photo_required]
-                gps_enabled:
-                  type: boolean
-                latitude:
-                  type: number
-                  minimum: -90
-                  maximum: 90
-                longitude:
-                  type: number
-                  minimum: -180
-                  maximum: 180
-                radius_meters:
-                  type: integer
-                  minimum: 10
-                  maximum: 5000
-                allow_employee_override:
-                  type: boolean
-      responses:
-        "200":
-          description: "Configuration mise a jour"
-        "401":
-          $ref: "#/components/responses/Error401"
-  /smart-attendance/config:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Lire la configuration de mode active pour l'employe connecte"
-      deprecated: true
-      description: "Resout le mode de pointage effectif (GPS/QR/manuel) et indique si une photo de pointage est obligatoire (punch_photo_mode=photo_required)."
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Configuration de mode active"
+          description: "Etat d'activation (etapes + apercus contact/facture)"
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   data:
-                    type: object
-                    properties:
-                      mode: { type: string, enum: [manual, gps_auto, qr, mixed] }
-                      can_override: { type: boolean }
-                      gps_enabled: { type: boolean }
-                      geofence:
-                        type: object
-                        nullable: true
-                        properties:
-                          latitude: { type: number, nullable: true }
-                          longitude: { type: number, nullable: true }
-                          radius_meters: { type: integer, nullable: true }
-                      requires_consent: { type: boolean }
-                      requires_punch_photo:
-                        type: boolean
-                        description: "true si l'entreprise impose une photo a chaque pointage mobile (arrivee/depart)."
-        "401":
-          $ref: "#/components/responses/Error401"
-  /smart-attendance/preferences:
-    put:
-      tags: ["SmartAttendance"]
-      summary: "Mettre à jour les préférences de pointage"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [preferred_mode]
-              properties:
-                preferred_mode:
-                  type: string
-                  enum: [gps_auto, qr, manual]
-                gps_consent_given:
-                  type: boolean
-                revoke_consent:
-                  type: boolean
-      responses:
-        "200":
-          description: "Préférences mises à jour"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                  data:
-                    $ref: "#/components/schemas/EmployeeAttendancePreference"
+                    $ref: "#/components/schemas/AccountingActivation"
         "403":
-          $ref: "#/components/responses/Error403"
-        "422":
-          $ref: "#/components/responses/Validation422"
-  /smart-attendance/geo-events:
+          $ref: "#/components/responses/Error401"
     post:
-      tags: ["SmartAttendance"]
-      summary: "Envoyer un événement géographique (entrée/sortie de zone)"
-      deprecated: true
-      security:
-        - BearerAuth: []
+      tags: ["Accounting"]
+      summary: "Executer l'activation guidee du module Comptabilite (wizard)"
+      description: |
+        Idempotent : persiste le parametrage (defauts pays si champ absent),
+        cree un contact de demonstration et une facture d'exemple jetable
+        (marquee EXEMPLE, statut brouillon) si absents. Un second appel ne
+        cree jamais de doublon. Payload identique a PUT /accounting/settings
+        (champs optionnels).
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GeoEventRequest"
+              $ref: "#/components/schemas/AccountingSettingsPayload"
       responses:
         "200":
-          description: "Événement enregistré"
+          description: "Activation executee (etat final)"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AccountingActivation"
         "422":
           $ref: "#/components/responses/Validation422"
-  /smart-attendance/sessions:
+        "403":
+          $ref: "#/components/responses/Error401"
+
+  /accounting/dashboard:
     get:
-      tags: ["SmartAttendance"]
-      summary: "Lister les sessions GPS"
-      deprecated: true
-      security:
-        - BearerAuth: []
+      tags: ["Accounting"]
+      summary: "Tableau de bord comptable — factures emises, encaissements, impayes, depenses"
+      description: |
+        Synthese de pilotage du tenant courant (issue #5230) : factures emises
+        (ventes, hors brouillons/annules), encaissements (paiements recus),
+        impayes (aging par retard d'echeance 0-30/31-60/61-90/90+ jours) et
+        depenses fournisseurs (documents lies a un contact fournisseur).
+        Periode par defaut : mois courant. Lecture seule.
       parameters:
-        - name: status
+        - name: from
           in: query
+          description: "Debut de periode (YYYY-MM-DD)."
           schema:
             type: string
-            enum: [detected, pending_validation, approved, rejected, cancelled]
-        - name: per_page
+            format: date
+        - name: to
           in: query
+          description: "Fin de periode (YYYY-MM-DD)."
           schema:
-            type: integer
-            default: 20
+            type: string
+            format: date
       responses:
         "200":
-          description: "Liste paginée des sessions GPS"
+          description: "Synthese du tableau de bord"
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   data:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/GeoAttendanceSession"
-  /smart-attendance/sessions/{id}:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Détail d'une session GPS"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: "Session GPS"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: "#/components/schemas/GeoAttendanceSession"
-        "404":
-          $ref: "#/components/responses/Error404"
-  /smart-attendance/sessions/{id}/approve:
-    post:
-      tags: ["SmartAttendance"]
-      summary: "Approuver une session GPS (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: "Session mise à jour"
-        "401":
+                    $ref: "#/components/schemas/AccountingDashboard"
+        "422":
+          $ref: "#/components/responses/Validation422"
+        "403":
           $ref: "#/components/responses/Error401"
-        "404":
-          $ref: "#/components/responses/Error404"
-  /smart-attendance/sessions/{id}/reject:
-    post:
-      tags: ["SmartAttendance"]
-      summary: "Rejeter une session GPS (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: "Session mise à jour"
-        "401":
-          $ref: "#/components/responses/Error401"
-        "404":
-          $ref: "#/components/responses/Error404"
-  /smart-attendance/dashboard:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Statistiques du jour — Smart Attendance (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Statistiques du jour"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SmartAttendanceDashboard"
 
-  # --- ZKTeco (pointeuses biometriques) ---
-  /smart-attendance/my-sessions:
+  /accounting/dashboard/export:
     get:
-      tags: ["SmartAttendance"]
-      summary: "Sessions GPS de l'employé courant"
-      deprecated: true
-      security:
-        - BearerAuth: []
-      responses:
-        "200":
-          description: "Sessions de l'employé"
-        "401":
-          $ref: "#/components/responses/Error401"
-  /smart-attendance/employees/{employeeId}/preference:
-    get:
-      tags: ["SmartAttendance"]
-      summary: "Préférence mode géolocalisation d'un employé (manager/RH)"
-      deprecated: true
-      security:
-        - BearerAuth: []
+      tags: ["Accounting"]
+      summary: "Export CSV de la liste des impayes"
+      description: |
+        Export CSV (UTF-8) de la liste des impayes du tenant courant (issue
+        #5230) : numero, contact, dates, retard, total TTC, paye, reste du,
+        statut. Fichier : accounting-dashboard-outstanding-<from>_<to>.csv.
       parameters:
-        - name: employeeId
-          in: path
-          required: true
+        - name: from
+          in: query
+          description: "Debut de periode (YYYY-MM-DD)."
           schema:
-            type: integer
+            type: string
+            format: date
+        - name: to
+          in: query
+          description: "Fin de periode (YYYY-MM-DD)."
+          schema:
+            type: string
+            format: date
       responses:
         "200":
-          description: "Préférence de l'employé"
-        "401":
+          description: "Fichier CSV (text/csv)"
+          content:
+            text/csv:
+              schema:
+                type: string
+        "422":
+          $ref: "#/components/responses/Validation422"
+        "403":
           $ref: "#/components/responses/Error401"
+
   /accounting/journal:
     get:
       tags: ["Accounting"]
@@ -20754,75 +20595,6 @@ paths:
         "422":
           description: "Periode cloturee (PERIOD_CLOSED) — aucun posting possible."
 components:
-
-  TwoFactorStatusResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          enabled:
-            type: boolean
-          mfa_required:
-            type: boolean
-
-  TwoFactorEnrollResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          secret:
-            type: string
-          qr_url:
-            type: string
-
-  TwoFactorConfirmResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          recovery_codes:
-            type: array
-            items:
-              type: string
-
-  TwoFactorVerifyRequest:
-    type: object
-    required: [challenge_token]
-    properties:
-      challenge_token:
-        type: string
-      code:
-        type: string
-        description: "Code TOTP (ou recovery_code)"
-      recovery_code:
-        type: string
-      device_name:
-        type: string
-        nullable: true
-      remember_device:
-        type: boolean
-
-  TwoFactorVerifyResponse:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          id:
-            type: integer
-          email:
-            type: string
-      token:
-        type: string
-      token_type:
-        type: string
-      token_expires_at:
-        type: string
-        nullable: true
-
   securitySchemes:
     BearerAuth:
       type: http
@@ -20978,6 +20750,8 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    Error409:
+      description: "Conflit (ex. import duplique)"
     Error422:
       description: "Erreur de validation"
       content:
@@ -20992,6 +20766,74 @@ components:
             $ref: "#/components/schemas/ValidationErrorResponse"
 
   schemas:
+    TwoFactorStatusResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            mfa_required:
+              type: boolean
+
+    TwoFactorEnrollResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            secret:
+              type: string
+            qr_url:
+              type: string
+
+    TwoFactorConfirmResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            recovery_codes:
+              type: array
+              items:
+                type: string
+
+    TwoFactorVerifyRequest:
+      type: object
+      required: [challenge_token]
+      properties:
+        challenge_token:
+          type: string
+        code:
+          type: string
+          description: "Code TOTP (ou recovery_code)"
+        recovery_code:
+          type: string
+        device_name:
+          type: string
+          nullable: true
+        remember_device:
+          type: boolean
+
+    TwoFactorVerifyResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: integer
+            email:
+              type: string
+        token:
+          type: string
+        token_type:
+          type: string
+        token_expires_at:
+          type: string
+          nullable: true
+
     # ── Attendance schemas (v4.18.0) ──
     AttendanceModeSettings:
       type: object
@@ -24266,6 +24108,152 @@ components:
           type: string
           maxLength: 500
 
+    AccountingDashboard:
+      type: object
+      description: "Synthese du tableau de bord comptable (issue #5230)."
+      properties:
+        period:
+          type: object
+          properties:
+            from:
+              type: string
+              format: date
+            to:
+              type: string
+              format: date
+        invoices:
+          type: object
+          description: "Factures emises (ventes, hors brouillons/annules) sur la periode."
+          properties:
+            count:
+              type: integer
+            total_ttc:
+              type: number
+              nullable: true
+        collections:
+          type: object
+          description: "Encaissements (paiements recus) sur la periode."
+          properties:
+            count:
+              type: integer
+            total:
+              type: number
+              nullable: true
+        expenses:
+          type: object
+          description: "Depenses fournisseurs (documents lies a un contact fournisseur) sur la periode."
+          properties:
+            count:
+              type: integer
+            total_ttc:
+              type: number
+              nullable: true
+        outstanding:
+          type: object
+          description: "Impayes : documents emis non soldes + aging par retard d'echeance."
+          properties:
+            count:
+              type: integer
+            total_due:
+              type: number
+            aging:
+              type: array
+              description: "Buckets 0_30 / 31_60 / 61_90 / 90_plus (documents en retard)."
+              items:
+                type: object
+                properties:
+                  bucket:
+                    type: string
+                  count:
+                    type: integer
+                  total_due:
+                    type: number
+            list:
+              type: array
+              description: "100 impayes les plus anciens (tri echeance ASC)."
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  number:
+                    type: string
+                  contact:
+                    type: string
+                  issue_date:
+                    type: string
+                    format: date
+                    nullable: true
+                  due_date:
+                    type: string
+                    format: date
+                    nullable: true
+                  days_late:
+                    type: integer
+                  total_ttc:
+                    type: number
+                  paid_amount:
+                    type: number
+                  due_amount:
+                    type: number
+                  status:
+                    type: string
+
+    AccountingActivation:
+      type: object
+      description: "Etat d'activation du module Comptabilite (issue #5288) — check-list du wizard."
+      properties:
+        completed:
+          type: boolean
+          description: "true quand les trois etapes sont satisfaites."
+        steps:
+          type: object
+          properties:
+            settings:
+              type: boolean
+              description: "Parametrage comptable persiste et complet."
+            contact:
+              type: boolean
+              description: "Contact de demonstration present (metadata.is_sample)."
+            example_invoice:
+              type: boolean
+              description: "Facture d'exemple presente (metadata.is_example)."
+        contact:
+          type: object
+          nullable: true
+          description: "Apercu du contact de demonstration, ou null."
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            email:
+              type: string
+              nullable: true
+            type:
+              type: string
+        example_invoice:
+          type: object
+          nullable: true
+          description: "Apercu de la facture d'exemple, ou null."
+          properties:
+            id:
+              type: integer
+            number:
+              type: string
+            status:
+              type: string
+            total_ttc:
+              type: number
+              nullable: true
+            currency:
+              type: string
+              nullable: true
+            issue_date:
+              type: string
+              format: date
+              nullable: true
+
     AccountingContact:
       type: object
       properties:
@@ -24449,6 +24437,24 @@ components:
             type: string
 
     AccountingCheckout:
+      type: object
+      description: "Session de paiement en ligne creee (issue #5272)."
+      required:
+        - checkout_url
+        - expires_at
+        - gateway
+      properties:
+        checkout_url:
+          type: string
+          format: uri
+          description: "URL de paiement hebergee par la passerelle (Chargily / Stripe)."
+        expires_at:
+          type: string
+          format: date-time
+          description: "Expiration de la session de paiement."
+        gateway:
+          type: string
+          enum: [chargily, stripe]
     BankStatementLine:
       type: object
       description: "Ligne de relevé bancaire (issue #5435)."
@@ -24477,24 +24483,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BankStatementLine"
-      type: object
-      description: "Session de paiement en ligne creee (issue #5272)."
-      required:
-        - checkout_url
-        - expires_at
-        - gateway
-      properties:
-        checkout_url:
-          type: string
-          format: uri
-          description: "URL de paiement hebergee par la passerelle (Chargily / Stripe)."
-        expires_at:
-          type: string
-          format: date-time
-          description: "Expiration de la session de paiement."
-        gateway:
-          type: string
-          enum: [chargily, stripe]
 
     AccountingCheckoutPayload:
       type: object
@@ -24508,6 +24496,7 @@ components:
           type: string
           format: uri
           nullable: true
+
 
     VatDeclaration:
       type: object

--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,13 +1,9 @@
 {
   "source": "api/openapi.yaml",
-<<<<<<< HEAD
-  "spec_sha256": "c8ca69ea74a0b13e66efe6d3a79f5a92d487f3537998374aa9d7021e23dce982",
-=======
-  "spec_sha256": "52ecf0a06af3c4b73154a8f71bf0f6b7c7ee966b5100341bf32b5c8b26ae1531",
->>>>>>> origin/main
+  "spec_sha256": "7f8bacbcb385417cea9598963f524f061608242efee4bc687bf7566d2b86c4af",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
-  "operation_count": 830,
+  "operation_count": 822,
   "targets": [
     "javascript",
     "python"

--- a/dev-hub/sdk/javascript/leopardoClient.js
+++ b/dev-hub/sdk/javascript/leopardoClient.js
@@ -140,6 +140,16 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("PUT", "/absences/{absence}/reject", options);
     },
 
+    /** Etat d'activation du module Comptabilite (check-list du wizard) */
+    getAccountingActivation(options = {}) {
+      return request("GET", "/accounting/activation", options);
+    },
+
+    /** Executer l'activation guidee du module Comptabilite (wizard) */
+    postAccountingActivation(options = {}) {
+      return request("POST", "/accounting/activation", options);
+    },
+
     /** Audit trail du module Comptabilité (qui/quoi/quand, #5273) */
     getAccountingAuditLogs(options = {}) {
       return request("GET", "/accounting/audit-logs", options);
@@ -203,6 +213,16 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Convertir un montant entre deux devises (multi-devises #5270) */
     postAccountingCurrencyConvert(options = {}) {
       return request("POST", "/accounting/currency/convert", options);
+    },
+
+    /** Tableau de bord comptable — factures emises, encaissements, impayes, depenses */
+    getAccountingDashboard(options = {}) {
+      return request("GET", "/accounting/dashboard", options);
+    },
+
+    /** Export CSV de la liste des impayes */
+    getAccountingDashboardExport(options = {}) {
+      return request("GET", "/accounting/dashboard/export", options);
     },
 
     /** Lister les documents comptables du tenant (pagine, filtres, #5223) */
@@ -3618,66 +3638,6 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
     /** Modifier un site */
     putSitesBySite(options = {}) {
       return request("PUT", "/sites/{site}", options);
-    },
-
-    /** Lire la configuration de mode active pour l'employe connecte */
-    getSmartAttendanceConfig(options = {}) {
-      return request("GET", "/smart-attendance/config", options);
-    },
-
-    /** Statistiques du jour — Smart Attendance (manager/RH) */
-    getSmartAttendanceDashboard(options = {}) {
-      return request("GET", "/smart-attendance/dashboard", options);
-    },
-
-    /** Préférence mode géolocalisation d'un employé (manager/RH) */
-    getSmartAttendanceEmployeesByEmployeeIdPreference(options = {}) {
-      return request("GET", "/smart-attendance/employees/{employeeId}/preference", options);
-    },
-
-    /** Envoyer un événement géographique (entrée/sortie de zone) */
-    postSmartAttendanceGeoEvents(options = {}) {
-      return request("POST", "/smart-attendance/geo-events", options);
-    },
-
-    /** Parametres du mode de pointage de l'entreprise */
-    getSmartAttendanceModeSettings(options = {}) {
-      return request("GET", "/smart-attendance/mode-settings", options);
-    },
-
-    /** Configurer le mode de pointage (principal) */
-    putSmartAttendanceModeSettings(options = {}) {
-      return request("PUT", "/smart-attendance/mode-settings", options);
-    },
-
-    /** Sessions GPS de l'employé courant */
-    getSmartAttendanceMySessions(options = {}) {
-      return request("GET", "/smart-attendance/my-sessions", options);
-    },
-
-    /** Mettre à jour les préférences de pointage */
-    putSmartAttendancePreferences(options = {}) {
-      return request("PUT", "/smart-attendance/preferences", options);
-    },
-
-    /** Lister les sessions GPS */
-    getSmartAttendanceSessions(options = {}) {
-      return request("GET", "/smart-attendance/sessions", options);
-    },
-
-    /** Détail d'une session GPS */
-    getSmartAttendanceSessionsById(options = {}) {
-      return request("GET", "/smart-attendance/sessions/{id}", options);
-    },
-
-    /** Approuver une session GPS (manager/RH) */
-    postSmartAttendanceSessionsByIdApprove(options = {}) {
-      return request("POST", "/smart-attendance/sessions/{id}/approve", options);
-    },
-
-    /** Rejeter une session GPS (manager/RH) */
-    postSmartAttendanceSessionsByIdReject(options = {}) {
-      return request("POST", "/smart-attendance/sessions/{id}/reject", options);
     },
 
     /** Lister les regles de cotisations sociales (manager) */

--- a/dev-hub/sdk/python/leopardo_client.py
+++ b/dev-hub/sdk/python/leopardo_client.py
@@ -132,6 +132,14 @@ class LeopardoClient:
         """Refuser une absence (déprécié — utiliser POST)"""
         return self.request("PUT", "/absences/{absence}/reject", **kwargs)
 
+    def get_accounting_activation(self, **kwargs):
+        """Etat d'activation du module Comptabilite (check-list du wizard)"""
+        return self.request("GET", "/accounting/activation", **kwargs)
+
+    def post_accounting_activation(self, **kwargs):
+        """Executer l'activation guidee du module Comptabilite (wizard)"""
+        return self.request("POST", "/accounting/activation", **kwargs)
+
     def get_accounting_audit_logs(self, **kwargs):
         """Audit trail du module Comptabilité (qui/quoi/quand, #5273)"""
         return self.request("GET", "/accounting/audit-logs", **kwargs)
@@ -183,6 +191,14 @@ class LeopardoClient:
     def post_accounting_currency_convert(self, **kwargs):
         """Convertir un montant entre deux devises (multi-devises #5270)"""
         return self.request("POST", "/accounting/currency/convert", **kwargs)
+
+    def get_accounting_dashboard(self, **kwargs):
+        """Tableau de bord comptable — factures emises, encaissements, impayes, depenses"""
+        return self.request("GET", "/accounting/dashboard", **kwargs)
+
+    def get_accounting_dashboard_export(self, **kwargs):
+        """Export CSV de la liste des impayes"""
+        return self.request("GET", "/accounting/dashboard/export", **kwargs)
 
     def get_accounting_documents(self, **kwargs):
         """Lister les documents comptables du tenant (pagine, filtres, #5223)"""
@@ -2915,54 +2931,6 @@ class LeopardoClient:
     def put_sites_by_site(self, **kwargs):
         """Modifier un site"""
         return self.request("PUT", "/sites/{site}", **kwargs)
-
-    def get_smart_attendance_config(self, **kwargs):
-        """Lire la configuration de mode active pour l'employe connecte"""
-        return self.request("GET", "/smart-attendance/config", **kwargs)
-
-    def get_smart_attendance_dashboard(self, **kwargs):
-        """Statistiques du jour — Smart Attendance (manager/RH)"""
-        return self.request("GET", "/smart-attendance/dashboard", **kwargs)
-
-    def get_smart_attendance_employees_by_employeeid_preference(self, **kwargs):
-        """Préférence mode géolocalisation d'un employé (manager/RH)"""
-        return self.request("GET", "/smart-attendance/employees/{employeeId}/preference", **kwargs)
-
-    def post_smart_attendance_geo_events(self, **kwargs):
-        """Envoyer un événement géographique (entrée/sortie de zone)"""
-        return self.request("POST", "/smart-attendance/geo-events", **kwargs)
-
-    def get_smart_attendance_mode_settings(self, **kwargs):
-        """Parametres du mode de pointage de l'entreprise"""
-        return self.request("GET", "/smart-attendance/mode-settings", **kwargs)
-
-    def put_smart_attendance_mode_settings(self, **kwargs):
-        """Configurer le mode de pointage (principal)"""
-        return self.request("PUT", "/smart-attendance/mode-settings", **kwargs)
-
-    def get_smart_attendance_my_sessions(self, **kwargs):
-        """Sessions GPS de l'employé courant"""
-        return self.request("GET", "/smart-attendance/my-sessions", **kwargs)
-
-    def put_smart_attendance_preferences(self, **kwargs):
-        """Mettre à jour les préférences de pointage"""
-        return self.request("PUT", "/smart-attendance/preferences", **kwargs)
-
-    def get_smart_attendance_sessions(self, **kwargs):
-        """Lister les sessions GPS"""
-        return self.request("GET", "/smart-attendance/sessions", **kwargs)
-
-    def get_smart_attendance_sessions_by_id(self, **kwargs):
-        """Détail d'une session GPS"""
-        return self.request("GET", "/smart-attendance/sessions/{id}", **kwargs)
-
-    def post_smart_attendance_sessions_by_id_approve(self, **kwargs):
-        """Approuver une session GPS (manager/RH)"""
-        return self.request("POST", "/smart-attendance/sessions/{id}/approve", **kwargs)
-
-    def post_smart_attendance_sessions_by_id_reject(self, **kwargs):
-        """Rejeter une session GPS (manager/RH)"""
-        return self.request("POST", "/smart-attendance/sessions/{id}/reject", **kwargs)
 
     def listsocialcontributions(self, **kwargs):
         """Lister les regles de cotisations sociales (manager)"""


### PR DESCRIPTION
## Résumé

**Déblocage CI main (v2)** — le merge de #5495 (fait via l'UI GitHub par le coordinateur) a committé **des marqueurs de conflit** : `AccountingServiceProvider.php` hybride cassé (parse error) + `routes/modules/accounting.php` corrompu. Main est toujours rouge. Cette PR corrige TOUT l'état du module Comptabilité sur main + les bugs du rapprochement bancaire (#5435) jamais vérifiés par CI.

## Correctifs

### Infrastructure main (parse errors / routes)
1. **`AccountingServiceProvider.php`** — fichier complet correct (class + `register()` avec bindings + `commands([SeedAccountingDemoCommand])` + `boot()`) — l'hybride committé par #5495 cassait le boot PHP de tous les jobs.
2. **`routes/modules/accounting.php`** — reconstruction complète : contacts/settings/TVA/convert/activation/dashboard (`comptable,principal`), documents/checkout/audit-logs/journal (`principal,comptable`), trésorerie + bank-statements, routes publiques shared. Marqueurs de conflit supprimés ; **RBAC de `vat-declaration`/`currency/convert` rétabli** (ils avaient été sortis du groupe manager → fuite données financières pour un employé).

### Bugs #5435 (rapprochement bancaire — jamais vérifiés par CI car main était rouge)
3. **Migration** : `bank_statement_lines.matched_payment_id` `uuid` → `unsignedBigInteger` (FK vers `accounting_payments.id` qui est bigint — le matching plantait avec `invalid input syntax for type uuid`).
4. **Routes bank** : `whereNumber` retiré (les ids `bank_statements`/`bank_statement_lines` sont des UUID → 404).
5. **`BankStatementImportService`** : validation de date STRICTE (round-trip `format() === input` — `2026-13-99` débordait silencieusement chez Carbon).
6. **`BankReconciliationService::refreshStatementStatus`** : statut `reconciling` quand des lignes ont une PROPOSITION (approximate match), pas seulement quand matchées.
7. **`BankStatementController`** : garde d'isolation tenant explicite (show/reconcile/status/match → 404 cross-tenant) — le scope global ne s'applique pas au route-model binding.
8. **`PaymentRegistrationService`** : `company_id` dérivé du document à la création (NOT NULL respecté hors contexte tenant).

### Qualité / contrats
9. **`JournalPostingService`** : `ACCOUNT_BY_METHOD` couvre `online_chargily`/`online_stripe` (PHPStan strict).
10. **i18n ×4** : parité rétablie (clés `bank_*` déplacées dans le groupe `validation`, apostrophes échappées, `ALREADY_SEEDED` + `DOCUMENT_PDF_NOT_READY` + `DOCUMENT_SHARE_NOT_FOUND` ajoutés à `errors.php` ×4).
11. **OpenAPI** : chemins `/smart-attendance/*` morts supprimés (Phase 5), schémas 2FA ré-indentés sous `components.schemas` (refs non résolues), chemins + schémas activation/dashboard ajoutés, `AccountingCheckout` rempli (vide après merges), `Error409` ajouté, clé `amount` dupliquée retirée — **Redocly 0 erreur** ; miroir + SDK régénérés.

## Vérifications (locales, PHP 8.4 + PostgreSQL)
- [x] Suite `tests/Feature/Accounting` : **228/228** (1937 assertions) — 0 échec
- [x] PHPStan strict level 8 : **0 erreur**
- [x] Pint : PASS · i18n ×4 : OK · Redocly : **0 erreur** · couverture OpenAPI : **822 opérations / 0 drift**

## Note
Régression des merges #5377/#5495 (leçons #2316/#5447 — merge via UI avec marqueurs). Refs #5435 (rapprochement bancaire), #5227 (i18n), #5270 (convert), #5288 (wizard), #5230 (dashboard), #5234 (journal).
