### PR TITLE
feat(ci): checks mobile requis — défilter le trigger PR (issue #5517)

### DIFF
--- a/.github/workflows/mobile-apps-ci.yml
+++ b/.github/workflows/mobile-apps-ci.yml
@@ -4,24 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - 'front/mobile_apps/**'
-      - 'dev-hub/tools/validate-mobile-apps-split.ps1'
-      - 'dev-hub/tools/validate-mobile-release-readiness.ps1'
-      - 'dev-hub/tools/validate-mobile-runtime-smoke.ps1'
-      - 'dev-hub/tools/validate-mobile-location-readiness.ps1'
-      - 'dev-hub/tools/validate-mobile-tenant-branding.ps1'
-      - 'dev-hub/tools/validate-mobile-notification-production-proof.ps1'
-      - 'dev-hub/tools/validate-mobile-workflow-contracts.ps1'
-      - 'dev-hub/tools/validate-mobile-plan28.ps1'
-      - 'dev-hub/tools/validate-mobile-plan29.ps1'
-      - 'dev-hub/tools/validate-mobile-color-tokens.ps1'
-      - 'dev-hub/tools/check-mobile-number-locale.sh'
-      - 'dev-hub/tools/check-mobile-l10n-sync.sh'
-      - 'dev-hub/tools/check-mobile-manifest-routes.sh'
-      - 'dev-hub/tools/mobile-workflow-contracts.json'
-      - 'api/app/Modules/HR/Infrastructure/Services/MobileExperienceService.php'
-      - '.github/workflows/mobile-apps-ci.yml'
+    # Issue #5517 : PAS de filtre paths — les checks Analyse mobile + Split
+    # guard deviennent REQUIS (protection de branche) ; un check requis doit
+    # s'exécuter sur CHAQUE PR (sinon blocage « expected — waiting »). Le
+    # build debug lourd reste filtré par le job `changes` ci-dessous.
   push:
     branches: [main]
     paths:
@@ -57,6 +43,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Detect mobile changes
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            mobile:
+              - 'front/mobile_apps/**'
+              - 'api/app/Modules/HR/Infrastructure/Services/MobileExperienceService.php'
+              - '.github/workflows/mobile-apps-ci.yml'
+
   mobile-apps-guard:
     timeout-minutes: 90
     name: Mobile apps split guard
@@ -252,6 +253,8 @@ jobs:
           fi
 
   flutter-build-debug:
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     timeout-minutes: 90
     name: Build Debug ${{ matrix.project.name }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Contexte

Les checks « Mobile apps split guard » + « Analyze leopardo_hr/manager » ne tournaient que si `front/mobile_apps/**` changeait (filtre paths) → impossibles à rendre REQUIS (un check requis doit s'exécuter sur chaque PR, sinon blocage « expected — waiting »).

## Correctif

- Filtre `paths` retiré du trigger `pull_request` ;
- Build debug lourd (non requis) filtré par `dorny/paths-filter` (job `changes`) ;
- Les checks Analyze + Split guard s'exécutent sur chaque PR → prêts à être promus requis (protection de branche mise à jour par le PM).

Closes #5517