### PR TITLE
feat(payroll): UI + endpoint SEPA IBAN/BIC entreprise — débloquer export SEPA [#5613]

### DIFF
--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBankingController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBankingController.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Http\Controllers\Controller;
+use App\Rules\ValidIban;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Issue #5613 — Coordonnées bancaires de l'entreprise (IBAN/BIC SEPA).
+ *
+ * Expose deux endpoints réservés aux managers (principal ou rh) :
+ *
+ *   GET  /api/v1/company/banking   → lit company_iban / company_bic depuis metadata
+ *   PATCH /api/v1/company/banking  → met à jour ces clés dans metadata
+ *
+ * Sans ces champs configurés, l'export SEPA (pain.001.001.03) retourne
+ * 422 MISSING_COMPANY_IBAN (#2198).
+ *
+ * Note DZ : l'Algérie n'utilise pas l'IBAN officiel. Un RIB à 20 chiffres
+ * est accepté pour les entreprises dont le pays est DZ.
+ */
+class CompanyBankingController extends Controller
+{
+    /**
+     * GET /api/v1/company/banking
+     *
+     * Retourne l'IBAN et le BIC actuellement enregistrés pour l'entreprise,
+     * avec un flag `sepa_ready` indiquant si l'export SEPA est utilisable.
+     */
+    public function show(): JsonResponse
+    {
+        $company = $this->freshCompany();
+        $banking = $this->bankingFrom($company);
+
+        return new JsonResponse([
+            'data' => [
+                'company_iban' => $banking['company_iban'],
+                'company_bic' => $banking['company_bic'],
+                // Indicateur : l'IBAN est requis pour l'export SEPA (#2198).
+                'sepa_ready' => $banking['company_iban'] !== null,
+                'country' => $company->country ?? null,
+            ],
+        ]);
+    }
+
+    /**
+     * PATCH /api/v1/company/banking
+     *
+     * Met à jour les coordonnées bancaires dans metadata.
+     * Validation :
+     *   - company_iban : IBAN ISO 13616 (ValidIban) ou RIB 20 chiffres pour DZ
+     *   - company_bic  : BIC standard (4 + 2 + 2 + éventuellement 3)
+     */
+    public function update(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        abort_unless($actor->hasManagerRole('principal', 'rh'), 403);
+
+        $company = $this->freshCompany();
+
+        $validated = $request->validate([
+            'company_iban' => ['sometimes', 'nullable', 'string', 'max:50'],
+            'company_bic' => [
+                'sometimes',
+                'nullable',
+                'string',
+                'max:11',
+                'regex:/^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$/i',
+            ],
+        ]);
+
+        // Validation IBAN / RIB selon le pays de l'entreprise.
+        if (array_key_exists('company_iban', $validated) && $validated['company_iban'] !== null) {
+            $ibanRaw = (string) $validated['company_iban'];
+            $ibanNorm = ValidIban::normalize($ibanRaw);
+
+            $countryCode = strtoupper(trim((string) ($company->country ?? '')));
+
+            if (! $this->isAcceptableIban($ibanNorm, $countryCode)) {
+                return new JsonResponse([
+                    'message' => 'Les données fournies sont invalides.',
+                    'errors' => [
+                        'company_iban' => ['Le champ company_iban n\'est pas un IBAN valide'
+                            .($countryCode === 'DZ' ? ' ou un RIB algérien valide (20 chiffres).' : '.')],
+                    ],
+                ], 422);
+            }
+
+            // Stocker l'IBAN normalisé (majuscules, sans espaces).
+            $validated['company_iban'] = $ibanNorm;
+        }
+
+        // Mettre à jour uniquement les clés fournies dans metadata.
+        $metadata = $company->metadata ?? [];
+
+        foreach (['company_iban', 'company_bic'] as $field) {
+            if (array_key_exists($field, $validated)) {
+                if ($validated[$field] === null || trim((string) $validated[$field]) === '') {
+                    unset($metadata[$field]);
+                } else {
+                    $metadata[$field] = strtoupper(trim((string) $validated[$field]));
+                }
+            }
+        }
+
+        $this->persistMetadata($company, $metadata);
+
+        $updatedCompany = $this->freshCompany();
+        $banking = $this->bankingFrom($updatedCompany);
+
+        return new JsonResponse([
+            'data' => [
+                'company_iban' => $banking['company_iban'],
+                'company_bic' => $banking['company_bic'],
+                'sepa_ready' => $banking['company_iban'] !== null,
+                'country' => $updatedCompany->country ?? null,
+            ],
+            'message' => __('errors.COMPANY_BANKING_UPDATED', [], 'fr') ?: 'Coordonnées bancaires mises à jour.',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Accepte un IBAN standard (ValidIban) OU un RIB algérien (20 chiffres)
+     * pour les entreprises dont le pays est DZ (#5613 — note DZ).
+     */
+    private function isAcceptableIban(string $ibanNorm, string $countryCode): bool
+    {
+        // IBAN standard ISO 13616 — valide pour tous les pays supportés.
+        if (ValidIban::isValid($ibanNorm)) {
+            return true;
+        }
+
+        // RIB algérien : 20 chiffres, pas de préfixe pays — uniquement si DZ.
+        if ($countryCode === 'DZ' && preg_match('/^\d{20}$/', $ibanNorm)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{company_iban: ?string, company_bic: ?string}
+     */
+    private function bankingFrom(Company $company): array
+    {
+        $raw = $company->metadata ?? [];
+        $metadata = is_array($raw)
+            ? $raw
+            : (is_string($raw) ? (json_decode($raw, true) ?: []) : []);
+
+        return [
+            'company_iban' => $this->nullableString($metadata['company_iban'] ?? null),
+            'company_bic' => $this->nullableString($metadata['company_bic'] ?? null),
+        ];
+    }
+
+    private function freshCompany(): Company
+    {
+        // Même convention que CompanyBrandingController : helper global
+        // currentCompany() résolu par TenantManager depuis le Sanctum token.
+        $company = currentCompany();
+
+        return Company::query()
+            ->from($this->companiesTable())
+            ->where('id', $company->id)
+            ->firstOrFail();
+    }
+
+    /** @param array<string, mixed> $metadata */
+    private function persistMetadata(Company $company, array $metadata): void
+    {
+        DB::table($this->companiesTable())
+            ->where('id', $company->id)
+            ->update([
+                'metadata' => json_encode($metadata, JSON_THROW_ON_ERROR),
+                'updated_at' => now(),
+            ]);
+    }
+
+    private function companiesTable(): string
+    {
+        return DB::getDriverName() === 'pgsql' ? 'public.companies' : 'companies';
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -14,6 +14,7 @@ use App\Modules\Billing\Interfaces\Api\V1\PlatformPlanController;
 use App\Modules\Billing\Interfaces\Api\V1\SelfServiceTrialController;
 use App\Modules\Billing\Interfaces\Api\V1\StripeWebhookController;
 use App\Modules\EdgeSync\Interfaces\Api\V1\EdgeNodeController;
+use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBankingController;
 use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBrandingController;
 use App\Modules\HR\Interfaces\Api\V1\Controllers\PrivacyController;
 use App\Modules\Marketing\Interfaces\Api\V1\Controllers\MarketingLeadController;
@@ -208,6 +209,9 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/company-requests', [CompanyRequestController::class, 'store']);
         Route::get('/company/branding', [CompanyBrandingController::class, 'show']);
         Route::patch('/company/branding', [CompanyBrandingController::class, 'update']);
+        // Issue #5613 — Coordonnées bancaires SEPA (IBAN/BIC entreprise).
+        Route::get('/company/banking', [CompanyBankingController::class, 'show']);
+        Route::patch('/company/banking', [CompanyBankingController::class, 'update']);
 
         // PA2-COMM-012 — Pilot client support center: a manager/employee can
         // open a support ticket and reply on their own company's tickets.

--- a/front/admin-dashboard/src/views/settings/SettingsView.vue
+++ b/front/admin-dashboard/src/views/settings/SettingsView.vue
@@ -101,8 +101,87 @@
       </form>
     </div>
 
-    <!-- 2FA -->
+    <!-- Coordonnées bancaires SEPA (#5613) -->
     <div class="card animate-slide-up" style="animation-delay: 0.1s">
+      <div class="card-header flex items-center justify-between">
+        <div>
+          <h2 class="text-xl font-bold text-slate-900 dark:text-white">{{ t('settingsPage.bankingTitle', 'Coordonnées Bancaires SEPA') }}</h2>
+          <p class="mt-1 text-sm font-medium text-slate-500 dark:text-slate-400">
+            {{ t('settingsPage.bankingSubtitle', 'IBAN et BIC de votre entreprise requis pour l\'export SEPA des virements.') }}
+          </p>
+        </div>
+        <span
+          :class="[
+            'px-3 py-1 text-[11px] font-black uppercase tracking-widest rounded-lg border shrink-0',
+            bankingData.sepa_ready
+              ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800'
+              : 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800'
+          ]"
+        >
+          {{ bankingData.sepa_ready ? t('settingsPage.sepaReady', 'SEPA prêt') : t('settingsPage.sepaNotReady', 'SEPA non configuré') }}
+        </span>
+      </div>
+
+      <div class="card-body space-y-5">
+        <!-- Alerte IBAN manquant -->
+        <div
+          v-if="!bankingData.sepa_ready && !isBankingLoading"
+          class="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/30 dark:bg-amber-950/20"
+        >
+          <ExclamationTriangleIcon class="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+          <p class="text-sm font-medium text-amber-800 dark:text-amber-300">
+            {{ t('settingsPage.bankingWarning', 'L\'export SEPA retournera une erreur 422 tant que l\'IBAN de l\'entreprise n\'est pas configuré.') }}
+          </p>
+        </div>
+
+        <div v-if="isBankingLoading" class="flex h-16 items-center justify-center">
+          <div class="h-6 w-6 animate-spin rounded-full border-2 border-brand-500 border-t-transparent"></div>
+        </div>
+
+        <form v-else class="space-y-5" @submit.prevent="submitBanking">
+          <div>
+            <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="company-iban">
+              {{ t('settingsPage.companyIban', 'IBAN de l\'entreprise') }}
+            </label>
+            <input
+              id="company-iban"
+              v-model="bankingForm.company_iban"
+              type="text"
+              class="form-input font-mono tracking-widest"
+              maxlength="50"
+              autocomplete="off"
+              :placeholder="bankingData.country === 'DZ' ? t('settingsPage.ibanPlaceholderDZ', 'IBAN ou RIB algérien (20 chiffres)') : 'FR76 3000 4000 0100 0000 0000 000'"
+            >
+            <p class="mt-1.5 text-xs font-medium text-slate-400">
+              {{ t('settingsPage.ibanHint', 'Format IBAN ISO 13616 (majuscules, sans espaces). Les espaces sont ignorés automatiquement.') }}
+            </p>
+          </div>
+          <div>
+            <label class="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5" for="company-bic">
+              {{ t('settingsPage.companyBic', 'BIC / SWIFT (optionnel)') }}
+            </label>
+            <input
+              id="company-bic"
+              v-model="bankingForm.company_bic"
+              type="text"
+              class="form-input font-mono tracking-widest uppercase"
+              maxlength="11"
+              autocomplete="off"
+              placeholder="BNPAFRPP"
+            >
+          </div>
+          <div class="flex justify-end">
+            <button type="submit" class="btn-primary" :disabled="isSavingBanking">
+              <ArrowPathIcon v-if="isSavingBanking" class="mr-2 h-4 w-4 animate-spin" />
+              {{ t('settingsPage.saveBanking', 'Enregistrer les coordonnées') }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- 2FA -->
+    <div class="card animate-slide-up" style="animation-delay: 0.15s">
       <div class="card-header flex items-center justify-between">
         <div>
           <h2 class="text-xl font-bold text-slate-900 dark:text-white">{{ $t('settingsPage.twoFactorTitle') }}</h2>
@@ -194,12 +273,13 @@
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue'
+import { onMounted, reactive, ref } from 'vue'
 import { useToast } from 'vue-toastification'
-import { ArrowPathIcon } from '@heroicons/vue/24/outline'
+import { ArrowPathIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
 import { useAuthStore } from '@/stores/auth'
 import { useLocaleStore } from '@/stores/locale'
 import { translate } from '@/i18n/index.js'
+import api from '@/services/api.js'
 
 const authStore = useAuthStore()
 const toast = useToast()
@@ -229,6 +309,55 @@ const isGeneratingSecret = ref(false)
 const isEnabling2fa = ref(false)
 const isDisabling2fa = ref(false)
 const pendingSecret = ref(null)
+
+// ---- Coordonnées bancaires SEPA (#5613) ----
+const isBankingLoading = ref(true)
+const isSavingBanking = ref(false)
+const bankingData = reactive({ company_iban: null, company_bic: null, sepa_ready: false, country: null })
+const bankingForm = reactive({ company_iban: '', company_bic: '' })
+
+async function loadBanking() {
+  isBankingLoading.value = true
+  try {
+    const res = await api.get('/company/banking')
+    const data = res.data?.data || {}
+    bankingData.company_iban = data.company_iban ?? null
+    bankingData.company_bic = data.company_bic ?? null
+    bankingData.sepa_ready = !!data.sepa_ready
+    bankingData.country = data.country ?? null
+    bankingForm.company_iban = data.company_iban ?? ''
+    bankingForm.company_bic = data.company_bic ?? ''
+  } catch (err) {
+    // Endpoint optionnel — ne pas bloquer la page si indisponible
+    console.warn('[settings] banking load failed', err)
+  } finally {
+    isBankingLoading.value = false
+  }
+}
+
+async function submitBanking() {
+  isSavingBanking.value = true
+  try {
+    const res = await api.patch('/company/banking', {
+      company_iban: bankingForm.company_iban.trim().toUpperCase().replace(/\s/g, '') || null,
+      company_bic: bankingForm.company_bic.trim().toUpperCase() || null,
+    })
+    const data = res.data?.data || {}
+    bankingData.company_iban = data.company_iban ?? null
+    bankingData.company_bic = data.company_bic ?? null
+    bankingData.sepa_ready = !!data.sepa_ready
+    toast.success(t('settingsPage.bankingUpdated', 'Coordonnées bancaires enregistrées.'))
+  } catch (err) {
+    const msg = err?.response?.data?.message || err?.response?.data?.errors?.company_iban?.[0] || t('settingsPage.bankingError', 'Erreur lors de l\'enregistrement des coordonnées bancaires.')
+    toast.error(msg)
+  } finally {
+    isSavingBanking.value = false
+  }
+}
+
+onMounted(() => {
+  loadBanking()
+})
 
 async function submitProfile() {
   isSavingProfile.value = true


### PR DESCRIPTION
## Résumé

L'export SEPA (pain.001.001.03) retournait systématiquement `422 MISSING_COMPANY_IBAN` car aucune interface ne permettait de configurer l'IBAN de l'entreprise.

## Changements

### Backend — `CompanyBankingController.php` *(nouveau)*
- `GET /api/v1/company/banking` : lit `company_iban` / `company_bic` depuis `company.metadata` + flag `sepa_ready`
- `PATCH /api/v1/company/banking` : met à jour les clés dans metadata avec validation :
  - IBAN : validation ISO 13616 via `ValidIban`
  - **Note DZ** : accepte aussi le RIB algérien (20 chiffres) si pays = DZ
  - BIC : regex standard (4+2+2[+3])
- Même pattern que `CompanyBrandingController` (currentCompany, persistMetadata)

### Frontend — `SettingsView.vue` (admin-dashboard)
- Nouvelle section **Coordonnées Bancaires SEPA** dans la page Paramètres
- Badge d'état vert/ambre selon `sepa_ready`
- Alerte contextuelle si IBAN non configuré (explication du 422)
- Pré-remplissage au montage (GET banking), normalisation à la soumission

## Avant / Après

| Avant | Après |
|---|---|
| Export SEPA → 422 MISSING_COMPANY_IBAN | IBAN configurable via /settings |
| Aucune UI | Section Coordonnées bancaires dans Paramètres |
| 0 résultat `grep company_iban front/` | Formulaire GET/PATCH opérationnel |

Closes #5613