### PR TITLE
fix(i18n/admin): lot P1 — Edge, Fleet, Users, Subscriptions, UserTable, NotFound (Closes #5628)

### DIFF
--- a/front/admin-dashboard/src/components/common/KeyboardShortcutsModal.vue
+++ b/front/admin-dashboard/src/components/common/KeyboardShortcutsModal.vue
@@ -6,13 +6,13 @@
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm outline-none"
       role="dialog"
       aria-modal="true"
-      aria-label="Raccourcis Clavier"
+      :aria-label="t('adminShortcuts.title', 'Raccourcis Clavier')"
       @click.self="visible = false"
       @keydown.escape="visible = false"
     >
       <div class="glass-card max-w-md w-full mx-4 overflow-hidden animate-fade-in">
         <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
-          <h2 class="text-lg font-bold text-gray-900 dark:text-white">Raccourcis Clavier</h2>
+          <h2 class="text-lg font-bold text-gray-900 dark:text-white">{{ t('adminShortcuts.title', 'Raccourcis Clavier') }}</h2>
           <button
             @click="visible = false"
             class="p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -28,6 +28,7 @@
             class="flex items-center justify-between py-1.5"
           >
             <span class="text-sm text-gray-600 dark:text-gray-300">{{ shortcut.description }}</span>
+
             <kbd class="inline-flex items-center gap-1 px-2 py-1 text-xs font-mono font-semibold text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md">
               {{ shortcut.keys }}
             </kbd>
@@ -35,7 +36,7 @@
         </div>
 
         <div class="px-6 py-3 bg-gray-50 dark:bg-gray-900 text-xs text-gray-500 dark:text-gray-400 text-center">
-          Appuyez sur <kbd class="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-xs font-mono">?</kbd> pour afficher ce menu
+          {{ t('adminShortcuts.footerPress', 'Appuyez sur') }} <kbd class="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-xs font-mono">?</kbd> {{ t('adminShortcuts.footerToShow', 'pour afficher ce menu') }}
         </div>
       </div>
     </div>
@@ -43,23 +44,32 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { XMarkIcon } from '@heroicons/vue/24/outline'
+import { useLocaleStore } from '@/stores/locale'
+import { translate } from '@/i18n/index.js'
+
+// #5628 — i18n : libellés via adminShortcuts.* (fallback FR). Les touches
+// (Ctrl+D, Alt+H…) restent techniques et non traduites (règle #2755).
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 
 const visible = ref(false)
 const { containerRef: trapRef } = useFocusTrap(visible)
 
-const shortcuts = [
-  { keys: 'Ctrl + D', description: 'Basculer mode sombre' },
-  { keys: 'Ctrl + K', description: 'Rechercher' },
-  { keys: 'Alt + H', description: 'Tableau de bord' },
-  { keys: 'Alt + U', description: 'Utilisateurs' },
-  { keys: 'Alt + C', description: 'Entreprises' },
-  { keys: 'Alt + S', description: 'Abonnements' },
-  { keys: 'Escape', description: 'Fermer les modales' },
-  { keys: '?', description: 'Aide raccourcis' },
-]
+const shortcuts = computed(() =>
+  [
+    { keys: 'Ctrl + D', descKey: 'descToggleDark' },
+    { keys: 'Ctrl + K', descKey: 'descSearch' },
+    { keys: 'Alt + H', descKey: 'descDashboard' },
+    { keys: 'Alt + U', descKey: 'descUsers' },
+    { keys: 'Alt + C', descKey: 'descCompanies' },
+    { keys: 'Alt + S', descKey: 'descSubscriptions' },
+    { keys: 'Escape', descKey: 'descCloseModals' },
+    { keys: '?', descKey: 'descHelp' },
+  ].map((s) => ({ ...s, description: t(`adminShortcuts.${s.descKey}`) }))
+)
 
 function onShowHelp() {
   visible.value = true

--- a/front/admin-dashboard/src/components/users/UserTable.vue
+++ b/front/admin-dashboard/src/components/users/UserTable.vue
@@ -51,7 +51,7 @@
           <td colspan="5" class="px-6 py-16 text-center">
             <div class="flex flex-col items-center justify-center">
               <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-brand-600 mb-4"></div>
-              <span class="text-sm font-bold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Chargement des utilisateurs...</span>
+              <span class="text-sm font-bold text-slate-500 dark:text-slate-400 uppercase tracking-widest">{{ t('users.table.loading', 'Chargement des utilisateurs...') }}</span>
             </div>
           </td>
         </tr>
@@ -60,9 +60,9 @@
         <tr v-else-if="users.length === 0">
           <td colspan="5" class="px-6 py-12 text-center">
             <UsersIcon class="mx-auto h-12 w-12 text-gray-400" />
-            <h3 class="mt-2 text-sm font-medium text-gray-900">Aucun utilisateur</h3>
+            <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('users.table.empty', 'Aucun utilisateur') }}</h3>
             <p class="mt-1 text-sm text-gray-500">
-              Aucun utilisateur ne correspond aux critères de recherche.
+              {{ t('users.table.emptyHint', 'Aucun utilisateur ne correspond aux critères de recherche.') }}
             </p>
           </td>
         </tr>
@@ -127,16 +127,16 @@
               <button
                 @click="$emit('view', user)"
                 class="p-1.5 rounded-lg text-slate-400 hover:text-brand-600 hover:bg-brand-50 dark:hover:bg-brand-900/30 transition-all duration-200"
-                title="Voir les détails"
-                aria-label="Voir les détails"
+                :title="t('users.table.viewDetails', 'Voir les détails')"
+                :aria-label="t('users.table.viewDetails', 'Voir les détails')"
               >
                 <EyeIcon class="h-4 w-4" />
               </button>
               <button
                 @click="$emit('delete', user)"
                 class="p-1.5 rounded-lg text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 transition-all duration-200"
-                title="Supprimer"
-                aria-label="Supprimer"
+                :title="t('common.delete', 'Supprimer')"
+                :aria-label="t('common.delete', 'Supprimer')"
               >
                 <TrashIcon class="h-4 w-4" />
               </button>
@@ -158,9 +158,10 @@ import {
   UsersIcon
 } from '@heroicons/vue/24/outline'
 import { useLocaleStore } from '@/stores/locale'
-import { toIntlLocale } from '@/i18n/index.js'
+import { toIntlLocale, translate } from '@/i18n/index.js'
 
 const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 
 const props = defineProps({
   users: {

--- a/front/admin-dashboard/src/i18n/locales/ar.json
+++ b/front/admin-dashboard/src/i18n/locales/ar.json
@@ -138,7 +138,9 @@
       "TR": "تركيا",
       "US": "الولايات المتحدة"
     },
-    "required": "مطلوب"
+    "required": "مطلوب",
+    "delete": "حذف",
+    "confirm": "تأكيد"
   },
   "modules": {
     "attendance": "الحضور",
@@ -342,6 +344,12 @@
       "title": "تعديل المستخدم",
       "status": "الحالة",
       "save": "تحديث"
+    },
+    "table": {
+      "loading": "جارٍ تحميل المستخدمين...",
+      "empty": "لا يوجد مستخدم",
+      "emptyHint": "لا يوجد مستخدم يطابق معايير البحث.",
+      "viewDetails": "عرض التفاصيل"
     }
   },
   "dashboard": {
@@ -3205,5 +3213,117 @@
     "matchDone": "تمت مطابقة البند.",
     "loading": "جارٍ التحميل…",
     "retry": "إعادة المحاولة"
+  },
+  "adminShortcuts": {
+    "title": "اختصارات لوحة المفاتيح",
+    "descToggleDark": "تبديل الوضع الداكن",
+    "descSearch": "بحث",
+    "descDashboard": "لوحة القيادة",
+    "descUsers": "المستخدمون",
+    "descCompanies": "الشركات",
+    "descSubscriptions": "الاشتراكات",
+    "descCloseModals": "إغلاق النوافذ المنبثقة",
+    "descHelp": "مساعدة الاختصارات",
+    "footerPress": "اضغط على",
+    "footerToShow": "لعرض هذه القائمة"
+  },
+  "edge": {
+    "statTotal": "إجمالي العقد",
+    "statOnline": "متصل",
+    "statOffline": "غير متصل",
+    "statExpiredLicenses": "تراخيص منتهية",
+    "loading": "جارٍ تحميل العقد…",
+    "empty": "لا توجد عقد Edge مسجلة",
+    "emptyHint": "تظهر العقد هنا بعد تسجيلها عبر واجهة Edge.",
+    "colNode": "العقدة",
+    "colStatus": "الحالة",
+    "colLicense": "الترخيص",
+    "colLastSync": "آخر مزامنة",
+    "colActions": "إجراءات",
+    "sync": "مزامنة",
+    "syncing": "مزامنة…",
+    "details": "تفاصيل",
+    "revoke": "إلغاء",
+    "revokeConfirm": "تأكيد الإلغاء؟",
+    "revoking": "جارٍ الإلغاء…",
+    "loadError": "خطأ في تحميل عقد Edge.",
+    "syncError": "خطأ في تشغيل المزامنة.",
+    "syncSuccess": "بدأت المزامنة لـ {name}",
+    "revokeSuccess": "تم إلغاء الترخيص لـ {name}",
+    "revokeError": "خطأ في إلغاء الترخيص."
+  },
+  "fleet": {
+    "tabsMap": "الخريطة",
+    "tabsList": "القائمة",
+    "tabsAlerts": "التنبيهات",
+    "statVehicles": "المركبات",
+    "statInService": "في الخدمة",
+    "statMaintenanceDue": "صيانة مستحقة",
+    "statAlerts": "التنبيهات",
+    "colPlate": "رقم اللوحة",
+    "colBrand": "العلامة",
+    "colModel": "الطراز",
+    "colAssignedTo": "مُسند إلى",
+    "colKm": "كم",
+    "colStatus": "الحالة",
+    "colVehicle": "المركبة",
+    "colType": "النوع",
+    "colSeverity": "الخطورة",
+    "colMessage": "الرسالة",
+    "colDate": "التاريخ",
+    "statusActive": "في الخدمة",
+    "statusMaintenance": "صيانة",
+    "statusInactive": "غير نشط",
+    "statusDecommissioned": "مُخرجة من الخدمة",
+    "severityLow": "منخفض",
+    "severityMedium": "متوسط",
+    "severityHigh": "مرتفع",
+    "severityCritical": "حرج",
+    "unassigned": "غير مُسند",
+    "searchVehicle": "ابحث عن مركبة...",
+    "searchAlert": "ابحث عن تنبيه..."
+  },
+  "notFound": {
+    "users": "المستخدمون",
+    "usersHint": "إدارة حسابات المستخدمين",
+    "companies": "الشركات",
+    "companiesHint": "إدارة الشركات"
+  },
+  "subscriptions": {
+    "title": "الاشتراكات",
+    "subtitle": "الخطط وصحة المحفظة ومخاطر إلغاء الاشتراك لشركات العملاء.",
+    "refresh": "تحديث",
+    "kpi": {
+      "portfolioMrr": "إيرادات المحفظة الشهرية",
+      "activeSubscriptions": "اشتراكات نشطة",
+      "pastDue": "متأخر",
+      "totalOverdue": "إجمالي المتأخرات",
+      "arr": "الإيرادات السنوية",
+      "collected30d": "محصّل 30 يومًا",
+      "totalSubscribers": "إجمالي المشتركين",
+      "trials": "تجارب"
+    },
+    "catalogTitle": "كتالوج الخطط",
+    "catalogSub": "العروض التجارية والحدود المرتبطة بها.",
+    "retry": "إعادة المحاولة",
+    "public": "عام",
+    "archived": "مؤرشف",
+    "perMonth": "/ شهريًا",
+    "billedAnnually": "تُفوتر سنويًا",
+    "healthTitle": "صحة المحفظة",
+    "retentionTitle": "مخاطر إلغاء الاشتراك",
+    "noPlan": "خطة غير معروفة",
+    "manage": "إدارة",
+    "noRisk": "لا توجد مخاطر",
+    "loadError": "خطأ في تحميل الاشتراكات.",
+    "employees": "موظف",
+    "unlimited": "غير محدود",
+    "trialDays": "أيام تجريبية",
+    "trialUnit": "يومًا",
+    "risk": {
+      "high": "مخاطر عالية",
+      "medium": "مخاطر متوسطة",
+      "low": "مخاطر منخفضة"
+    }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -138,7 +138,9 @@
       "TR": "Türkiye",
       "US": "United States"
     },
-    "required": "Required"
+    "required": "Required",
+    "delete": "Delete",
+    "confirm": "Confirm"
   },
   "modules": {
     "attendance": "Attendance",
@@ -342,6 +344,12 @@
       "title": "Edit user",
       "status": "Status",
       "save": "Update"
+    },
+    "table": {
+      "loading": "Loading users...",
+      "empty": "No user",
+      "emptyHint": "No user matches the search criteria.",
+      "viewDetails": "View details"
     }
   },
   "dashboard": {
@@ -3205,5 +3213,117 @@
     "matchDone": "Line matched.",
     "loading": "Loading…",
     "retry": "Retry"
+  },
+  "adminShortcuts": {
+    "title": "Keyboard shortcuts",
+    "descToggleDark": "Toggle dark mode",
+    "descSearch": "Search",
+    "descDashboard": "Dashboard",
+    "descUsers": "Users",
+    "descCompanies": "Companies",
+    "descSubscriptions": "Subscriptions",
+    "descCloseModals": "Close modals",
+    "descHelp": "Shortcut help",
+    "footerPress": "Press",
+    "footerToShow": "to show this menu"
+  },
+  "edge": {
+    "statTotal": "Total nodes",
+    "statOnline": "Online",
+    "statOffline": "Offline",
+    "statExpiredLicenses": "Expired licenses",
+    "loading": "Loading nodes…",
+    "empty": "No Edge node registered",
+    "emptyHint": "Nodes appear here once registered via the Edge API.",
+    "colNode": "Node",
+    "colStatus": "Status",
+    "colLicense": "License",
+    "colLastSync": "Last sync",
+    "colActions": "Actions",
+    "sync": "Sync",
+    "syncing": "Sync…",
+    "details": "Details",
+    "revoke": "Revoke",
+    "revokeConfirm": "Confirm revocation?",
+    "revoking": "Revoking…",
+    "loadError": "Error loading Edge nodes.",
+    "syncError": "Error triggering the sync.",
+    "syncSuccess": "Sync started for {name}",
+    "revokeSuccess": "License revoked for {name}",
+    "revokeError": "Error revoking the license."
+  },
+  "fleet": {
+    "tabsMap": "Map",
+    "tabsList": "List",
+    "tabsAlerts": "Alerts",
+    "statVehicles": "Vehicles",
+    "statInService": "In service",
+    "statMaintenanceDue": "Maintenance due",
+    "statAlerts": "Alerts",
+    "colPlate": "Plate number",
+    "colBrand": "Brand",
+    "colModel": "Model",
+    "colAssignedTo": "Assigned to",
+    "colKm": "Km",
+    "colStatus": "Status",
+    "colVehicle": "Vehicle",
+    "colType": "Type",
+    "colSeverity": "Severity",
+    "colMessage": "Message",
+    "colDate": "Date",
+    "statusActive": "In service",
+    "statusMaintenance": "Maintenance",
+    "statusInactive": "Inactive",
+    "statusDecommissioned": "Decommissioned",
+    "severityLow": "Low",
+    "severityMedium": "Medium",
+    "severityHigh": "High",
+    "severityCritical": "Critical",
+    "unassigned": "Unassigned",
+    "searchVehicle": "Search a vehicle...",
+    "searchAlert": "Search an alert..."
+  },
+  "notFound": {
+    "users": "Users",
+    "usersHint": "Manage user accounts",
+    "companies": "Companies",
+    "companiesHint": "Manage companies"
+  },
+  "subscriptions": {
+    "title": "Subscriptions",
+    "subtitle": "Plans, portfolio health and churn risk for customer companies.",
+    "refresh": "Refresh",
+    "kpi": {
+      "portfolioMrr": "Portfolio MRR",
+      "activeSubscriptions": "Active subscriptions",
+      "pastDue": "Past due",
+      "totalOverdue": "Total overdue",
+      "arr": "ARR",
+      "collected30d": "Collected 30d",
+      "totalSubscribers": "Total subscribers",
+      "trials": "Trials"
+    },
+    "catalogTitle": "Plans catalog",
+    "catalogSub": "Commercial offers and associated limits.",
+    "retry": "Retry",
+    "public": "Public",
+    "archived": "Archived",
+    "perMonth": "/ month",
+    "billedAnnually": "billed annually",
+    "healthTitle": "Portfolio health",
+    "retentionTitle": "Churn risks",
+    "noPlan": "Unknown plan",
+    "manage": "Manage",
+    "noRisk": "No risk detected",
+    "loadError": "Error loading subscriptions.",
+    "employees": "employees",
+    "unlimited": "Unlimited",
+    "trialDays": "trial days",
+    "trialUnit": "days",
+    "risk": {
+      "high": "High risk",
+      "medium": "Medium risk",
+      "low": "Low risk"
+    }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -138,7 +138,9 @@
       "TR": "Turquie",
       "US": "États-Unis"
     },
-    "required": "Requis"
+    "required": "Requis",
+    "delete": "Supprimer",
+    "confirm": "Confirmer"
   },
   "modules": {
     "attendance": "Pointage",
@@ -342,6 +344,12 @@
       "title": "Modifier l'utilisateur",
       "status": "Statut",
       "save": "Mettre à jour"
+    },
+    "table": {
+      "loading": "Chargement des utilisateurs...",
+      "empty": "Aucun utilisateur",
+      "emptyHint": "Aucun utilisateur ne correspond aux critères de recherche.",
+      "viewDetails": "Voir les détails"
     }
   },
   "dashboard": {
@@ -3205,5 +3213,117 @@
     "matchDone": "Ligne rapprochée.",
     "loading": "Chargement…",
     "retry": "Réessayer"
+  },
+  "adminShortcuts": {
+    "title": "Raccourcis Clavier",
+    "descToggleDark": "Basculer mode sombre",
+    "descSearch": "Rechercher",
+    "descDashboard": "Tableau de bord",
+    "descUsers": "Utilisateurs",
+    "descCompanies": "Entreprises",
+    "descSubscriptions": "Abonnements",
+    "descCloseModals": "Fermer les modales",
+    "descHelp": "Aide raccourcis",
+    "footerPress": "Appuyez sur",
+    "footerToShow": "pour afficher ce menu"
+  },
+  "edge": {
+    "statTotal": "Nodes total",
+    "statOnline": "En ligne",
+    "statOffline": "Hors ligne",
+    "statExpiredLicenses": "Licences expirées",
+    "loading": "Chargement des nodes…",
+    "empty": "Aucun node Edge enregistré",
+    "emptyHint": "Les nodes apparaissent ici une fois enregistrés via l'API Edge.",
+    "colNode": "Node",
+    "colStatus": "Statut",
+    "colLicense": "Licence",
+    "colLastSync": "Dernière sync",
+    "colActions": "Actions",
+    "sync": "Sync",
+    "syncing": "Sync…",
+    "details": "Détails",
+    "revoke": "Révoquer",
+    "revokeConfirm": "Confirmer la révocation ?",
+    "revoking": "Révoquer…",
+    "loadError": "Erreur lors du chargement des nodes Edge.",
+    "syncError": "Erreur lors du déclenchement de la synchronisation.",
+    "syncSuccess": "Synchronisation lancée pour {name}",
+    "revokeSuccess": "Licence révoquée pour {name}",
+    "revokeError": "Erreur lors de la révocation de la licence."
+  },
+  "fleet": {
+    "tabsMap": "Carte",
+    "tabsList": "Liste",
+    "tabsAlerts": "Alertes",
+    "statVehicles": "Véhicules",
+    "statInService": "En service",
+    "statMaintenanceDue": "Maintenance due",
+    "statAlerts": "Alertes",
+    "colPlate": "Immatriculation",
+    "colBrand": "Marque",
+    "colModel": "Modèle",
+    "colAssignedTo": "Assigné à",
+    "colKm": "Km",
+    "colStatus": "Statut",
+    "colVehicle": "Véhicule",
+    "colType": "Type",
+    "colSeverity": "Sévérité",
+    "colMessage": "Message",
+    "colDate": "Date",
+    "statusActive": "En service",
+    "statusMaintenance": "Maintenance",
+    "statusInactive": "Inactif",
+    "statusDecommissioned": "Réformé",
+    "severityLow": "Faible",
+    "severityMedium": "Moyen",
+    "severityHigh": "Élevé",
+    "severityCritical": "Critique",
+    "unassigned": "Non assigné",
+    "searchVehicle": "Rechercher un véhicule...",
+    "searchAlert": "Rechercher une alerte..."
+  },
+  "notFound": {
+    "users": "Utilisateurs",
+    "usersHint": "Gérer les comptes utilisateurs",
+    "companies": "Entreprises",
+    "companiesHint": "Gérer les entreprises"
+  },
+  "subscriptions": {
+    "title": "Abonnements",
+    "subtitle": "Plans, santé du portefeuille et risques de désabonnement des entreprises clientes.",
+    "refresh": "Actualiser",
+    "kpi": {
+      "portfolioMrr": "MRR portefeuille",
+      "activeSubscriptions": "Abonnements actifs",
+      "pastDue": "En retard",
+      "totalOverdue": "Impayés total",
+      "arr": "ARR",
+      "collected30d": "Encaissé 30 j",
+      "totalSubscribers": "Abonnés total",
+      "trials": "Essais"
+    },
+    "catalogTitle": "Catalogue des plans",
+    "catalogSub": "Offres commerciales et limites associées.",
+    "retry": "Réessayer",
+    "public": "Public",
+    "archived": "Archivé",
+    "perMonth": "/ mois",
+    "billedAnnually": "facturé annuellement",
+    "healthTitle": "Santé du portefeuille",
+    "retentionTitle": "Risques de désabonnement",
+    "noPlan": "Plan inconnu",
+    "manage": "Gérer",
+    "noRisk": "Aucun risque détecté",
+    "loadError": "Erreur lors du chargement des abonnements.",
+    "employees": "employés",
+    "unlimited": "Illimité",
+    "trialDays": "jours d'essai",
+    "trialUnit": "jours",
+    "risk": {
+      "high": "Risque élevé",
+      "medium": "Risque moyen",
+      "low": "Risque faible"
+    }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/tr.json
+++ b/front/admin-dashboard/src/i18n/locales/tr.json
@@ -138,7 +138,9 @@
       "TR": "Türkiye",
       "US": "Amerika Birleşik Devletleri"
     },
-    "required": "Gerekli"
+    "required": "Gerekli",
+    "delete": "Sil",
+    "confirm": "Onayla"
   },
   "modules": {
     "attendance": "Puantaj",
@@ -342,6 +344,12 @@
       "title": "Kullanıcıyı düzenle",
       "status": "Durum",
       "save": "Güncelle"
+    },
+    "table": {
+      "loading": "Kullanıcılar yükleniyor...",
+      "empty": "Kullanıcı yok",
+      "emptyHint": "Arama kriterlerine uyan kullanıcı yok.",
+      "viewDetails": "Detayları gör"
     }
   },
   "dashboard": {
@@ -3205,5 +3213,117 @@
     "matchDone": "Satır mutabık kılındı.",
     "loading": "Yükleniyor…",
     "retry": "Yeniden dene"
+  },
+  "adminShortcuts": {
+    "title": "Klavye Kısayolları",
+    "descToggleDark": "Karanlık modu değiştir",
+    "descSearch": "Ara",
+    "descDashboard": "Panel",
+    "descUsers": "Kullanıcılar",
+    "descCompanies": "Şirketler",
+    "descSubscriptions": "Abonelikler",
+    "descCloseModals": "Pencereleri kapat",
+    "descHelp": "Kısayol yardımı",
+    "footerPress": "Basın",
+    "footerToShow": "bu menüyü göstermek için"
+  },
+  "edge": {
+    "statTotal": "Toplam düğüm",
+    "statOnline": "Çevrimiçi",
+    "statOffline": "Çevrimdışı",
+    "statExpiredLicenses": "Süresi dolan lisanslar",
+    "loading": "Düğümler yükleniyor…",
+    "empty": "Kayıtlı Edge düğümü yok",
+    "emptyHint": "Düğümler Edge API üzerinden kaydedildikten sonra burada görünür.",
+    "colNode": "Düğüm",
+    "colStatus": "Durum",
+    "colLicense": "Lisans",
+    "colLastSync": "Son senkronizasyon",
+    "colActions": "İşlemler",
+    "sync": "Senkronize",
+    "syncing": "Senkronize ediliyor…",
+    "details": "Detaylar",
+    "revoke": "İptal et",
+    "revokeConfirm": "İptal onaylansın mı?",
+    "revoking": "İptal ediliyor…",
+    "loadError": "Edge düğümleri yüklenirken hata.",
+    "syncError": "Senkronizasyon başlatılırken hata.",
+    "syncSuccess": "{name} için senkronizasyon başladı",
+    "revokeSuccess": "{name} için lisans iptal edildi",
+    "revokeError": "Lisans iptal edilirken hata."
+  },
+  "fleet": {
+    "tabsMap": "Harita",
+    "tabsList": "Liste",
+    "tabsAlerts": "Uyarılar",
+    "statVehicles": "Araçlar",
+    "statInService": "Hizmette",
+    "statMaintenanceDue": "Bakım gerekli",
+    "statAlerts": "Uyarılar",
+    "colPlate": "Plaka",
+    "colBrand": "Marka",
+    "colModel": "Model",
+    "colAssignedTo": "Atanan",
+    "colKm": "Km",
+    "colStatus": "Durum",
+    "colVehicle": "Araç",
+    "colType": "Tür",
+    "colSeverity": "Önem",
+    "colMessage": "Mesaj",
+    "colDate": "Tarih",
+    "statusActive": "Hizmette",
+    "statusMaintenance": "Bakım",
+    "statusInactive": "Pasif",
+    "statusDecommissioned": "Hurda",
+    "severityLow": "Düşük",
+    "severityMedium": "Orta",
+    "severityHigh": "Yüksek",
+    "severityCritical": "Kritik",
+    "unassigned": "Atanmamış",
+    "searchVehicle": "Araç ara...",
+    "searchAlert": "Uyarı ara..."
+  },
+  "notFound": {
+    "users": "Kullanıcılar",
+    "usersHint": "Kullanıcı hesaplarını yönet",
+    "companies": "Şirketler",
+    "companiesHint": "Şirketleri yönet"
+  },
+  "subscriptions": {
+    "title": "Abonelikler",
+    "subtitle": "Müşteri şirketlerin planları, portföy sağlığı ve abonelik iptal riskleri.",
+    "refresh": "Yenile",
+    "kpi": {
+      "portfolioMrr": "Portföy MRR",
+      "activeSubscriptions": "Aktif abonelikler",
+      "pastDue": "Gecikmiş",
+      "totalOverdue": "Toplam gecikme",
+      "arr": "Yıllık gelir",
+      "collected30d": "30 günlük tahsilat",
+      "totalSubscribers": "Toplam abone",
+      "trials": "Denemeler"
+    },
+    "catalogTitle": "Plan kataloğu",
+    "catalogSub": "Ticari teklifler ve ilgili limitler.",
+    "retry": "Tekrar dene",
+    "public": "Genel",
+    "archived": "Arşivlendi",
+    "perMonth": "/ ay",
+    "billedAnnually": "yıllık faturalandırılır",
+    "healthTitle": "Portföy sağlığı",
+    "retentionTitle": "İptal riskleri",
+    "noPlan": "Bilinmeyen plan",
+    "manage": "Yönet",
+    "noRisk": "Risk tespit edilmedi",
+    "loadError": "Abonelikler yüklenirken hata.",
+    "employees": "çalışan",
+    "unlimited": "Sınırsız",
+    "trialDays": "deneme günü",
+    "trialUnit": "gün",
+    "risk": {
+      "high": "Yüksek risk",
+      "medium": "Orta risk",
+      "low": "Düşük risk"
+    }
   }
 }

--- a/front/admin-dashboard/src/views/NotFoundView.vue
+++ b/front/admin-dashboard/src/views/NotFoundView.vue
@@ -43,8 +43,8 @@
               <div class="flex items-center">
                 <UsersIcon class="h-6 w-6 text-gray-400 group-hover:text-gray-500" />
                 <div class="ml-3">
-                  <p class="text-sm font-medium text-gray-900">Utilisateurs</p>
-                  <p class="text-sm text-gray-500">Gérer les comptes utilisateurs</p>
+                  <p class="text-sm font-medium text-gray-900">{{ t('notFound.users', 'Utilisateurs') }}</p>
+                  <p class="text-sm text-gray-500">{{ t('notFound.usersHint', 'Gérer les comptes utilisateurs') }}</p>
                 </div>
               </div>
             </div>
@@ -59,8 +59,8 @@
               <div class="flex items-center">
                 <BuildingOfficeIcon class="h-6 w-6 text-gray-400 group-hover:text-gray-500" />
                 <div class="ml-3">
-                  <p class="text-sm font-medium text-gray-900">Entreprises</p>
-                  <p class="text-sm text-gray-500">Gérer les entreprises</p>
+                  <p class="text-sm font-medium text-gray-900">{{ t('notFound.companies', 'Entreprises') }}</p>
+                  <p class="text-sm text-gray-500">{{ t('notFound.companiesHint', 'Gérer les entreprises') }}</p>
                 </div>
               </div>
             </div>
@@ -104,6 +104,10 @@
 </template>
 
 <script setup>
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale'
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 import { useRouter } from 'vue-router'
 import {
   ArrowLeftIcon,

--- a/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
+++ b/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
@@ -29,33 +29,33 @@
 
     <!-- Stats row -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-      <EdgeStatCard label="Nodes total" :value="stats.total" icon="🖥️" color="indigo" />
-      <EdgeStatCard label="En ligne" :value="stats.online" icon="✅" color="green" />
-      <EdgeStatCard label="Hors ligne" :value="stats.offline" icon="⭕" color="gray" />
-      <EdgeStatCard label="Licences expirées" :value="stats.licenseExpired" icon="⚠️" color="red" />
+      <EdgeStatCard :label="t('edge.statTotal', 'Nodes total')" :value="stats.total" icon="🖥️" color="indigo" />
+      <EdgeStatCard :label="t('edge.statOnline', 'En ligne')" :value="stats.online" icon="✅" color="green" />
+      <EdgeStatCard :label="t('edge.statOffline', 'Hors ligne')" :value="stats.offline" icon="⭕" color="gray" />
+      <EdgeStatCard :label="t('edge.statExpiredLicenses', 'Licences expirées')" :value="stats.licenseExpired" icon="⚠️" color="red" />
     </div>
 
     <!-- Nodes table -->
     <div class="glass-card dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
       <div v-if="loading && nodes.length === 0" class="p-12 text-center text-gray-400">
         <div class="text-4xl mb-3 animate-spin inline-block">↻</div>
-        <p>Chargement des nodes…</p>
+        <p>{{ t('edge.loading', 'Chargement des nodes…') }}</p>
       </div>
 
       <div v-else-if="!loading && nodes.length === 0" class="p-12 text-center text-gray-400">
         <div class="text-4xl mb-3 opacity-30">🖥️</div>
-        <p class="font-medium">Aucun node Edge enregistré</p>
-        <p class="text-sm mt-1">Les nodes apparaissent ici une fois enregistrés via l'API Edge.</p>
+        <p class="font-medium">{{ t('edge.empty', 'Aucun node Edge enregistré') }}</p>
+        <p class="text-sm mt-1">{{ t('edge.emptyHint', "Les nodes apparaissent ici une fois enregistrés via l'API Edge.") }}</p>
       </div>
 
       <table v-else class="w-full text-sm">
         <thead>
           <tr class="glass-bg dark:bg-slate-800/50 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-            <th class="px-4 py-3 font-medium">Node</th>
-            <th class="px-4 py-3 font-medium">Statut</th>
-            <th class="px-4 py-3 font-medium">Licence</th>
-            <th class="px-4 py-3 font-medium">Dernière sync</th>
-            <th class="px-4 py-3 font-medium">Actions</th>
+            <th class="px-4 py-3 font-medium">{{ t('edge.colNode', 'Node') }}</th>
+            <th class="px-4 py-3 font-medium">{{ t('edge.colStatus', 'Statut') }}</th>
+            <th class="px-4 py-3 font-medium">{{ t('edge.colLicense', 'Licence') }}</th>
+            <th class="px-4 py-3 font-medium">{{ t('edge.colLastSync', 'Dernière sync') }}</th>
+            <th class="px-4 py-3 font-medium">{{ t('edge.colActions', 'Actions') }}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
@@ -106,11 +106,11 @@
                   :disabled="!node.is_online || syncingNodeId === node.id"
                   class="text-xs text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 font-medium disabled:opacity-30 disabled:cursor-not-allowed"
                 >
-                  {{ syncingNodeId === node.id ? 'Sync…' : 'Sync' }}
+                  {{ syncingNodeId === node.id ? t('edge.syncing', 'Sync…') : t('edge.sync', 'Sync') }}
                 </button>
                 <span class="text-gray-300 dark:text-gray-600">|</span>
                 <button @click="viewNode(node)" class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 font-medium">
-                  Détails
+                  {{ t('edge.details', 'Détails') }}
                 </button>
                 <!-- #4935 : bouton « Révoquer licence » branché sur le store
                      (endpoint POST /admin/edge-nodes/{id}/revoke existant) —
@@ -123,14 +123,14 @@
                     :disabled="revokingNodeId === node.id"
                     class="text-xs text-red-600 hover:text-red-800 dark:text-red-400 font-medium disabled:opacity-30"
                   >
-                    {{ revokingNodeId === node.id ? 'Révoquer…' : 'Confirmer la révocation ?' }}
+                    {{ revokingNodeId === node.id ? t('edge.revoking', 'Révoquer…') : t('edge.revokeConfirm', 'Confirmer la révocation ?') }}
                   </button>
                   <button
                     v-else
                     @click="confirmRevokeId = node.id"
                     class="text-xs text-red-500 hover:text-red-700 dark:text-red-400 font-medium"
                   >
-                    Révoquer
+                    {{ t('edge.revoke', 'Révoquer') }}
                   </button>
                 </template>
               </div>
@@ -191,7 +191,7 @@ async function refresh() {
   } catch (err) {
     loadError.value = err?.response?.data?.localized_message
       || err?.message
-      || 'Erreur lors du chargement des nodes Edge.';
+      || t('edge.loadError', 'Erreur lors du chargement des nodes Edge.');
     toast.error(loadError.value);
   } finally {
     loading.value = false;
@@ -204,11 +204,11 @@ async function triggerSync(node) {
   try {
     await store.triggerSync(node.id);
     await refresh();
-    toast.success(`Synchronisation lancée pour ${node.name || node.id}`);
+    toast.success(t('edge.syncSuccess', 'Synchronisation lancée pour {name}').replace('{name}', node.name || node.id));
   } catch (err) {
     loadError.value = err?.response?.data?.localized_message
       || err?.message
-      || 'Erreur lors du déclenchement de la synchronisation.';
+      || t('edge.syncError', 'Erreur lors du déclenchement de la synchronisation.');
     toast.error(loadError.value);
   } finally {
     syncingNodeId.value = null;
@@ -227,11 +227,11 @@ async function revokeLicense(node) {
     await store.revokeLicense(node.id);
     await refresh();
     confirmRevokeId.value = null;
-    toast.success(`Licence révoquée pour ${node.name || node.id}`);
+    toast.success(t('edge.revokeSuccess', 'Licence révoquée pour {name}').replace('{name}', node.name || node.id));
   } catch (err) {
     loadError.value = err?.response?.data?.localized_message
       || err?.message
-      || 'Erreur lors de la révocation de la licence.';
+      || t('edge.revokeError', 'Erreur lors de la révocation de la licence.');
     toast.error(loadError.value);
   } finally {
     revokingNodeId.value = null;

--- a/front/admin-dashboard/src/views/fleet/FleetView.vue
+++ b/front/admin-dashboard/src/views/fleet/FleetView.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="space-y-6">
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
-      <StatsCard title="Vehicules" :value="stats.total" icon="ChartBarIcon" color="blue" />
-      <StatsCard title="En service" :value="stats.in_service" icon="ChartBarIcon" color="green" />
-      <StatsCard title="Maintenance due" :value="stats.maintenance_due" icon="ChartBarIcon" color="yellow" />
-      <StatsCard title="Alertes" :value="stats.alerts" icon="ChartBarIcon" color="red" />
+      <StatsCard :title="t('fleet.statVehicles', 'Vehicules')" :value="stats.total" icon="ChartBarIcon" color="blue" />
+      <StatsCard :title="t('fleet.statInService', 'En service')" :value="stats.in_service" icon="ChartBarIcon" color="green" />
+      <StatsCard :title="t('fleet.statMaintenanceDue', 'Maintenance due')" :value="stats.maintenance_due" icon="ChartBarIcon" color="yellow" />
+      <StatsCard :title="t('fleet.statAlerts', 'Alertes')" :value="stats.alerts" icon="ChartBarIcon" color="red" />
     </div>
 
     <div v-if="alertsError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
@@ -40,7 +40,7 @@
       :loading="loading"
       :error="error"
       :search-keys="['plate_number', 'brand', 'model', 'assigned_to']"
-      search-placeholder="Rechercher un vehicule..."
+      :search-placeholder="t('fleet.searchVehicle', 'Rechercher un vehicule...')"
       default-sort="plate_number"
       exportable
       @export="exportVehicles"
@@ -67,7 +67,7 @@
       :loading="loading"
       :error="alertsError"
       :search-keys="['vehicle_plate', 'type', 'message']"
-      search-placeholder="Rechercher une alerte..."
+      :search-placeholder="t('fleet.searchAlert', 'Rechercher une alerte...')"
       default-sort="created_at"
       default-sort-dir="desc"
     >
@@ -91,6 +91,11 @@ import StatsCard from '@/components/dashboard/StatsCard.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import VehicleDetailModal from '@/components/fleet/VehicleDetailModal.vue'
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale'
+
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 
 const loading = ref(false)
 const error = ref('')
@@ -105,40 +110,40 @@ let leafletMap = null
 const stats = ref({ total: 0, in_service: 0, maintenance_due: 0, alerts: 0 })
 
 const tabs = [
-  { key: 'map', label: 'Carte' },
-  { key: 'list', label: 'Liste' },
-  { key: 'alerts', label: 'Alertes' },
+  { key: 'map', label: t('fleet.tabsMap', 'Carte') },
+  { key: 'list', label: t('fleet.tabsList', 'Liste') },
+  { key: 'alerts', label: t('fleet.tabsAlerts', 'Alertes') },
 ]
 
 const vehicleColumns = [
-  { key: 'plate_number', label: 'Immatriculation', sortable: true },
-  { key: 'brand', label: 'Marque', sortable: true },
-  { key: 'model', label: 'Modele', sortable: true },
-  { key: 'assigned_to', label: 'Assigne a', sortable: true },
-  { key: 'km_current', label: 'Km', sortable: true },
-  { key: 'status', label: 'Statut', sortable: true },
+  { key: 'plate_number', label: t('fleet.colPlate', 'Immatriculation'), sortable: true },
+  { key: 'brand', label: t('fleet.colBrand', 'Marque'), sortable: true },
+  { key: 'model', label: t('fleet.colModel', 'Modele'), sortable: true },
+  { key: 'assigned_to', label: t('fleet.colAssignedTo', 'Assigne a'), sortable: true },
+  { key: 'km_current', label: t('fleet.colKm', 'Km'), sortable: true },
+  { key: 'status', label: t('fleet.colStatus', 'Statut'), sortable: true },
 ]
 
 const alertColumns = [
-  { key: 'vehicle_plate', label: 'Vehicule', sortable: true },
-  { key: 'type', label: 'Type', sortable: true },
-  { key: 'severity', label: 'Severite', sortable: true },
-  { key: 'message', label: 'Message' },
-  { key: 'created_at', label: 'Date', sortable: true },
+  { key: 'vehicle_plate', label: t('fleet.colVehicle', 'Vehicule'), sortable: true },
+  { key: 'type', label: t('fleet.colType', 'Type'), sortable: true },
+  { key: 'severity', label: t('fleet.colSeverity', 'Severite'), sortable: true },
+  { key: 'message', label: t('fleet.colMessage', 'Message') },
+  { key: 'created_at', label: t('fleet.colDate', 'Date'), sortable: true },
 ]
 
 const vehicleStatusMap = {
-  active: { label: 'En service', color: 'green' },
-  maintenance: { label: 'Maintenance', color: 'yellow' },
-  inactive: { label: 'Inactif', color: 'gray' },
-  decommissioned: { label: 'Reforme', color: 'red' },
+  active: { label: t('fleet.statusActive', 'En service'), color: 'green' },
+  maintenance: { label: t('fleet.statusMaintenance', 'Maintenance'), color: 'yellow' },
+  inactive: { label: t('fleet.statusInactive', 'Inactif'), color: 'gray' },
+  decommissioned: { label: t('fleet.statusDecommissioned', 'Reforme'), color: 'red' },
 }
 
 const severityMap = {
-  low: { label: 'Faible', color: 'blue' },
-  medium: { label: 'Moyen', color: 'yellow' },
-  high: { label: 'Eleve', color: 'red' },
-  critical: { label: 'Critique', color: 'red' },
+  low: { label: t('fleet.severityLow', 'Faible'), color: 'blue' },
+  medium: { label: t('fleet.severityMedium', 'Moyen'), color: 'yellow' },
+  high: { label: t('fleet.severityHigh', 'Eleve'), color: 'red' },
+  critical: { label: t('fleet.severityCritical', 'Critique'), color: 'red' },
 }
 
 async function initMap() {
@@ -168,7 +173,7 @@ function plotVehicles(L) {
   vehicles.value.forEach(v => {
     if (v.latitude && v.longitude) {
       L.marker([v.latitude, v.longitude])
-        .bindPopup(`<b>${escapeHtml(v.plate_number)}</b><br>${escapeHtml(v.brand)} ${escapeHtml(v.model)}<br>${escapeHtml(v.assigned_to || 'Non assigne')}`)
+        .bindPopup(`<b>${escapeHtml(v.plate_number)}</b><br>${escapeHtml(v.brand)} ${escapeHtml(v.model)}<br>${escapeHtml(v.assigned_to || t('fleet.unassigned', 'Non assigne'))}`)
         .addTo(leafletMap)
     }
   })

--- a/front/admin-dashboard/src/views/settings/HolidaysView.vue
+++ b/front/admin-dashboard/src/views/settings/HolidaysView.vue
@@ -224,7 +224,7 @@
     :open="deleteOpen"
     :title="t('holidays.islamic.delete_confirm_title', 'Supprimer ce jour férié ?')"
     :message="deleteTarget ? t('holidays.islamic.delete_confirm_dialog', { name: deleteTarget.name }) : ''"
-    confirm-label="Supprimer"
+    :confirm-label="t('common.delete', 'Supprimer')"
     @confirm="removeHoliday"
     @cancel="deleteOpen = false"
   />
@@ -232,7 +232,7 @@
     :open="confirmYearOpen"
     :title="t('holidays.islamic.confirm_title', 'Confirmer l\'année ?')"
     :message="t('holidays.islamic.confirm_dialog', { year: islamicYear })"
-    confirm-label="Confirmer"
+    :confirm-label="t('common.confirm', 'Confirmer')"
     @confirm="confirmYear"
     @cancel="confirmYearOpen = false"
   />

--- a/front/admin-dashboard/src/views/settings/SocialContributionsView.vue
+++ b/front/admin-dashboard/src/views/settings/SocialContributionsView.vue
@@ -181,7 +181,7 @@
     :open="deleteOpen"
     :title="t('social_contrib.delete_confirm_title', 'Supprimer cette cotisation ?')"
     :message="deleteTarget ? t('social_contrib.delete_confirm', { name: deleteTarget.name }) : ''"
-    confirm-label="Supprimer"
+    :confirm-label="t('common.delete', 'Supprimer')"
     @confirm="removeItem"
     @cancel="deleteOpen = false"
   />

--- a/front/admin-dashboard/src/views/users/UsersView.vue
+++ b/front/admin-dashboard/src/views/users/UsersView.vue
@@ -201,7 +201,7 @@
     :open="deleteOpen"
     :title="t('users.confirm.title', 'Supprimer cet utilisateur ?')"
     :message="deleteTarget ? t('users.confirm.delete', 'Êtes-vous sûr de vouloir supprimer :name ?').replace(':name', deleteTarget.name) : ''"
-    confirm-label="Supprimer"
+    :confirm-label="t('common.delete', 'Supprimer')"
     @confirm="confirmDeleteUser"
     @cancel="deleteOpen = false"
   />


### PR DESCRIPTION
## Contexte
Issue #5628 : 499 signaux P1 de chaînes hardcodées dans l'admin-dashboard. Les composants « top 5 » cités (DataTable, ConfirmDialog, CommandPalette) étaient déjà localisés par les lots précédents (#5508) ; le scan réel révèle les vrais restants : Edge, Fleet, Subscriptions (pire : namespace absent → écran VIDE), Users, UserTable, NotFound, KeyboardShortcutsModal.

## Changements (~110 chaînes localisées ×4)
- **KeyboardShortcutsModal** : titre + aria-label + 8 descriptions + footer → `adminShortcuts.*` (11 clés ; touches Ctrl+D/Alt+H conservées techniques, règle #2755)
- **EdgeNodesView** : 23 clés `edge.*` (stats, colonnes table, actions sync/révoquer, erreurs, toasts avec interpolation `{name}`)
- **FleetView** : 29 clés `fleet.*` (onglets, StatsCard, colonnes véhicule/alertes, statuts, sévérités, placeholders, popup carte) + helper `t()` ajouté
- **SubscriptionsView** : namespace `subscriptions.*` **reconstruit ×4** (33 clés) — l'écran appelait `t('subscriptions.xxx')` sans fallback et le namespace n'existait dans AUCUN catalogue → titres/sections affichés vides
- **UsersView / SocialContributionsView / HolidaysView** : `confirm-label` → `common.delete` / `common.confirm`
- **UserTable** : chargement, état vide, emptyHint, boutons détails/supprimer (title + aria-label)
- **NotFoundView** : liens + descriptions localisés

## Vérifications
- Parité stricte ×4 : 2502 clés/locale, 0 écart
- `npm run build` (vite) ✓ · `npm run lint` (eslint .) ✓ · i18n-diff guard ✓
- Le scan i18n-debt (admin_dashboard) retombe sous les 25 signaux « réels » hors faux positifs techniques (CSS, touches, code)

Closes #5628