### PR TITLE
fix(ops): Sentry câblé en prod — DSN attendu sur les 3 services Render + LOG_LEVEL info (Closes #5586)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -46,7 +46,12 @@ services:
       - key: LOG_CHANNEL
         value: stderr
       - key: LOG_LEVEL
-        value: error
+        value: info
+      # #5586 : Sentry branché — DSN à saisir dans le dashboard Render
+      # (secret, sync: false) sur les 3 services. Sans DSN, aucun événement
+      # ne quitte la prod (config/sentry.php retombe sur null).
+      - key: SENTRY_LARAVEL_DSN
+        sync: false
       # Database
       - key: DB_CONNECTION
         value: pgsql
@@ -198,7 +203,10 @@ services:
       - key: LOG_CHANNEL
         value: stderr
       - key: LOG_LEVEL
-        value: error
+        value: info
+      # #5586 : Sentry branché — DSN à saisir dans le dashboard Render.
+      - key: SENTRY_LARAVEL_DSN
+        sync: false
       - key: DB_CONNECTION
         value: pgsql
       - key: DB_HOST
@@ -306,6 +314,13 @@ services:
           property: host
       - key: LOG_CHANNEL
         value: stderr
+      # #5586 : aligné sur web/worker — le canal structured (StructuredLogging)
+      # filtre à info ; sans LOG_LEVEL explicite, le scheduler repartait sur le
+      # défaut debug.
+      - key: LOG_LEVEL
+        value: info
+      - key: SENTRY_LARAVEL_DSN
+        sync: false
       - key: DB_CONNECTION
         value: pgsql
       - key: DB_HOST


### PR DESCRIPTION
## Résumé
`sentry/sentry-laravel` ^4.0 était installé, `config/sentry.php` complet, `SentryContextMiddleware` + `Integration::handles()` branchés — mais **0 occurrence de SENTRY dans render.yaml** et DSN vide → aucun événement ne quittait la prod.

- **render.yaml** : `SENTRY_LARAVEL_DSN` (`sync: false` → à saisir dans le dashboard Render) ajouté au web `gestionemployerbackend`, au worker `leopardo-queue-worker` et au scheduler. Sans DSN, `config/sentry.php` retombe sur null (aucun crash, aucun envoi).
- **LOG_LEVEL error → info** sur les 3 services : le canal `structured` (StructuredLogging middleware, filtre info) était mort en prod ; le scheduler n'avait pas de LOG_LEVEL explicite (défaut debug) — aligné.
- Aucune clé à ajouter à `.env.example` (SENTRY_LARAVEL_DSN déjà documenté).

## Action ops requise
Poser `SENTRY_LARAVEL_DSN` dans le dashboard Render (3 services) puis redéployer. Sans ça, la config reste inerte (aucune télémétrie) — comportement inchangé.

## Vérifications
- render.yaml valide (YAML).
- Parité `config/ ↔ .env.example` OK (check-env-example-parity.sh : 286 clés, 0 manquante).
- `check-render-env-parity.sh` non impacté (SENTRY = secret `sync: false`, LOG_LEVEL hors clés critiques).