### PR TITLE
fix(P0): 2FA front/web, SEPA IBAN/BIC, SSO OIDC, sécurité TTS (#5612 #5613 #5614 #5616)

### DIFF
--- a/api/app/Console/Commands/PurgeTtsFilesCommand.php
+++ b/api/app/Console/Commands/PurgeTtsFilesCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * #5616 — Purge des fichiers TTS audio générés plus d'une heure plus tôt.
+ *
+ * Les fichiers TTS sont stockés dans storage/app/tts/ avec des URL signées
+ * de 60 secondes : au-delà ils sont inaccessibles mais occupent du disque.
+ * Ce cron supprime les fichiers > 1 h pour respecter les obligations RGPD
+ * (minimisation des données) et éviter la saturation disque.
+ *
+ * Planification : toutes les heures (voir routes/console.php).
+ */
+class PurgeTtsFilesCommand extends Command
+{
+    protected $signature = 'tts:purge {--older-than=3600 : Supprimer les fichiers plus anciens que N secondes (défaut : 3600 = 1 h)}';
+
+    protected $description = 'Supprime les fichiers TTS générés il y a plus d\'une heure (#5616 — RGPD)';
+
+    public function handle(): int
+    {
+        $olderThan = (int) $this->option('older-than');
+        $cutoff = now()->subSeconds($olderThan);
+
+        $disk = Storage::disk('local');
+        $files = $disk->files('tts');
+
+        $deleted = 0;
+        $errors = 0;
+
+        foreach ($files as $file) {
+            // N'opérer que sur les fichiers générés par le TTS (tts_<hex>.mp3).
+            $basename = basename($file);
+            if (! preg_match('/^tts_[a-f0-9]+\.mp3$/', $basename)) {
+                continue;
+            }
+
+            try {
+                $lastModified = $disk->lastModified($file);
+                if ($lastModified < $cutoff->timestamp) {
+                    $disk->delete($file);
+                    $deleted++;
+                }
+            } catch (\Throwable $e) {
+                $this->warn("Impossible de supprimer {$file} : ".$e->getMessage());
+                $errors++;
+            }
+        }
+
+        $this->info("TTS purge : {$deleted} fichier(s) supprimé(s), {$errors} erreur(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/api/app/Core/Auth/Infrastructure/Services/SSO/SSOService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/SSO/SSOService.php
@@ -19,11 +19,17 @@ class SSOService
     private const SENSITIVE_FIELDS = ['certificate', 'client_secret'];
 
     /**
-     * Audit #1694 : la validation des assertions SAML/OIDC n'est pas
-     * implémentée — exposer false tant que le moteur de validation n'existe
-     * pas (les intégrateurs doivent afficher « SSO en cours de déploiement »).
+     * Retourne si la validation SSO est disponible pour un provider donné.
+     *
+     * - OIDC (#2231) : OidcFlowService est pleinement implémenté → true.
+     * - SAML         : validation OneLogin non implémentée (audit #1694) → false.
+     *
+     * Issue #5614 : l'ancien VALIDATION_AVAILABLE = false bloquait aussi OIDC.
      */
-    private const VALIDATION_AVAILABLE = false;
+    private function isValidationAvailableForProvider(string $provider): bool
+    {
+        return $provider === 'oidc';
+    }
 
     /**
      * @return array{enabled: bool, provider: string|null, config: SSOProviderConfig|null, validation_available: bool}
@@ -40,8 +46,7 @@ class SSOService
                 'enabled' => false,
                 'provider' => null,
                 'config' => null,
-                // Audit #1694 : validation non implémentée.
-                'validation_available' => self::VALIDATION_AVAILABLE,
+                'validation_available' => false,
             ];
         }
 
@@ -65,8 +70,8 @@ class SSOService
                 'provider' => $provider,
                 ...$configData,
             ]),
-            // Audit #1694 : validation non implémentée.
-            'validation_available' => self::VALIDATION_AVAILABLE,
+            // #5614 : true pour OIDC (OidcFlowService implémenté), false pour SAML.
+            'validation_available' => $this->isValidationAvailableForProvider($provider),
         ];
     }
 
@@ -135,11 +140,12 @@ class SSOService
         }
 
         if ($canActivate) {
-            Log::info('OIDC SSO configured and active (validation implemented — issue #2231)', [
+            Log::info('OIDC SSO configuré et actif (issue #2231/#5614)', [
                 'company_id' => $companyId,
             ]);
         } else {
-            Log::warning('SSO configured but kept inactive (validation not implemented — audit #1694)', [
+            // SAML : en attente de l'implémentation OneLogin/php-saml (audit #1694).
+            Log::warning('SSO configuré mais inactif (SAML non implémenté ou config OIDC incomplète)', [
                 'company_id' => $companyId,
                 'provider' => $provider,
             ]);

--- a/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/SSOController.php
@@ -38,14 +38,18 @@ class SSOController extends Controller
 
         $sso = $this->ssoService->getCompanySSO($actor->company_id);
 
+        // #5614 — Pour OIDC, la validation est disponible sans gate SAML_ENABLED.
+        // Pour SAML, le flag config('services.saml.enabled') reste requis jusqu'à
+        // l'implémentation de la librairie OneLogin (audit #1694).
+        $samlGate = $sso['provider'] !== 'oidc'
+            ? (bool) config('services.saml.enabled', false)
+            : true;
+
         return response()->json([
             'data' => [
                 'enabled' => $sso['enabled'],
                 'provider' => $sso['provider'],
-                // Audit #1694 + gate #3890 : la validation SAML/OIDC n'est
-                // disponible que si le moteur existe ET le flag SAML_ENABLED est posé.
-                'validation_available' => $sso['validation_available']
-                    && (bool) config('services.saml.enabled', false),
+                'validation_available' => $sso['validation_available'] && $samlGate,
             ],
         ]);
     }

--- a/api/app/Http/Controllers/AI/VoiceController.php
+++ b/api/app/Http/Controllers/AI/VoiceController.php
@@ -9,9 +9,12 @@ use App\AI\Orchestrator;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 
 class VoiceController extends Controller
 {
@@ -179,6 +182,14 @@ class VoiceController extends Controller
 
     private function textToSpeech(string $text, string $language, ?string $voice, string $provider): ?string
     {
+        // #5616 — Si ElevenLabs est configuré, il est prioritaire sur edge-tts
+        // qui n'est pas installé en production et utilise exec() non maîtrisé.
+        $elevenLabsKey = config('ai.voice.elevenlabs_key');
+        if ($elevenLabsKey && $provider === 'edge_tts') {
+            Log::info('TTS: edge-tts demandé mais ElevenLabs disponible — basculement automatique (issue #5616)');
+            $provider = 'elevenlabs';
+        }
+
         if ($provider === 'edge_tts') {
             return $this->edgeTtsSynthesize($text, $language, $voice);
         }
@@ -190,8 +201,62 @@ class VoiceController extends Controller
         return null;
     }
 
+    /**
+     * Sert un fichier TTS privé via une URL signée temporaire (60 s).
+     * Route : GET /ai/voice/download/{filename}?signature=...&expires=...
+     *
+     * #5616 — Les fichiers audio ne sont plus exposés publiquement de façon permanente.
+     */
+    public function download(string $filename): Response
+    {
+        // Sécurité : seul un nom de fichier simple (sans chemin) est accepté.
+        if (! preg_match('/^tts_[a-f0-9]+\.mp3$/', $filename)) {
+            abort(404);
+        }
+
+        $path = 'tts/'.$filename;
+
+        if (! Storage::disk('local')->exists($path)) {
+            abort(404);
+        }
+
+        $content = Storage::disk('local')->get($path);
+
+        if ($content === null) {
+            abort(404);
+        }
+
+        return response($content, 200, [
+            'Content-Type'        => 'audio/mpeg',
+            'Content-Disposition' => 'inline; filename="'.$filename.'"',
+            'Cache-Control'       => 'no-store, max-age=0',
+        ]);
+    }
+
+    /**
+     * Génère une URL signée temporaire (60 s) vers le fichier TTS stocké
+     * en disque local privé.  N'est jamais une URL publique permanente.
+     * #5616 — Remplace url('storage/tts/...')
+     */
+    private function signedTtsUrl(string $filename): string
+    {
+        return URL::temporarySignedRoute(
+            'ai.voice.download',
+            now()->addSeconds(60),
+            ['filename' => $filename],
+        );
+    }
+
     private function edgeTtsSynthesize(string $text, string $language, ?string $voice): ?string
     {
+        // #5616 — Vérifier que edge-tts est bien installé avant tout appel exec().
+        exec('which edge-tts 2>/dev/null', $which, $whichCode);
+        if ($whichCode !== 0) {
+            Log::warning('edge-tts non trouvé sur le système — TTS désactivé (issue #5616). Installez-le via pip install edge-tts ou configurez ELEVENLABS_API_KEY.');
+
+            return null;
+        }
+
         $voiceMap = [
             'fr' => 'fr-FR-DeniseNeural',
             'ar' => 'ar-SA-ZariyahNeural',
@@ -200,7 +265,7 @@ class VoiceController extends Controller
         ];
 
         $selectedVoice = $voice ?? ($voiceMap[$language] ?? 'fr-FR-DeniseNeural');
-        $filename = 'tts_'.uniqid().'.mp3';
+        $filename = 'tts_'.bin2hex(random_bytes(8)).'.mp3';
         $storagePath = storage_path('app/tts/'.$filename);
 
         if (! is_dir(dirname($storagePath))) {
@@ -214,12 +279,13 @@ class VoiceController extends Controller
         exec("edge-tts --voice={$escaped} --text={$escapedText} --write-media={$escapedPath} 2>&1", $output, $code);
 
         if ($code !== 0) {
-            Log::warning('Edge TTS failed, returning null', ['code' => $code, 'output' => implode("\n", $output)]);
+            Log::warning('Edge TTS failed', ['code' => $code, 'output' => implode("\n", $output)]);
 
             return null;
         }
 
-        return url('storage/tts/'.$filename);
+        // #5616 — URL signée 60 s, non publique permanente.
+        return $this->signedTtsUrl($filename);
     }
 
     private function elevenLabsSynthesize(string $text, ?string $voiceId): ?string
@@ -241,14 +307,12 @@ class VoiceController extends Controller
             ]);
 
         if ($response->successful()) {
-            $filename = 'tts_'.uniqid().'.mp3';
-            $storagePath = storage_path('app/tts/'.$filename);
-            if (! is_dir(dirname($storagePath))) {
-                mkdir(dirname($storagePath), 0755, true);
-            }
-            file_put_contents($storagePath, $response->body());
+            $filename = 'tts_'.bin2hex(random_bytes(8)).'.mp3';
+            // #5616 — Stocké dans le disque local privé (hors public/).
+            Storage::disk('local')->put('tts/'.$filename, $response->body());
 
-            return url('storage/tts/'.$filename);
+            // #5616 — URL signée 60 s, non publique permanente.
+            return $this->signedTtsUrl($filename);
         }
 
         Log::error('ElevenLabs TTS failed', ['status' => $response->status()]);

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBankDetailsController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBankDetailsController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\HR\Interfaces\Api\V1\Controllers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Http\Controllers\Controller;
+use App\Rules\ValidIban;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Coordonnées bancaires de l'entreprise (IBAN / BIC) nécessaires à
+ * l'export SEPA pain.001.001.03.
+ *
+ * Issue #5613 — ces champs existaient côté backend (CompanyBankDetails,
+ * ValidIban, BankExportGenerator) mais aucune UI ne permettait de les saisir ;
+ * l'export SEPA retournait systématiquement 422 MISSING_COMPANY_IBAN.
+ *
+ * Stockage : `companies.metadata.company_iban` / `.company_bic` (clés plates
+ * héritées de l'issue #2198, cohérentes avec CompanyBankDetails::forCompany()).
+ */
+class CompanyBankDetailsController extends Controller
+{
+    /**
+     * GET /api/v1/company/bank-details
+     * Retourne l'IBAN et le BIC actuellement configurés.
+     */
+    public function show(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        abort_unless($actor->hasManagerRole('principal', 'rh'), 403);
+
+        $company = $this->freshCompany($actor->company_id);
+        $metadata = $this->parseMetadata($company);
+
+        return new JsonResponse([
+            'data' => $this->payload($metadata),
+        ]);
+    }
+
+    /**
+     * PATCH /api/v1/company/bank-details
+     * Met à jour l'IBAN et/ou le BIC de l'entreprise.
+     */
+    public function update(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+        abort_unless($actor->hasManagerRole('principal', 'rh'), 403);
+
+        $validated = $request->validate([
+            // ValidIban accepte DZ (RIB 20 chiffres), MA, FR, TR et les IBAN
+            // officiels — voir api/app/Rules/ValidIban.php (issue #2198).
+            'company_iban' => ['required', 'string', 'max:64', new ValidIban],
+            'company_bic'  => ['nullable', 'string', 'max:11', 'regex:/^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/'],
+        ]);
+
+        $company  = $this->freshCompany($actor->company_id);
+        $metadata = $this->parseMetadata($company);
+
+        // Normalisation : IBAN sans espaces, BIC en majuscules.
+        $metadata['company_iban'] = strtoupper(str_replace([' ', '-'], '', (string) $validated['company_iban']));
+
+        if (array_key_exists('company_bic', $validated)) {
+            $metadata['company_bic'] = $validated['company_bic'] !== null
+                ? strtoupper(trim((string) $validated['company_bic']))
+                : null;
+        }
+
+        $this->persistMetadata($company->id, $metadata);
+
+        return new JsonResponse([
+            'data'    => $this->payload($metadata),
+            'message' => __('errors.COMPANY_BANK_DETAILS_UPDATED', [], 'fr')
+                ?: 'Coordonnées bancaires mises à jour.',
+        ]);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private function freshCompany(string $companyId): Company
+    {
+        /** @var Company $company */
+        $company = Company::query()
+            ->from($this->companiesTable())
+            ->where('id', $companyId)
+            ->firstOrFail();
+
+        return $company;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseMetadata(Company $company): array
+    {
+        $raw = $company->metadata ?? [];
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        return is_string($raw) ? (json_decode($raw, true) ?: []) : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @return array{company_iban: string|null, company_bic: string|null}
+     */
+    private function payload(array $metadata): array
+    {
+        return [
+            'company_iban' => isset($metadata['company_iban']) && $metadata['company_iban'] !== ''
+                ? (string) $metadata['company_iban']
+                : null,
+            'company_bic'  => isset($metadata['company_bic']) && $metadata['company_bic'] !== ''
+                ? (string) $metadata['company_bic']
+                : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function persistMetadata(string $companyId, array $metadata): void
+    {
+        DB::table($this->companiesTable())
+            ->where('id', $companyId)
+            ->update([
+                'metadata'   => json_encode($metadata, JSON_THROW_ON_ERROR),
+                'updated_at' => now(),
+            ]);
+    }
+
+    private function companiesTable(): string
+    {
+        return DB::getDriverName() === 'pgsql' ? 'public.companies' : 'companies';
+    }
+}

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -11,6 +11,12 @@ use App\Http\Middleware\AI\AITenantInjector;
 use App\Http\Middleware\AI\EnsureAIAnalyticsAccess;
 use Illuminate\Support\Facades\Route;
 
+// #5616 — Téléchargement de fichiers TTS via URL signée temporaire (60 s).
+// Pas de middleware auth : la signature cryptographique garantit l'authenticité.
+Route::get('/ai/voice/download/{filename}', [VoiceController::class, 'download'])
+    ->name('ai.voice.download')
+    ->middleware(['signed']);
+
 Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'throttle:ai-sensitive', AIFeatureCheck::class, AITenantInjector::class, 'throttle:api-plan'])->prefix('ai')->group(function () {
 
     // Phase 1 — Chat IA

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -14,6 +14,7 @@ use App\Modules\Billing\Interfaces\Api\V1\PlatformPlanController;
 use App\Modules\Billing\Interfaces\Api\V1\SelfServiceTrialController;
 use App\Modules\Billing\Interfaces\Api\V1\StripeWebhookController;
 use App\Modules\EdgeSync\Interfaces\Api\V1\EdgeNodeController;
+use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBankDetailsController;
 use App\Modules\HR\Interfaces\Api\V1\Controllers\CompanyBrandingController;
 use App\Modules\HR\Interfaces\Api\V1\Controllers\PrivacyController;
 use App\Modules\Marketing\Interfaces\Api\V1\Controllers\MarketingLeadController;
@@ -208,6 +209,9 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/company-requests', [CompanyRequestController::class, 'store']);
         Route::get('/company/branding', [CompanyBrandingController::class, 'show']);
         Route::patch('/company/branding', [CompanyBrandingController::class, 'update']);
+        // #5613 — Coordonnées bancaires entreprise (IBAN/BIC) pour l'export SEPA.
+        Route::get('/company/bank-details', [CompanyBankDetailsController::class, 'show']);
+        Route::patch('/company/bank-details', [CompanyBankDetailsController::class, 'update']);
 
         // PA2-COMM-012 — Pilot client support center: a manager/employee can
         // open a support ticket and reply on their own company's tickets.

--- a/api/routes/console.php
+++ b/api/routes/console.php
@@ -197,3 +197,10 @@ Artisan::command('super-admin:reset-password {email} {password}', function (stri
 // confirmer avant la clôture (novembre).
 Schedule::command('islamic:check-unconfirmed')
     ->yearlyOn(11, 15, '09:00');
+
+// #5616 — RGPD : purge des fichiers TTS audio générés > 1 h (URL signées 60 s
+// déjà expirées, les fichiers sont inaccessibles mais occupent le disque).
+Schedule::command('tts:purge')
+    ->hourly()
+    ->withoutOverlapping()
+    ->onOneServer();

--- a/front/web/package-lock.json
+++ b/front/web/package-lock.json
@@ -2140,7 +2140,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
       "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.62.1"
@@ -2159,7 +2159,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.52",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
@@ -2520,25 +2520,6 @@
         "tailwindcss": "4.3.3"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
@@ -2623,12 +2604,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4126,12 +4101,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7332,15 +7301,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "dev": true,
@@ -8006,7 +7966,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.62.1"
@@ -8025,7 +7985,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
       "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8038,6 +7998,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8099,32 +8060,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/prop-types": {
@@ -8385,12 +8320,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",

--- a/front/web/src/app/(dashboard)/settings/company/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/company/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+/**
+ * Paramètres entreprise — Coordonnées bancaires (IBAN / BIC).
+ *
+ * Issue #5613 — L'export SEPA pain.001.001.03 retournait 422
+ * MISSING_COMPANY_IBAN faute de cette interface de saisie.
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { Building2, AlertTriangle, CheckCircle2, Loader2, Save } from 'lucide-react';
+import { ApiError, apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { Button } from '@/components/ui/Button';
+import { getPreferredLocale, type AppLocale } from '@/lib/i18n';
+import { t as i18nT } from '@/lib/i18n/locale-catalog';
+
+const emptySubscribe = () => () => {};
+
+type BankDetails = {
+  company_iban: string | null;
+  company_bic: string | null;
+};
+
+/** Formate un IBAN brut en groupes de 4 caractères (lisibilité). */
+function formatIban(raw: string): string {
+  return raw.replace(/\s/g, '').replace(/(.{4})/g, '$1 ').trim();
+}
+
+/** Normalise un IBAN pour l'envoi API (sans espaces, majuscules). */
+function normalizeIban(raw: string): string {
+  return raw.replace(/\s/g, '').toUpperCase();
+}
+
+/** Validation côté client — le backend revalide avec ValidIban. */
+function isIbanLike(value: string): boolean {
+  const normalized = normalizeIban(value);
+  return /^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test(normalized);
+}
+
+/** Validation BIC/SWIFT : 8 ou 11 caractères alphanumériques. */
+function isBicLike(value: string): boolean {
+  if (!value) return true; // BIC optionnel
+  return /^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/.test(value.toUpperCase());
+}
+
+export default function CompanyBankDetailsPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [iban, setIban] = useState('');
+  const [bic, setBic] = useState('');
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Chargement initial
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+
+    apiFetch('/company/bank-details')
+      .then((r) => r.json() as Promise<{ data?: BankDetails }>)
+      .then((payload) => {
+        if (!active) return;
+        setIban(payload.data?.company_iban ? formatIban(payload.data.company_iban) : '');
+        setBic(payload.data?.company_bic ?? '');
+      })
+      .catch(() => {
+        if (active) setErrorMsg(i18nT(locale, 'bankDetails.loadError', 'Impossible de charger les coordonnées bancaires.'));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => { active = false; };
+  }, [locale]);
+
+  const handleSave = useCallback(async () => {
+    setSuccessMsg(null);
+    setErrorMsg(null);
+
+    const normalizedIban = normalizeIban(iban);
+    const normalizedBic = bic.trim().toUpperCase() || null;
+
+    if (!isIbanLike(normalizedIban)) {
+      setErrorMsg(i18nT(locale, 'bankDetails.invalidIban', 'IBAN invalide. Vérifiez le format (ex : FR76 3000 6000 0112 3456 7890 189).'));
+      return;
+    }
+
+    if (bic && !isBicLike(bic)) {
+      setErrorMsg(i18nT(locale, 'bankDetails.invalidBic', 'BIC invalide. Format attendu : 8 ou 11 caractères (ex : BNPAFRPPXXX).'));
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      await apiFetch('/company/bank-details', {
+        method: 'PATCH',
+        body: JSON.stringify({ company_iban: normalizedIban, company_bic: normalizedBic }),
+      });
+      setSuccessMsg(i18nT(locale, 'bankDetails.saveSuccess', 'Coordonnées bancaires enregistrées. L\'export SEPA est désormais disponible.'));
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setErrorMsg(err.message);
+      } else {
+        setErrorMsg(i18nT(locale, 'bankDetails.saveError', 'Une erreur est survenue lors de la sauvegarde.'));
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [iban, bic, locale]);
+
+  const ibanValid = isIbanLike(normalizeIban(iban));
+  const bicValid = !bic || isBicLike(bic);
+
+  return (
+    <ModulePageShell
+      title={i18nT(locale, 'bankDetails.pageTitle', 'Coordonnées bancaires')}
+      subtitle={i18nT(locale, 'bankDetails.pageSubtitle', 'IBAN et BIC de votre entreprise, requis pour l\'export des virements SEPA.')}
+      accentClassName="border-emerald-200/50"
+    >
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-emerald-500" aria-hidden="true" />
+        </div>
+      ) : (
+        <div className="max-w-2xl space-y-6">
+          {/* Bannière d'information SEPA */}
+          {!iban && (
+            <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-800">
+              <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" aria-hidden="true" />
+              <div>
+                <p className="font-bold">
+                  {i18nT(locale, 'bankDetails.warningTitle', 'Export SEPA indisponible')}
+                </p>
+                <p className="mt-1">
+                  {i18nT(locale, 'bankDetails.warningBody', 'Aucun IBAN d\'entreprise n\'est configuré. L\'export des virements salariaux retournera une erreur tant que ce champ n\'est pas renseigné.')}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Messages de retour */}
+          {successMsg && (
+            <div className="flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800">
+              <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-500" aria-hidden="true" />
+              {successMsg}
+            </div>
+          )}
+          {errorMsg && (
+            <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-800">
+              {errorMsg}
+            </div>
+          )}
+
+          {/* Formulaire */}
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="mb-6 flex items-center gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-slate-950 text-white">
+                <Building2 className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <div>
+                <h2 className="text-lg font-black text-slate-950">
+                  {i18nT(locale, 'bankDetails.sectionTitle', 'Compte débiteur SEPA')}
+                </h2>
+                <p className="text-xs text-slate-500">
+                  {i18nT(locale, 'bankDetails.sectionSubtitle', 'Ces informations apparaissent dans le fichier pain.001.001.03 envoyé à votre banque.')}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-5">
+              {/* IBAN */}
+              <div>
+                <label
+                  htmlFor="company-iban"
+                  className="block text-sm font-bold text-slate-700 mb-1.5"
+                >
+                  {i18nT(locale, 'bankDetails.ibanLabel', 'IBAN')}
+                  {' '}
+                  <span className="text-red-500" aria-label="obligatoire">*</span>
+                </label>
+                <input
+                  id="company-iban"
+                  type="text"
+                  inputMode="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="FR76 3000 6000 0112 3456 7890 189"
+                  className={[
+                    'block h-12 w-full rounded-2xl border bg-transparent/50 px-4 text-slate-950 shadow-sm outline-none transition',
+                    'placeholder:text-slate-400 focus:ring-2 focus:ring-emerald-500/20 font-mono text-sm',
+                    iban && !ibanValid
+                      ? 'border-red-300 focus:border-red-500'
+                      : 'border-slate-200 focus:border-emerald-500',
+                  ].join(' ')}
+                  value={iban}
+                  onChange={(e) => {
+                    setIban(formatIban(e.target.value));
+                    setSuccessMsg(null);
+                    setErrorMsg(null);
+                  }}
+                />
+                <p className="mt-1.5 text-xs text-slate-500">
+                  {i18nT(locale, 'bankDetails.ibanHint', 'Pour DZ : saisissez votre RIB à 20 chiffres. Pour MA : RIB 24 caractères.')}
+                </p>
+              </div>
+
+              {/* BIC */}
+              <div>
+                <label
+                  htmlFor="company-bic"
+                  className="block text-sm font-bold text-slate-700 mb-1.5"
+                >
+                  {i18nT(locale, 'bankDetails.bicLabel', 'BIC / SWIFT')}
+                  {' '}
+                  <span className="text-slate-400 text-xs font-normal">
+                    {i18nT(locale, 'bankDetails.bicOptional', '(optionnel)')}
+                  </span>
+                </label>
+                <input
+                  id="company-bic"
+                  type="text"
+                  inputMode="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="BNPAFRPPXXX"
+                  className={[
+                    'block h-12 w-full rounded-2xl border bg-transparent/50 px-4 text-slate-950 shadow-sm outline-none transition',
+                    'placeholder:text-slate-400 focus:ring-2 focus:ring-emerald-500/20 font-mono text-sm',
+                    bic && !bicValid
+                      ? 'border-red-300 focus:border-red-500'
+                      : 'border-slate-200 focus:border-emerald-500',
+                  ].join(' ')}
+                  value={bic}
+                  onChange={(e) => {
+                    setBic(e.target.value.toUpperCase());
+                    setSuccessMsg(null);
+                    setErrorMsg(null);
+                  }}
+                />
+              </div>
+
+              {/* Bouton sauvegarde */}
+              <div className="flex justify-end pt-2">
+                <Button
+                  type="button"
+                  loading={saving}
+                  disabled={saving || !ibanValid}
+                  className="inline-flex h-11 items-center gap-2 rounded-2xl bg-emerald-600 px-6 text-xs font-black uppercase tracking-widest text-white shadow-lg hover:bg-emerald-500 disabled:opacity-50"
+                  onClick={() => void handleSave()}
+                >
+                  {!saving && <Save className="h-4 w-4" aria-hidden="true" />}
+                  {saving
+                    ? i18nT(locale, 'bankDetails.saving', 'Enregistrement...')
+                    : i18nT(locale, 'bankDetails.save', 'Enregistrer')}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/(dashboard)/settings/security/page.tsx
+++ b/front/web/src/app/(dashboard)/settings/security/page.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+/**
+ * Paramètres de sécurité — Authentification à deux facteurs (2FA / TOTP).
+ *
+ * Issue #5612 — front/web ne disposait d'aucune interface pour enrôler ou
+ * désactiver la 2FA. Un manager ayant activé la 2FA depuis l'admin-dashboard
+ * se retrouvait bloqué à la connexion via front/web.
+ *
+ * Flux d'enrôlement :
+ *   1. POST /auth/2fa/enroll  → { secret, qr_url }
+ *   2. Utilisateur scanne le QR ou entre le secret dans son appli TOTP.
+ *   3. POST /auth/2fa/confirm { code } → { recovery_codes: string[] }
+ *   4. Afficher les 8 codes de récupération à copier.
+ *
+ * Désactivation :
+ *   POST /auth/2fa/disable { code } (code TOTP courant requis)
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import {
+  ShieldCheck,
+  ShieldOff,
+  QrCode,
+  Copy,
+  Check,
+  Loader2,
+  AlertTriangle,
+  CheckCircle2,
+  Key,
+} from 'lucide-react';
+import QRCode from 'qrcode';
+import { ApiError, apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { Button } from '@/components/ui/Button';
+import { getPreferredLocale, type AppLocale } from '@/lib/i18n';
+import { t as i18nT } from '@/lib/i18n/locale-catalog';
+
+const emptySubscribe = () => () => {};
+
+type TwoFaStatus = {
+  enabled: boolean;
+  mfa_required: boolean;
+};
+
+type EnrollData = {
+  secret: string;
+  qr_url: string;
+};
+
+type Step = 'idle' | 'enrolling' | 'confirming' | 'done' | 'disabling';
+
+export default function SecuritySettingsPage() {
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
+
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<TwoFaStatus | null>(null);
+  const [step, setStep] = useState<Step>('idle');
+  const [enrollData, setEnrollData] = useState<EnrollData | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [code, setCode] = useState('');
+  const [disableCode, setDisableCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Chargement du statut 2FA
+  const loadStatus = useCallback(() => {
+    setLoading(true);
+    apiFetch('/auth/2fa/status')
+      .then((r) => r.json() as Promise<{ data?: TwoFaStatus }>)
+      .then((payload) => {
+        if (payload.data) setStatus(payload.data);
+      })
+      .catch(() => {
+        setError(i18nT(locale, 'twoFa.loadError', 'Impossible de charger le statut 2FA.'));
+      })
+      .finally(() => setLoading(false));
+  }, [locale]);
+
+  useEffect(() => { loadStatus(); }, [loadStatus]);
+
+  // Étape 1 : démarrer l'enrôlement
+  const handleStartEnroll = useCallback(async () => {
+    setError(null);
+    setSubmitting(true);
+    try {
+      const r = await apiFetch('/auth/2fa/enroll', { method: 'POST' });
+      const payload = (await r.json()) as { data?: EnrollData };
+      if (!payload.data) throw new Error('Invalid response');
+      setEnrollData(payload.data);
+      // Génère le QR code (data URL PNG) depuis l'otpauth:// URI retourné par l'API.
+      const dataUrl = await QRCode.toDataURL(payload.data.qr_url, { width: 200, margin: 1 });
+      setQrDataUrl(dataUrl);
+      setStep('enrolling');
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : i18nT(locale, 'twoFa.enrollError', 'Impossible de démarrer l\'enrôlement.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [locale]);
+
+  // Étape 2 : confirmer avec le premier code TOTP
+  const handleConfirm = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const r = await apiFetch('/auth/2fa/confirm', {
+        method: 'POST',
+        body: JSON.stringify({ code: code.replace(/\s/g, '') }),
+      });
+      const payload = (await r.json()) as { data?: { recovery_codes?: string[] } };
+      const codes = payload.data?.recovery_codes ?? [];
+      setRecoveryCodes(codes);
+      setStep('done');
+      setStatus((s) => s ? { ...s, enabled: true } : { enabled: true, mfa_required: false });
+      setSuccessMsg(i18nT(locale, 'twoFa.activationSuccess', 'La 2FA est activée. Conservez vos codes de récupération en lieu sûr.'));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : i18nT(locale, 'twoFa.confirmError', 'Code incorrect. Réessayez.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [code, locale]);
+
+  // Désactivation
+  const handleDisable = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!disableCode) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      await apiFetch('/auth/2fa/disable', {
+        method: 'POST',
+        body: JSON.stringify({ code: disableCode.replace(/\s/g, '') }),
+      });
+      setStatus((s) => s ? { ...s, enabled: false } : { enabled: false, mfa_required: false });
+      setStep('idle');
+      setDisableCode('');
+      setSuccessMsg(i18nT(locale, 'twoFa.disableSuccess', 'La 2FA a été désactivée.'));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : i18nT(locale, 'twoFa.disableError', 'Code incorrect ou erreur serveur.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [disableCode, locale]);
+
+  const copyRecoveryCodes = useCallback(() => {
+    void navigator.clipboard.writeText(recoveryCodes.join('\n')).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [recoveryCodes]);
+
+  if (loading) {
+    return (
+      <ModulePageShell title="Sécurité" subtitle="2FA" accentClassName="border-emerald-200/50">
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-emerald-500" aria-hidden="true" />
+        </div>
+      </ModulePageShell>
+    );
+  }
+
+  return (
+    <ModulePageShell
+      title={i18nT(locale, 'twoFa.pageTitle', 'Sécurité')}
+      subtitle={i18nT(locale, 'twoFa.pageSubtitle', 'Authentification à deux facteurs (TOTP) — protège votre compte en cas de mot de passe compromis.')}
+      accentClassName="border-emerald-200/50"
+    >
+      <div className="max-w-xl space-y-6">
+        {/* Messages */}
+        {successMsg && (
+          <div className="flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800">
+            <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-500" />
+            {successMsg}
+          </div>
+        )}
+        {error && (
+          <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-800">
+            {error}
+          </div>
+        )}
+
+        {/* Statut */}
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className={`flex h-11 w-11 items-center justify-center rounded-xl text-white ${status?.enabled ? 'bg-emerald-600' : 'bg-slate-400'}`}>
+                {status?.enabled ? <ShieldCheck className="h-5 w-5" /> : <ShieldOff className="h-5 w-5" />}
+              </div>
+              <div>
+                <h2 className="text-base font-black text-slate-950">
+                  {i18nT(locale, 'twoFa.title', 'Authentification à deux facteurs')}
+                </h2>
+                <p className={`text-xs font-bold ${status?.enabled ? 'text-emerald-600' : 'text-slate-500'}`}>
+                  {status?.enabled
+                    ? i18nT(locale, 'twoFa.statusEnabled', 'Activée')
+                    : i18nT(locale, 'twoFa.statusDisabled', 'Désactivée')}
+                  {status?.mfa_required && !status.enabled && (
+                    <span className="ml-2 text-amber-600 flex items-center gap-1">
+                      <AlertTriangle className="h-3.5 w-3.5 inline" />
+                      {i18nT(locale, 'twoFa.required', 'Requise par votre organisation')}
+                    </span>
+                  )}
+                </p>
+              </div>
+            </div>
+
+            {!status?.enabled && step === 'idle' && (
+              <Button
+                type="button"
+                loading={submitting}
+                className="rounded-xl bg-emerald-600 px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-emerald-500"
+                onClick={() => void handleStartEnroll()}
+              >
+                {i18nT(locale, 'twoFa.enable', 'Activer')}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Étape enrôlement : QR Code */}
+        {step === 'enrolling' && enrollData && (
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-5">
+            <div className="flex items-center gap-2">
+              <QrCode className="h-5 w-5 text-slate-500" />
+              <h3 className="text-base font-black text-slate-950">
+                {i18nT(locale, 'twoFa.scanQr', 'Scannez le QR avec votre application TOTP')}
+              </h3>
+            </div>
+            <p className="text-sm text-slate-600">
+              {i18nT(locale, 'twoFa.scanHint', 'Utilisez Google Authenticator, Authy ou une application compatible TOTP (RFC 6238).')}
+            </p>
+
+            <div className="flex justify-center">
+              <div className="rounded-2xl border border-slate-200 bg-white p-2 shadow-sm">
+                {qrDataUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={qrDataUrl} alt="QR Code 2FA" width={200} height={200} className="rounded-xl" />
+                ) : (
+                  <div className="flex h-[200px] w-[200px] items-center justify-center rounded-xl bg-slate-100">
+                    <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <details className="text-xs text-slate-500">
+              <summary className="cursor-pointer hover:text-slate-700 font-semibold">
+                {i18nT(locale, 'twoFa.manualEntry', 'Saisie manuelle du secret')}
+              </summary>
+              <code className="mt-2 block rounded-xl bg-slate-100 px-4 py-2 font-mono text-slate-800 break-all">{enrollData.secret}</code>
+            </details>
+
+            <form onSubmit={(e) => void handleConfirm(e)} className="space-y-4">
+              <div>
+                <label htmlFor="totp-confirm" className="block text-sm font-bold text-slate-700 mb-1.5">
+                  {i18nT(locale, 'twoFa.enterFirst', 'Entrez le premier code généré pour confirmer')}
+                </label>
+                <input
+                  id="totp-confirm"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9 ]{6,7}"
+                  maxLength={7}
+                  autoFocus
+                  placeholder="000 000"
+                  className="block h-14 w-full rounded-2xl border border-slate-200 bg-transparent/50 px-4 text-center text-2xl font-mono font-bold tracking-[0.3em] text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+                  value={code}
+                  onChange={(e) => { setCode(e.target.value); setError(null); }}
+                />
+              </div>
+              <Button
+                type="submit"
+                loading={submitting}
+                disabled={!code || submitting}
+                fullWidth
+                className="h-11 rounded-2xl bg-emerald-600 text-xs font-black uppercase tracking-widest text-white hover:bg-emerald-500 disabled:opacity-50"
+              >
+                {i18nT(locale, 'twoFa.confirm', 'Confirmer l\'activation')}
+              </Button>
+            </form>
+          </div>
+        )}
+
+        {/* Étape terminée : affichage des codes de récupération */}
+        {step === 'done' && recoveryCodes.length > 0 && (
+          <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 space-y-4">
+            <div className="flex items-center gap-2">
+              <Key className="h-5 w-5 text-amber-600" />
+              <h3 className="text-base font-black text-amber-900">
+                {i18nT(locale, 'twoFa.recoveryCodes', 'Codes de récupération — conservez-les précieusement')}
+              </h3>
+            </div>
+            <p className="text-sm text-amber-800">
+              {i18nT(locale, 'twoFa.recoveryCodesHint', 'En cas de perte de votre téléphone, utilisez un de ces codes à usage unique pour vous connecter. Chaque code ne peut être utilisé qu\'une seule fois.')}
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {recoveryCodes.map((c) => (
+                <code key={c} className="rounded-xl bg-white border border-amber-200 px-3 py-2 text-center text-sm font-mono font-bold text-amber-900">{c}</code>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={copyRecoveryCodes}
+              className="inline-flex items-center gap-2 rounded-xl border border-amber-300 bg-white px-4 py-2 text-sm font-bold text-amber-800 hover:bg-amber-100 transition"
+            >
+              {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+              {copied
+                ? i18nT(locale, 'twoFa.copied', 'Copié !')
+                : i18nT(locale, 'twoFa.copy', 'Copier les codes')}
+            </button>
+          </div>
+        )}
+
+        {/* Désactivation */}
+        {status?.enabled && step !== 'done' && (
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+            <h3 className="text-base font-black text-slate-950">
+              {i18nT(locale, 'twoFa.disableTitle', 'Désactiver la 2FA')}
+            </h3>
+            <p className="text-sm text-slate-600">
+              {i18nT(locale, 'twoFa.disableHint', 'Saisissez votre code TOTP actuel pour confirmer la désactivation.')}
+            </p>
+            <form onSubmit={(e) => void handleDisable(e)} className="flex flex-col sm:flex-row gap-3">
+              <input
+                type="text"
+                inputMode="numeric"
+                maxLength={7}
+                placeholder="000 000"
+                className="h-11 rounded-2xl border border-slate-200 bg-transparent/50 px-4 text-center font-mono font-bold tracking-[0.3em] text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-red-400 focus:ring-2 focus:ring-red-400/20 flex-1"
+                value={disableCode}
+                onChange={(e) => { setDisableCode(e.target.value); setError(null); }}
+              />
+              <Button
+                type="submit"
+                loading={submitting}
+                disabled={!disableCode || submitting}
+                className="h-11 rounded-2xl border border-red-300 bg-red-50 px-5 text-xs font-black uppercase tracking-widest text-red-700 hover:bg-red-100 disabled:opacity-50 shrink-0"
+              >
+                {i18nT(locale, 'twoFa.disable', 'Désactiver')}
+              </Button>
+            </form>
+          </div>
+        )}
+      </div>
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/api/v1/auth/2fa/verify/route.ts
+++ b/front/web/src/app/api/v1/auth/2fa/verify/route.ts
@@ -1,0 +1,99 @@
+/**
+ * Proxy serveur pour la vérification du code 2FA (#5612).
+ *
+ * Même motif que /api/v1/auth/login/route.ts : on intercepte la réponse
+ * du backend, on extrait le token Sanctum et on le pose dans un cookie
+ * httpOnly pour que le JS de la page ne puisse jamais le lire.
+ *
+ * Flux :
+ *   POST /api/v1/auth/2fa/verify
+ *     ← { challenge_token, code, device_name?, remember_device? }
+ *   → Forward vers Laravel POST /auth/2fa/verify
+ *   ← { data: { id, email }, token, token_type, token_expires_at }
+ *   → Extrait token → cookie httpOnly leopardo_token
+ *   → Renvoie { data: { id, email } } (sans le token brut)
+ */
+
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendBaseUrl } from "@/lib/backend-url";
+
+const COOKIE_NAME = "leopardo_token";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 jours
+const VERIFY_TIMEOUT_MS = 30_000;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "INVALID_JSON", message: "Corps de requête invalide." }, { status: 400 });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(`${resolveBackendBaseUrl()}/auth/2fa/verify`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Accept-Language": request.headers.get("Accept-Language") || "fr",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+      cache: "no-store",
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    const isTimeout = error instanceof DOMException && error.name === "AbortError";
+    return NextResponse.json(
+      { error: isTimeout ? "TIMEOUT" : "NETWORK_ERROR", message: isTimeout ? "Le serveur ne répond pas." : "Impossible de contacter le serveur." },
+      { status: isTimeout ? 408 : 502 },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  let payload: Record<string, unknown>;
+
+  try {
+    payload = (await backendResponse.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "BACKEND_ERROR", message: "Réponse serveur inattendue." }, { status: 502 });
+  }
+
+  if (!backendResponse.ok) {
+    return NextResponse.json(payload, { status: backendResponse.status });
+  }
+
+  const token = payload?.token as string | undefined;
+
+  if (!token) {
+    return NextResponse.json(payload, { status: backendResponse.status });
+  }
+
+  const isSecure =
+    request.nextUrl.protocol === "https:" || process.env.NODE_ENV === "production";
+
+  const cookieStore = await cookies();
+  cookieStore.set(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "strict",
+    maxAge: COOKIE_MAX_AGE,
+    path: "/",
+  });
+
+  // On renvoie uniquement les données user — le token reste côté serveur.
+  const { token: _stripped, token_type: _type, token_expires_at: _exp, ...safePayload } = payload;
+
+  return NextResponse.json(safePayload, {
+    status: 200,
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/front/web/src/app/auth/2fa/challenge/page.tsx
+++ b/front/web/src/app/auth/2fa/challenge/page.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+/**
+ * Page de challenge 2FA (#5612).
+ *
+ * Affichée après /auth/login quand le backend retourne mfa_challenge: true.
+ * Lit le challenge_token depuis sessionStorage (posé par la page login),
+ * soumet le code TOTP ou le code de récupération, puis redirige vers le
+ * dashboard si le backend valide.
+ */
+
+import { Suspense, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowRight, ShieldCheck, Loader2, KeyRound } from 'lucide-react';
+import { ApiError, apiFetch } from '@/lib/api-client';
+import { Button } from '@/components/ui/Button';
+import {
+  applyDocumentLocale,
+  getCopy,
+  getPreferredLocale,
+  normalizeLocale,
+  storeAuthSession,
+  type AppLocale,
+  type StoredAuthUser,
+} from '@/lib/i18n';
+
+const MFA_CHALLENGE_TOKEN_KEY = 'mfa_challenge_token';
+const emptySubscribe = () => () => {};
+
+function TwoFaChallengeInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
+  const labels = useMemo(() => getCopy(locale), [locale]);
+
+  const [code, setCode] = useState('');
+  const [recoveryCode, setRecoveryCode] = useState('');
+  const [useRecovery, setUseRecovery] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rememberDevice, setRememberDevice] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    applyDocumentLocale(locale);
+  }, [locale]);
+
+  // Récupère le challenge token depuis sessionStorage ou depuis le query param.
+  const getChallengeToken = useCallback((): string | null => {
+    if (typeof window === 'undefined') return null;
+    const fromStorage = window.sessionStorage.getItem(MFA_CHALLENGE_TOKEN_KEY);
+    if (fromStorage) return fromStorage;
+    return searchParams.get('token');
+  }, [searchParams]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const challengeToken = getChallengeToken();
+    if (!challengeToken) {
+      setError(
+        locale === 'fr'
+          ? 'Session expirée. Veuillez vous reconnecter.'
+          : locale === 'ar'
+            ? 'انتهت الجلسة. يرجى إعادة تسجيل الدخول.'
+            : locale === 'tr'
+              ? 'Oturum süresi doldu. Lütfen tekrar giriş yapın.'
+              : 'Session expired. Please log in again.',
+      );
+      return;
+    }
+
+    const value = useRecovery ? recoveryCode.trim() : code.replace(/\s/g, '');
+
+    if (!value) {
+      setError(
+        locale === 'fr'
+          ? 'Veuillez saisir un code.'
+          : locale === 'ar'
+            ? 'يرجى إدخال الرمز.'
+            : locale === 'tr'
+              ? 'Lütfen kodu girin.'
+              : 'Please enter a code.',
+      );
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      const body: Record<string, unknown> = {
+        challenge_token: challengeToken,
+        device_name: 'Web App',
+        remember_device: rememberDevice,
+      };
+
+      if (useRecovery) {
+        body.recovery_code = value;
+      } else {
+        body.code = value;
+      }
+
+      await apiFetch('/auth/2fa/verify', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+
+      // Nettoyage du token de challenge — consommé.
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.removeItem(MFA_CHALLENGE_TOKEN_KEY);
+      }
+
+      // Récupération du profil utilisateur (le cookie httpOnly est posé par le proxy).
+      const meResponse = await apiFetch('/auth/me');
+      const mePayload = (await meResponse.json()) as { data?: StoredAuthUser };
+      const user = mePayload.data;
+
+      if (user) {
+        storeAuthSession(null, user);
+        applyDocumentLocale(normalizeLocale(user.language), user.is_rtl);
+      }
+
+      router.push('/dashboard');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError(
+          locale === 'fr'
+            ? 'Code invalide ou expiré. Réessayez.'
+            : locale === 'ar'
+              ? 'الرمز غير صحيح أو منتهي الصلاحية. حاول مجدداً.'
+              : locale === 'tr'
+                ? 'Geçersiz veya süresi dolmuş kod. Tekrar deneyin.'
+                : 'Invalid or expired code. Please try again.',
+        );
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [code, recoveryCode, useRecovery, rememberDevice, locale, getChallengeToken, router]);
+
+  if (!mounted) return null;
+
+  return (
+    <main className="min-h-screen bg-transparent dark:bg-slate-950 px-4 py-6 text-slate-950 dark:text-white sm:px-6 lg:px-8 relative overflow-hidden flex items-center justify-center">
+      {/* Background */}
+      <div className="absolute inset-0 z-0">
+        <div className="absolute top-[-10%] left-[-10%] w-[50%] h-[50%] bg-emerald-500/10 rounded-full blur-[120px] animate-pulse-slow" />
+        <div className="absolute bottom-[-10%] right-[-10%] w-[50%] h-[50%] bg-emerald-500/10 rounded-full blur-[120px] animate-pulse-slow" style={{ animationDelay: '1.5s' }} />
+      </div>
+
+      <div className="relative z-10 w-full max-w-md animate-fade-in">
+        <div className="rounded-[28px] border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 backdrop-blur-xl shadow-2xl p-8 space-y-7">
+          {/* Header */}
+          <div className="flex flex-col items-center gap-3 text-center">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-600 text-white shadow-lg">
+              <ShieldCheck className="h-7 w-7" aria-hidden="true" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-black tracking-tight text-slate-950 dark:text-white">
+                {locale === 'fr' ? 'Vérification 2FA'
+                  : locale === 'ar' ? 'التحقق بخطوتين'
+                    : locale === 'tr' ? 'İki Faktörlü Doğrulama'
+                      : '2FA Verification'}
+              </h1>
+              <p className="mt-1 text-sm text-slate-500">
+                {locale === 'fr'
+                  ? 'Ouvrez votre application d\'authentification et saisissez le code à 6 chiffres.'
+                  : locale === 'ar'
+                    ? 'افتح تطبيق المصادقة وأدخل الرمز المكون من 6 أرقام.'
+                    : locale === 'tr'
+                      ? 'Kimlik doğrulama uygulamanızı açın ve 6 haneli kodu girin.'
+                      : 'Open your authenticator app and enter the 6-digit code.'}
+              </p>
+            </div>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div role="alert" className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
+            {!useRecovery ? (
+              /* Code TOTP */
+              <div>
+                <label htmlFor="totp-code" className="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5">
+                  {locale === 'fr' ? 'Code de vérification'
+                    : locale === 'ar' ? 'رمز التحقق'
+                      : locale === 'tr' ? 'Doğrulama kodu'
+                        : 'Verification code'}
+                </label>
+                <input
+                  id="totp-code"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  pattern="[0-9 ]{6,7}"
+                  maxLength={7}
+                  autoFocus
+                  placeholder="000 000"
+                  className="block h-14 w-full rounded-2xl border border-slate-200 dark:border-slate-700 bg-transparent/50 dark:bg-slate-800/50 px-4 text-center text-2xl font-mono font-bold tracking-[0.3em] text-slate-950 dark:text-white shadow-sm outline-none transition placeholder:text-slate-400 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+                  value={code}
+                  onChange={(e) => { setCode(e.target.value); setError(null); }}
+                />
+              </div>
+            ) : (
+              /* Code de récupération */
+              <div>
+                <label htmlFor="recovery-code" className="block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5">
+                  <KeyRound className="inline h-4 w-4 mr-1" aria-hidden="true" />
+                  {locale === 'fr' ? 'Code de récupération'
+                    : locale === 'ar' ? 'رمز الاسترداد'
+                      : locale === 'tr' ? 'Kurtarma kodu'
+                        : 'Recovery code'}
+                </label>
+                <input
+                  id="recovery-code"
+                  type="text"
+                  autoComplete="off"
+                  autoFocus
+                  placeholder="xxxx-xxxx"
+                  className="block h-12 w-full rounded-2xl border border-slate-200 dark:border-slate-700 bg-transparent/50 dark:bg-slate-800/50 px-4 font-mono text-sm text-slate-950 dark:text-white shadow-sm outline-none transition placeholder:text-slate-400 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+                  value={recoveryCode}
+                  onChange={(e) => { setRecoveryCode(e.target.value); setError(null); }}
+                />
+              </div>
+            )}
+
+            {/* Remember device */}
+            <label className="flex items-center gap-2.5 text-sm text-slate-700 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                checked={rememberDevice}
+                onChange={(e) => setRememberDevice(e.target.checked)}
+              />
+              {locale === 'fr' ? 'Se souvenir de cet appareil 30 jours'
+                : locale === 'ar' ? 'تذكر هذا الجهاز لمدة 30 يومًا'
+                  : locale === 'tr' ? 'Bu cihazı 30 gün hatırla'
+                    : 'Remember this device for 30 days'}
+            </label>
+
+            <Button
+              type="submit"
+              loading={submitting}
+              fullWidth
+              className="h-12 rounded-2xl bg-emerald-600 px-4 text-xs font-black uppercase tracking-widest text-white shadow-lg hover:bg-emerald-500 focus:ring-emerald-500"
+            >
+              {submitting
+                ? (locale === 'fr' ? 'Vérification...' : locale === 'ar' ? 'جارٍ التحقق...' : locale === 'tr' ? 'Doğrulanıyor...' : 'Verifying...')
+                : (locale === 'fr' ? 'Vérifier' : locale === 'ar' ? 'تحقق' : locale === 'tr' ? 'Doğrula' : 'Verify')}
+            </Button>
+          </form>
+
+          {/* Basculer code de récupération / TOTP */}
+          <div className="text-center">
+            <button
+              type="button"
+              className="text-sm text-teal-700 font-semibold hover:text-teal-900 transition"
+              onClick={() => { setUseRecovery((v) => !v); setCode(''); setRecoveryCode(''); setError(null); }}
+            >
+              {useRecovery
+                ? (locale === 'fr' ? '← Utiliser le code TOTP' : locale === 'ar' ? '← استخدام رمز TOTP' : locale === 'tr' ? '← TOTP kodu kullan' : '← Use TOTP code')
+                : (locale === 'fr' ? 'Utiliser un code de récupération' : locale === 'ar' ? 'استخدام رمز الاسترداد' : locale === 'tr' ? 'Kurtarma kodu kullan' : 'Use a recovery code')}
+            </button>
+          </div>
+
+          <div className="text-center">
+            <Link href="/auth/login" className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-slate-800 transition">
+              <ArrowRight className="h-3 w-3 rotate-180" aria-hidden="true" />
+              {labels.login.back}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default function TwoFaChallengePage() {
+  return (
+    <Suspense fallback={null}>
+      <TwoFaChallengeInner />
+    </Suspense>
+  );
+}

--- a/front/web/src/app/auth/login/page.tsx
+++ b/front/web/src/app/auth/login/page.tsx
@@ -224,7 +224,24 @@ function LoginInner() {
         },
       });
 
-      const loginPayload = await loginResponse.json() as { data?: StoredAuthUser | { token?: string }; token?: string };
+      const loginPayload = await loginResponse.json() as {
+        data?: StoredAuthUser | { token?: string };
+        token?: string;
+        mfa_challenge?: boolean;
+        mfa_challenge_token?: string;
+        mfa_challenge_expires_in?: number;
+      };
+
+      // #5612 — Si le backend exige la 2FA, stocker le challenge_token et
+      // rediriger vers la page de challenge. Le cookie httpOnly n'est pas
+      // encore posé à ce stade (le token n'est émis qu'après la vérification).
+      if (loginPayload?.mfa_challenge === true && loginPayload?.mfa_challenge_token) {
+        if (typeof window !== 'undefined') {
+          window.sessionStorage.setItem('mfa_challenge_token', loginPayload.mfa_challenge_token);
+        }
+        router.push('/auth/2fa/challenge');
+        return;
+      }
 
       // Audit #1699 : le token vit dans le cookie httpOnly `leopardo_token`
       // posé par le route handler /api/v1/auth/login — il n'est jamais


### PR DESCRIPTION
## Résumé

Ce PR résout 4 issues **P0/P0-SEC** bloquantes en production.

---

### #5612 — 2FA web frontend manquant (P0)

**Avant :** Un manager ayant activé la 2FA depuis l'admin-dashboard ne pouvait plus se connecter via front/web. Le login ignorait `mfa_challenge: true` et affichait une erreur générique.

**Après :**
- `/auth/2fa/challenge` : page de vérification TOTP + code de récupération + remember_device
- `/settings/security` : enrôlement complet (QR code `qrcode` lib, confirmation, affichage des 8 codes de récupération, désactivation)
- `/api/v1/auth/2fa/verify/route.ts` : proxy serveur qui pose le cookie httpOnly (même motif que login)
- `front/web/src/app/auth/login/page.tsx` : détection `mfa_challenge: true` → stockage `sessionStorage` + redirect

---

### #5613 — Export SEPA inutilisable, pas d'UI IBAN/BIC (P0)

**Avant :** `POST /bank-exports` retournait 422 MISSING_COMPANY_IBAN systématiquement — aucune UI ne permettait de saisir ces champs.

**Après :**
- Nouveau backend `PATCH /api/v1/company/bank-details` (`CompanyBankDetailsController`)
- Validation serveur avec `ValidIban` (IBAN/RIB DZ, MA, FR, TR...) + regex BIC
- Page `/settings/company` : formulaire IBAN (formatage auto, validation inline) + BIC, bannière d'alerte si IBAN absent

---

### #5614 — SSO SAML/OIDC bloqué par VALIDATION_AVAILABLE=false (P0)

**Avant :** La constante `VALIDATION_AVAILABLE = false` dans `SSOService` bloquait OIDC alors que `OidcFlowService` est pleinement implémenté depuis #2231.

**Après :**
- Suppression de la constante et remplacement par `isValidationAvailableForProvider()` : `true` pour `oidc`, `false` pour `saml`
- `SSOController::status()` : gate `services.saml.enabled` appliquée uniquement à SAML, pas à OIDC
- Les entreprises qui ont configuré un SSO OIDC complet peuvent maintenant s'en servir

---

### #5616 — AI Voice TTS : exec(edge-tts) + URLs publiques permanentes (P0-SEC)

**Avant :** edge-tts appelé via `exec()` sans vérification d'installation ; fichiers audio stockés en accès public permanent.

**Après :**
- Fallback automatique vers ElevenLabs si `ELEVENLABS_API_KEY` est configuré (évite exec)
- Vérification `which edge-tts` avant tout exec — log warning si absent
- `Storage::temporaryUrl()` → `URL::temporarySignedRoute()` : URLs signées expirantes 60 s
- Nouveau endpoint `GET /ai/voice/download/{filename}` (middleware `signed`) pour servir les fichiers privés
- `PurgeTtsFilesCommand` + schedule horaire `tts:purge` : suppression des fichiers TTS > 1 h (RGPD)

---

## Fichiers modifiés

| Fichier | Change |
|---|---|
| `api/app/Http/Controllers/AI/VoiceController.php` | Signed URLs, ElevenLabs fallback, edge-tts check |
| `api/app/Console/Commands/PurgeTtsFilesCommand.php` | Nouveau — purge horaire fichiers TTS |
| `api/routes/ai.php` | Route download signée |
| `api/routes/console.php` | Schedule tts:purge |
| `api/app/Core/Auth/Infrastructure/Services/SSO/SSOService.php` | VALIDATION_AVAILABLE → provider-aware |
| `api/app/Core/Auth/Interfaces/Api/V1/SSOController.php` | Gate SAML_ENABLED uniquement pour SAML |
| `api/app/Modules/HR/Interfaces/Api/V1/Controllers/CompanyBankDetailsController.php` | Nouveau — GET/PATCH bank-details |
| `api/routes/api.php` | Route company/bank-details |
| `front/web/src/app/auth/login/page.tsx` | Interception MFA challenge → redirect |
| `front/web/src/app/auth/2fa/challenge/page.tsx` | Nouveau — page challenge TOTP |
| `front/web/src/app/api/v1/auth/2fa/verify/route.ts` | Nouveau — proxy 2FA verify (cookie httpOnly) |
| `front/web/src/app/(dashboard)/settings/security/page.tsx` | Nouveau — enrôlement 2FA |
| `front/web/src/app/(dashboard)/settings/company/page.tsx` | Nouveau — IBAN/BIC entreprise |

Closes #5612 — Closes #5613 — Closes #5614 — Closes #5616