### PR TITLE
docs(accounting): URL canonique webhooks payment-webhooks + guide Stripe/Chargily (Closes #5537)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -5,6 +5,12 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
 ## [Unreleased]
 
+### Webhooks Stripe/Chargily — URL canonique documentée (#5537)
+- `ChargilyPaymentGateway::webhookUrl()` confirmé : retourne `/api/v1/accounting/payment-webhooks/chargily` (nouvelle URL, PR #5525).
+- ADR-0017 mis à jour : diagramme d'architecture corrigé (ancienne URL → nouvelle), historique des changements ajouté.
+- `docs/accounting/RUNBOOK.md` : nouvelle section §10 « Paiement en ligne — webhooks » — URL canonique, procédures de configuration Stripe/Chargily, vérification HMAC, dépannage.
+- **Action manuelle requise** : reconfigurer les URLs dans les dashboards Stripe et Chargily vers `/api/v1/accounting/payment-webhooks/{gateway}`.
+
 ### i18n — Parité errors.php ×4 vérifiée + garde consolidée (#5524)
 - `ALREADY_SEEDED` présent dans `lang/{ar,en,fr,tr}/errors.php` (introduit par #5525) — parité 236 clés ×4 vérifiée.
 - `check-accounting-i18n.py` : `ACCOUNTING_I18N_OK — 0 chaîne hardcodée, parité ×4`.

--- a/docs/accounting/RUNBOOK.md
+++ b/docs/accounting/RUNBOOK.md
@@ -133,7 +133,55 @@ le mouvement de trésorerie (pas de double comptage).
   `accounting_documents (company_id, due_date)`,
   `accounting_journal_entries (company_id, period)`.
 
-## 10. Supervision
+## 10. Paiement en ligne — webhooks (issue #5272/#5525/#5537)
+
+### URL canonique des webhooks
+
+```
+POST https://<domaine>/api/v1/accounting/payment-webhooks/{gateway}
+```
+
+| Passerelle | `{gateway}` | URL complète (exemple staging) |
+|---|---|---|
+| Chargily (DZ) | `chargily` | `https://app.leopardo.io/api/v1/accounting/payment-webhooks/chargily` |
+| Stripe (FR/UK/US/CI) | `stripe` | `https://app.leopardo.io/api/v1/accounting/payment-webhooks/stripe` |
+
+> **Changement de contrat (2026-08-25, PR #5525)** : l'ancienne URL
+> `/api/v1/accounting/payments/webhook/{gateway}` est supprimée. **Tout
+> dashboard Stripe / Chargily encore configuré sur l'ancien path doit être
+> mis à jour.**
+
+### Configuration dashboard Stripe
+
+1. Aller dans **Stripe Dashboard → Développeurs → Webhooks → Add endpoint**.
+2. URL : `https://<domaine>/api/v1/accounting/payment-webhooks/stripe`.
+3. Événements à écouter : `checkout.session.completed`, `payment_intent.succeeded`, `payment_intent.payment_failed`.
+4. Copier le **Signing secret** (`whsec_…`) dans la variable d'environnement `STRIPE_WEBHOOK_SECRET`.
+5. Vérifier la signature via la section « Tester les webhooks » (envoyer un événement test).
+
+### Configuration dashboard Chargily
+
+1. Aller dans **Chargily Dashboard → Paramètres → Webhooks**.
+2. URL : `https://<domaine>/api/v1/accounting/payment-webhooks/chargily`.
+3. Copier le **Webhook Secret** dans la variable d'environnement `CHARGILY_WEBHOOK_SECRET`.
+4. Le code `ChargilyPaymentGateway::webhookUrl()` retourne automatiquement la bonne URL ;
+   aucune config PHP à toucher.
+
+### Vérification de la signature HMAC
+
+- **Chargily** : `HMAC-SHA256(payload, CHARGILY_WEBHOOK_SECRET)` — comparé en `hash_equals` (fail-closed : 400 si secret absent ou signature non concordante).
+- **Stripe** : vérification via `Stripe\Webhook::constructEvent()` ou équivalent REST.
+- Toute signature invalide → `400 WEBHOOK_SIGNATURE_INVALID` (aucun effet de bord).
+
+### Dépannage webhook
+
+| Symptôme | Cause probable | Action |
+|---|---|---|
+| 404 sur la notification | Ancienne URL encore configurée | Mettre à jour le dashboard passerelle |
+| 400 `WEBHOOK_SIGNATURE_INVALID` | Secret non configuré ou incorrect | Vérifier `CHARGILY_WEBHOOK_SECRET` / `STRIPE_WEBHOOK_SECRET` |
+| Paiement doublon | Webhook rejoué sans idempotence | Vérifier `webhook_events.source+event_id` (table d'idempotence #5444) |
+
+## 11. Supervision
 
 - Journal déséquilibré = anomalie grave : `GET /accounting/journal?period=…`
   doit toujours rendre `balanced: true`.

--- a/docs/architecture/adr/0017-paiement-en-ligne-portail-client.md
+++ b/docs/architecture/adr/0017-paiement-en-ligne-portail-client.md
@@ -3,8 +3,16 @@
 ## Statut
 
 **Proposée** — issue #5272, décision fondateur requise (choix de la passerelle pilote).
+**Implémentée (partiel)** — issue #5525 a livré la couche backend (Chargily + Stripe, PR #5525).
 
 **Date** : 2026-08-24
+
+## Historique des changements
+
+| Date | Description |
+|------|-------------|
+| 2026-08-24 | ADR proposée (choix architecture dual-PSP) |
+| 2026-08-25 | PR #5525 — URL webhook renommée : `POST /api/v1/accounting/payments/webhook/{gateway}` → `POST /api/v1/accounting/payment-webhooks/{gateway}` (levée d'ambiguïté de path redocly). **Les dashboards Stripe/Chargily doivent pointer la nouvelle URL** (issue #5537). |
 
 ## Contexte
 
@@ -117,7 +125,7 @@ PaymentGatewayFactory (routing par devise/pays entreprise)
         ▼
 Retour client → passerelle → webhook
         ▼
-POST /accounting/payments/webhook/{gateway}   (signature HMAC, fail-closed — pattern ChargilyService)
+POST /accounting/payment-webhooks/{gateway}   (signature HMAC, fail-closed — pattern ChargilyService, URL renommée #5525)
         ▼
 Événement paiement (idempotent : Idempotency-Key #5277 + UNIQUE gateway_payment_id)
         ▼


### PR DESCRIPTION
## Résumé

Closes #5537

## Vérification du code (partie automatisable)

✅ `ChargilyPaymentGateway::webhookUrl()` retourne déjà la bonne URL :
```php
private function webhookUrl(): string
{
    return rtrim((string) config('app.url'), '/').'/api/v1/accounting/payment-webhooks/chargily';
}
```

✅ Route Laravel : `POST /accounting/payment-webhooks/{gateway}` (api.php ligne 143)

✅ OpenAPI : `/accounting/payment-webhooks/{gateway}` enregistré

## Documentation ajoutée

### ADR-0017
- Statut mis à jour : Proposée + Implémentée (partiel)
- Historique des changements (URL renommée par PR #5525)
- Diagramme d'architecture corrigé (ancienne URL → nouvelle)

### docs/accounting/RUNBOOK.md — Section §10
- URL canonique des webhooks + tableau par passerelle
- Procédures de configuration Stripe et Chargily
- Vérification HMAC (Chargily HMAC-SHA256, Stripe signature)
- Tableau de dépannage (404 ancienne URL, 400 signature, doublons)

## ⚠️ Action manuelle requise

Les URLs dans les **dashboards Stripe** et **Chargily** doivent être reconfigurées vers :
`POST https://<domaine>/api/v1/accounting/payment-webhooks/{gateway}`

Cette étape ne peut pas être automatisée (accès aux dashboards externes requis).