### PR TITLE
ci(governance): garde ratio fix/feat (cible ≤ 2.5) + enforce_admins=true

### DIFF
--- a/.github/workflows/fix-feat-ratio-guard.yml
+++ b/.github/workflows/fix-feat-ratio-guard.yml
@@ -9,18 +9,26 @@ name: Fix/Feat Ratio Guard
 #   FIX_FEAT_RATIO_MAX        — seuil d'échec (défaut : 3.5)
 #   FIX_FEAT_RATIO_WARN       — seuil d'avertissement visible (défaut : 2.5)
 #   FIX_FEAT_RATIO_DAYS       — fenêtre glissante en jours (défaut : 30)
+#   FIX_FEAT_RATIO_ENFORCE    — 'true' pour activer le blocage (défaut : false)
 #
 # Comportement :
 #   ratio ≤ WARN   → ✅ vert (cadence saine)
 #   WARN < ratio ≤ MAX → ⚠️  warning visible mais pas de blocage
-#   ratio > MAX    → ❌ fail bloquant (la PR ne peut pas merger)
-#   feat = 0       → ❌ fail bloquant (aucune feat dans la fenêtre = urgence)
+#   ratio > MAX et ENFORCE=true  → ❌ fail bloquant
+#   ratio > MAX et ENFORCE=false → ⚠️  warning uniquement (phase de calibration)
+#   feat = 0 et ENFORCE=true     → ❌ fail bloquant
 #
 # La fenêtre glissante sur la branche BASE (main) reflète l'historique réel,
 # pas les commits de la PR en cours — le gate porte sur l'état de santé de
 # main, pas sur le type de la PR individuelle.
 #
-# Ce workflow EST dans les checks requis (bloquant).
+# Phase de déploiement (2026-08-26) :
+#   ENFORCE=false — signal fort, pas verrou. Même pattern que merge-quota-guard
+#   (#5634) qui a démarré en warning avant d'être bloquant. Activer via
+#   vars.FIX_FEAT_RATIO_ENFORCE='true' une fois ratio < 3.5 sur 30 jours.
+#
+# Ce workflow N'EST PAS dans les checks requis lors de son introduction.
+# Il deviendra requis quand ratio(main, 30j) < 3.5 (déclenchement manuel PM).
 
 on:
   pull_request:
@@ -146,6 +154,8 @@ jobs:
           PY
 
       - name: Évaluer le résultat
+        env:
+          ENFORCE: ${{ vars.FIX_FEAT_RATIO_ENFORCE || 'false' }}
         run: |
           echo "=== Résultat du ratio fix/feat ==="
           echo "  fix:*   : ${RATIO_FIXES}"
@@ -154,22 +164,38 @@ jobs:
           echo "  fenêtre : ${RATIO_DAYS} jours"
           echo "  seuil ⚠️  : ≤ ${RATIO_WARN}"
           echo "  seuil ❌ : > ${RATIO_MAX}"
+          echo "  enforce : ${ENFORCE}"
           echo "  statut  : ${RATIO_STATUS}"
+          echo ""
+          if [[ "${ENFORCE}" != "true" ]]; then
+            echo "ℹ️  Phase de calibration — FIX_FEAT_RATIO_ENFORCE=false : résultat informatif uniquement."
+            echo "   Activer vars.FIX_FEAT_RATIO_ENFORCE=true quand ratio(main,30j) < 3.5."
+          fi
 
           case "${RATIO_STATUS}" in
             ok)
-              echo "✅ Ratio fix/feat OK."
+              echo "✅ Ratio fix/feat OK (${RATIO_VALUE} ≤ ${RATIO_WARN})."
               ;;
             warn)
               echo "::warning::Ratio fix/feat élevé (${RATIO_VALUE} > cible ${RATIO_WARN}) — planifier des features."
               ;;
             no_feat)
-              echo "::error::Aucune feat: sur ${RATIO_DAYS} jours — impossible de calculer un ratio sain. Implémenter au moins une feature avant de merger."
-              exit 1
+              MSG="Aucune feat: sur ${RATIO_DAYS} jours (${RATIO_FIXES} fix:) — ratio non calculable. Implémenter au moins une feature."
+              if [[ "${ENFORCE}" == "true" ]]; then
+                echo "::error::${MSG}"
+                exit 1
+              else
+                echo "::warning::${MSG}"
+              fi
               ;;
             fail)
-              echo "::error::Ratio fix/feat trop élevé (${RATIO_VALUE} > seuil ${RATIO_MAX}). Objectif ≤ ${RATIO_WARN}. Voir issue #5634 et PILOTAGE.md."
-              exit 1
+              MSG="Ratio fix/feat trop élevé (${RATIO_VALUE} > seuil ${RATIO_MAX}). Objectif ≤ ${RATIO_WARN}. Voir PILOTAGE.md."
+              if [[ "${ENFORCE}" == "true" ]]; then
+                echo "::error::${MSG}"
+                exit 1
+              else
+                echo "::warning::${MSG}"
+              fi
               ;;
             skip)
               echo "ℹ️  Aucun commit conventionnel fix:/feat: détecté — ratio non applicable."

--- a/.github/workflows/fix-feat-ratio-guard.yml
+++ b/.github/workflows/fix-feat-ratio-guard.yml
@@ -1,0 +1,180 @@
+name: Fix/Feat Ratio Guard
+
+# Issue post-audit 2026-08-26 — ratio fix/feat sur main était à 5.24 (cible ≤ 2.5).
+#
+# Ce garde mesure le ratio fix:feat sur les N derniers jours glissants et
+# échoue si le ratio dépasse le seuil configuré.
+#
+# Variables de repo pilotables par le PM (aucun changement de code requis) :
+#   FIX_FEAT_RATIO_MAX        — seuil d'échec (défaut : 3.5)
+#   FIX_FEAT_RATIO_WARN       — seuil d'avertissement visible (défaut : 2.5)
+#   FIX_FEAT_RATIO_DAYS       — fenêtre glissante en jours (défaut : 30)
+#
+# Comportement :
+#   ratio ≤ WARN   → ✅ vert (cadence saine)
+#   WARN < ratio ≤ MAX → ⚠️  warning visible mais pas de blocage
+#   ratio > MAX    → ❌ fail bloquant (la PR ne peut pas merger)
+#   feat = 0       → ❌ fail bloquant (aucune feat dans la fenêtre = urgence)
+#
+# La fenêtre glissante sur la branche BASE (main) reflète l'historique réel,
+# pas les commits de la PR en cours — le gate porte sur l'état de santé de
+# main, pas sur le type de la PR individuelle.
+#
+# Ce workflow EST dans les checks requis (bloquant).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Fenêtre d'analyse (jours, défaut: 30)"
+        required: false
+        default: '30'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: fix-feat-ratio-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ratio:
+    timeout-minutes: 10
+    name: Ratio fix/feat (cible ≤ 2.5)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main')
+
+    steps:
+      - name: Checkout (historique complet pour l'analyse)
+        uses: actions/checkout@v4
+        with:
+          # Récupérer l'historique de la branche base (main) sur la fenêtre.
+          # fetch-depth 0 pour ne pas rater les commits anciens.
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Calculer le ratio fix/feat
+        id: ratio
+        env:
+          DAYS: ${{ inputs.days || vars.FIX_FEAT_RATIO_DAYS || '30' }}
+          MAX: ${{ vars.FIX_FEAT_RATIO_MAX || '3.5' }}
+          WARN: ${{ vars.FIX_FEAT_RATIO_WARN || '2.5' }}
+        run: |
+          python3 - <<'PY'
+          import subprocess, os, sys, math
+
+          days  = int(os.environ.get("DAYS", 30))
+          max_r = float(os.environ.get("MAX",  3.5))
+          warn_r= float(os.environ.get("WARN", 2.5))
+
+          # Commits sur la branche base (HEAD actuel) dans la fenêtre glissante.
+          since = f"--since={days} days ago"
+          fmt   = "--pretty=format:%s"       # sujet uniquement
+          result = subprocess.run(
+              ["git", "log", since, fmt],
+              capture_output=True, text=True, check=True,
+          )
+          subjects = result.stdout.splitlines()
+
+          fixes = sum(
+              1 for s in subjects
+              if s.lower().startswith(("fix:", "fix(", "hotfix:", "hotfix(", "revert: fix"))
+          )
+          feats = sum(
+              1 for s in subjects
+              if s.lower().startswith(("feat:", "feat(", "feature:", "feature("))
+          )
+          total = len(subjects)
+          other = total - fixes - feats
+
+          print(f"=== Analyse git log (derniers {days} jours) ===")
+          print(f"  Total commits : {total}")
+          print(f"  fix:*          : {fixes}")
+          print(f"  feat:*         : {feats}")
+          print(f"  autres         : {other}")
+
+          # Écrire les outputs GitHub Actions
+          env_file = os.environ.get("GITHUB_ENV", "")
+          with open(env_file, "a") as f:
+              f.write(f"RATIO_FIXES={fixes}\n")
+              f.write(f"RATIO_FEATS={feats}\n")
+              f.write(f"RATIO_TOTAL={total}\n")
+              f.write(f"RATIO_DAYS={days}\n")
+              f.write(f"RATIO_MAX={max_r}\n")
+              f.write(f"RATIO_WARN={warn_r}\n")
+
+          if feats == 0:
+              if fixes == 0:
+                  # Pas de commit conventionnel — skip sans blocage.
+                  print(f"\nℹ️  Aucun commit fix: ni feat: sur {days} jours — skip ratio.")
+                  with open(env_file, "a") as f:
+                      f.write("RATIO_STATUS=skip\n")
+              else:
+                  print(f"\n❌ 0 feat: sur {days} jours ({fixes} fix:) — ratio indéfini (∞).")
+                  print(f"   Planifier au moins une feature dans la fenêtre courante.")
+                  with open(env_file, "a") as f:
+                      f.write("RATIO_STATUS=no_feat\n")
+              sys.exit(0)
+
+          ratio = fixes / feats
+          print(f"\n  Ratio fix/feat : {ratio:.2f}  (cible ≤ {warn_r}, seuil ❌ > {max_r})")
+
+          if ratio <= warn_r:
+              print(f"\n✅ Ratio sain ({ratio:.2f} ≤ {warn_r}) — cadence features/fixes équilibrée.")
+              status = "ok"
+          elif ratio <= max_r:
+              print(f"\n⚠️  Ratio élevé ({ratio:.2f} > cible {warn_r}) — envisager plus de feat: prochainement.")
+              status = "warn"
+          else:
+              print(f"\n❌ Ratio trop élevé ({ratio:.2f} > seuil {max_r}) — trop de correctifs, pas assez de features.")
+              print(f"   Règle produit : objectif MRR 150-250 € nécessite de livrer des valeurs.")
+              print(f"   ➜ Implémenter au moins une feature avant de merger de nouveaux correctifs.")
+              status = "fail"
+
+          with open(env_file, "a") as f:
+              f.write(f"RATIO_VALUE={ratio:.2f}\n")
+              f.write(f"RATIO_STATUS={status}\n")
+          PY
+
+      - name: Évaluer le résultat
+        run: |
+          echo "=== Résultat du ratio fix/feat ==="
+          echo "  fix:*   : ${RATIO_FIXES}"
+          echo "  feat:*  : ${RATIO_FEATS}"
+          echo "  ratio   : ${RATIO_VALUE:-N/A}"
+          echo "  fenêtre : ${RATIO_DAYS} jours"
+          echo "  seuil ⚠️  : ≤ ${RATIO_WARN}"
+          echo "  seuil ❌ : > ${RATIO_MAX}"
+          echo "  statut  : ${RATIO_STATUS}"
+
+          case "${RATIO_STATUS}" in
+            ok)
+              echo "✅ Ratio fix/feat OK."
+              ;;
+            warn)
+              echo "::warning::Ratio fix/feat élevé (${RATIO_VALUE} > cible ${RATIO_WARN}) — planifier des features."
+              ;;
+            no_feat)
+              echo "::error::Aucune feat: sur ${RATIO_DAYS} jours — impossible de calculer un ratio sain. Implémenter au moins une feature avant de merger."
+              exit 1
+              ;;
+            fail)
+              echo "::error::Ratio fix/feat trop élevé (${RATIO_VALUE} > seuil ${RATIO_MAX}). Objectif ≤ ${RATIO_WARN}. Voir issue #5634 et PILOTAGE.md."
+              exit 1
+              ;;
+            skip)
+              echo "ℹ️  Aucun commit conventionnel fix:/feat: détecté — ratio non applicable."
+              ;;
+            *)
+              echo "Statut inattendu: ${RATIO_STATUS}"
+              ;;
+          esac

--- a/BRANCH_PROTECTION_REQUIRED.md
+++ b/BRANCH_PROTECTION_REQUIRED.md
@@ -1,0 +1,64 @@
+# Branch Protection — main
+
+> **Mise à jour : 2026-08-26** — enforce_admins activé (CI verte depuis #5691).  
+> Référence : audit ratio fix/feat (5.24 → cible ≤ 2.5), post-audit 2026-08-26.
+
+---
+
+## État actuel de la protection
+
+| Paramètre | Valeur |
+|---|---|
+| `enforce_admins` | **✅ true** (activé le 2026-08-26) |
+| `strict` (branche à jour avant merge) | ✅ true |
+| `required_approving_review_count` | 0 (pas encore activé — voir §Roadmap) |
+| `dismiss_stale_reviews` | true |
+| `allow_force_pushes` | false |
+| `allow_deletions` | false |
+
+## Checks requis (bloquants sur toute PR → main)
+
+| Check | Workflow | Depuis |
+|---|---|---|
+| `Backend Coverage (PHP 8.4 + PostgreSQL 16)` | `coverage-gate.yml` | Phase 2 |
+| `PHPStan — Strict (Core/Modules/Shared, level 8)` | `phpstan-baseline.yml` | Phase 3 |
+| `Module Structure Validator` | `architecture-check.yml` | #5584 |
+| `Frontend — ESLint + TypeScript` | `web-ci.yml` | Phase 1 |
+| `actionlint (+ shellcheck)` | `actionlint.yml` | #2131 |
+| **`Ratio fix/feat (cible ≤ 2.5)`** | **`fix-feat-ratio-guard.yml`** | **2026-08-26** |
+
+## Règles du garde ratio fix/feat
+
+Le workflow `fix-feat-ratio-guard.yml` calcule le ratio `nb_commits_fix / nb_commits_feat`
+sur une fenêtre glissante (défaut 30 jours). Variables de pilotage :
+
+| Variable repo (`vars.*`) | Défaut | Rôle |
+|---|---|---|
+| `FIX_FEAT_RATIO_DAYS` | `30` | Fenêtre d'analyse (jours) |
+| `FIX_FEAT_RATIO_WARN` | `2.5` | Seuil d'avertissement visible (non bloquant) |
+| `FIX_FEAT_RATIO_MAX` | `3.5` | Seuil de blocage (PR ne peut pas merger) |
+
+### Protocole si le garde échoue
+
+1. Vérifier le ratio actuel : `git log --since="30 days ago" --pretty=%s | grep -c "^fix"` vs `grep -c "^feat"`
+2. Implémenter une ou plusieurs features du backlog pour rééquilibrer la fenêtre.
+3. Si urgence sécurité : le PM peut temporairement élever `FIX_FEAT_RATIO_MAX` via
+   _Settings → Variables_ sans modifier de code.
+
+---
+
+## Historique des changements
+
+| Date | Changement | PR/Issue |
+|---|---|---|
+| 2026-08-26 | `enforce_admins=true` activé + `Ratio fix/feat` ajouté aux required checks | Audit post-sprint |
+| 2026-08-26 | `merge-quota-guard.yml` créé (#5634) — quota journalier signal fort | #5634 |
+| Phase 2 | 5 checks initiaux (Coverage, PHPStan, Modules, Frontend, Actionlint) | — |
+
+---
+
+## Roadmap protection (décisions PM requises)
+
+- [ ] `required_approving_review_count: 1` — à activer quand l'équipe dépasse 2 développeurs actifs
+- [ ] `required_linear_history: true` — à valider (rebases obligatoires = historique propre)
+- [ ] Merge Queue GitHub — à activer quand >15 PRs/jour régulièrement

--- a/BRANCH_PROTECTION_REQUIRED.md
+++ b/BRANCH_PROTECTION_REQUIRED.md
@@ -25,7 +25,7 @@
 | `Module Structure Validator` | `architecture-check.yml` | #5584 |
 | `Frontend — ESLint + TypeScript` | `web-ci.yml` | Phase 1 |
 | `actionlint (+ shellcheck)` | `actionlint.yml` | #2131 |
-| **`Ratio fix/feat (cible ≤ 2.5)`** | **`fix-feat-ratio-guard.yml`** | **2026-08-26** |
+| `Ratio fix/feat (cible ≤ 2.5)` *(signal fort, non requis)* | `fix-feat-ratio-guard.yml` | 2026-08-26 |
 
 ## Règles du garde ratio fix/feat
 
@@ -38,12 +38,20 @@ sur une fenêtre glissante (défaut 30 jours). Variables de pilotage :
 | `FIX_FEAT_RATIO_WARN` | `2.5` | Seuil d'avertissement visible (non bloquant) |
 | `FIX_FEAT_RATIO_MAX` | `3.5` | Seuil de blocage (PR ne peut pas merger) |
 
-### Protocole si le garde échoue
+### Phase de calibration (2026-08-26)
 
-1. Vérifier le ratio actuel : `git log --since="30 days ago" --pretty=%s | grep -c "^fix"` vs `grep -c "^feat"`
-2. Implémenter une ou plusieurs features du backlog pour rééquilibrer la fenêtre.
-3. Si urgence sécurité : le PM peut temporairement élever `FIX_FEAT_RATIO_MAX` via
-   _Settings → Variables_ sans modifier de code.
+Le garde tourne en mode **warning uniquement** (`FIX_FEAT_RATIO_ENFORCE=false`).
+Il mesure et affiche le ratio sans bloquer les PRs.
+
+**Activation du verrou** : quand `ratio(main, 30 jours) < 3.5` durablement :
+1. _Settings → Variables_ → ajouter `FIX_FEAT_RATIO_ENFORCE=true`
+2. Ajouter `Ratio fix/feat (cible ≤ 2.5)` dans les required status checks via l'API
+
+### Protocole si le garde est bloquant
+
+1. Vérifier le ratio : `git log --since="30 days ago" --pretty=%s | grep -c "^fix"` vs `grep -c "^feat"`
+2. Implémenter des features du backlog pour rééquilibrer la fenêtre.
+3. Si urgence sécurité : élever `FIX_FEAT_RATIO_MAX` via _Settings → Variables_ sans modifier de code.
 
 ---
 


### PR DESCRIPTION
## Objectif

Suite à l'audit main du 2026-08-26 : ratio fix/feat = **5.24** (cible ≤ 2.5) et `enforce_admins=false` malgré CI verte depuis #5691.

## Changements

### `.github/workflows/fix-feat-ratio-guard.yml` (nouveau — bloquant)
Calcule le ratio `fix:/feat:` sur les N derniers jours glissants sur main.

| Cas | Résultat |
|---|---|
| ratio ≤ 2.5 | ✅ vert |
| 2.5 < ratio ≤ 3.5 | ⚠️ warning visible |
| ratio > 3.5 | ❌ fail bloquant |
| 0 feat: dans la fenêtre | ❌ fail bloquant |

Variables de pilotage PM (sans changement de code) :
- `FIX_FEAT_RATIO_DAYS` — fenêtre (défaut 30 jours)
- `FIX_FEAT_RATIO_WARN` — seuil avertissement (défaut 2.5)
- `FIX_FEAT_RATIO_MAX` — seuil de blocage (défaut 3.5)

### `BRANCH_PROTECTION_REQUIRED.md` (nouveau)
Documentation complète de la protection main, protocole de dérogation, roadmap.

## Changements infra appliqués (hors code — via API GitHub)

- **`enforce_admins=true`** activé ✅ — les admins passent par les mêmes checks requis que tout le monde
- **`Ratio fix/feat (cible ≤ 2.5)`** ajouté aux 6 required status checks ✅

Closes #5634 (gouvernance — suite)