### PR TITLE
fix(ci): composer audit renforcé + phpstan.neon aligné sur le périmètre réellement enforce (Closes #5590)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,8 +222,13 @@ jobs:
           coverage: none
 
       - name: Run Composer audit
+        # #5590 : le job audit existait (CodeQL + TruffleHog ne couvrent pas
+        # les dépendances PHP). composer audit échoue dès qu'une advisory
+        # existe (fail-on-any, strict par défaut) ; on ajoute le rapport des
+        # paquets abandonnés (non bloquant) pour la visibilité.
         working-directory: ./api
-        run: composer audit --locked --no-dev
+        run: |
+          composer audit --locked --no-dev --abandoned=report
 
   backend-quality:
     # This job may push an explicitly generated Pint formatting commit on

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -28,10 +28,15 @@ leopardo-hr/
 - **`declare(strict_types=1);`** en haut de chaque fichier PHP (sauf config)
 - **Namespace PSR-4** — `App\Modules\<NomModule>\*`, `App\Core\*`, `App\Shared\*`
   _(Les anciens espaces `App\Http\Controllers\Api\V1\*` et `App\Services\*` sont supprimés — voir `api/ARCHITECTURE.md`)_
-- **PHPStan** — `phpstan.neon` declare `level: max` pour l'ensemble de `app/`, mais aucun job CI ne l'execute directement aujourd'hui. Ce que la CI verifie reellement, de facon bloquante :
+- **PHPStan** — la config « max » (`phpstan.neon`) est alignée sur le périmètre
+  réellement enforce en CI (#5590) : fichiers modifiés de `app/AI`,
+  `app/Http/Middleware` et `routes` (job backend-quality de tests.yml, via
+  `phpstan.ci.neon`). Ce que la CI verifie reellement, de facon bloquante :
   - `phpstan-modules.neon` (niveau 5, `app/Core`/`app/Modules`/`app/Shared`) — job `phpstan-modules` (bloquant).
   - `phpstan-strict.neon` (niveau 8, meme perimetre) — job `phpstan-strict`, bloquant sur le **delta** uniquement depuis #1413 : `phpstan-strict-baseline.neon` gele les ~2950 erreurs pre-existantes (voir `api/ARCHITECTURE.md` section "Trajectoire PHPStan" pour la repartition par module et la trajectoire de reduction), toute nouvelle erreur hors baseline fait echouer la CI.
-  - "level max" n'est donc pas un standard verifie en CI aujourd'hui ; le niveau 8 bloquant-sur-delta est l'etat reel le plus proche.
+  - Le niveau 8 bloquant-sur-delta est l'etat reel le plus proche de « max » ;
+    etendre le max a tout `app/` exigerait d'augmenter `phpstan-baseline.neon`,
+    ce que la ratchet `check-phpstan-baseline-debt.sh` interdit (voir #5590).
 - **Pas de `Any`, `mixed` sauf absolument necessaire** — typer tous les parametres et retours
 
 ### 2.2 Nommage

--- a/api/ARCHITECTURE.md
+++ b/api/ARCHITECTURE.md
@@ -166,7 +166,7 @@ _Issue #1413, complétant le suivi de la ligne ci-dessus._
 
 | Config | Portée | Niveau actuel | Statut CI | Cible |
 |---|---|---|---|---|
-| `phpstan.neon` | tout `app/` | `max` | non branché à un job CI dédié (voir `phpstan-modules`/`phpstan-strict` ci-dessous) | n/a |
+| `phpstan.neon` | `app/AI`, `app/Http/Middleware`, `routes` | `max` | **bloquant sur fichiers modifiés** (tests.yml `backend-quality`, via `phpstan.ci.neon`) — périmètre aligné sur le réel (#5590) | rester sur ce périmètre ; l'étendre à tout `app/` exigerait une baseline que la ratchet `check-phpstan-baseline-debt.sh` interdit d'augmenter |
 | `phpstan-modules.neon` | `app/Core`, `app/Modules`, `app/Shared` | `5` | **bloquant** (`architecture-check.yml`, job `phpstan-modules`) | rester à 5 pour l'instant ; réévaluer une montée à 6/7 une fois `phpstan-strict` stabilisé (voir ci-dessous) |
 | `phpstan-strict.neon` | `app/Core`, `app/Modules`, `app/Shared` | `8` | **bloquant sur delta uniquement** depuis #1413 (`phpstan-strict-baseline.neon`, 2950 erreurs pré-existantes gelées ; `continue-on-error` retiré du job `phpstan-strict`) | réduire progressivement la baseline module par module (voir répartition ci-dessous), jamais l'augmenter |
 

--- a/api/phpstan.neon
+++ b/api/phpstan.neon
@@ -1,3 +1,18 @@
+# PHPStan « max » — config alignée sur le périmètre RÉELLEMENT enforce en CI.
+#
+# #5590 (audit 2026-08-26) : la config déclarait `level: max` sur tout `app/`
+# + `routes` + `tests`, mais aucun job ne l'exécutait sur ce périmètre — la
+# CI (tests.yml, job backend-quality) ne lance `phpstan.neon` (via
+# `phpstan.ci.neon`) que sur les fichiers modifiés de `app/AI`,
+# `app/Http/Middleware` et `routes`. Le reste du backend est couvert par :
+#   - `phpstan-modules.neon` (niveau 5, bloquant) — app/Core|Modules|Shared
+#   - `phpstan-strict.neon`  (niveau 8, bloquant sur delta, baseline #1413)
+# La ratchet check-phpstan-baseline-debt.sh interdit d'étendre
+# `phpstan-baseline.neon` (8795 erreurs max sur le scope déclaré à l'audit) :
+# le niveau max ne peut donc pas devenir un gate plein-app sans régresser.
+#
+# → `paths` réduit au périmètre réellement enforce au niveau max en CI.
+#   Les chemins passés en argument CLI (gate tests.yml) priment sur `paths`.
 includes:
     - phpstan-baseline.neon
     - vendor/larastan/larastan/extension.neon
@@ -7,9 +22,9 @@ parameters:
         - phpstan-bootstrap.php
     level: max
     paths:
-        - app
+        - app/AI
+        - app/Http/Middleware
         - routes
-        - tests
     tmpDir: storage/phpstan
     excludePaths:
         - bootstrap/cache


### PR DESCRIPTION
## Résumé
Audit 2026-08-26 : **composer audit était en réalité déjà présent** (job `backend-security` de tests.yml, depuis avril) — l'issue le croyait absent. Ce qui manquait :

1. **Composer audit renforcé** : `composer audit --locked --no-dev --abandoned=report` — en plus des advisories (fail-on-any par défaut, inchangé), signale désormais les **paquets abandonnés** (point 3 optionnel de l'issue).
2. **`phpstan.neon` (level max) rendu honnête** : il déclarait `level: max` sur `app/` + `routes` + `tests` mais la CI ne l'exécute (via `phpstan.ci.neon`) que sur les fichiers **modifiés** de `app/AI`, `app/Http/Middleware`, `routes`. L'étendre à tout `app/` exigerait ~8795 nouvelles entrées de baseline (2990 app/ + 5822 tests/ mesurés), ce que la ratchet `check-phpstan-baseline-debt.sh` (0 nouvelle entrée, garde globale) interdit structurellement — la trajectoire assumée du repo est lvl 5 modules + lvl 8-delta (voir CONVENTIONS.md §2.1).
   → `paths` réduits au périmètre réellement enforce au niveau max + docblock explicite. Aucun changement de comportement CI (les chemins CLI priment sur `paths`).
3. **Docs** : CONVENTIONS.md §2.1 + api/ARCHITECTURE.md (tableau Trajectoire PHPStan) corrigés — plus de config « trompeuse ».

## Décision
« Soit brancher, soit supprimer » → ni l'un ni l'autre n'était viable proprement (ratchet anti-baseline) : on **aligne la config sur la réalité enforce** et on documente. La dette max restante (89 erreurs AI/Middleware/routes non baselinées) est préexistante et inchangée (le gate CI ne les voit que si ces fichiers sont modifiés — comportement d'origine).