### PR TITLE
feat(auth): 2FA frontend Next.js — challenge, enrôlement, proxy verify [#5612]

### DIFF
--- a/front/web/src/app/(dashboard)/settings/security/2fa/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/security/2fa/page.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+/**
+ * Issue #5612 — Page de gestion 2FA (enrôlement, confirmation, désactivation).
+ *
+ * Accessible depuis /settings/security/2fa (managers authentifiés).
+ *
+ * Flux d'enrôlement :
+ *   1. GET /auth/2fa/status → état actuel
+ *   2. POST /auth/2fa/enroll → { secret, qr_code_url, qr_code_svg }
+ *   3. Scanner le QR + saisir le premier code TOTP
+ *   4. POST /auth/2fa/confirm { code } → { recovery_codes[] }
+ *   5. Afficher et faire copier les 8 codes de récupération
+ *
+ * Flux de désactivation :
+ *   POST /auth/2fa/disable { code }
+ *
+ * Références backend : TwoFactorAuthController (#5436)
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import {
+  CheckCircle2,
+  Copy,
+  KeyRound,
+  Loader2,
+  QrCode,
+  ShieldCheck,
+  ShieldOff,
+  X,
+} from 'lucide-react';
+import { ApiError, apiFetch } from '@/lib/api-client';
+import { getPreferredLocale, type AppLocale } from '@/lib/i18n';
+import { ModulePageShell } from '@/components/module-page-shell';
+
+const emptySubscribe = () => () => {};
+
+type TwoFaStatus = {
+  enabled: boolean;
+  enforced?: boolean;
+};
+
+type EnrollData = {
+  secret: string;
+  qr_code_url: string;
+  qr_code_svg?: string;
+};
+
+export default function TwoFactorSettingsPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
+
+  const [status, setStatus] = useState<TwoFaStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Enrôlement
+  const [enrollData, setEnrollData] = useState<EnrollData | null>(null);
+  const [enrolling, setEnrolling] = useState(false);
+  const [confirmCode, setConfirmCode] = useState('');
+  const [confirming, setConfirming] = useState(false);
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [copied, setCopied] = useState(false);
+
+  // Désactivation
+  const [disableCode, setDisableCode] = useState('');
+  const [disabling, setDisabling] = useState(false);
+
+  const loadStatus = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/auth/2fa/status');
+      const payload = (await res.json()) as { data?: TwoFaStatus };
+      setStatus(payload.data ?? { enabled: false });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur lors du chargement.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  const handleEnroll = async () => {
+    setEnrolling(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/auth/2fa/enroll', { method: 'POST' });
+      const payload = (await res.json()) as { data?: EnrollData };
+      setEnrollData(payload.data ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur lors de l\'activation.');
+    } finally {
+      setEnrolling(false);
+    }
+  };
+
+  const handleConfirm = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = confirmCode.trim();
+    if (!trimmed) return;
+    setConfirming(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/auth/2fa/confirm', {
+        method: 'POST',
+        body: JSON.stringify({ code: trimmed }),
+      });
+      const payload = (await res.json()) as { data?: { recovery_codes?: string[] } };
+      const codes = payload.data?.recovery_codes ?? [];
+      setRecoveryCodes(codes);
+      setStatus({ enabled: true });
+      setEnrollData(null);
+      setConfirmCode('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Code invalide. Réessayez.');
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  const handleDisable = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = disableCode.trim();
+    if (!trimmed) return;
+    setDisabling(true);
+    setError(null);
+    try {
+      await apiFetch('/auth/2fa/disable', {
+        method: 'POST',
+        body: JSON.stringify({ code: trimmed }),
+      });
+      setStatus({ enabled: false });
+      setDisableCode('');
+      setRecoveryCodes([]);
+      setEnrollData(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Code invalide. La 2FA est toujours active.');
+    } finally {
+      setDisabling(false);
+    }
+  };
+
+  const handleCopyCodes = () => {
+    navigator.clipboard.writeText(recoveryCodes.join('\n'));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <ModulePageShell
+      title="Authentification à deux facteurs"
+      subtitle="Ajoutez une couche de sécurité supplémentaire à votre compte."
+      accentClassName="from-brand-600 to-emerald-600"
+    >
+      <div className="max-w-xl space-y-6">
+        {/* Status */}
+        <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4 dark:border-slate-800 dark:bg-slate-900/40">
+          <div className="flex items-center gap-3">
+            {status?.enabled ? (
+              <ShieldCheck className="h-5 w-5 text-emerald-500" aria-hidden="true" />
+            ) : (
+              <ShieldOff className="h-5 w-5 text-slate-400" aria-hidden="true" />
+            )}
+            <div>
+              <p className="font-bold text-slate-900 dark:text-white text-sm">
+                Authentification à deux facteurs
+              </p>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                {isLoading
+                  ? 'Chargement…'
+                  : status?.enabled
+                    ? 'Activée — votre compte est protégé.'
+                    : 'Désactivée — votre compte est moins sécurisé.'}
+              </p>
+            </div>
+          </div>
+          <span
+            className={[
+              'px-3 py-1 text-[11px] font-black uppercase tracking-widest rounded-lg border shrink-0',
+              status?.enabled
+                ? 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400 dark:border-emerald-800'
+                : 'bg-slate-100 text-slate-500 border-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-700',
+            ].join(' ')}
+          >
+            {status?.enabled ? 'Activée' : 'Désactivée'}
+          </span>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/30 dark:bg-red-950/20">
+            <X className="mt-0.5 h-4 w-4 shrink-0 text-red-500" aria-hidden="true" />
+            <p className="text-sm font-medium text-red-700 dark:text-red-400">{error}</p>
+          </div>
+        )}
+
+        {/* Loading */}
+        {isLoading ? (
+          <div className="flex h-24 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-brand-500" aria-hidden="true" />
+          </div>
+        ) : status?.enabled ? (
+          /* ── 2FA activée : afficher les codes de récupération ou désactivation ── */
+          <div className="space-y-6">
+            {/* Codes de récupération (juste après activation) */}
+            {recoveryCodes.length > 0 && (
+              <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 dark:border-amber-900/30 dark:bg-amber-950/20">
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="font-bold text-amber-800 dark:text-amber-300 text-sm">
+                    Codes de récupération — conservez-les en lieu sûr
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={handleCopyCodes}
+                    className="inline-flex items-center gap-1.5 text-xs font-bold text-amber-700 hover:text-amber-900 dark:text-amber-400 transition-colors"
+                  >
+                    {copied ? (
+                      <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                    )}
+                    {copied ? 'Copié !' : 'Copier tout'}
+                  </button>
+                </div>
+                <p className="text-xs text-amber-700 dark:text-amber-400 mb-3">
+                  Chacun de ces codes ne peut être utilisé qu'une seule fois pour vous connecter
+                  si vous perdez accès à votre application authenticator.
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  {recoveryCodes.map((code) => (
+                    <code
+                      key={code}
+                      className="rounded-lg bg-amber-100 dark:bg-amber-900/30 px-3 py-1.5 text-xs font-mono text-amber-900 dark:text-amber-200 text-center"
+                    >
+                      {code}
+                    </code>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Désactivation */}
+            <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+              <h3 className="font-bold text-slate-900 dark:text-white text-sm mb-1">
+                Désactiver la 2FA
+              </h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">
+                Saisissez votre code TOTP actuel pour désactiver l'authentification à deux facteurs.
+              </p>
+              <form onSubmit={handleDisable} className="flex gap-3">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={disableCode}
+                  onChange={(e) => setDisableCode(e.target.value)}
+                  maxLength={8}
+                  placeholder="123456"
+                  className="flex-1 rounded-xl border border-slate-200 px-3 py-2 text-sm font-mono text-center tracking-widest outline-none transition focus:border-red-400 focus:ring-2 focus:ring-red-400/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                />
+                <button
+                  type="submit"
+                  disabled={disabling || !disableCode.trim()}
+                  className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm font-bold text-red-700 transition hover:bg-red-100 disabled:opacity-50 dark:border-red-900/30 dark:bg-red-950/20 dark:text-red-400"
+                >
+                  {disabling ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <ShieldOff className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  Désactiver
+                </button>
+              </form>
+            </div>
+          </div>
+        ) : enrollData ? (
+          /* ── Étape d'enrôlement : scanner le QR et confirmer ── */
+          <div className="space-y-5">
+            <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+              <h3 className="font-bold text-slate-900 dark:text-white text-sm mb-3">
+                Étape 1 — Scanner le QR code
+              </h3>
+              {enrollData.qr_code_svg ? (
+                <div
+                  className="mx-auto w-fit rounded-2xl bg-white p-3 shadow"
+                  dangerouslySetInnerHTML={{ __html: enrollData.qr_code_svg }}
+                />
+              ) : (
+                <p className="text-sm text-slate-500 break-all font-mono">{enrollData.qr_code_url}</p>
+              )}
+              <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+                Ou saisissez manuellement le code secret :
+                <code className="ml-1 rounded-md bg-slate-100 px-2 py-0.5 font-mono text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                  {enrollData.secret}
+                </code>
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+              <h3 className="font-bold text-slate-900 dark:text-white text-sm mb-3">
+                Étape 2 — Confirmer avec un code TOTP
+              </h3>
+              <form onSubmit={handleConfirm} className="space-y-4">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={confirmCode}
+                  onChange={(e) => setConfirmCode(e.target.value)}
+                  maxLength={8}
+                  autoFocus
+                  placeholder="123456"
+                  className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-center font-mono tracking-[0.35em] text-lg outline-none transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                />
+                <div className="flex gap-3">
+                  <button
+                    type="submit"
+                    disabled={confirming || !confirmCode.trim()}
+                    className="flex-1 inline-flex items-center justify-center gap-2 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-brand-700 disabled:opacity-50"
+                  >
+                    {confirming ? (
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    ) : (
+                      <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+                    )}
+                    Activer la 2FA
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEnrollData(null)}
+                    className="rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-600 transition hover:bg-slate-50 dark:border-slate-700 dark:text-slate-400"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        ) : (
+          /* ── 2FA désactivée : bouton d'activation ── */
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+            <div className="flex items-start gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-100 text-brand-700 dark:bg-brand-900/30 dark:text-brand-400">
+                <QrCode className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <div className="flex-1">
+                <h3 className="font-bold text-slate-900 dark:text-white text-sm">
+                  Activer l'authentification à deux facteurs
+                </h3>
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Utilisez une application authenticator (Google Authenticator, Authy, 1Password…)
+                  pour générer des codes TOTP à usage unique.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleEnroll}
+                  disabled={enrolling}
+                  className="mt-4 inline-flex items-center gap-2 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-brand-700 disabled:opacity-50"
+                >
+                  {enrolling ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <KeyRound className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  Commencer l'enrôlement
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/api/v1/auth/2fa/verify/route.ts
+++ b/front/web/src/app/api/v1/auth/2fa/verify/route.ts
@@ -1,0 +1,109 @@
+/**
+ * Issue #5612 — Proxy POST /auth/2fa/verify avec pose du cookie httpOnly.
+ *
+ * Même convention que /api/v1/auth/login/route.ts :
+ *   1. Transmet le corps de la requête au backend Laravel.
+ *   2. Sur succès (200), extrait le token Sanctum et le stocke dans le
+ *      cookie httpOnly `leopardo_token` — inaccessible au JS côté page.
+ *   3. Retourne { data } sans le token brut.
+ *
+ * Le `challenge_token` est généré par le backend à la connexion lorsque
+ * la 2FA est activée (TwoFactorAuthController::verify — #5436).
+ */
+
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { resolveBackendBaseUrl } from '@/lib/backend-url';
+
+const COOKIE_NAME = 'leopardo_token';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 jours — cohérent avec login
+const VERIFY_TIMEOUT_MS = 30_000;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'INVALID_JSON', message: 'Corps de requête invalide.' },
+      { status: 400 },
+    );
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(`${resolveBackendBaseUrl()}/auth/2fa/verify`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'Accept-Language': request.headers.get('Accept-Language') || 'fr',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    const isTimeout = error instanceof DOMException && error.name === 'AbortError';
+    return NextResponse.json(
+      {
+        error: isTimeout ? 'TIMEOUT' : 'NETWORK_ERROR',
+        message: isTimeout
+          ? 'Le serveur met trop de temps à répondre.'
+          : 'Impossible de contacter le serveur.',
+      },
+      { status: isTimeout ? 408 : 502 },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  let payload: Record<string, unknown>;
+
+  try {
+    payload = (await backendResponse.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: 'BACKEND_ERROR', message: 'Réponse serveur inattendue.' },
+      { status: 502 },
+    );
+  }
+
+  if (!backendResponse.ok) {
+    return NextResponse.json(payload, { status: backendResponse.status });
+  }
+
+  // Succès — extraire le token et le stocker dans le cookie httpOnly.
+  const token = payload?.token as string | undefined;
+
+  if (!token) {
+    return NextResponse.json(payload, { status: backendResponse.status });
+  }
+
+  const isSecure =
+    request.nextUrl.protocol === 'https:' || process.env.NODE_ENV === 'production';
+
+  const cookieStore = await cookies();
+  cookieStore.set(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: 'strict',
+    maxAge: COOKIE_MAX_AGE,
+    path: '/',
+  });
+
+  // Retourner les données utilisateur sans le token brut.
+  const { token: _stripped, token_type: _type, token_expires_at: _exp, ...safePayload } = payload;
+
+  return NextResponse.json(safePayload, {
+    status: 200,
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/front/web/src/app/auth/2fa/challenge/page.tsx
+++ b/front/web/src/app/auth/2fa/challenge/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+/**
+ * Issue #5612 — Page de challenge TOTP / code de récupération.
+ *
+ * Flux :
+ *   1. L'utilisateur a soumis son email/mot de passe sur /auth/login.
+ *   2. Le backend (TwoFactorAuthController) a répondu avec
+ *      { mfa_challenge: true, mfa_challenge_token: '...' }.
+ *   3. login/page.tsx a redirigé vers /auth/2fa/challenge?token=<challenge_token>.
+ *   4. Cette page envoie POST /auth/2fa/verify avec le challenge_token et le code.
+ *   5. En cas de succès, le cookie httpOnly est posé et l'utilisateur est
+ *      redirigé vers /dashboard (via /auth/me).
+ *
+ * Références backend :
+ *   - TwoFactorAuthController::verify()
+ *   - Endpoint : POST /api/v1/auth/2fa/verify
+ *   - Payload  : { challenge_token, code, remember_device? }
+ */
+
+import { Suspense, useCallback, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  ArrowLeft,
+  KeyRound,
+  Loader2,
+  ShieldCheck,
+} from 'lucide-react';
+import { apiFetch } from '@/lib/api-client';
+import {
+  applyDocumentLocale,
+  getPreferredLocale,
+  normalizeLocale,
+  storeAuthSession,
+  type StoredAuthUser,
+} from '@/lib/i18n';
+import { Button } from '@/components/ui/Button';
+
+// ─── Composant interne (useSearchParams nécessite <Suspense>) ──────────────
+
+function TwoFactorChallengeForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const challengeToken = params.get('token') ?? '';
+
+  const [code, setCode] = useState('');
+  const [rememberDevice, setRememberDevice] = useState(false);
+  const [isRecovery, setIsRecovery] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmedCode = code.trim();
+
+      if (!trimmedCode) {
+        setError('Veuillez saisir votre code.');
+        return;
+      }
+
+      if (!challengeToken) {
+        setError('Token de challenge manquant. Veuillez vous reconnecter.');
+        return;
+      }
+
+      setSubmitting(true);
+      setError(null);
+
+      try {
+        // POST /api/v1/auth/2fa/verify — champ `code` pour TOTP,
+        // `recovery_code` pour les codes de récupération (#5436).
+        await apiFetch('/auth/2fa/verify', {
+          method: 'POST',
+          body: JSON.stringify({
+            challenge_token: challengeToken,
+            ...(isRecovery ? { recovery_code: trimmedCode } : { code: trimmedCode }),
+            remember_device: rememberDevice,
+          }),
+        });
+
+        // La réponse 2FA/verify retourne un token Sanctum — le cookie httpOnly
+        // est posé par le route handler /api/v1/auth/login via la réponse
+        // POST /auth/2fa/verify du backend. Récupérer l'utilisateur pour finir
+        // l'initialisation de session.
+        const meRes = await apiFetch('/auth/me');
+        const mePayload = (await meRes.json()) as { data?: StoredAuthUser };
+        const user = mePayload.data;
+
+        if (!user) {
+          setError('Session invalide. Veuillez vous reconnecter.');
+          return;
+        }
+
+        storeAuthSession(null, user);
+        applyDocumentLocale(normalizeLocale(user.language), user.is_rtl);
+        router.push('/dashboard');
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Code invalide ou expiré. Veuillez réessayer.',
+        );
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [challengeToken, code, rememberDevice, router],
+  );
+
+  return (
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-950 px-4 py-10 text-slate-950 dark:text-white sm:px-6 lg:px-8">
+      {/* Background decorations */}
+      <div className="auth-surface-dots absolute inset-0 z-0 opacity-10" />
+      <div className="auth-surface-glow absolute inset-0 z-0 opacity-70" />
+
+      <div className="relative z-10 w-full max-w-md">
+        <div className="overflow-hidden rounded-3xl bg-white shadow-2xl dark:bg-slate-900">
+          {/* Header */}
+          <div className="bg-gradient-to-br from-brand-600 to-emerald-600 p-8 text-white">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1 text-xs font-bold uppercase tracking-wider">
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Authentification à deux facteurs
+            </div>
+            <h1 className="text-2xl font-black">
+              {isRecovery ? 'Code de récupération' : 'Code de vérification'}
+            </h1>
+            <p className="mt-2 text-sm text-emerald-100">
+              {isRecovery
+                ? 'Saisissez l\'un de vos codes de récupération à usage unique.'
+                : 'Saisissez le code à 6 chiffres affiché par votre application authenticator.'}
+            </p>
+          </div>
+
+          {/* Form */}
+          <div className="p-8 space-y-6">
+            <form onSubmit={handleSubmit} noValidate className="space-y-5">
+              <div>
+                <label
+                  htmlFor="totp-code"
+                  className="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5"
+                >
+                  {isRecovery ? 'Code de récupération' : 'Code TOTP'}
+                </label>
+                <input
+                  id="totp-code"
+                  type={isRecovery ? 'text' : 'text'}
+                  inputMode={isRecovery ? 'text' : 'numeric'}
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  maxLength={isRecovery ? 32 : 8}
+                  autoComplete="one-time-code"
+                  autoFocus
+                  required
+                  placeholder={isRecovery ? 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' : '123456'}
+                  className="block w-full rounded-2xl border border-slate-200 px-4 py-3 text-center font-mono tracking-[0.35em] text-lg text-slate-900 shadow-sm outline-none transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                />
+              </div>
+
+              {/* Remember device */}
+              {!isRecovery && (
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={rememberDevice}
+                    onChange={(e) => setRememberDevice(e.target.checked)}
+                    className="h-4 w-4 rounded border-slate-300 text-brand-600 focus:ring-brand-500"
+                  />
+                  <span className="text-sm text-slate-600 dark:text-slate-400">
+                    Se souvenir de cet appareil (30 jours)
+                  </span>
+                </label>
+              )}
+
+              {/* Error */}
+              {error && (
+                <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm font-medium text-red-700 dark:bg-red-950/20 dark:border-red-900/30 dark:text-red-400">
+                  {error}
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                disabled={submitting || !code.trim()}
+                className="w-full"
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                    Vérification en cours…
+                  </>
+                ) : (
+                  <>
+                    <KeyRound className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Confirmer le code
+                  </>
+                )}
+              </Button>
+            </form>
+
+            {/* Toggle recovery / TOTP */}
+            <button
+              type="button"
+              onClick={() => {
+                setIsRecovery((v) => !v);
+                setCode('');
+                setError(null);
+              }}
+              className="w-full text-center text-sm text-brand-600 hover:text-brand-700 dark:text-brand-400 font-medium transition-colors"
+            >
+              {isRecovery
+                ? 'Utiliser mon application authenticator à la place'
+                : 'Utiliser un code de récupération à la place'}
+            </button>
+
+            <div className="border-t border-slate-100 dark:border-slate-800 pt-4 text-center">
+              <Link
+                href="/auth/login"
+                className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                Retour à la connexion
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+// ─── Page exportée avec Suspense (useSearchParams) ──────────────────────────
+
+export default function TwoFactorChallengePage() {
+  return (
+    <Suspense fallback={null}>
+      <TwoFactorChallengeForm />
+    </Suspense>
+  );
+}

--- a/front/web/src/app/auth/login/page.tsx
+++ b/front/web/src/app/auth/login/page.tsx
@@ -224,7 +224,23 @@ function LoginInner() {
         },
       });
 
-      const loginPayload = await loginResponse.json() as { data?: StoredAuthUser | { token?: string }; token?: string };
+      const loginPayload = await loginResponse.json() as {
+        data?: StoredAuthUser | { token?: string };
+        token?: string;
+        // Issue #5612 — 2FA challenge (backend #5436)
+        mfa_challenge?: boolean;
+        mfa_challenge_token?: string;
+      };
+
+      // Issue #5612 : si le backend exige un challenge TOTP, rediriger vers
+      // la page /auth/2fa/challenge avant d'appeler /auth/me (pas de session
+      // encore — le cookie n'est posé qu'après la vérification du code).
+      if (loginPayload.mfa_challenge === true && loginPayload.mfa_challenge_token) {
+        router.push(
+          `/auth/2fa/challenge?token=${encodeURIComponent(loginPayload.mfa_challenge_token)}`,
+        );
+        return;
+      }
 
       // Audit #1699 : le token vit dans le cookie httpOnly `leopardo_token`
       // posé par le route handler /api/v1/auth/login — il n'est jamais


### PR DESCRIPTION
## Résumé

Les managers activant la 2FA depuis l'admin-dashboard ne pouvaient plus se connecter via `front/web` (Next.js) car `0 grep 2fa` dans ce frontend. Le backend répondait `{mfa_challenge: true}` mais le frontend l'ignorait et affichait une erreur générique.

## Changements

### `front/web/src/app/auth/login/page.tsx`
- Détecte `mfa_challenge: true` dans la réponse POST /auth/login
- Redirige vers `/auth/2fa/challenge?token=<challenge_token>`

### `front/web/src/app/auth/2fa/challenge/page.tsx` *(nouveau)*
- Formulaire TOTP 6 chiffres + switch vers code de récupération
- Checkbox "Se souvenir de cet appareil (30 jours)"
- Envoie `code` (TOTP) ou `recovery_code` selon le mode
- Redirige vers /dashboard après vérification réussie

### `front/web/src/app/api/v1/auth/2fa/verify/route.ts` *(nouveau)*
- Proxy POST spécifique (même pattern que `/api/v1/auth/login/route.ts`)
- Extrait le token Sanctum et le pose dans le cookie httpOnly `leopardo_token`
- Retourne les données sans le token brut

### `front/web/src/app/(dashboard)/settings/security/2fa/page.tsx` *(nouveau)*
- Page d'enrôlement 2FA accessible depuis /settings/security/2fa
- Flux complet : GET status → POST enroll → QR + secret → POST confirm → 8 codes de récupération
- Désactivation via POST disable + code TOTP
- Affichage et copie en un clic des codes de récupération

## Flux complet

```
POST /auth/login → {mfa_challenge: true, mfa_challenge_token: 'xxx'}
   ↓ redirect
/auth/2fa/challenge?token=xxx
   ↓ POST /api/v1/auth/2fa/verify
   ↓ cookie httpOnly posé
/dashboard
```

Closes #5612