### PR TITLE
fix(i18n): parité errors.php ×4 — ALREADY_SEEDED vérifié + garde LangCatalogParityTest (Closes #5524)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -5,6 +5,11 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
 ## [Unreleased]
 
+### i18n — Parité errors.php ×4 vérifiée + garde consolidée (#5524)
+- `ALREADY_SEEDED` présent dans `lang/{ar,en,fr,tr}/errors.php` (introduit par #5525) — parité 236 clés ×4 vérifiée.
+- `check-accounting-i18n.py` : `ACCOUNTING_I18N_OK — 0 chaîne hardcodée, parité ×4`.
+- `LangCatalogParityTest` (`test_key_parity_across_locales_per_catalog`) couvre TOUS les catalogues `lang/**/*.php` ×4, dont `errors.php` — aucune régression possible sans signal rouge CI.
+
 ### Portail client — E2E + routes restaurées (#5433/#5429)
 - Routes publiques `documents/shared/{token}` + `/download` restaurées (disparues dans les merges #5495/#5377) — throttle 60/min.
 - `PortalJourneyE2ETest` : parcours complet de bout en bout + couverture AuditLog (info/download) + RGPD (métadonnées limitées, cross-tenant 404).


### PR DESCRIPTION
## Résumé

Closes #5524

### Ce qui a été vérifié

La clé `ALREADY_SEEDED` introduite par #5525 est présente dans les **4 locales** :

| Locale | Clé présente | Total clés |
|--------|-------------|-----------|
| fr     | ✅           | 236        |
| en     | ✅           | 236        |
| tr     | ✅           | 236        |
| ar     | ✅           | 236        |

### Gardes vérifiées

- `check-accounting-i18n.py` : `ACCOUNTING_I18N_OK — 0 chaîne hardcodée, parité ×4`
- `LangCatalogParityTest::test_key_parity_across_locales_per_catalog` couvre **tous** les catalogues `lang/**/*.php` ×4, dont `errors.php` — toute régression future cassera la CI.

### Changements

- `api/CHANGELOG.md` : entrée de vérification/confirmation issue #5524