### PR TITLE
fix(attendance): alias déprécié pour l'ancienne URL punch-photo (issue #5538)

### DIFF
--- a/api/app/Modules/Attendance/Interfaces/Api/V1/AttendanceController.php
+++ b/api/app/Modules/Attendance/Interfaces/Api/V1/AttendanceController.php
@@ -615,7 +615,7 @@ class AttendanceController extends Controller
     }
 
     /**
-     * GET /api/v1/attendance/{attendanceLog}/punch-photo
+     * GET /api/v1/attendance/attendance-logs/{attendanceLog}/punch-photo (alias déprécié : /attendance/{attendanceLog}/punch-photo #5538)
      * Retourne la photo de pointage associee a un log (mode photo_required).
      * Accessible a l'employe concerne et aux managers autorises a voir ce log.
      */

--- a/api/routes/modules/rh.php
+++ b/api/routes/modules/rh.php
@@ -106,7 +106,12 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 't
         Route::put('/attendance/corrections/{correction}/reject', [AttendanceController::class, 'rejectCorrection'])->whereNumber('correction')->middleware('api.manager'); // déprécié #4930
     Route::get('/attendance/corrections/{correction}/proof', [AttendanceController::class, 'downloadProofCorrection'])->whereNumber('correction')->name('attendance.corrections.proof');
     Route::put('/attendance/{attendanceLog}', [AttendanceController::class, 'update'])->whereNumber('attendanceLog')->middleware('api.manager');
+    // #5538 — URL canonique (désambiguïsée redocly, #5525).
     Route::get('/attendance/attendance-logs/{attendanceLog}/punch-photo', [AttendanceController::class, 'punchPhoto'])->whereNumber('attendanceLog')->name('attendance.punch-photo');
+
+    // #5538 — alias DÉPRÉCIÉ de l'ancien chemin /attendance/{attendanceLog}/punch-photo
+    // (clients en circulation). À supprimer après la fenêtre de compat.
+    Route::get('/attendance/{attendanceLog}/punch-photo', [AttendanceController::class, 'punchPhoto'])->whereNumber('attendanceLog');
 
     // ── Invitations ───────────────────────────────────────────────────────────
     Route::get('/invitations', [InvitationController::class, 'index']);


### PR DESCRIPTION
## Contexte

La route `GET /attendance/{attendanceLog}/punch-photo` a été renommée `/attendance/attendance-logs/{attendanceLog}/punch-photo` (#5525, désambiguïsation redocly).

## Audit des consommateurs

- Aucun hardcodé dans le repo ni les apps mobiles (tous passent par le nom de route `attendance.punch-photo` → URL auto-générée, mise à jour automatiquement) ;
- Alias **déprécié** ajouté pour les clients en circulation (ancien chemin, sans nom de route pour forcer les nouveaux appels vers le canonique) ;
- Docblock du contrôleur mis à jour.

Closes #5538