### PR TITLE
fix(routes): garde CI contre les collisions (METHOD, URI) — #5577

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -105,6 +105,23 @@ jobs:
         working-directory: api
         run: vendor/bin/phpstan analyse --configuration=phpstan-modules.neon --memory-limit=1G --no-progress
 
+      - name: Duplicate routes guard — collisions (METHOD, URI) (#5577)
+        working-directory: api
+        run: |
+          # .env minimal pour que artisan route:list puisse bootstrapper
+          # sans DB réelle (les routes sont enregistrées lors du boot, pas de requête DB)
+          cp .env.example .env.ci-routes
+          echo "APP_ENV=testing"                    >> .env.ci-routes
+          echo "DB_CONNECTION=sqlite"               >> .env.ci-routes
+          echo "DB_DATABASE=:memory:"               >> .env.ci-routes
+          echo "CACHE_DRIVER=array"                 >> .env.ci-routes
+          echo "SESSION_DRIVER=array"               >> .env.ci-routes
+          echo "QUEUE_CONNECTION=sync"              >> .env.ci-routes
+          cp .env.ci-routes .env
+          php artisan key:generate --no-interaction
+          php ../dev-hub/tools/check-duplicate-routes.php .
+          rm -f .env .env.ci-routes
+
   # Audit §2.3 / Plan P1: phpstan-strict.neon existed in the repo (level 8 on
   # app/Core, app/Modules, app/Shared) but was never invoked by any workflow
   # — the audit flagged this as a dead config that quietly gave a false sense

--- a/dev-hub/tools/check-duplicate-routes.php
+++ b/dev-hub/tools/check-duplicate-routes.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * check-duplicate-routes.php — garde CI contre les collisions de routes (#5577)
+ *
+ * Utilise `php artisan route:list --json` pour obtenir les routes Laravel avec
+ * leurs URIs complètes (préfixes inclus), puis détecte les paires (METHOD, URI)
+ * enregistrées plusieurs fois — ce qui rend l'un des contrôleurs silencieusement
+ * inatteignable (Laravel ne sert que la première déclaration).
+ *
+ * Usage : php dev-hub/tools/check-duplicate-routes.php [api_dir]
+ * Exemple depuis la racine du monorepo : php dev-hub/tools/check-duplicate-routes.php api
+ *
+ * Retour : 0 si aucun doublon, 1 si au moins un doublon détecté.
+ *
+ * Ignorés intentionnellement :
+ *   - Routes de HEAD (Laravel génère automatiquement HEAD pour chaque GET).
+ *   - Routes dont l'URI ou la méthode est vide.
+ *   - Routes tagged comme "deprecated" dans leur nom (ex. aliases rétro-compat).
+ */
+
+$apiDir = $argv[1] ?? 'api';
+
+if (! is_dir($apiDir)) {
+    fwrite(STDERR, "❌  Répertoire introuvable : {$apiDir}\n");
+    exit(2);
+}
+
+// Exécuter artisan route:list en JSON
+$cmd = sprintf(
+    'cd %s && php artisan route:list --json --columns=method,uri,name,action 2>&1',
+    escapeshellarg($apiDir)
+);
+
+$output = [];
+$exitCode = 0;
+exec($cmd, $output, $exitCode);
+
+$json = implode("\n", $output);
+
+if ($exitCode !== 0) {
+    fwrite(STDERR, "❌  artisan route:list a échoué (code {$exitCode}) :\n{$json}\n");
+    exit(2);
+}
+
+$routes = json_decode($json, true);
+
+if (! is_array($routes)) {
+    fwrite(STDERR, "❌  Impossible de décoder le JSON de route:list.\n");
+    fwrite(STDERR, "Output brut : " . substr($json, 0, 500) . "\n");
+    exit(2);
+}
+
+// Construire une map (METHOD|URI → [routes…])
+$seen = [];
+
+foreach ($routes as $route) {
+    $method = strtoupper(trim((string) ($route['method'] ?? '')));
+    $uri = trim((string) ($route['uri'] ?? ''));
+    $name = (string) ($route['name'] ?? '');
+    $action = (string) ($route['action'] ?? '');
+
+    // Ignorer les routes HEAD (générées automatiquement par Laravel pour chaque GET)
+    if ($method === 'HEAD') {
+        continue;
+    }
+
+    // Ignorer les routes vides
+    if ($method === '' || $uri === '') {
+        continue;
+    }
+
+    // Ignorer les aliases dépréciés (nom de route contient "deprecated" ou "legacy")
+    if (preg_match('/déprécié|deprecated|legacy[._-]alias/i', $name)) {
+        continue;
+    }
+
+    // Laravel liste GET|HEAD ensemble — on prend GET uniquement
+    if (str_contains($method, '|')) {
+        $methods = explode('|', $method);
+        foreach ($methods as $m) {
+            $m = trim($m);
+            if ($m === 'HEAD') {
+                continue;
+            }
+            $key = strtoupper($m) . '|' . $uri;
+            $seen[$key][] = ['method' => strtoupper($m), 'uri' => $uri, 'action' => $action, 'name' => $name];
+        }
+        continue;
+    }
+
+    $key = "{$method}|{$uri}";
+    $seen[$key][] = ['method' => $method, 'uri' => $uri, 'action' => $action, 'name' => $name];
+}
+
+// Filtrer les doublons
+$duplicates = array_filter($seen, fn (array $routes): bool => count($routes) > 1);
+
+if (count($duplicates) === 0) {
+    $total = count($routes);
+    echo "✅  Aucune route dupliquée (méthode + URI) détectée ({$total} routes analysées).\n";
+    exit(0);
+}
+
+echo "\n";
+echo "❌  Routes dupliquées détectées (" . count($duplicates) . " collision(s)) :\n";
+echo "\n";
+
+foreach ($duplicates as $key => $collisions) {
+    [$method, $uri] = explode('|', $key, 2);
+    echo "   {$method} /{$uri}\n";
+    foreach ($collisions as $r) {
+        $action = $r['action'] !== '' ? $r['action'] : '(closure)';
+        echo "     → {$action}\n";
+    }
+    echo "\n";
+}
+
+echo "  " . count($duplicates) . " collision(s) détectée(s).\n";
+echo "  Laravel ne sert que la PREMIÈRE déclaration : les contrôleurs suivants\n";
+echo "  sont silencieusement inatteignables.\n";
+echo "  Ref : issue #5577\n\n";
+
+exit(1);


### PR DESCRIPTION
## Contexte

La collision `POST /accounting/documents/{document}/payments` (AccountingDocumentController vs AccountingPaymentController) était déclarée deux fois dans `accounting.php`. Laravel ne servant que la première déclaration, l'un des contrôleurs était silencieusement inatteignable.

**Les doublons concrets ont déjà été corrigés dans main** (commentaire explicatif en place dans accounting.php et geo.php).

## Ce PR ajoute

### `dev-hub/tools/check-duplicate-routes.php`
- Utilise `php artisan route:list --json` pour obtenir les routes avec leurs URIs **complètes** (préfixes inclus)
- Détecte les paires (METHOD, URI) enregistrées plusieurs fois → sortie avec les actions conflictuelles
- Ignore HEAD (généré automatiquement par Laravel pour chaque GET)
- Ignore les alias dépréciés (compatibilité intentionnelle)

### `.github/workflows/architecture-check.yml`
- Nouveau step `Duplicate routes guard` dans le job `phpstan-modules` (PHP + Composer déjà disponibles)
- Setup `.env` minimal (sqlite :memory:, APP_KEY généré) pour bootstrapper artisan sans DB réelle

Closes #5577