### PR TITLE
fix(admin): responsive < 768px — tables scrollables restantes + vérif 375px (Closes #5632)

### DIFF
--- a/front/admin-dashboard/src/components/users/UserTable.vue
+++ b/front/admin-dashboard/src/components/users/UserTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="overflow-hidden">
+  <div class="overflow-x-auto">
     <table class="min-w-full divide-y divide-slate-200/50 dark:divide-slate-800/50">
       <thead class="bg-slate-50/50 dark:bg-slate-900/30">
         <tr>

--- a/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
+++ b/front/admin-dashboard/src/views/edge/EdgeNodesView.vue
@@ -48,7 +48,8 @@
         <p class="text-sm mt-1">{{ t('edge.emptyHint', "Les nodes apparaissent ici une fois enregistrés via l'API Edge.") }}</p>
       </div>
 
-      <table v-else class="w-full text-sm">
+      <div v-else class="overflow-x-auto">
+      <table class="w-full text-sm">
         <thead>
           <tr class="glass-bg dark:bg-slate-800/50 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
             <th class="px-4 py-3 font-medium">{{ t('edge.colNode', 'Node') }}</th>
@@ -138,6 +139,7 @@
           </tr>
         </tbody>
       </table>
+      </div>
     </div>
 
     <!-- Node detail modal -->

--- a/front/admin-dashboard/src/views/growth/GrowthDashboardView.vue
+++ b/front/admin-dashboard/src/views/growth/GrowthDashboardView.vue
@@ -33,6 +33,7 @@
     <div v-else>
       <div v-if="currentTab === 'partners'" class="space-y-6">
         <div class="glass-card overflow-hidden">
+          <div class="overflow-x-auto">
           <table class="w-full text-left">
             <thead class="bg-slate-50">
               <tr>
@@ -76,6 +77,7 @@
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Contexte
Issue #5632 : admin-dashboard inutilisable < 768px (sidebar fixe qui écrase le contenu, tables qui débordent, modals hors écran).

## État constaté (code + navigateur)
Une partie du correctif était déjà livrée (PR #5622/WCAG) : **sidebar off-canvas** (`-translate-x-full` + overlay + `lg:static`), **bouton hamburger** (`lg:hidden`), **DataTable** déjà en `overflow-x-auto`, modals en `w-full max-w-* mx-4` (compatibles 375px). Vérifié visuellement : page de login à 375px sans aucun débordement.

## Ce que cette PR corrige (les vrais restants)
3 tables brutes débordaient encore horizontalement sur mobile — enveloppées dans `overflow-x-auto` :
- `components/users/UserTable.vue`
- `views/growth/GrowthDashboardView.vue` (table partenaires)
- `views/edge/EdgeNodesView.vue` (table nodes)

## Vérifications
- `npm run build` (vite) ✓ · `npm run lint` (eslint .) ✓
- Les 10 autres vues à `<table>` brut avaient déjà un wrapper overflow (vérifié)
- Sidebar/hamburger/DataTable confirmés par lecture du code (classes `lg:`, `lg:hidden`, `overflow-x-auto`)

Closes #5632