### PR TITLE
fix(main): stabilité — Gate viewApiDocs (fillable company_id) + parité i18n bank_* ×4 dans validation

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,9 @@ Toutes les modifications notables de ce projet sont documentées ici.
 Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
 ## [Unreleased]
+### Audit stabilité main — régressions corrigées (2026-08-27)
+- `OpenApiDocsTest` : `company_id` n'est pas fillable sur le modèle Employee — le test construisait un employé sans tenant (Gate `viewApiDocs` → 403 en prod). Assignation directe de l'attribut pour refléter un utilisateur hydraté depuis la DB (7/7).
+- Parité i18n comptabilité (#5524) : les clés `bank_*` vivaient au top-level dans en/tr/ar mais dans `validation.*` en fr (chemin réellement utilisé par les Requests, `__('accounting.validation.bank_*')`) → messages de validation renvoyés bruts en en/tr/ar. Alignées ×4 dans `validation`, doublon top-level fr supprimé (LangCatalogParityTest + AccountingI18nTest verts, 96 clés ×4).
 
 ### Webhooks Stripe/Chargily — URL canonique documentée (#5537)
 - `ChargilyPaymentGateway::webhookUrl()` confirmé : retourne `/api/v1/accounting/payment-webhooks/chargily` (nouvelle URL, PR #5525).

--- a/api/lang/ar/accounting.php
+++ b/api/lang/ar/accounting.php
@@ -61,6 +61,14 @@ return [
         'amount_min' => 'يجب أن يكون المبلغ موجباً تماماً.',
         'method_invalid' => 'طريقة دفع غير صالحة (cash, bank_transfer, check, card, other).',
         'series_unknown' => 'سلسلة غير معروفة: « :key » ليست نوع مستند (:allowed).',
+        'bank_file_required' => 'ملف CSV مطلوب.',
+        'bank_file_mimes' => 'يجب أن يكون الملف بصيغة CSV.',
+        'bank_period_required' => 'فترة الكشف مطلوبة (YYYY-MM).',
+        'bank_period_format' => 'يجب أن تكون الفترة بصيغة YYYY-MM.',
+        'bank_reference_required' => 'مرجع الاستيراد مطلوب.',
+        'bank_payment_required' => 'الدفعة المراد مطابقتها مطلوبة.',
+        'bank_payment_exists' => 'الدفعة المحددة غير موجودة.',
+
         // Rapprochement / profondeur (issue #5422)
         'year_required' => 'السنة مطلوبة.',
         'year_integer' => 'يجب أن تكون السنة رقماً صحيحاً.',
@@ -75,13 +83,6 @@ return [
         'year_between' => 'يجب أن تكون السنة بين 2000 و 2100.',
     ],
 
-        'bank_file_required' => 'ملف CSV مطلوب.',
-        'bank_file_mimes' => 'يجب أن يكون الملف بصيغة CSV.',
-        'bank_period_required' => 'فترة الكشف مطلوبة (YYYY-MM).',
-        'bank_period_format' => 'يجب أن تكون الفترة بصيغة YYYY-MM.',
-        'bank_reference_required' => 'مرجع الاستيراد مطلوب.',
-        'bank_payment_required' => 'الدفعة المراد مطابقتها مطلوبة.',
-        'bank_payment_exists' => 'الدفعة المحددة غير موجودة.',
     'errors' => [
         'gateway_checkout_failed' => 'بوابة الدفع غير متاحة مؤقتًا. يرجى المحاولة لاحقًا.',
         'payment_amount_positive' => 'يجب أن يكون مبلغ الدفع موجباً تماماً.',

--- a/api/lang/en/accounting.php
+++ b/api/lang/en/accounting.php
@@ -61,6 +61,14 @@ return [
         'amount_min' => 'The amount must be strictly positive.',
         'method_invalid' => 'Invalid payment method (cash, bank_transfer, check, card, other).',
         'series_unknown' => 'Unknown series: « :key » is not a document type (:allowed).',
+        'bank_file_required' => 'The CSV file is required.',
+        'bank_file_mimes' => 'The file must be CSV.',
+        'bank_period_required' => 'The statement period is required (YYYY-MM).',
+        'bank_period_format' => 'The period must use the YYYY-MM format.',
+        'bank_reference_required' => 'The import reference is required.',
+        'bank_payment_required' => 'The payment to reconcile is required.',
+        'bank_payment_exists' => 'The selected payment does not exist.',
+
         // Rapprochement / profondeur (issue #5422)
         'year_required' => 'The year is required.',
         'year_integer' => 'The year must be an integer.',
@@ -75,13 +83,6 @@ return [
         'year_between' => 'The year must be between 2000 and 2100.',
     ],
 
-        'bank_file_required' => 'The CSV file is required.',
-        'bank_file_mimes' => 'The file must be CSV.',
-        'bank_period_required' => 'The statement period is required (YYYY-MM).',
-        'bank_period_format' => 'The period must use the YYYY-MM format.',
-        'bank_reference_required' => 'The import reference is required.',
-        'bank_payment_required' => 'The payment to reconcile is required.',
-        'bank_payment_exists' => 'The selected payment does not exist.',
     'errors' => [
         'gateway_checkout_failed' => 'The payment gateway is temporarily unavailable. Please try again later.',
         'payment_amount_positive' => 'The payment amount must be strictly positive.',

--- a/api/lang/fr/accounting.php
+++ b/api/lang/fr/accounting.php
@@ -125,14 +125,8 @@ return [
     'lettering_unbalanced' => 'Le lettrage doit être équilibré : la somme des débits doit égaler la somme des crédits.',
     'lettering_invalid' => 'Lettrage invalide : les écritures doivent porter sur le même compte.',
     'lettering_already_used' => 'Une ou plusieurs écritures sont déjà lettrées avec une autre lettre.',
-    // Rapprochement bancaire (issue #5435) — parité avec en/tr/ar (#5627 audit).
-    'bank_file_mimes' => 'Le fichier doit être au format CSV.',
-    'bank_file_required' => 'Le fichier CSV est requis.',
-    'bank_payment_exists' => 'Le paiement sélectionné n\'existe pas.',
-    'bank_payment_required' => 'Le paiement à rapprocher est requis.',
-    'bank_period_format' => 'La période doit utiliser le format AAAA-MM.',
-    'bank_period_required' => 'La période du relevé est requise (AAAA-MM).',
-    'bank_reference_required' => 'La référence d\'import est requise.',
+    // Les messages bank_* vivent dans le sous-tableau `validation.*` (chemin
+    // utilisé par les Request — doublon top-level supprimé, #5524 parité).
 ];
 
 

--- a/api/lang/tr/accounting.php
+++ b/api/lang/tr/accounting.php
@@ -61,6 +61,14 @@ return [
         'amount_min' => 'Tutar kesinlikle pozitif olmalıdır.',
         'method_invalid' => 'Geçersiz ödeme yöntemi (cash, bank_transfer, check, card, other).',
         'series_unknown' => 'Bilinmeyen seri: « :key » bir belge türü değil (:allowed).',
+        'bank_file_required' => 'CSV dosyası zorunludur.',
+        'bank_file_mimes' => 'Dosya CSV formatında olmalıdır.',
+        'bank_period_required' => 'Dönem zorunludur (YYYY-MM).',
+        'bank_period_format' => 'Dönem YYYY-MM formatında olmalıdır.',
+        'bank_reference_required' => 'İçe aktarma referansı zorunludur.',
+        'bank_payment_required' => 'Eşleştirilecek ödeme zorunludur.',
+        'bank_payment_exists' => 'Seçilen ödeme mevcut değil.',
+
         // Rapprochement / profondeur (issue #5422)
         'year_required' => 'Yıl zorunludur.',
         'year_integer' => 'Yıl bir tam sayı olmalıdır.',
@@ -75,13 +83,6 @@ return [
         'year_between' => 'Yıl 2000 ile 2100 arasında olmalıdır.',
     ],
 
-        'bank_file_required' => 'CSV dosyası zorunludur.',
-        'bank_file_mimes' => 'Dosya CSV formatında olmalıdır.',
-        'bank_period_required' => 'Dönem zorunludur (YYYY-MM).',
-        'bank_period_format' => 'Dönem YYYY-MM formatında olmalıdır.',
-        'bank_reference_required' => 'İçe aktarma referansı zorunludur.',
-        'bank_payment_required' => 'Eşleştirilecek ödeme zorunludur.',
-        'bank_payment_exists' => 'Seçilen ödeme mevcut değil.',
     'errors' => [
         'gateway_checkout_failed' => 'Ödeme sağlayıcısı geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin.',
         'payment_amount_positive' => 'Ödeme tutarı kesinlikle pozitif olmalıdır.',

--- a/api/tests/Feature/Accounting/BankReconciliationTest.php
+++ b/api/tests/Feature/Accounting/BankReconciliationTest.php
@@ -189,7 +189,8 @@ class BankReconciliationTest extends TestCase
 
         // L'export renvoie une Response classique (petit CSV en mémoire, pas de
         // streaming nécessaire — parité #5573) : getContent(), pas streamedContent().
-        $csv = $response->getContent();
+        // (string) : getContent() renvoie string|false — PHPStan strict (level 8).
+        $csv = (string) $response->getContent();
         // BOM UTF-8 + en-tête.
         $this->assertStringStartsWith("\xEF\xBB\xBF", $csv);
         $this->assertStringContainsString('Ligne;Date;Libelle;Montant;Statut', $csv);

--- a/api/tests/Feature/OpenApiDocsTest.php
+++ b/api/tests/Feature/OpenApiDocsTest.php
@@ -102,7 +102,12 @@ class OpenApiDocsTest extends TestCase
         // détecter l'environnement pour que la gate prod s'applique.
         app()->detectEnvironment(fn () => 'production');
 
-        $employee = new Employee(['company_id' => '00000000-0000-0000-0000-000000000001']);
+        // company_id n'est PAS dans $fillable (modèle Employee) : le passage
+        // par le constructeur est silencieusement ignoré → Gate viewApiDocs
+        // échoue. Un utilisateur chargé depuis la DB a l'attribut hydraté ;
+        // on force l'assignation pour refléter cet état.
+        $employee = new Employee;
+        $employee->company_id = '00000000-0000-0000-0000-000000000001';
 
         $this->actingAs($employee, 'web')
             ->get('/docs')


### PR DESCRIPTION
## Stabilité de main (audit 2026-08-27)

### 1. OpenApiDocsTest — 403 `/docs` en prod (régression réelle sur main)
`company_id` n'est **pas dans `$fillable`** du modèle `Employee` (Core\Auth) : `new Employee(['company_id' => ...])` l'ignore silencieusement → la Gate `viewApiDocs` (`$user && $user->company_id`) renvoie false en production → 403 sur `/docs`, `/docs/openapi.yaml`, `/tester-guide`, `/api-explorer` pour un tenant authentifié.

Le middleware/Gate sont corrects (un utilisateur chargé depuis la DB a l'attribut hydraté) — c'est le test qui construisait un modèle invalide. Fix : assignation directe de l'attribut. **OpenApiDocsTest 7/7.**

### 2. Parité i18n comptabilité — clés `bank_*` mal placées (échecs CI LangCatalogParity + AccountingI18n)
Les 7 clés `bank_*` (#5435) vivaient **au top-level** dans en/tr/ar mais **dans `validation.*`** en fr — or le code utilise `__('accounting.validation.bank_*')` (Requests) → les messages de validation de l'import bancaire étaient **renvoyés bruts** en en/tr/ar.

Fix : déplacement ×4 dans `validation` (traductions locales conservées), doublon top-level fr supprimé → structure identique 96 clés ×4 (LangCatalogParityTest multiset + AccountingI18nTest verts).

## Validation locale
43 tests / 1634 assertions **OK** : LangCatalogParity ×2, AccountingI18n (10), OpenApiDocs (7), Activation (9), BankReconciliation (6), ShareAccessAudit, PortalJourneyE2E, RouteCollisionGuard.

Closes : aucune (pas d'issue ouverte — audit stabilité).