### PR TITLE
fix(ai): sécuriser VoiceController TTS — URLs signées + purge + bascule ElevenLabs [#5616]

### DIFF
--- a/api/app/Console/Commands/PurgeTtsFilesCommand.php
+++ b/api/app/Console/Commands/PurgeTtsFilesCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Issue #5616 — Purge des fichiers audio TTS temporaires.
+ *
+ * Les fichiers générés par VoiceController (edge-tts ou ElevenLabs) sont
+ * stockés dans `storage/app/tts/` et servis via des URLs signées à courte
+ * durée (60 s). Ce scheduler les supprime après `--max-age` minutes (défaut :
+ * 60 min) pour éviter l'accumulation sur le disque.
+ *
+ * Usage :
+ *   php artisan tts:purge [--max-age=60] [--dry-run]
+ */
+class PurgeTtsFilesCommand extends Command
+{
+    protected $signature = 'tts:purge
+        {--max-age=60 : Âge maximum des fichiers en minutes (défaut : 60)}
+        {--dry-run    : Affiche les fichiers qui seraient supprimés sans les supprimer}';
+
+    protected $description = 'Purge les fichiers audio TTS temporaires (issue #5616 — RGPD + espace disque)';
+
+    public function handle(): int
+    {
+        $maxAgeMinutes = (int) $this->option('max-age');
+        $dryRun = (bool) $this->option('dry-run');
+        $cutoff = Carbon::now()->subMinutes($maxAgeMinutes);
+
+        $disk = Storage::disk('local');
+        $files = $disk->files('tts');
+
+        $deleted = 0;
+        $skipped = 0;
+
+        foreach ($files as $file) {
+            // Ignorer les fichiers dont le nom ne correspond pas au pattern
+            // généré par VoiceController (tts_<hex>.mp3).
+            if (! preg_match('/^tts\/tts_[a-f0-9]+\.mp3$/', $file)) {
+                $skipped++;
+                continue;
+            }
+
+            $lastModified = Carbon::createFromTimestamp($disk->lastModified($file));
+
+            if ($lastModified->isBefore($cutoff)) {
+                if ($dryRun) {
+                    $this->line("[dry-run] Supprimerait : {$file} (modifié le {$lastModified->toIso8601String()})");
+                } else {
+                    $disk->delete($file);
+                    $this->line("Supprimé : {$file}");
+                }
+                $deleted++;
+            }
+        }
+
+        $action = $dryRun ? 'à supprimer' : 'supprimés';
+        $this->info("Purge TTS terminée — {$deleted} fichier(s) {$action}, {$skipped} ignoré(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/api/app/Http/Controllers/AI/VoiceController.php
+++ b/api/app/Http/Controllers/AI/VoiceController.php
@@ -12,9 +12,15 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class VoiceController extends Controller
 {
+    /** Durée de validité des URLs audio signées (en secondes). */
+    private const TTS_URL_TTL_SECONDS = 60;
+
     public function transcribe(Request $request): JsonResponse
     {
         $validated = $request->validate([
@@ -45,7 +51,7 @@ class VoiceController extends Controller
             'voice' => ['nullable', 'string', 'max:80', 'regex:/^[A-Za-z0-9._-]+$/'],
         ]);
 
-        $provider = config('ai.voice.tts_provider', 'edge_tts');
+        $provider = $this->resolveEffectiveTtsProvider(config('ai.voice.tts_provider', 'edge_tts'));
         $audioUrl = $this->textToSpeech(
             $validated['text'],
             $validated['language'] ?? 'fr',
@@ -85,7 +91,7 @@ class VoiceController extends Controller
             conversationId: is_numeric($conversationId) ? (int) $conversationId : null,
         ));
 
-        $ttsProvider = config('ai.voice.tts_provider', 'edge_tts');
+        $ttsProvider = $this->resolveEffectiveTtsProvider(config('ai.voice.tts_provider', 'edge_tts'));
         $audioUrl = $this->textToSpeech(
             $aiResponse['response'] ?? $transcribedText,
             $language,
@@ -102,6 +108,60 @@ class VoiceController extends Controller
                 'language' => $language,
             ],
         ]);
+    }
+
+    /**
+     * Sert un fichier TTS via URL signée temporaire (#5616).
+     *
+     * Route nommée `tts.serve` — accessible sans authentification Sanctum mais
+     * protégée par une signature Laravel expirante (TTL = TTS_URL_TTL_SECONDS).
+     */
+    public function serveTts(Request $request, string $filename): StreamedResponse
+    {
+        // hasValidSignature() vérifie la signature absolue (schéma + domaine),
+        // cohérent avec URL::temporarySignedRoute() qui génère des URLs absolues.
+        abort_unless($request->hasValidSignature(), 403);
+
+        // Sanity check : accepter uniquement les noms générés par ce contrôleur.
+        if (! preg_match('/^tts_[a-f0-9]+\.mp3$/', $filename)) {
+            abort(404);
+        }
+
+        $path = 'tts/'.$filename;
+
+        if (! Storage::disk('local')->exists($path)) {
+            abort(404);
+        }
+
+        return response()->streamDownload(function () use ($path): void {
+            echo Storage::disk('local')->get($path);
+        }, $filename, [
+            'Content-Type' => 'audio/mpeg',
+            'Content-Length' => Storage::disk('local')->size($path),
+            'Cache-Control' => 'private, no-store',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Résout le provider TTS effectif.
+     *
+     * Règle issue #5616 : si `edge_tts` est configuré mais qu'une clé
+     * ElevenLabs est disponible, on préfère le cloud (aucun exec()) pour éviter
+     * la dépendance au binaire Python en production.
+     */
+    private function resolveEffectiveTtsProvider(string $configured): string
+    {
+        if ($configured === 'edge_tts' && (bool) config('ai.voice.elevenlabs_key')) {
+            Log::info('TTS: edge_tts configuré mais ElevenLabs disponible — bascule automatique (#5616)');
+
+            return 'elevenlabs';
+        }
+
+        return $configured;
     }
 
     /**
@@ -190,6 +250,14 @@ class VoiceController extends Controller
         return null;
     }
 
+    /**
+     * Synthèse edge-tts (fallback sans clé cloud).
+     *
+     * Issue #5616 — correctifs sécurité :
+     *  - Les fichiers sont stockés dans le disk `local` (non public).
+     *  - L'URL renvoyée est une URL signée temporaire (TTL = TTS_URL_TTL_SECONDS)
+     *    via la route nommée `tts.serve` — plus aucun accès public permanent.
+     */
     private function edgeTtsSynthesize(string $text, string $language, ?string $voice): ?string
     {
         $voiceMap = [
@@ -200,7 +268,7 @@ class VoiceController extends Controller
         ];
 
         $selectedVoice = $voice ?? ($voiceMap[$language] ?? 'fr-FR-DeniseNeural');
-        $filename = 'tts_'.uniqid().'.mp3';
+        $filename = 'tts_'.bin2hex(random_bytes(8)).'.mp3';
         $storagePath = storage_path('app/tts/'.$filename);
 
         if (! is_dir(dirname($storagePath))) {
@@ -219,9 +287,20 @@ class VoiceController extends Controller
             return null;
         }
 
-        return url('storage/tts/'.$filename);
+        // Issue #5616 : URL signée expirant dans TTS_URL_TTL_SECONDS secondes
+        // (plus d'URL publique permanente).
+        return URL::temporarySignedRoute(
+            'tts.serve',
+            now()->addSeconds(self::TTS_URL_TTL_SECONDS),
+            ['filename' => $filename],
+        );
     }
 
+    /**
+     * Synthèse ElevenLabs (provider cloud préféré).
+     *
+     * Issue #5616 : URL signée temporaire, stockage privé (disk local).
+     */
     private function elevenLabsSynthesize(string $text, ?string $voiceId): ?string
     {
         $apiKey = config('ai.voice.elevenlabs_key');
@@ -241,14 +320,15 @@ class VoiceController extends Controller
             ]);
 
         if ($response->successful()) {
-            $filename = 'tts_'.uniqid().'.mp3';
-            $storagePath = storage_path('app/tts/'.$filename);
-            if (! is_dir(dirname($storagePath))) {
-                mkdir(dirname($storagePath), 0755, true);
-            }
-            file_put_contents($storagePath, $response->body());
+            $filename = 'tts_'.bin2hex(random_bytes(8)).'.mp3';
+            Storage::disk('local')->put('tts/'.$filename, $response->body());
 
-            return url('storage/tts/'.$filename);
+            // Issue #5616 : URL signée expirant dans TTS_URL_TTL_SECONDS secondes.
+            return URL::temporarySignedRoute(
+                'tts.serve',
+                now()->addSeconds(self::TTS_URL_TTL_SECONDS),
+                ['filename' => $filename],
+            );
         }
 
         Log::error('ElevenLabs TTS failed', ['status' => $response->status()]);

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -67,6 +67,10 @@ return Application::configure(basePath: dirname(__DIR__))
         // monitored by `edge:monitor` below. See issue #1291 and
         // docs/audits/AUDIT_MOBILE_EDGE_2026-07-26.md sections 1.3/1.4.
         $schedule->command('edge:monitor')->everyThirtyMinutes()->withoutOverlapping();
+        // Issue #5616 — Purge des fichiers TTS temporaires (RGPD + espace disque).
+        // Les URLs signées expirent en 60 s ; purger les fichiers > 60 min suffit
+        // pour garantir qu'aucun fichier accessible ne subsiste sur disque.
+        $schedule->command('tts:purge')->hourly();
     })
     ->withRouting(
         api: __DIR__.'/../routes/api.php',

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -5,6 +5,7 @@ use App\Core\Auth\Interfaces\Api\V1\TwoFactorAuthController;
 use App\Core\Auth\Interfaces\Api\V1\PasswordResetController;
 use App\Core\Auth\Interfaces\Api\V1\PlatformAuthController;
 use App\Core\Feature\Interfaces\Api\V1\FeatureManifestController;
+use App\Http\Controllers\AI\VoiceController;
 use App\Http\Controllers\Web\PlatformCompanyController;
 use App\Modules\Attendance\Interfaces\Api\V1\BiometricEnrollmentController;
 use App\Modules\Billing\Interfaces\Api\V1\CompanyRequestController;
@@ -76,6 +77,13 @@ Route::prefix('v1')->group(function (): void {
     // they must not be served anonymously. See issue #1466.
     Route::get('/metrics', MetricsController::class)
         ->middleware(['auth:super_admin_api', 'throttle:metrics']);
+
+    // Issue #5616 — Serve TTS audio via URL signée temporaire (sans auth Sanctum).
+    // La route est protégée par la signature Laravel (hasValidRelativeSignature),
+    // TTL = VoiceController::TTS_URL_TTL_SECONDS (60 s).
+    Route::get('/voice/tts/{filename}', [VoiceController::class, 'serveTts'])
+        ->name('tts.serve')
+        ->middleware('throttle:60,1');
 
     // Auth (core, hors module)
     Route::middleware(['throttle:auth-sensitive'])->group(function (): void {


### PR DESCRIPTION
## Résumé

Correctifs de sécurité pour le module AI Voice TTS (issue #5616 P0-SEC).

## Changements

### `api/app/Http/Controllers/AI/VoiceController.php`
- **URL signée temporaire** : remplacement de `url('storage/tts/...')` par `URL::temporarySignedRoute('tts.serve', now()->addSeconds(60))` dans `edgeTtsSynthesize()` et `elevenLabsSynthesize()` — plus aucune URL publique permanente
- **Stockage privé** : ElevenLabs stocke désormais dans `Storage::disk('local')` (hors webroot public)
- **Bascule automatique** : si `edge_tts` est configuré mais qu'une clé ElevenLabs est disponible → bascule vers ElevenLabs (pas d'`exec()` en prod)
- **Endpoint de service** : nouveau `serveTts()` qui vérifie la signature avant de streamer le fichier

### `api/app/Console/Commands/PurgeTtsFilesCommand.php` *(nouveau)*
- Commande `tts:purge` : supprime les fichiers `storage/app/tts/tts_*.mp3` de plus de 60 min

### `api/routes/api.php`
- Route `GET /v1/voice/tts/{filename}` nommée `tts.serve` (hors auth Sanctum, signature Laravel obligatoire)

### `api/bootstrap/app.php`
- Scheduler `tts:purge` enregistré en tâche **horaire**

## Sécurité

| Avant | Après |
|---|---|
| URL publique permanente | URL signée, expiration 60 s |
| Fichiers ElevenLabs dans storage public | Disk local (hors webroot) |
| edge-tts toujours utilisé en prod | Bascule auto vers ElevenLabs si clé dispo |
| Aucune purge | Purge horaire automatique |

Closes #5616