### PR TITLE
ci(phpstan): brancher phpstan.neon (level max) en CI — composer audit verifie (Closes #5590)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -473,6 +473,40 @@ jobs:
           echo "PHPStan/Larastan failed."
           exit 1
 
+  phpstan-max:
+    # Issue #5590 : phpstan.neon (level: max, app+routes+tests) etait declare
+    # mais jamais execute en CI — la config « max » etait trompeuse (seuls
+    # lvl 5 + lvl 8-delta tournaient reellement). Ce job branche la config max
+    # sur le codebase complet, appuye sur phpstan-baseline.neon (regenere via
+    # le workflow phpstan-baseline.yml). Informational tant qu'il n'est pas
+    # liste dans les required checks (branch-protection-canonical.json) : il
+    # rend les violations « max » visibles sans bloquer les PR.
+    timeout-minutes: 45
+    name: PHPStan — Max (full codebase, informational)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api_changed == 'true'
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: true
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: "8.4"
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        working-directory: ./api
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run PHPStan (level max, full app+routes+tests)
+        working-directory: ./api
+        run: vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=1G --no-progress --error-format=github
+
   backend-coverage:
     name: Backend Coverage (PHPUnit)
     runs-on: ubuntu-latest

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -28,10 +28,11 @@ leopardo-hr/
 - **`declare(strict_types=1);`** en haut de chaque fichier PHP (sauf config)
 - **Namespace PSR-4** — `App\Modules\<NomModule>\*`, `App\Core\*`, `App\Shared\*`
   _(Les anciens espaces `App\Http\Controllers\Api\V1\*` et `App\Services\*` sont supprimés — voir `api/ARCHITECTURE.md`)_
-- **PHPStan** — `phpstan.neon` declare `level: max` pour l'ensemble de `app/`, mais aucun job CI ne l'execute directement aujourd'hui. Ce que la CI verifie reellement, de facon bloquante :
+- **PHPStan** — trois configurations reelles (issue #5590) :
   - `phpstan-modules.neon` (niveau 5, `app/Core`/`app/Modules`/`app/Shared`) — job `phpstan-modules` (bloquant).
   - `phpstan-strict.neon` (niveau 8, meme perimetre) — job `phpstan-strict`, bloquant sur le **delta** uniquement depuis #1413 : `phpstan-strict-baseline.neon` gele les ~2950 erreurs pre-existantes (voir `api/ARCHITECTURE.md` section "Trajectoire PHPStan" pour la repartition par module et la trajectoire de reduction), toute nouvelle erreur hors baseline fait echouer la CI.
-  - "level max" n'est donc pas un standard verifie en CI aujourd'hui ; le niveau 8 bloquant-sur-delta est l'etat reel le plus proche.
+  - `phpstan.neon` (`level: max`, perimetre `app`/`routes`/`tests`) — execute en CI sur le codebase complet par le job `phpstan-max` (tests.yml, informatif, appuye sur `phpstan-baseline.neon` regenere via `phpstan-baseline.yml`) ; la config max n'est plus une coquille vide — elle deviendra bloquante si elle est ajoutee aux required checks.
+- **Composer audit** — job `backend-security` (tests.yml) : `composer audit --locked --no-dev` sur chaque PR/push touchant `api/` (vulnerabilites des dependances prod, echec si advisory).
 - **Pas de `Any`, `mixed` sauf absolument necessaire** — typer tous les parametres et retours
 
 ### 2.2 Nommage


### PR DESCRIPTION
## 🚀 Changes
- `phpstan.neon` (level max, app/routes/tests) etait declare mais jamais execute en CI — ajout du job `phpstan-max` (tests.yml) qui lance la config max sur le codebase complet, appuye sur `phpstan-baseline.neon` (regenere via `phpstan-baseline.yml`).
- Informational (non liste dans les required checks) : rend les violations max visibles sans bloquer les PR.
- `composer audit` : deja present en CI depuis 2026-04-17 (job `backend-security`, `composer audit --locked --no-dev`) — point 1 de #5590 deja couvert, verifie.
- CONVENTIONS.md 2.1 : etat reel documente (3 configs PHPStan + jobs associes).

Closes #5590

## 🗺️ Surfaces
- [x] CI / GitHub Actions
- [x] Docs uniquement
- [ ] API