### PR TITLE
fix(ci): Module Structure Validator — fetch-depth 0 (base_sha irrésolvable en checkout shallow)

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -164,6 +164,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           lfs: true
+          # Issue #5629 : le checkout par défaut (depth 1) ne contient pas le
+          # base_sha des PRs à base ancienne → les gardes de diff (cross-module
+          # imports, strict_types, accented messages, baseline PHPStan)
+          # échouent en exit 128 sur `git rev-parse` → check requis rouge
+          # systématique. Historique complet requis.
+          fetch-depth: 0
 
       - name: Check module structure
         run: |


### PR DESCRIPTION
## fix(ci): Module Structure Validator — `fetch-depth: 0` (base_sha irrésolvable en checkout shallow)

### Bug (cause racine du check requis rouge sur TOUTES les PRs)
Le job `Module Structure Validator` (check requis) fait un `actions/checkout` par défaut (**depth 1**). Les gardes de diff de ce job (`check-cross-module-imports.sh`, `check-strict-types-new-files.sh`, `check-hardcoded-accented-messages.sh`, baseline PHPStan) reçoivent `github.event.pull_request.base.sha` — un commit **absent du checkout shallow** dès que la base de la PR est ancienne (tout le backlog actuel) :

```
git rev-parse "<base_sha>"  →  fatal (exit 128)  →  STEP "Cross-module import guard" failure
```

Vérifié sur le run de #5635 (run 32998753205, job 98274711755) : steps 1-6 OK (structure, isolation, orphelins, docs parity **passent tous**), step 7 échoue en 14 s à cause de `rev-parse`.

### Fix
`fetch-depth: 0` sur le checkout de ce job uniquement (timeout 45 min — coût OK). Les gardes de diff redeviennent exécutables sur toutes les PRs, quelle que soit l'ancienneté de leur base.

Ref #5629
