### PR TITLE
fix: lot #5579 #5580 #5581 #5585 — 2FA bypass SSO, email_verified, rotation atomique, tests Growth

### DIFF
--- a/api/app/Core/Auth/Infrastructure/Services/SSO/OidcFlowService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/SSO/OidcFlowService.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Core\Auth\Infrastructure\Services\SSO;
 
+use App\Core\Auth\Domain\Exceptions\TwoFactorException;
 use App\Core\Auth\Infrastructure\Services\AuthService;
+use App\Core\Auth\Infrastructure\Services\TwoFactorAuthService;
 use App\Rules\NotPrivateUrl;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 /**
@@ -30,6 +33,7 @@ final class OidcFlowService
         private readonly SSOService $ssoService,
         private readonly OidcIdTokenValidator $idTokenValidator,
         private readonly AuthService $authService,
+        private readonly TwoFactorAuthService $twoFactorService,
     ) {}
 
     /**
@@ -97,6 +101,19 @@ final class OidcFlowService
             'jwks_uri' => (string) $config->jwksUri,
         ]);
 
+        // Issue #5580 : exiger email_verified=true dans les claims OIDC.
+        // Un IdP peut émettre un id_token avec email_verified=false pour un
+        // compte non vérifié — accepter cet email permettrait une prise de
+        // contrôle du compte employé correspondant.
+        $emailVerified = $claims['email_verified'] ?? null;
+        if ($emailVerified !== true && $emailVerified !== 'true') {
+            Log::warning('sso.oidc_email_not_verified', [
+                'company_id' => $companyId,
+                'claim_value' => $emailVerified,
+            ]);
+            throw new \RuntimeException('SSO_EMAIL_NOT_VERIFIED: l\'id_token atteste un email non vérifié.');
+        }
+
         $email = $this->extractEmail($claims);
 
         try {
@@ -107,7 +124,36 @@ final class OidcFlowService
 
         $employee = $result['employee'];
         if ((string) $employee->company_id !== $companyId) {
+            // Révoquer le token créé par loginViaEmail avant de lever l'erreur.
+            $employee->tokens()->where('name', 'sso-oidc')->latest('id')->first()?->delete();
             throw new \RuntimeException('SSO_TENANT_MISMATCH: l\'email SSO appartient à une autre entreprise.');
+        }
+
+        // Issue #5579 : garde 2FA sur le flux OIDC — sans cette vérification un
+        // employé ayant activé le TOTP pouvait contourner le challenge via SSO.
+        if ($employee->two_fa_enabled_at !== null) {
+            // Révoquer le token avant d'émettre le challenge.
+            $employee->tokens()->where('name', 'sso-oidc')->latest('id')->first()?->delete();
+
+            $challenge = $this->twoFactorService->issueChallenge([
+                'employee_id' => $employee->id,
+                'company_id' => (string) $employee->company_id,
+                'tenant_schema' => null,
+                'email' => (string) $employee->email,
+                'device_name' => 'sso-oidc',
+            ]);
+
+            return [
+                'mfa_challenge' => true,
+                'mfa_challenge_token' => $challenge['token'],
+                'mfa_challenge_expires_in' => $challenge['expires_in'],
+            ];
+        }
+
+        // Politique tenant : rôle sensible + 2FA non activée → blocage.
+        if ($this->twoFactorService->requiresMfa($employee)) {
+            $employee->tokens()->where('name', 'sso-oidc')->latest('id')->first()?->delete();
+            throw TwoFactorException::required();
         }
 
         return [

--- a/api/app/Core/Auth/Interfaces/Api/V1/AuthController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/AuthController.php
@@ -278,6 +278,19 @@ class AuthController extends Controller
             ], 422);
         }
 
+        // Issue #5580 : exiger email_verified=true — un compte Google non vérifié
+        // (ou un IdP qui n'atteste pas la possession) pourrait usurper n'importe
+        // quel employé partageant le même email.
+        $rawGoogleUser = $googleUser->getRaw();
+        if (empty($rawGoogleUser['email_verified'])) {
+            Log::warning('auth.google.callback_email_not_verified', ['email' => $googleUser->getEmail()]);
+
+            return new JsonResponse([
+                'error' => 'EMAIL_NOT_VERIFIED',
+                'message' => __('errors.EMAIL_NOT_VERIFIED'),
+            ], 401);
+        }
+
         /** @var Employee|null $employee */
         $employee = Employee::withoutGlobalScopes()->where('email', $googleUser->getEmail())->first();
 
@@ -324,6 +337,34 @@ class AuthController extends Controller
             }
         }
 
+        // Issue #5579 : garde 2FA sur les flux SSO — sans cette vérification un
+        // employé ayant activé la TOTP pouvait contourner le challenge via Google.
+        if ($employee->two_fa_enabled_at !== null) {
+            // Appareil de confiance (cookie signé) : pas de challenge.
+            $expected = $this->twoFactorService->rememberCookieValue($employee);
+            $provided = $request->cookie('mfa_remember_'.$employee->id);
+            if (! is_string($provided) || ! hash_equals($expected, $provided)) {
+                $challenge = $this->twoFactorService->issueChallenge([
+                    'employee_id' => $employee->id,
+                    'company_id' => (string) $employee->company_id,
+                    'tenant_schema' => null,
+                    'email' => (string) $employee->email,
+                    'device_name' => null,
+                ]);
+
+                return new JsonResponse([
+                    'mfa_challenge' => true,
+                    'mfa_challenge_token' => $challenge['token'],
+                    'mfa_challenge_expires_in' => $challenge['expires_in'],
+                ]);
+            }
+        }
+
+        // Politique tenant : rôle sensible + 2FA non activée → blocage.
+        if ($this->twoFactorService->requiresMfa($employee)) {
+            throw TwoFactorException::required();
+        }
+
         $token = $employee->createToken('google-auth');
 
         return (new EmployeeResource($employee))
@@ -353,6 +394,17 @@ class AuthController extends Controller
             ], 422);
         }
 
+        // Issue #5580 : exiger email_verified=true (parité avec handleGoogleCallback).
+        $rawGoogleUser = $googleUser->getRaw();
+        if (empty($rawGoogleUser['email_verified'])) {
+            Log::warning('auth.google.token_email_not_verified', ['email' => $googleUser->getEmail()]);
+
+            return new JsonResponse([
+                'error' => 'EMAIL_NOT_VERIFIED',
+                'message' => __('errors.EMAIL_NOT_VERIFIED'),
+            ], 401);
+        }
+
         /** @var Employee|null $employee */
         $employee = Employee::withoutGlobalScopes()->where('email', $googleUser->getEmail())->first();
 
@@ -369,6 +421,30 @@ class AuthController extends Controller
             if ($company && in_array($company->status, ['suspended', 'expired'], true)) {
                 throw new AccountSuspendedException;
             }
+        }
+
+        // Issue #5579 : garde 2FA (parité avec handleGoogleCallback).
+        // Note : le flux mobile ne dispose pas du cookie remember ; le challenge
+        // TOTP est systématique si la 2FA est activée.
+        if ($employee->two_fa_enabled_at !== null) {
+            $challenge = $this->twoFactorService->issueChallenge([
+                'employee_id' => $employee->id,
+                'company_id' => (string) $employee->company_id,
+                'tenant_schema' => null,
+                'email' => (string) $employee->email,
+                'device_name' => $validated['device_name'] ?? null,
+            ]);
+
+            return new JsonResponse([
+                'mfa_challenge' => true,
+                'mfa_challenge_token' => $challenge['token'],
+                'mfa_challenge_expires_in' => $challenge['expires_in'],
+            ]);
+        }
+
+        // Politique tenant : rôle sensible + 2FA non activée → blocage.
+        if ($this->twoFactorService->requiresMfa($employee)) {
+            throw TwoFactorException::required();
         }
 
         $tokenName = $validated['device_name'] ?? 'google-mobile';

--- a/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Core\Auth\Interfaces\Api\V1;
 
 use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Auth\Domain\Exceptions\TwoFactorException;
 use App\Core\Auth\Infrastructure\Services\SSO\OidcFlowService;
 use App\Core\Auth\Infrastructure\Services\SSO\SSOService;
 use App\Core\Auth\Infrastructure\Services\SSO\SSOValidationNotImplementedException;
@@ -164,10 +165,19 @@ class SSOController extends Controller
         try {
             $result = $this->oidcFlowService->complete($companyId, $tokenData);
 
+            // Issue #5579 : le service peut retourner un challenge 2FA (mfa_challenge=true)
+            // si l'employé a la TOTP activée ; dans ce cas, on ne renvoie PAS de token.
+            if (! empty($result['mfa_challenge'])) {
+                return response()->json(['data' => $result]);
+            }
+
             return response()->json([
                 'data' => $result,
                 'message' => __('errors.OIDC_LOGIN_SUCCESS'),
             ]);
+        } catch (TwoFactorException $e) {
+            // Issue #5579 : laisser remonter au handler global (403 TWO_FACTOR_REQUIRED).
+            throw $e;
         } catch (\RuntimeException $e) {
             Log::error('sso.oidc_callback_failed', ['company_id' => $companyId, 'error' => $e->getMessage()]);
 


### PR DESCRIPTION
## Résumé

Ce PR corrige 4 issues de sécurité/qualité (lot 2 agent Neo).

---

### #5580 — email_verified jamais exigé sur SSO Google + OIDC

**Avant :** Les flux `handleGoogleCallback` / `handleGoogleToken` / OIDC matchaient par email sans vérifier la possession du compte.

**Après :**
- `handleGoogleCallback` et `handleGoogleToken` : `getRaw()['email_verified']` vérifié → 401 `EMAIL_NOT_VERIFIED` si absent/false.
- `OidcFlowService::complete()` : claim `email_verified` des JWT claims vérifié avant toute résolution d'employé.

---

### #5579 — Bypass 2FA sur flux SSO Google/OIDC

**Avant :** La garde TOTP n'existait que sur `login()` — les flux Google/OIDC émettaient un token sans challenge.

**Après :**
- `handleGoogleCallback` : check cookie remember + `issueChallenge` avant `createToken`.
- `handleGoogleToken` : challenge TOTP systématique si `two_fa_enabled_at` set.
- `OidcFlowService::complete()` : injection `TwoFactorAuthService` ; token révoqué + challenge retourné si 2FA active ; `requiresMfa()` → `TwoFactorException`.
- `SSOController` : re-propage `TwoFactorException` (403 global handler) ; détecte `mfa_challenge` dans la réponse.

---

### #5581 — Rotation de token non atomique + X-New-Token en header

**Avant :** `createToken` puis `delete` sans verrou → deux requêtes concurrentes émettent chacune un nouveau token valide. Token secret exposé dans `X-New-Token` (loggué par proxies).

**Après :**
- `TokenAutoRefreshMiddleware` et `RefreshTokenAction` : `SELECT FOR UPDATE` + transaction autour du create+delete.
- `X-New-Token` supprimé. Le token est injecté dans le corps JSON sous `_token_refresh` (uniquement si `JsonResponse`). `X-Token-Refreshed: true` reste (booléen, pas de secret).

---

### #5585 — Tests GrowthControllerTest non-déterministes

**Avant :** `assertContains($status, [200, 404])`, `[403, 404]`, `[200, 403, 404]` — passaient quelle que soit la réponse. Routes fantômes utilisées (`/growth/admin/stats`, `/growth/partners`).

**Après :** Assertions précises sur le contrat réel (404 NOT_A_PARTNER, 401 mauvais guard, 422 validation). Routes corrigées.

---

Closes #5579
Closes #5580
Closes #5581
Closes #5585