### PR TITLE
fix(ops): câbler Sentry en prod (DSN render.yaml) + LOG_LEVEL=info pour StructuredLogging (Closes #5586)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -24,8 +24,10 @@ DISABLE_DEMO_SEEDING=true
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
-LOG_LEVEL=error
+LOG_LEVEL=info
 
+# Issue #5586 : DSN Sentry (format https://<key>@<org>.ingest.sentry.io/<id>).
+# En prod, posé via le secret Render SENTRY_LARAVEL_DSN (render.yaml, sync: false).
 SENTRY_LARAVEL_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.1
 

--- a/render.yaml
+++ b/render.yaml
@@ -45,8 +45,15 @@ services:
           property: host
       - key: LOG_CHANNEL
         value: stderr
+      # Issue #5586 : LOG_LEVEL=info requis pour que le canal `structured`
+      # (StructuredLogging middleware, config/logging.php) soit effectif en
+      # prod — `error` filtrait tous les logs info structurés.
       - key: LOG_LEVEL
-        value: error
+        value: info
+      # Issue #5586 : DSN Sentry posé à la main dans le dashboard Render
+      # (sync: false = jamais écrasé par le déploiement). Vide = SDK no-op.
+      - key: SENTRY_LARAVEL_DSN
+        sync: false
       # Database
       - key: DB_CONNECTION
         value: pgsql
@@ -197,8 +204,11 @@ services:
           property: host
       - key: LOG_CHANNEL
         value: stderr
+      # Issue #5586 : LOG_LEVEL=info (canal structured effectif, cf. web).
       - key: LOG_LEVEL
-        value: error
+        value: info
+      - key: SENTRY_LARAVEL_DSN
+        sync: false
       - key: DB_CONNECTION
         value: pgsql
       - key: DB_HOST
@@ -306,6 +316,11 @@ services:
           property: host
       - key: LOG_CHANNEL
         value: stderr
+      # Issue #5586 : LOG_LEVEL aligné sur web/worker (canal structured).
+      - key: LOG_LEVEL
+        value: info
+      - key: SENTRY_LARAVEL_DSN
+        sync: false
       - key: DB_CONNECTION
         value: pgsql
       - key: DB_HOST


### PR DESCRIPTION
## 🚀 Changes
- `render.yaml` : `SENTRY_LARAVEL_DSN` (sync: false) sur web + queue-worker + scheduler — le DSN est posé à la main dans le dashboard Render et ne sera jamais écrasé par un déploiement. DSN vide = SDK no-op (garde déjà présente dans config/sentry.php).
- `LOG_LEVEL` : error → info sur les 3 services — le canal `structured` (config/logging.php) lit `LOG_LEVEL`, le middleware `StructuredLogging` était donc filtré en prod.
- `api/.env.example` : LOG_LEVEL=info + commentaire SENTRY_LARAVEL_DSN (parité config vérifiée : 0 clé manquante).
- `SentryContextMiddleware` est bien enregistré (bootstrap/app.php) — il était inerte faute de DSN ; aucun middleware mort à retirer.

Closes #5586

## 🗺️ Surfaces
- [x] CI / GitHub Actions
- [x] Docs uniquement
- [x] Infra / config (render.yaml)