### PR TITLE
fix(payroll): FK explicite ordres de paiement + tests comptables — 10 tests rouges réparés

### DIFF
--- a/api/app/Modules/Payroll/Domain/Models/PayrollPaymentOrder.php
+++ b/api/app/Modules/Payroll/Domain/Models/PayrollPaymentOrder.php
@@ -68,6 +68,8 @@ class PayrollPaymentOrder extends Model
     /** @return HasMany<PayrollPaymentOrderItem, $this> */
     public function items(): HasMany
     {
-        return $this->hasMany(PayrollPaymentOrderItem::class);
+        // La migration crée `payment_order_id` (pas la convention
+        // `payroll_payment_order_id`) — FK explicite pour éviter SQLSTATE 42703.
+        return $this->hasMany(PayrollPaymentOrderItem::class, 'payment_order_id');
     }
 }

--- a/api/app/Modules/Payroll/Domain/Models/PayrollPaymentOrderItem.php
+++ b/api/app/Modules/Payroll/Domain/Models/PayrollPaymentOrderItem.php
@@ -35,6 +35,8 @@ class PayrollPaymentOrderItem extends Model
     /** @return BelongsTo<PayrollPaymentOrder, $this> */
     public function paymentOrder(): BelongsTo
     {
-        return $this->belongsTo(PayrollPaymentOrder::class);
+        // Même FK explicite que PayrollPaymentOrder::items() (colonne
+        // `payment_order_id` dans la migration).
+        return $this->belongsTo(PayrollPaymentOrder::class, 'payment_order_id');
     }
 }

--- a/api/tests/Feature/Payroll/PayrollAccountingEntriesFlowTest.php
+++ b/api/tests/Feature/Payroll/PayrollAccountingEntriesFlowTest.php
@@ -47,6 +47,11 @@ class PayrollAccountingEntriesFlowTest extends TestCase
             'validated_at' => now(),
         ]);
 
+        // Miroir de PayrollClosingService::validateRh() : les BULLETINS sont
+        // validés atomiquement avec le run (journalLines filtre
+        // status='validated' — sinon 0 écritures, le test ne teste rien).
+        $run->paySlips()->update(['status' => 'validated']);
+
         AuditLog::create([
             'company_id' => $company->id,
             'user_id' => null,
@@ -206,7 +211,7 @@ class PayrollAccountingEntriesFlowTest extends TestCase
 
         // Run en statut calculated : la génération échoue (RuntimeException) mais
         // l'observer doit LOGGER sans propager (la validation ne casse pas).
-        Log::spy();
+        $logSpy = Log::spy();
 
         AuditLog::create([
             'company_id' => $company->id,
@@ -218,7 +223,9 @@ class PayrollAccountingEntriesFlowTest extends TestCase
             'new_values' => ['status' => 'validated'],
         ]);
 
-        Log::spy()->shouldHaveReceived('error')->once();
+        // NB : un 2e appel Log::spy() renvoie null en Laravel 12 (déjà mock)
+        // — le spy est capturé une fois et réutilisé.
+        $logSpy->shouldHaveReceived('error')->once();
     }
 
     // ── API ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Réparation de 10 tests rouges sur main (suite paie)

Suite à la clôture de l'audit 2026-08-26, vérification de la suite `tests/Feature/Payroll` sur main : **10 échecs** réels. Ce PR les élimine.

### 1. `SQLSTATE 42703` sur les ordres de paiement (8-9 tests)
`PayrollPaymentOrder::items()` et `PayrollPaymentOrderItem::paymentOrder()` utilisaient la **convention Eloquent** (`payroll_payment_order_id`) alors que la migration `2026_08_24_000004` crée **`payment_order_id`** (et que `PayrollPaymentOrderService` écrit bien `payment_order_id`). Toute lecture `$order->items` / `$order->load('items')` plantait → `PayrollPaymentOrderFlowTest` rouge, et la route `GET /payroll-runs/{id}/accounting-entries` dépendante de la même table.

**Correctif** : FK explicite `payment_order_id` sur les 2 relations (1 ligne chacune).

### 2. `PayrollAccountingEntriesFlowTest` (2 tests)
- `test_validation_audit_triggers_automatic_generation` : le test passait le **run** en `validated` mais **pas les bulletins** — or `journalLines()` filtre `status='validated'` → 0 écritures, le test ne testait rien. Ajout de la validation des bulletins (miroir de `PayrollClosingService::validateRh()`, qui les valide atomiquement).
- `test_observer_failure_is_logged_not_propagated` : 2ᵉ appel `Log::spy()` renvoie **null en Laravel 12** (déjà mock) → spy capturé une fois et réutilisé.

### Validation
- Suite `tests/Feature/Payroll` + `CotisationSimulationTest` : **892 passés, 0 échec** (1 risky pré-existant sans assertion).
- Le seul échec résiduel observé (`bulk-pay` → 503) est un **artefact d'env local** (`REDIS_HOST=redis` du `.env` Docker vs Redis local 127.0.0.1) — comportement fail-closed #3857 correct, vert avec le bon host. Non lié au code.
- Pint ✓, lint PHP 8.4 ✓.