### PR TITLE
refactor(archi): composition root décentralisée — purge 2 paires d'isolation (#5584)

### DIFF
--- a/api/app/Modules/Cabinet/Providers/CabinetServiceProvider.php
+++ b/api/app/Modules/Cabinet/Providers/CabinetServiceProvider.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace App\Modules\Cabinet\Providers;
 
+use App\Modules\Cabinet\Infrastructure\Services\ContractPdfGenerator;
+use App\Modules\HR\Domain\Contracts\ContractDocumentGeneratorInterface;
 use Illuminate\Support\ServiceProvider;
 
 class CabinetServiceProvider extends ServiceProvider
 {
-    public function register(): void {}
+    public function register(): void
+    {
+        // PA2-ARCH-003 — chaque module enregistre SA propre implémentation des
+        // contrats qu'il fournit (composition root décentralisée).
+        $this->app->bind(ContractDocumentGeneratorInterface::class, ContractPdfGenerator::class);
+    }
+
     public function boot(): void {}
 }
-

--- a/api/app/Modules/HR/Domain/Contracts/ContractDocumentGeneratorInterface.php
+++ b/api/app/Modules/HR/Domain/Contracts/ContractDocumentGeneratorInterface.php
@@ -10,8 +10,8 @@ use App\Modules\HR\Domain\Models\Contract;
  * Contract for generating a printable document (PDF) for an employment
  * contract. Owned by HR so ContractController depends on this interface
  * instead of importing App\Modules\Cabinet\Infrastructure\Services\ContractPdfGenerator
- * directly (PA2-ARCH-003). Bound to the existing Cabinet implementation in
- * HRServiceProvider.
+ * directly (PA2-ARCH-003). Bound to the existing Cabinet implementation by
+ * CabinetServiceProvider (composition root décentralisée).
  */
 interface ContractDocumentGeneratorInterface
 {

--- a/api/app/Modules/HR/Domain/Contracts/OnboardingQrInterface.php
+++ b/api/app/Modules/HR/Domain/Contracts/OnboardingQrInterface.php
@@ -12,8 +12,8 @@ use App\Core\Tenant\Domain\Models\Company;
  * flow (employee self-profile QR, company invite QR). Owned by HR so
  * OnboardingQrController depends on this interface instead of importing
  * App\Modules\Onboarding\Infrastructure\Services\OnboardingQrService
- * directly (PA2-ARCH-003). Bound to the existing Onboarding implementation
- * in HRServiceProvider.
+ * directly (PA2-ARCH-003). Bound to the existing Onboarding implementation by
+ * OnboardingServiceProvider (composition root décentralisée).
  */
 interface OnboardingQrInterface
 {

--- a/api/app/Modules/HR/Providers/HRServiceProvider.php
+++ b/api/app/Modules/HR/Providers/HRServiceProvider.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace App\Modules\HR\Providers;
 
-use App\Modules\Cabinet\Infrastructure\Services\ContractPdfGenerator;
 use App\Modules\HR\Domain\Contracts\ApplicantPipelineReaderInterface;
-use App\Modules\HR\Domain\Contracts\ContractDocumentGeneratorInterface;
-use App\Modules\HR\Domain\Contracts\OnboardingQrInterface;
-use App\Modules\Onboarding\Infrastructure\Services\OnboardingQrService;
 use App\Modules\Recruitment\Infrastructure\Services\ApplicantPipelineReader;
 use Illuminate\Support\ServiceProvider;
 
@@ -21,8 +17,6 @@ class HRServiceProvider extends ServiceProvider
         // directly in its controllers. Bindings below wire the existing
         // implementations from those modules (reused, not duplicated).
         $this->app->bind(ApplicantPipelineReaderInterface::class, ApplicantPipelineReader::class);
-        $this->app->bind(ContractDocumentGeneratorInterface::class, ContractPdfGenerator::class);
-        $this->app->bind(OnboardingQrInterface::class, OnboardingQrService::class);
     }
 
     public function boot(): void

--- a/api/app/Modules/Onboarding/Providers/OnboardingServiceProvider.php
+++ b/api/app/Modules/Onboarding/Providers/OnboardingServiceProvider.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace App\Modules\Onboarding\Providers;
 
+use App\Modules\HR\Domain\Contracts\OnboardingQrInterface;
+use App\Modules\Onboarding\Infrastructure\Services\OnboardingQrService;
 use Illuminate\Support\ServiceProvider;
 
 class OnboardingServiceProvider extends ServiceProvider
 {
-    public function register(): void {}
+    public function register(): void
+    {
+        // PA2-ARCH-003 — chaque module enregistre SA propre implémentation des
+        // contrats qu'il fournit (composition root décentralisée).
+        $this->app->bind(OnboardingQrInterface::class, OnboardingQrService::class);
+    }
 
     public function boot(): void {}
 }

--- a/dev-hub/tools/module-isolation-allowlist.txt
+++ b/dev-hub/tools/module-isolation-allowlist.txt
@@ -25,8 +25,6 @@ Modules/Fleet -> Modules/Attendance
 Modules/Growth -> Modules/Billing
 Modules/Growth -> Modules/Payroll
 Modules/HR -> Modules/Attendance
-Modules/HR -> Modules/Cabinet
-Modules/HR -> Modules/Onboarding
 Modules/HR -> Modules/Payroll
 Modules/HR -> Modules/Planning
 Modules/HR -> Modules/Recruitment


### PR DESCRIPTION
## Purge de l'allowlist d'isolation (#5584) — composition root décentralisée

Premier lot de purge de la dette d'isolation : les bindings DI cross-modules vivaient dans `HRServiceProvider` (composition root central). Chaque module fournit pourtant le service → il doit enregistrer **sa propre implémentation** (PA2-ARCH-003).

### Changements
- **`CabinetServiceProvider::register()`** : `ContractDocumentGeneratorInterface` → `ContractPdfGenerator`
- **`OnboardingServiceProvider::register()`** : `OnboardingQrInterface` → `OnboardingQrService`
- **`HRServiceProvider`** : 2 bindings + imports externes supprimés (reste `ApplicantPipelineReader` → paire HR→Recruitment persistante via `CandidateHiringService`, dette documentée)
- Docblocks des 2 interfaces mis à jour (point de bind ≠ HR)
- **Allowlist : 52 → 50 paires** (retrait de `Modules/HR -> Modules/Cabinet` et `Modules/HR -> Modules/Onboarding`)

### Validation
- Garde `check-module-isolation.sh` ✓
- Suites Onboarding + Cabinet + Contracts + QR + HR : **214 tests verts, 0 échec** (résolution des interfaces via le conteneur exercée par `app(OnboardingQrInterface::class)` et les flux PDF)
- Pint ✓, lint PHP 8.4 ✓

### Note de méthode
Le premier jet a planté (classe résolue dans le namespace `Providers\` au lieu de `Infrastructure\Services\` — import oublié dans le nouveau fichier) → corrigé et vérifié par les tests ciblés QR/PDF.