### PR TITLE
fix(ci): ne plus annuler les runs PR — les queuer pour que les checks se terminent (issue #5536)

### DIFF
--- a/.github/workflows/accounting-ci.yml
+++ b/.github/workflows/accounting-ci.yml
@@ -44,7 +44,7 @@ env:
 
 concurrency:
   group: accounting-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false  # #5536 : queuer au lieu d'annuler (les runs PR ne démarrent jamais sous congestion)
 
 jobs:
   accounting-tests:

--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -21,7 +21,7 @@ concurrency:
   # Frontend ESLint+TS) — sur main, un push ne doit jamais annuler le run du
   # commit précédent (sinon le dernier commit de main reste pending 20+ min).
   # Les runs PR gardent l'annulation (feedback rapide sur une même branche).
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false  # #5536 : queuer au lieu d'annuler (les runs PR ne démarrent jamais sous congestion)
 
 jobs:
   # Issue #3708 : les gardes dev-hub (bash pur) n'étaient appelées par aucun

--- a/.github/workflows/backend-jobs-ci.yml
+++ b/.github/workflows/backend-jobs-ci.yml
@@ -33,7 +33,7 @@ env:
 
 concurrency:
   group: backend-jobs-ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false  # #5536 : queuer au lieu d'annuler (les runs PR ne démarrent jamais sous congestion)
 
 jobs:
   jobs-and-queues:

--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -54,7 +54,7 @@ concurrency:
   group: mobile-apps-ci-${{ github.ref }}
   # Issue #2131 : sur main, ne jamais annuler le run du commit précédent
   # (builds Flutter longs relancés en cascade). Runs PR annulés.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false  # #5536 : queuer au lieu d'annuler (les runs PR ne démarrent jamais sous congestion)
 
 jobs:
   mobile-apps-guard:

--- a/.github/workflows/openapi-ci.yml
+++ b/.github/workflows/openapi-ci.yml
@@ -27,7 +27,7 @@ env:
 
 concurrency:
   group: openapi-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false  # #5536 : queuer au lieu d'annuler (les runs PR ne démarrent jamais sous congestion)
 
 jobs:
   lint-openapi:

--- a/.github/workflows/payroll-ci.yml
+++ b/.github/workflows/payroll-ci.yml
@@ -51,7 +51,7 @@ concurrency:
   # Issue #2131 : sur main, ne jamais annuler le run du commit précédent
   # (chaque merge relançait l'annulation en cascade des runs paie utiles).
   # Les runs PR gardent l'annulation (feedback rapide sur une même branche).
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false  # #5536 : queuer au lieu d'annuler (les runs PR ne démarrent jamais sous congestion)
 
 jobs:
   golden:


### PR DESCRIPTION
## Contexte (constat session 2026-08-25)

Sous congestion (file 300+ runs), `cancel-in-progress: true` sur les événements PR tuait chaque run AVANT son démarrage : le bot de sync re-merge main → push → nouveau run → l'ancien (encore en file) est annulé. Résultat : **des dizaines de PRs mergées sans AUCUN check exécuté** (#5410, #5451, #5486, #5490, #5504, #5505, #5513, #5525).

## Correctif

`cancel-in-progress: false` sur les workflows PR (backend-jobs, openapi, accounting, mobile-apps, architecture, payroll) → les runs se **queuent** et se terminent (le run du head final passe). Comportement main (#2131) inchangé.

Closes #5536