### PR TITLE
fix(sso): activer VALIDATION_AVAILABLE=true pour OIDC — OidcFlowService opérationnel [#5614]

### DIFF
--- a/api/app/Core/Auth/Infrastructure/Services/SSO/SSOService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/SSO/SSOService.php
@@ -19,11 +19,19 @@ class SSOService
     private const SENSITIVE_FIELDS = ['certificate', 'client_secret'];
 
     /**
-     * Audit #1694 : la validation des assertions SAML/OIDC n'est pas
-     * implémentée — exposer false tant que le moteur de validation n'existe
-     * pas (les intégrateurs doivent afficher « SSO en cours de déploiement »).
+     * Issue #5614 — Disponibilité de validation par provider.
+     *
+     * OIDC : implémenté dans OidcFlowService (issue #2231/#2197/#2251) —
+     *   validation signature JWKS + iss/aud/exp/nonce. true.
+     * SAML : validation (OneLogin/php-saml) non implémentée (audit #1694) —
+     *   connexion refusée explicitement dans handleSAMLResponse(). false.
+     *
+     * @var array<string, bool>
      */
-    private const VALIDATION_AVAILABLE = false;
+    private const VALIDATION_AVAILABLE_BY_PROVIDER = [
+        'oidc' => true,
+        'saml' => false,
+    ];
 
     /**
      * @return array{enabled: bool, provider: string|null, config: SSOProviderConfig|null, validation_available: bool}
@@ -40,8 +48,7 @@ class SSOService
                 'enabled' => false,
                 'provider' => null,
                 'config' => null,
-                // Audit #1694 : validation non implémentée.
-                'validation_available' => self::VALIDATION_AVAILABLE,
+                'validation_available' => false,
             ];
         }
 
@@ -65,8 +72,9 @@ class SSOService
                 'provider' => $provider,
                 ...$configData,
             ]),
-            // Audit #1694 : validation non implémentée.
-            'validation_available' => self::VALIDATION_AVAILABLE,
+            // Issue #5614 : disponibilité de validation per-provider
+            // (OIDC = true depuis issue #2231, SAML = false jusqu'à intégration php-saml).
+            'validation_available' => self::VALIDATION_AVAILABLE_BY_PROVIDER[$provider] ?? false,
         ];
     }
 
@@ -135,11 +143,13 @@ class SSOService
         }
 
         if ($canActivate) {
-            Log::info('OIDC SSO configured and active (validation implemented — issue #2231)', [
+            Log::info('OIDC SSO configured and active (validation implemented — issue #2231/#5614)', [
                 'company_id' => $companyId,
             ]);
         } else {
-            Log::warning('SSO configured but kept inactive (validation not implemented — audit #1694)', [
+            // SAML : validation (php-saml) non implémentée — config enregistrée
+            // mais non activée. OIDC inactif = config incomplète (isOidcFlowReady()=false).
+            Log::warning('SSO configured but kept inactive (provider not ready or SAML pending — audit #1694)', [
                 'company_id' => $companyId,
                 'provider' => $provider,
             ]);

--- a/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
@@ -39,14 +39,15 @@ class SSOController extends Controller
 
         $sso = $this->ssoService->getCompanySSO($actor->company_id);
 
+        // Issue #5614 : validation_available vient maintenant du service
+        // (per-provider : OIDC = true, SAML = false). Le gate SAML_ENABLED
+        // ne s'applique qu'au callback SAML (samlCallback()), pas au status
+        // OIDC qui est pleinement opérationnel via OidcFlowService (#2231).
         return response()->json([
             'data' => [
                 'enabled' => $sso['enabled'],
                 'provider' => $sso['provider'],
-                // Audit #1694 + gate #3890 : la validation SAML/OIDC n'est
-                // disponible que si le moteur existe ET le flag SAML_ENABLED est posé.
-                'validation_available' => $sso['validation_available']
-                    && (bool) config('services.saml.enabled', false),
+                'validation_available' => $sso['validation_available'],
             ],
         ]);
     }


### PR DESCRIPTION
## Résumé

Débloque le SSO OIDC qui était bloqué par un flag global `VALIDATION_AVAILABLE=false` datant de l'audit #1694, alors que `OidcFlowService` (issue #2231) implémente déjà la validation complète.

## Changements

### `SSOService.php`
- Remplace `VALIDATION_AVAILABLE = false` par `VALIDATION_AVAILABLE_BY_PROVIDER` :
  - `oidc` → `true` (OidcFlowService : JWKS + iss/aud/exp/nonce ✅)
  - `saml` → `false` (php-saml non intégré, cf. audit #1694)
- Le `getCompanySSO()` retourne maintenant `validation_available` per-provider

### `SSOController.php`
- Supprime le gate `config('services.saml.enabled', false)` dans `status()` qui masquait incorrectement les configs OIDC
- `validation_available` vient directement du service (source de vérité unique)

## Impact

Les entreprises avec un SSO OIDC complet configuré (issuer, jwks_uri, redirect_uri) peuvent désormais s'authentifier via `/auth/sso/oidc/{company}/authorize` → callback.

SAML reste `validation_available: false` et retourne `501 SAML_FEATURE_DISABLED` (inchangé).

Closes #5614