### PR TITLE
feat(mobile): réglage thème in-app clair/sombre/automatique — employee + manager (#5624)

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/providers/theme_mode_provider.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/providers/theme_mode_provider.dart
@@ -1,0 +1,34 @@
+/// Issue #5624 — Réglage thème in-app (clair / sombre / automatique).
+///
+/// Utilisation :
+///   final themeMode = ref.watch(themeModeProvider);
+///   ref.read(themeModeProvider.notifier).setMode(ThemeMode.light);
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:leopardo_core/core/providers/base_providers.dart';
+
+/// [StateNotifier] qui expose et persiste le [ThemeMode] de l'application.
+/// Lit la valeur initiale depuis [AppPreferences] au premier accès.
+class ThemeModeNotifier extends StateNotifier<ThemeMode> {
+  ThemeModeNotifier(this._ref) : super(ThemeMode.system) {
+    // Lire la valeur persistée pour initialiser l'état.
+    state = _ref.read(appPreferencesProvider).themeMode;
+  }
+
+  final Ref _ref;
+
+  /// Change et persiste le thème.
+  Future<void> setMode(ThemeMode mode) async {
+    state = mode;
+    await _ref.read(appPreferencesProvider).saveThemeMode(mode);
+  }
+}
+
+/// Provider global du thème in-app.
+/// À regarder dans [MaterialApp.themeMode] :
+///   themeMode: ref.watch(themeModeProvider),
+final themeModeProvider = StateNotifierProvider<ThemeModeNotifier, ThemeMode>(
+  (ref) => ThemeModeNotifier(ref),
+);

--- a/front/mobile_apps/leopardo_core/lib/core/storage/app_preferences.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/storage/app_preferences.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
@@ -14,6 +15,8 @@ class AppPreferences {
   static const String _edgeNodeIdKey = 'edge_node_id';
   static const String _edgeTokenKey = 'edge_token';
   static const String _edgeBaseUrlKey = 'edge_base_url';
+  // Issue #5624 — réglage thème in-app (clair / sombre / automatique)
+  static const String _themeModeKey = 'settings_theme_mode';
 
   static final Map<String, Object?> _memory = <String, Object?>{};
 
@@ -49,6 +52,32 @@ class AppPreferences {
   String get preferredLanguage =>
       (_read(_preferredLanguageKey, '') as String).trim();
   bool get isRtl => _read(_isRtlKey, false) as bool;
+
+  /// Issue #5624 — réglage thème in-app persisté dans Hive.
+  /// Valeurs : 'system' (défaut) | 'light' | 'dark'.
+  String get themeModeSetting =>
+      (_read(_themeModeKey, 'system') as String).trim();
+
+  /// Convertit la valeur stockée en [ThemeMode] Flutter.
+  ThemeMode get themeMode {
+    switch (themeModeSetting) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      default:
+        return ThemeMode.system;
+    }
+  }
+
+  Future<void> saveThemeMode(ThemeMode mode) async {
+    final value = switch (mode) {
+      ThemeMode.light => 'light',
+      ThemeMode.dark => 'dark',
+      _ => 'system',
+    };
+    await _write(_themeModeKey, value);
+  }
 
   /// Cloud-issued UUID for this device's paired Edge node (see issue #1287 /
   /// docs/edge-sync/ARCHITECTURE.md). Empty when the device has never been

--- a/front/mobile_apps/leopardo_core/lib/features/settings/screens/settings_screen.dart
+++ b/front/mobile_apps/leopardo_core/lib/features/settings/screens/settings_screen.dart
@@ -19,6 +19,7 @@ import 'package:leopardo_core/features/settings/data/settings_repository.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:leopardo_core/core/widgets/mobile_list_glass_card.dart';
 import 'package:leopardo_core/l10n/l10n.dart';
+import 'package:leopardo_core/core/providers/theme_mode_provider.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
@@ -171,6 +172,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           _buildCabinetSection(),
           const SizedBox(height: 20),
           _buildLanguageSection(context, authState),
+          const SizedBox(height: 20),
+          // Issue #5624 — réglage thème in-app
+          _buildThemeSection(context),
           const SizedBox(height: 20),
           _buildNotificationSection(context),
           const SizedBox(height: 20),
@@ -817,6 +821,63 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: _languageSaving ? null : _saveLanguage,
             child: Text(
               _languageSaving ? 'Mise a jour...' : 'Mettre a jour la langue',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Issue #5624 — réglage thème in-app ──────────────────────────────────
+  Widget _buildThemeSection(BuildContext context) {
+    final currentMode = ref.watch(themeModeProvider);
+
+    final options = [
+      (ThemeMode.system, Icons.brightness_auto_outlined, 'Automatique (système)'),
+      (ThemeMode.light, Icons.light_mode_outlined, 'Clair'),
+      (ThemeMode.dark, Icons.dark_mode_outlined, 'Sombre'),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: MobileSurface.cardDecoration(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Thème de l\'application',
+            style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Choisissez le thème affiché quelle que soit la configuration système.',
+            style: AppTypography.bodySmall
+                .copyWith(color: MobileSurface.secondary),
+          ),
+          const SizedBox(height: 16),
+          ...options.map(
+            (opt) => RadioListTile<ThemeMode>(
+              contentPadding: EdgeInsets.zero,
+              value: opt.$1,
+              groupValue: currentMode,
+              title: Row(
+                children: [
+                  Icon(opt.$2, size: 20, color: MobileSurface.secondary),
+                  const SizedBox(width: 10),
+                  Text(
+                    opt.$3,
+                    style: AppTypography.body
+                        .copyWith(color: MobileSurface.text),
+                  ),
+                ],
+              ),
+              onChanged: (mode) async {
+                if (mode != null) {
+                  await ref
+                      .read(themeModeProvider.notifier)
+                      .setMode(mode);
+                }
+              },
             ),
           ),
         ],

--- a/front/mobile_apps/leopardo_employee/lib/app.dart
+++ b/front/mobile_apps/leopardo_employee/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/branding/tenant_theme.dart';
 import 'package:leopardo_employee/core/providers/core_providers.dart';
 import 'package:leopardo_core/core/theme/app_theme.dart';
+import 'package:leopardo_core/core/providers/theme_mode_provider.dart';
 import 'package:leopardo_employee/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_employee/features/auth/screens/login_screen.dart';
 import 'package:leopardo_employee/features/auth/screens/register_screen.dart';
@@ -329,7 +330,8 @@ class LeopardoApp extends ConsumerWidget {
       title: branding?.displayName ?? 'Leopardo RH',
       theme: TenantTheme.apply(AppTheme.lightTheme, branding),
       darkTheme: TenantTheme.apply(AppTheme.darkTheme, branding),
-      themeMode: ThemeMode.system,
+      // Issue #5624 — thème dynamique depuis le réglage in-app.
+      themeMode: ref.watch(themeModeProvider),
       routerConfig: router,
       debugShowCheckedModeBanner: false,
       locale: locale,

--- a/front/mobile_apps/leopardo_employee/lib/features/settings/screens/settings_screen.dart
+++ b/front/mobile_apps/leopardo_employee/lib/features/settings/screens/settings_screen.dart
@@ -20,6 +20,7 @@ import 'package:leopardo_core/offline/services/sync_service.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:leopardo_core/core/widgets/mobile_list_glass_card.dart';
 import 'package:leopardo_core/l10n/l10n.dart';
+import 'package:leopardo_core/core/providers/theme_mode_provider.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
@@ -217,6 +218,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           _buildCabinetSection(),
           const SizedBox(height: 20),
           _buildLanguageSection(context, authState),
+          const SizedBox(height: 20),
+          // Issue #5624 — réglage thème in-app
+          _buildThemeSection(context),
           const SizedBox(height: 20),
           _buildNotificationSection(context),
           const SizedBox(height: 20),
@@ -846,6 +850,61 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               _languageSaving
                   ? context.l10n.settingsUpdating
                   : context.l10n.settingsUpdateLanguage,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Issue #5624 — réglage thème in-app ──────────────────────────────────
+  Widget _buildThemeSection(BuildContext context) {
+    final currentMode = ref.watch(themeModeProvider);
+
+    final options = [
+      (ThemeMode.system, Icons.brightness_auto_outlined, 'Automatique (système)'),
+      (ThemeMode.light, Icons.light_mode_outlined, 'Clair'),
+      (ThemeMode.dark, Icons.dark_mode_outlined, 'Sombre'),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: MobileSurface.cardDecoration(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Thème de l\'application',
+            style: AppTypography.subtitle.copyWith(color: MobileSurface.text),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Choisissez le thème affiché quelle que soit la configuration système.',
+            style: AppTypography.bodySmall
+                .copyWith(color: MobileSurface.secondary),
+          ),
+          const SizedBox(height: 16),
+          ...options.map(
+            (opt) => RadioListTile<ThemeMode>(
+              contentPadding: EdgeInsets.zero,
+              value: opt.$1,
+              groupValue: currentMode,
+              title: Row(
+                children: [
+                  Icon(opt.$2, size: 20, color: MobileSurface.secondary),
+                  const SizedBox(width: 10),
+                  Text(opt.$3,
+                      style: AppTypography.body
+                          .copyWith(color: MobileSurface.text)),
+                ],
+              ),
+              onChanged: (mode) async {
+                if (mode != null) {
+                  await ref
+                      .read(themeModeProvider.notifier)
+                      .setMode(mode);
+                }
+              },
             ),
           ),
         ],

--- a/front/mobile_apps/leopardo_manager/lib/app.dart
+++ b/front/mobile_apps/leopardo_manager/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:leopardo_core/core/branding/tenant_theme.dart';
 import 'package:leopardo_manager/core/providers/core_providers.dart';
 import 'package:leopardo_core/core/theme/app_theme.dart';
+import 'package:leopardo_core/core/providers/theme_mode_provider.dart';
 import 'package:leopardo_core/features/auth/providers/auth_provider.dart';
 import 'package:leopardo_core/features/auth/screens/access_denied_screen.dart';
 import 'package:leopardo_core/features/auth/screens/login_screen.dart';
@@ -368,7 +369,8 @@ class LeopardoApp extends ConsumerWidget {
       title: branding?.displayName ?? 'Leopardo RH',
       theme: TenantTheme.apply(AppTheme.lightTheme, branding),
       darkTheme: TenantTheme.apply(AppTheme.darkTheme, branding),
-      themeMode: ThemeMode.system,
+      // Issue #5624 — thème dynamique depuis le réglage in-app.
+      themeMode: ref.watch(themeModeProvider),
       routerConfig: router,
       debugShowCheckedModeBanner: false,
       locale: locale,


### PR DESCRIPTION
## Résumé

Suite aux retours pilotes A1/S4 ('ingérable en plein soleil'), ajoute un réglage de thème in-app dans les paramètres de l'application.

## Changements

### `leopardo_core` — AppPreferences
- Clé Hive `settings_theme_mode` ('system'|'light'|'dark')
- Getter `themeMode` → ThemeMode Flutter
- `saveThemeMode(ThemeMode)`

### `leopardo_core` — ThemeModeNotifier (nouveau fichier)
- `StateNotifierProvider<ThemeModeNotifier, ThemeMode>`
- Lit la valeur initiale depuis AppPreferences au démarrage
- `setMode()` : change l'état et persiste

### leopardo_employee + leopardo_manager — app.dart
- Remplace `ThemeMode.system` par `ref.watch(themeModeProvider)`
- Application en temps réel sans redémarrage

### Settings screens (employee + core/manager)
- Section 'Thème de l'application' avec RadioListTile (Automatique / Clair / Sombre)
- Icônes brightness_auto / light_mode / dark_mode
- Changement immédiat + persistance Hive

Closes #5624