### PR TITLE
fix(accounting): AuditLog unifié portail — AuditLog::record() + module + request_id (Closes #5520)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,11 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 - `ALREADY_SEEDED` présent dans `lang/{ar,en,fr,tr}/errors.php` (introduit par #5525) — parité 236 clés ×4 vérifiée.
 - `check-accounting-i18n.py` : `ACCOUNTING_I18N_OK — 0 chaîne hardcodée, parité ×4`.
 - `LangCatalogParityTest` (`test_key_parity_across_locales_per_catalog`) couvre TOUS les catalogues `lang/**/*.php` ×4, dont `errors.php` — aucune régression possible sans signal rouge CI.
+### AuditLog unifié — accès portail client (#5520)
+- `PublicDocumentShareController::auditAccess()` refactoré pour utiliser `AuditLog::record()` (#5439) au lieu de `AuditLog::create()` direct.
+- `module: 'accounting'` + `request_id` (via `correlation_id()`) désormais renseignés sur chaque entrée portail : les accès sont chaînables via les logs de corrélation.
+- Actions renommées : `'accounting.share.info'` → `'share.info'`, `'accounting.share.download'` → `'share.download'` (module dédié).
+- `PortalJourneyE2ETest` adapté : assertions `module`, `request_id` non nul.
 
 ### Portail client — E2E + routes restaurées (#5433/#5429)
 - Routes publiques `documents/shared/{token}` + `/download` restaurées (disparues dans les merges #5495/#5377) — throttle 60/min.

--- a/api/app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php
+++ b/api/app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php
@@ -35,7 +35,7 @@ final class PublicDocumentShareController
             abort(404, 'DOCUMENT_SHARE_NOT_FOUND');
         }
 
-        $this->auditAccess($share, 'accounting.share.info');
+        $this->auditAccess($share, 'share.info');
 
         /** @var AccountingDocument $document */
         $document = $share->document;
@@ -62,7 +62,7 @@ final class PublicDocumentShareController
             abort(404, 'DOCUMENT_SHARE_NOT_FOUND');
         }
 
-        $this->auditAccess($share, 'accounting.share.download');
+        $this->auditAccess($share, 'share.download');
 
         /** @var AccountingDocument $document */
         $document = $share->document;
@@ -127,9 +127,14 @@ final class PublicDocumentShareController
     }
 
     /**
-     * Trace un accès public au portail (issue #5429) — RGPD : qui a consulté
-     * / téléchargé quel document partagé, quand, depuis quelle IP. Écrit dans
-     * le tenant de la compagnie du partage (user_id null : accès non authentifié).
+     * Trace un accès public au portail (issue #5429/#5520) — RGPD : qui a
+     * consulté / téléchargé quel document partagé, quand, depuis quelle IP.
+     *
+     * Utilise l'API unifiée AuditLog::record() (#5439) pour garantir que
+     * `module` et `request_id` (corrélation) sont toujours renseignés.
+     * user_id = null : accès non authentifié (token de partage = credential).
+     *
+     * @param  string  $action  Sous-action sans préfixe module : 'share.info' | 'share.download'
      */
     private function auditAccess(AccountingDocumentShare $share, string $action): void
     {
@@ -140,18 +145,13 @@ final class PublicDocumentShareController
         }
 
         app(TenantManager::class)->withinTenant($company, function () use ($share, $action): void {
-            AuditLog::create([
-                'company_id' => $share->company_id,
-                'user_id' => null,
-                'action' => $action,
-                'auditable_type' => $share->getMorphClass(),
-                'auditable_id' => $share->id,
-                'old_values' => [],
-                'new_values' => [],
-                'ip_address' => request()->ip(),
-                'user_agent' => substr((string) request()->userAgent(), 0, 255),
-                'metadata' => ['share_token' => $share->share_token],
-            ]);
+            AuditLog::record(
+                module: 'accounting',
+                action: $action,
+                subject: $share,
+                actor: null,
+                metadata: ['share_token' => $share->share_token],
+            );
         });
     }
 }

--- a/api/tests/Feature/Accounting/PortalJourneyE2ETest.php
+++ b/api/tests/Feature/Accounting/PortalJourneyE2ETest.php
@@ -86,9 +86,21 @@ class PortalJourneyE2ETest extends TestCase
             ->assertHeader('content-type', 'application/pdf')
             ->assertHeader('referrer-policy', 'no-referrer');  // #5521
 
-        // 4bis) RGPD — les accès info/download sont tracés (issue #5429).
-        $this->assertSame(1, AuditLog::query()->where('action', 'accounting.share.info')->count());
-        $this->assertSame(1, AuditLog::query()->where('action', 'accounting.share.download')->count());
+        // 4bis) RGPD — les accès info/download sont tracés (issue #5429/#5520).
+        // #5520 : AuditLog::record() utilisé → module + request_id renseignés.
+        $infoLog = AuditLog::query()
+            ->where('action', 'share.info')
+            ->where('module', 'accounting')
+            ->first();
+        $this->assertNotNull($infoLog, 'AuditLog share.info introuvable');
+        $this->assertNotNull($infoLog->request_id, 'request_id doit être renseigné (corrélation #5520)');
+
+        $downloadLog = AuditLog::query()
+            ->where('action', 'share.download')
+            ->where('module', 'accounting')
+            ->first();
+        $this->assertNotNull($downloadLog, 'AuditLog share.download introuvable');
+        $this->assertNotNull($downloadLog->request_id, 'request_id doit être renseigné (corrélation #5520)');
 
         // 4ter) RGPD — les métadonnées exposées sont limitées (pas de données sensibles).
         $this->getJson('/api/v1/accounting/documents/shared/'.$token)


### PR DESCRIPTION
## Résumé

Closes #5520

## Problème

`PublicDocumentShareController::auditAccess()` utilisait `AuditLog::create()` en direct, contournant l'API unifiée `AuditLog::record()` (#5439). Conséquences :
- `module` non renseigné → filtrage/rapports difficiles
- `request_id` absent → impossibilité de chaîner avec les logs de corrélation

## Solution

### Contrôleur (`PublicDocumentShareController`)
- Remplacé `AuditLog::create([...])` par `AuditLog::record(module: 'accounting', action: $action, subject: $share, actor: null, metadata: [...])`
- Actions simplifiées : `'accounting.share.info'` → `'share.info'`, `'accounting.share.download'` → `'share.download'` (module séparé)
- `user_id = null` conservé (accès non authentifié)
- `share_token` conservé dans metadata

### Tests (`PortalJourneyE2ETest`)
- Assertions adaptées : filtre sur `module = 'accounting'` + `action = 'share.info|share.download'`
- Nouvelle assertion : `request_id` non nul (corrélation garantie)

## Changements
| Fichier | Type |
|---------|------|
| `app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php` | Refactor |
| `tests/Feature/Accounting/PortalJourneyE2ETest.php` | Adaptation tests |
| `CHANGELOG.md` | Documentation |