### PR TITLE
fix(security): garde 2FA sur les flux SSO Google + OIDC (#5579)

### DIFF
--- a/api/app/Core/Auth/Infrastructure/Services/SSO/OidcFlowService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/SSO/OidcFlowService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Core\Auth\Infrastructure\Services\SSO;
 
+use App\Core\Auth\Domain\Exceptions\TwoFactorException;
 use App\Core\Auth\Infrastructure\Services\AuthService;
+use App\Core\Auth\Infrastructure\Services\TwoFactorAuthService;
 use App\Rules\NotPrivateUrl;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -30,6 +32,7 @@ final class OidcFlowService
         private readonly SSOService $ssoService,
         private readonly OidcIdTokenValidator $idTokenValidator,
         private readonly AuthService $authService,
+        private readonly TwoFactorAuthService $twoFactorAuthService,
     ) {}
 
     /**
@@ -66,9 +69,11 @@ final class OidcFlowService
 
     /**
      * @param  array<string, mixed>  $callbackData  code + state (+ id_token direct optionnel)
-     * @return array{employee: array<string, mixed>, token: string, token_type: string, token_expires_at: ?string}
+     * @param  array<string, mixed>|null  $cookies  cookies de la requête (cookie appareil de
+     *                                              confiance 2FA `mfa_remember_{id}`, #5579)
+     * @return array{employee: array<string, mixed>, token?: string, token_type?: string, token_expires_at?: ?string, mfa_challenge?: true, mfa_challenge_token?: string, mfa_challenge_expires_in?: int}
      */
-    public function complete(string $companyId, array $callbackData): array
+    public function complete(string $companyId, array $callbackData, ?array $cookies = null): array
     {
         $config = $this->oidcConfig($companyId);
 
@@ -108,6 +113,46 @@ final class OidcFlowService
         $employee = $result['employee'];
         if ((string) $employee->company_id !== $companyId) {
             throw new \RuntimeException('SSO_TENANT_MISMATCH: l\'email SSO appartient à une autre entreprise.');
+        }
+
+        // #5579 : garde 2FA factorisée (même gate que login()/Google) — un
+        // compte enrôlé exige un challenge TOTP post-SSO, une politique tenant
+        // mfa_required_roles non satisfaite bloque. Le token créé par
+        // loginViaEmail est révoqué dans les deux cas.
+        $rememberCookie = null;
+        if (is_array($cookies) && isset($cookies['mfa_remember_'.$employee->id]) && is_string($cookies['mfa_remember_'.$employee->id])) {
+            $rememberCookie = $cookies['mfa_remember_'.$employee->id];
+        }
+
+        try {
+            $gate = $this->twoFactorAuthService->enforceLoginPolicy(
+                $employee,
+                $result['tenant_schema'] ?? null,
+                'sso-oidc',
+                $rememberCookie,
+            );
+        } catch (TwoFactorException $e) {
+            $employee->tokens()->latest('id')->first()?->delete();
+
+            throw $e;
+        }
+
+        if ($gate !== null) {
+            $employee->tokens()->latest('id')->first()?->delete();
+
+            return [
+                'employee' => [
+                    'id' => $employee->id,
+                    'first_name' => $employee->first_name,
+                    'last_name' => $employee->last_name,
+                    'email' => $employee->email,
+                    'role' => $employee->role,
+                    'manager_role' => $employee->manager_role,
+                ],
+                'mfa_challenge' => true,
+                'mfa_challenge_token' => $gate['challenge']['token'],
+                'mfa_challenge_expires_in' => $gate['challenge']['expires_in'],
+            ];
         }
 
         return [

--- a/api/app/Core/Auth/Infrastructure/Services/TwoFactorAuthService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/TwoFactorAuthService.php
@@ -126,6 +126,57 @@ final class TwoFactorAuthService
     }
 
     /**
+     * #5579 — garde 2FA commune à TOUS les chemins d'authentification
+     * (login, Google callback/token, OIDC). Auparavant seule `login()`
+     * consultait `two_fa_enabled_at` / `requiresMfa()` : les flux SSO
+     * émettaient un token Sanctum sans jamais exiger de challenge TOTP.
+     *
+     * - Compte enrôlé (`two_fa_enabled_at`) → challenge TOTP émis, token
+     *   NON délivré — sauf appareil de confiance (cookie HMAC valide) ;
+     * - Politique tenant `mfa_required_roles` + 2FA non activée →
+     *   `TwoFactorException::required()` (blocage 403).
+     *
+     * Retourne `null` quand le token peut être délivré, sinon la structure
+     * challenge à renvoyer au client (POST /auth/2fa/verify).
+     *
+     * @param  string|null  $providedRememberCookie  valeur du cookie
+     *                                               `mfa_remember_{id}` portée par la requête
+     * @return array{challenge: array{token: string, expires_in: int}}|null
+     *
+     * @throws TwoFactorException
+     */
+    public function enforceLoginPolicy(
+        Employee $employee,
+        ?string $tenantSchema = null,
+        ?string $deviceName = null,
+        ?string $providedRememberCookie = null,
+    ): ?array {
+        if ($employee->two_fa_enabled_at !== null) {
+            $expected = $this->rememberCookieValue($employee);
+
+            if (is_string($providedRememberCookie) && hash_equals($expected, $providedRememberCookie)) {
+                return null;
+            }
+
+            return [
+                'challenge' => $this->issueChallenge([
+                    'employee_id' => $employee->id,
+                    'company_id' => (string) $employee->company_id,
+                    'tenant_schema' => $tenantSchema,
+                    'email' => (string) $employee->email,
+                    'device_name' => $deviceName,
+                ]),
+            ];
+        }
+
+        if ($this->requiresMfa($employee)) {
+            throw TwoFactorException::required();
+        }
+
+        return null;
+    }
+
+    /**
      * La politique tenant impose-t-elle la 2FA pour ce compte ?
      */
     public function requiresMfa(Employee $employee): bool

--- a/api/app/Core/Auth/Interfaces/Api/V1/AuthController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/AuthController.php
@@ -53,46 +53,34 @@ class AuthController extends Controller
 
         $employee = $result['employee'];
 
-        // #5436 : 2FA — le token vient d'être créé par AuthService ; s'il ne
-        // doit pas être délivré (challenge ou politique), on le révoque.
-        if ($employee->two_fa_enabled_at !== null) {
-            // Appareil de confiance (cookie signé) : pas de challenge.
-            $expected = $this->twoFactorService->rememberCookieValue($employee);
-            $provided = $request->cookie('mfa_remember_'.$employee->id);
-            if (is_string($provided) && hash_equals($expected, $provided)) {
-                return (new EmployeeResource($employee))
-                    ->additional([
-                        'token' => $result['token'],
-                        'token_type' => $result['token_type'],
-                        'token_expires_at' => $result['token_expires_at'],
-                    ])
-                    ->response();
-            }
-
+        // #5436/#5579 : 2FA — le token vient d'être créé par AuthService ; la
+        // garde factorisée (enforceLoginPolicy) décide s'il doit être délivré :
+        // challenge TOTP (compte enrôlé) ou blocage (politique tenant
+        // mfa_required_roles). Même gate sur les 4 chemins d'authentification.
+        try {
+            $gate = $this->twoFactorService->enforceLoginPolicy(
+                $employee,
+                $result['tenant_schema'] ?? null,
+                $request->validated('device_name'),
+                $request->cookie('mfa_remember_'.$employee->id),
+            );
+        } catch (TwoFactorException $e) {
+            // Le token créé par LoginAction ne doit pas survivre à un blocage.
             $employee->tokens()->latest('id')->first()?->delete();
 
-            $deviceName = $request->validated('device_name');
+            throw $e;
+        }
 
-            $challenge = $this->twoFactorService->issueChallenge([
-                'employee_id' => $employee->id,
-                'company_id' => (string) $employee->company_id,
-                'tenant_schema' => $result['tenant_schema'],
-                'email' => (string) $employee->email,
-                'device_name' => is_string($deviceName) ? $deviceName : null,
-            ]);
+        if ($gate !== null) {
+            // Token révoqué tant que le challenge n'est pas résolu
+            // (POST /auth/2fa/verify avec le token de challenge).
+            $employee->tokens()->latest('id')->first()?->delete();
 
             return new JsonResponse([
                 'mfa_challenge' => true,
-                'mfa_challenge_token' => $challenge['token'],
-                'mfa_challenge_expires_in' => $challenge['expires_in'],
+                'mfa_challenge_token' => $gate['challenge']['token'],
+                'mfa_challenge_expires_in' => $gate['challenge']['expires_in'],
             ]);
-        }
-
-        // Politique tenant : rôle sensible + 2FA non activée → blocage.
-        if ($this->twoFactorService->requiresMfa($employee)) {
-            $employee->tokens()->latest('id')->first()?->delete();
-
-            throw TwoFactorException::required();
         }
 
         return (new EmployeeResource($employee))
@@ -324,6 +312,23 @@ class AuthController extends Controller
             }
         }
 
+        // #5579 : garde 2FA factorisée — compte enrôlé → challenge TOTP (pas
+        // de token), politique tenant mfa_required_roles → blocage 403.
+        $gate = $this->twoFactorService->enforceLoginPolicy(
+            $employee,
+            null,
+            null,
+            $request->cookie('mfa_remember_'.$employee->id),
+        );
+
+        if ($gate !== null) {
+            return new JsonResponse([
+                'mfa_challenge' => true,
+                'mfa_challenge_token' => $gate['challenge']['token'],
+                'mfa_challenge_expires_in' => $gate['challenge']['expires_in'],
+            ]);
+        }
+
         $token = $employee->createToken('google-auth');
 
         return (new EmployeeResource($employee))
@@ -369,6 +374,23 @@ class AuthController extends Controller
             if ($company && in_array($company->status, ['suspended', 'expired'], true)) {
                 throw new AccountSuspendedException;
             }
+        }
+
+        // #5579 : garde 2FA factorisée — même gate que le callback (challenge
+        // TOTP si enrôlé, blocage 403 si politique tenant non satisfaite).
+        $gate = $this->twoFactorService->enforceLoginPolicy(
+            $employee,
+            null,
+            $validated['device_name'] ?? null,
+            $request->cookie('mfa_remember_'.$employee->id),
+        );
+
+        if ($gate !== null) {
+            return new JsonResponse([
+                'mfa_challenge' => true,
+                'mfa_challenge_token' => $gate['challenge']['token'],
+                'mfa_challenge_expires_in' => $gate['challenge']['expires_in'],
+            ]);
         }
 
         $tokenName = $validated['device_name'] ?? 'google-mobile';

--- a/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
@@ -162,7 +162,8 @@ class SSOController extends Controller
         }
 
         try {
-            $result = $this->oidcFlowService->complete($companyId, $tokenData);
+            // #5579 : cookies transmis pour honorer l'appareil de confiance 2FA.
+            $result = $this->oidcFlowService->complete($companyId, $tokenData, $request->cookies->all());
 
             return response()->json([
                 'data' => $result,

--- a/api/tests/Feature/AuthGoogleSignInTest.php
+++ b/api/tests/Feature/AuthGoogleSignInTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Feature;
 
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Auth\Infrastructure\Services\TotpService;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\CompanySetting;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Socialite\Facades\Socialite;
 use Tests\RefreshTenantDatabase;
@@ -118,6 +121,66 @@ class AuthGoogleSignInTest extends TestCase
             ->getJson('/api/v1/auth/google/callback?state=valid-state');
 
         $response->assertStatus(403);
+    }
+
+    public function test_google_callback_enrolled_2fa_requires_challenge(): void
+    {
+        // #5579 — un employé ayant activé la 2FA ne reçoit PAS de token via le
+        // callback Google : challenge TOTP uniquement (POST /auth/2fa/verify).
+        $this->mockGoogleUser('2fa-google@example.com');
+
+        $company = Company::factory()->create(['country' => 'DZ']);
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => '2fa-google@example.com',
+            'password_hash' => Hash::make('secret1234'),
+            'role' => 'ordinary',
+            'status' => 'active',
+            'two_fa_secret' => (new TotpService())->generateSecret(),
+            'two_fa_enabled_at' => now(),
+        ]);
+
+        $response = $this->withSession(['google_oauth_state' => 'valid-state'])
+            ->getJson('/api/v1/auth/google/callback?state=valid-state');
+
+        $response->assertOk()
+            ->assertJsonPath('mfa_challenge', true)
+            ->assertJsonStructure(['mfa_challenge_token', 'mfa_challenge_expires_in'])
+            ->assertJsonMissingPath('token');
+
+        // Aucun token Sanctum émis pour l'employé.
+        $this->assertSame(0, $employee->tokens()->count());
+    }
+
+
+    public function test_google_callback_policy_mfa_required_blocks(): void
+    {
+        // #5579 — politique tenant mfa_required_roles (rôle sensible) + 2FA
+        // non activée → le flux Google bloque, comme le login classique.
+        $this->mockGoogleUser('mfa-policy-google@example.com');
+
+        $company = Company::factory()->create(['country' => 'DZ']);
+        Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => 'mfa-policy-google@example.com',
+            'password_hash' => Hash::make('secret1234'),
+            'role' => 'manager',
+            'manager_role' => 'principal',
+            'status' => 'active',
+        ]);
+        CompanySetting::query()->create([
+            'key' => 'mfa_required_roles',
+            'company_id' => $company->id,
+            'value' => 'rh,principal',
+            'value_type' => 'string',
+        ]);
+
+        $response = $this->withSession(['google_oauth_state' => 'valid-state'])
+            ->getJson('/api/v1/auth/google/callback?state=valid-state');
+
+        $response->assertStatus(403)
+            ->assertJsonPath('error', 'TWO_FACTOR_REQUIRED');
     }
 
     public function test_google_redirect_returns_503_when_oauth_not_configured(): void

--- a/api/tests/Feature/SSOOidcFlowTest.php
+++ b/api/tests/Feature/SSOOidcFlowTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
+use App\Core\Tenant\Domain\Models\CompanySetting;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -168,6 +169,111 @@ class SSOOidcFlowTest extends TestCase
         // message d'exception brut — le détail (état inconnu/expiré/consommé)
         // reste en logs pour ne pas fuiter d'information sur un endpoint public.
         $this->assertSame('OIDC_CALLBACK_FAILED', $response->json('error'));
+    }
+
+    public function test_oidc_callback_enrolled_2fa_requires_challenge(): void
+    {
+        // #5579 — un employé 2FA enrôlé ne reçoit PAS de token via OIDC :
+        // challenge TOTP (data.mfa_challenge) à résoudre via /auth/2fa/verify.
+        $this->configureOidc();
+        [$privateKey, $jwks] = $this->rsaKeyPair();
+        $employee = $this->seedEmployeeForSso();
+        $employee->forceFill([
+            'two_fa_secret' => 'JBSWY3DPEHPK3PXP',
+            'two_fa_enabled_at' => now(),
+        ])->save();
+
+        $authorize = $this->getJson('/api/v1/sso/oidc/'.$this->company->id.'/authorize')->assertOk()->json('data.authorize_url');
+        $authorizeQuery = parse_url($authorize, PHP_URL_QUERY);
+        parse_str(is_string($authorizeQuery) ? $authorizeQuery : '', $query);
+        $state = is_string($query['state'] ?? null) ? $query['state'] : '';
+        $nonce = is_string($query['nonce'] ?? null) ? $query['nonce'] : '';
+
+        Http::fake([
+            $this->issuer.'/jwks*' => Http::response(['keys' => [$jwks]], 200),
+        ]);
+
+        $idToken = $this->signIdToken($privateKey, $nonce);
+
+        $this->getJson('/api/v1/sso/oidc/'.$this->company->id.'/callback?state='.$state.'&id_token='.urlencode($idToken))
+            ->assertOk()
+            ->assertJsonPath('data.mfa_challenge', true)
+            ->assertJsonStructure(['data' => ['mfa_challenge_token', 'mfa_challenge_expires_in']])
+            ->assertJsonMissingPath('data.token');
+
+        // Le token créé par loginViaEmail a été révoqué : aucun token persistant.
+        $this->assertSame(0, $employee->tokens()->count());
+    }
+
+
+    public function test_oidc_callback_policy_mfa_required_blocks(): void
+    {
+        // #5579 — politique tenant mfa_required_roles (rôle sensible) + 2FA non
+        // activée → le flux OIDC bloque (403 TWO_FACTOR_REQUIRED), aucun token.
+        $this->configureOidc();
+        [$privateKey, $jwks] = $this->rsaKeyPair();
+        $employee = $this->seedEmployeeForSso();
+        $employee->forceFill(['role' => 'manager', 'manager_role' => 'principal'])->save();
+
+        CompanySetting::query()->create([
+            'key' => 'mfa_required_roles',
+            'company_id' => $this->company->id,
+            'value' => 'rh,principal',
+            'value_type' => 'string',
+        ]);
+
+        $authorize = $this->getJson('/api/v1/sso/oidc/'.$this->company->id.'/authorize')->assertOk()->json('data.authorize_url');
+        $authorizeQuery = parse_url($authorize, PHP_URL_QUERY);
+        parse_str(is_string($authorizeQuery) ? $authorizeQuery : '', $query);
+        $state = is_string($query['state'] ?? null) ? $query['state'] : '';
+        $nonce = is_string($query['nonce'] ?? null) ? $query['nonce'] : '';
+
+        Http::fake([
+            $this->issuer.'/jwks*' => Http::response(['keys' => [$jwks]], 200),
+        ]);
+
+        $idToken = $this->signIdToken($privateKey, $nonce);
+
+        $this->getJson('/api/v1/sso/oidc/'.$this->company->id.'/callback?state='.$state.'&id_token='.urlencode($idToken))
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'TWO_FACTOR_REQUIRED');
+
+        $this->assertSame(0, $employee->tokens()->count());
+    }
+
+
+    public function test_oidc_callback_remember_device_cookie_skips_challenge(): void
+    {
+        // #5579 — appareil de confiance (cookie HMAC valide) : le challenge est
+        // sauté, le token est délivré — parité avec le login classique.
+        $this->configureOidc();
+        [$privateKey, $jwks] = $this->rsaKeyPair();
+        $employee = $this->seedEmployeeForSso();
+        $employee->forceFill([
+            'two_fa_secret' => 'JBSWY3DPEHPK3PXP',
+            'two_fa_enabled_at' => now(),
+        ])->save();
+
+        $remember = app(\App\Core\Auth\Infrastructure\Services\TwoFactorAuthService::class)
+            ->rememberCookieValue($employee);
+
+        $authorize = $this->getJson('/api/v1/sso/oidc/'.$this->company->id.'/authorize')->assertOk()->json('data.authorize_url');
+        $authorizeQuery = parse_url($authorize, PHP_URL_QUERY);
+        parse_str(is_string($authorizeQuery) ? $authorizeQuery : '', $query);
+        $state = is_string($query['state'] ?? null) ? $query['state'] : '';
+        $nonce = is_string($query['nonce'] ?? null) ? $query['nonce'] : '';
+
+        Http::fake([
+            $this->issuer.'/jwks*' => Http::response(['keys' => [$jwks]], 200),
+        ]);
+
+        $idToken = $this->signIdToken($privateKey, $nonce);
+
+        $this->withCookie('mfa_remember_'.$employee->id, $remember)
+            ->getJson('/api/v1/sso/oidc/'.$this->company->id.'/callback?state='.$state.'&id_token='.urlencode($idToken))
+            ->assertOk()
+            ->assertJsonMissingPath('data.mfa_challenge')
+            ->assertJsonPath('data.employee.email', 'sso.employee@example.com');
     }
 
     public function test_callback_rejects_bad_signature(): void

--- a/api/tests/Feature/Security/GoogleAuthGlobalLookupTest.php
+++ b/api/tests/Feature/Security/GoogleAuthGlobalLookupTest.php
@@ -136,4 +136,43 @@ class GoogleAuthGlobalLookupTest extends TestCase
         // Verify no employee was silently created
         $this->assertEquals(0, Employee::withoutGlobalScopes()->where('email', 'nobody@unknown.example')->count());
     }
+    public function test_google_token_login_enrolled_2fa_requires_challenge(): void
+    {
+        // #5579 — le flux token mobile ne délivre pas de token à un compte 2FA
+        // enrôlé : challenge TOTP uniquement (même gate que le callback).
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'DZ']);
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'email' => '2fa-token@example.com',
+            'role' => 'employee',
+            'status' => 'active',
+            'two_fa_secret' => (new \App\Core\Auth\Infrastructure\Services\TotpService())->generateSecret(),
+            'two_fa_enabled_at' => now(),
+        ]);
+
+        $abstractUser = \Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser->shouldReceive('getEmail')->andReturn('2fa-token@example.com');
+        $abstractUser->shouldReceive('getName')->andReturn('TwoFA User');
+        $abstractUser->shouldReceive('offsetGet')->with('email_verified')->andReturn(true);
+
+        $provider = \Mockery::mock('Laravel\Socialite\Two\GoogleProvider');
+        $provider->shouldReceive('stateless')->once()->andReturn($provider);
+        $provider->shouldReceive('userFromToken')->once()->with('2fa-token')->andReturn($abstractUser);
+
+        Socialite::shouldReceive('driver')->with('google')->once()->andReturn($provider);
+
+        $response = $this->postJson('/api/v1/auth/google/token', [
+            'access_token' => '2fa-token',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mfa_challenge', true)
+            ->assertJsonStructure(['mfa_challenge_token', 'mfa_challenge_expires_in'])
+            ->assertJsonMissingPath('token');
+
+        $this->assertSame(0, $employee->tokens()->count());
+    }
+
 }

--- a/api/tests/Support/CreatesMvpSchema.php
+++ b/api/tests/Support/CreatesMvpSchema.php
@@ -253,6 +253,11 @@ trait CreatesMvpSchema
             $table->string('phone', 30)->nullable();
             $table->string('personal_phone', 30)->nullable();
             $table->string('password_hash', 255);
+            // #5436 : 2FA/TOTP comptes entreprise (miroir migration tenant
+            // 2026_08_25_000006_5454_add_two_fa_to_employees_table).
+            $table->string('two_fa_secret')->nullable();
+            $table->timestamp('two_fa_enabled_at')->nullable();
+            $table->json('two_fa_recovery_codes')->nullable();
             $table->date('date_of_birth')->nullable();
             $table->string('place_of_birth', 120)->nullable();
             $table->char('gender', 1)->nullable();


### PR DESCRIPTION
## Contexte
Closes #5579 — la garde 2FA n'existait que sur `login()` : Google callback/token et OIDC émettaient un token Sanctum sans consulter `two_fa_enabled_at` ni la politique `mfa_required_roles` → un compte Google/OIDC compromis contournait la 2FA.

## Changements
- `TwoFactorAuthService::enforceLoginPolicy()` : gate factorisée — compte enrôlé → challenge TOTP (token NON délivré), sauf appareil de confiance (cookie HMAC) ; politique `mfa_required_roles` non satisfaite → 403 `TWO_FACTOR_REQUIRED`. Comportement de `login()` inchangé (refactoré sur la gate).
- `AuthController::handleGoogleCallback` / `handleGoogleToken` : gate avant `createToken`.
- `OidcFlowService::complete()` : gate après `loginViaEmail` — token révoqué si challenge/blocage ; cookies transmis par `SSOController` pour l'appareil de confiance. Challenge résolu via `POST /auth/2fa/verify` existant.

## Tests
Google callback/token enrôlé → `mfa_challenge` sans token ; politique → 403 ; OIDC enrôlé → challenge, politique → 403, cookie de confiance → token. Colonnes 2FA ajoutées au schéma MVP de test (miroir migration tenant #5436).

Agent lot 1/4 — implémentation complète A→Z.