### PR TITLE
feat(security): Referrer-Policy no-referrer sur tous les endpoints tokenisés (issue #5521)

### DIFF
--- a/api/app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php
+++ b/api/app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php
@@ -51,7 +51,7 @@ final class PublicDocumentShareController
                 'total_ttc' => round((float) $document->total_ttc, 2),
                 'expires_at' => $share->expires_at?->toIso8601String(),
             ],
-        ]);
+        ])->header('Referrer-Policy', 'no-referrer');
     }
 
     public function download(string $token): StreamedResponse
@@ -73,7 +73,11 @@ final class PublicDocumentShareController
 
         $filename = $document->type.'-'.$document->number.'.pdf';
 
-        return Storage::disk(GenerateDocumentPdf::DISK)->download($document->pdf_path, $filename);
+        // #5521 — no-referrer strict : le token ne doit pas fuiter via Referer
+        // lors du téléchargement (règles navigateur + défense en profondeur).
+        return Storage::disk(GenerateDocumentPdf::DISK)
+            ->download($document->pdf_path, $filename)
+            ->header('Referrer-Policy', 'no-referrer');
     }
 
     /**

--- a/api/tests/Feature/Accounting/PortalJourneyE2ETest.php
+++ b/api/tests/Feature/Accounting/PortalJourneyE2ETest.php
@@ -77,12 +77,14 @@ class PortalJourneyE2ETest extends TestCase
         $this->getJson('/api/v1/accounting/documents/shared/'.$token)
             ->assertOk()
             ->assertJsonPath('data.number', $document->number)
-            ->assertJsonPath('data.status', 'sent');
+            ->assertJsonPath('data.status', 'sent')
+            ->assertHeader('referrer-policy', 'no-referrer');  // #5521
 
         // 4) Téléchargement du PDF réel.
         $this->get('/api/v1/accounting/documents/shared/'.$token.'/download')
             ->assertOk()
-            ->assertHeader('content-type', 'application/pdf');
+            ->assertHeader('content-type', 'application/pdf')
+            ->assertHeader('referrer-policy', 'no-referrer');  // #5521
 
         // 4bis) RGPD — les accès info/download sont tracés (issue #5429).
         $this->assertSame(1, AuditLog::query()->where('action', 'accounting.share.info')->count());


### PR DESCRIPTION
## Contexte

Le portail `/documents/shared/*` est couvert côté web (#5505). Audit complémentaire : `/share` = PWA share target sans token ; aucun autre pattern tokenisé dans l'app web. **Manque API** : les réponses des endpoints tokenisés ne portaient pas de Referrer-Policy (le PDF peut charger des ressources externes → fuite du token via Referer).

## Correctifs

- `Referrer-Policy: no-referrer` sur les réponses `info` + `download` du portail client (défense en profondeur) ;
- Assertions header ajoutées au test E2E portail.

Closes #5521