### PR TITLE
feat(crm): squelette DDD du module CRM client (Closes #5707)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ Modules/<Name>/
 └── Providers/          # ServiceProvider du module
 ```
 
-Modules actifs (18, sous `api/app/Modules/`) : `Absence`, `Accounting`, `Attendance`, `Billing`, `Cabinet`, `Cameras`, `EdgeSync`, `Expense`, `Fleet`, `Growth`, `HR`, `Marketing`, `Notification`, `Onboarding`, `Payroll`, `Planning`, `Platform`, `Recruitment` + socle transversal `Core/Auth`, `Core/Tenant`, `Core/Feature` (sous `api/app/Core/`).
+Modules actifs (19, sous `api/app/Modules/`) : `Absence`, `Accounting`, `Attendance`, `Billing`, `Cabinet`, `Cameras`, `CRM`, `EdgeSync`, `Expense`, `Fleet`, `Growth`, `HR`, `Marketing`, `Notification`, `Onboarding`, `Payroll`, `Planning`, `Platform`, `Recruitment` + socle transversal `Core/Auth`, `Core/Tenant`, `Core/Feature` (sous `api/app/Core/`).
 
 > Décompte vérifié via `ls api/app/Modules | wc -l`. Voir `docs/ARCHITECTURE_STATUS.md` pour l'état couche-par-couche (Domain/Application/Infrastructure/Interfaces/Providers/Tests) de chaque module.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- **feat(crm): squelette DDD du module CRM client (Closes #5707, CRM-V0-03).** Nouveau module `api/app/Modules/CRM/` conforme constitution §VI (Application/Domain/Infrastructure/Interfaces/Providers + `CrmServiceProvider` enregistré dans `bootstrap/providers.php`), sans logique métier prématurée et sans import vers Platform/Marketing (garde isolation #5584 verte — le CRM commercial Leopardo n'est pas touché, ADR-CRM-001/002). Docs d'architecture mises à jour ×4 (parité #5589) : `ARCHITECTURE.md`, `docs/ARCHITECTURE_STATUS.md`, `docs/CONTRIBUTING_DDD.md`, `api/ARCHITECTURE.md` — 19 modules actifs. Vérifié localement : `check-architecture-docs-parity.sh` OK, `check-module-isolation.sh` OK (0 nouvel import croisé), structure 5 couches présente.
+
 - **fix(ci): garde inter-PR des préfixes de migrations (#5437) — faux positif sur push main : baseSha vide faisait considérer toutes les migrations de main comme nouvelles et les comparer aux PRs ouvertes (collision fantôme dès quune PR est ouverte).** Le contrôle ne sapplique plus quaux PRs ouvertes ; bug latent du mode --local (currentNewNames) corrigé au passage — tests 8/8.
 - **docs(api): note ops — healthcheck (GET /api/v1/health, match PROGRAM_VERSION, uptime < 900 s), CORS E2E (origine 127.0.0.1:4173 whitelistée, déploiement requis), incident Redis (healthcheck fail-closed).**
 

--- a/api/ARCHITECTURE.md
+++ b/api/ARCHITECTURE.md
@@ -92,6 +92,7 @@ consommateurs).
 | `Modules/Cabinet` | ✅ routes/modules/cabinet.php | ✅ complet | `CabinetServiceProvider` |
 | `Modules/Fleet` | ✅ routes/modules/hr_extended.php | ✅ complet | `FleetServiceProvider` |
 | `Modules/Cameras` | ✅ routes/modules/cameras.php | ✅ complet | `CamerasServiceProvider` |
+| `Modules/CRM` | 🔶 en cours (squelette #5707, routes #5712) | 🔶 Application/Domain/Infrastructure/Interfaces + Providers (squelette) | `CrmServiceProvider` |
 | `Modules/Growth` | ✅ routes/modules/growth.php | ✅ complet | `GrowthServiceProvider` |
 | `Modules/Marketing` | ✅ routes/modules/marketing.php | ✅ complet | `MarketingServiceProvider` |
 | `Modules/EdgeSync` | ✅ module routes | ✅ complet | `EdgeSyncServiceProvider` |

--- a/api/app/Modules/CRM/Application/README.md
+++ b/api/app/Modules/CRM/Application/README.md
@@ -1,0 +1,1 @@
+Squelette DDD du module CRM client (issue #5707, CRM-V0-03). Les classes de la couche Application arrivent avec les issues CRM-V0-04+ (voir docs/specifications/MODULE_CRM_INTERNE_CLIENT.md).

--- a/api/app/Modules/CRM/Domain/README.md
+++ b/api/app/Modules/CRM/Domain/README.md
@@ -1,0 +1,1 @@
+Squelette DDD du module CRM client (issue #5707, CRM-V0-03). Les classes de la couche Domain arrivent avec les issues CRM-V0-04+ (voir docs/specifications/MODULE_CRM_INTERNE_CLIENT.md).

--- a/api/app/Modules/CRM/Infrastructure/README.md
+++ b/api/app/Modules/CRM/Infrastructure/README.md
@@ -1,0 +1,1 @@
+Squelette DDD du module CRM client (issue #5707, CRM-V0-03). Les classes de la couche Infrastructure arrivent avec les issues CRM-V0-04+ (voir docs/specifications/MODULE_CRM_INTERNE_CLIENT.md).

--- a/api/app/Modules/CRM/Interfaces/README.md
+++ b/api/app/Modules/CRM/Interfaces/README.md
@@ -1,0 +1,1 @@
+Squelette DDD du module CRM client (issue #5707, CRM-V0-03). Les classes de la couche Interfaces arrivent avec les issues CRM-V0-04+ (voir docs/specifications/MODULE_CRM_INTERNE_CLIENT.md).

--- a/api/app/Modules/CRM/Providers/CrmServiceProvider.php
+++ b/api/app/Modules/CRM/Providers/CrmServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\CRM\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * CRM Client (interne tenant) — provider du module (issue #5707, CRM-V0-03).
+ *
+ * Squelette DDD ratifié par l'ADR-CRM-DUAL-CONTEXTS : le CRM client est un
+ * module tenant-scoped distinct du CRM commercial Leopardo (Platform/
+ * Marketing). Aucune logique métier ici — les couches Application/Domain/
+ * Infrastructure/Interfaces se remplissent au fil des issues CRM-V0-04+.
+ */
+class CrmServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // Bind CRM module contracts here (CRM-V0-04+)
+    }
+
+    public function boot(): void
+    {
+        // Boot CRM module — routes loaded via routes/modules/crm.php (CRM-V0-08)
+    }
+}

--- a/api/bootstrap/providers.php
+++ b/api/bootstrap/providers.php
@@ -6,6 +6,7 @@ use App\Modules\Attendance\Providers\AttendanceServiceProvider;
 use App\Modules\Billing\Providers\BillingServiceProvider;
 use App\Modules\Cabinet\Providers\CabinetServiceProvider;
 use App\Modules\Cameras\Providers\CamerasServiceProvider;
+use App\Modules\CRM\Providers\CrmServiceProvider;
 use App\Modules\EdgeSync\Providers\EdgeSyncServiceProvider;
 use App\Modules\Expense\Providers\ExpenseServiceProvider;
 use App\Modules\Fleet\Providers\FleetServiceProvider;
@@ -39,6 +40,8 @@ return [
     FleetServiceProvider::class,
     BillingServiceProvider::class,
     CamerasServiceProvider::class,
+    // — CRM client (issue #5707, ADR-CRM-DUAL-CONTEXTS)
+    CrmServiceProvider::class,
     // — New DDD modules (Phase 2)
     GrowthServiceProvider::class,
     AbsenceServiceProvider::class,

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -2,7 +2,7 @@
 
 > Mis à jour le 2026-07-19 (audit doc) | Phase 5 en cours — nettoyage legacy (PR #824)
 
-## 1. Tableau de l'état DDD — 18 modules actifs
+## 1. Tableau de l'état DDD — 19 modules actifs
 
 | Module          | Domain | Contracts | Exceptions | Application | DTOs | Infra | Interfaces | Providers | Tests |
 |-----------------|:------:|:---------:|:----------:|:-----------:|:----:|:-----:|:----------:|:---------:|:-----:|
@@ -11,6 +11,7 @@
 | **Billing**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Cabinet**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Cameras**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **CRM** 🆕      | — | — | — | — | — | — | — | ✅ | — |
 | **EdgeSync** 🆕  | ✅ | — | — | ✅ | — | — | ✅ | ✅ | ⚠️ |
 | **Expense**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Fleet**       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/docs/CONTRIBUTING_DDD.md
+++ b/docs/CONTRIBUTING_DDD.md
@@ -15,7 +15,7 @@ Dossiers encore en coexistence partielle — ne pas y ajouter de nouveau code :
 | ~~`api/app/Services/`~~ — répertoire **supprimé** (2026-08-11, #1728), ne rien y ajouter | `Modules/<Name>/Infrastructure/Services/` |
 | `api/app/Exceptions/` (base `DomainException` partagée, encore étendue par des modules) | `Modules/<Name>/Domain/Exceptions/` |
 
-## Modules existants (18 modules)
+## Modules existants (19 modules)
 
 | Module | Domaine couvert |
 |---|---|
@@ -24,6 +24,7 @@ Dossiers encore en coexistence partielle — ne pas y ajouter de nouveau code :
 | `Billing` | Abonnements, webhooks Stripe, facturation |
 | `Cabinet` | Gestion documentaire, partage |
 | `Cameras` | Surveillance, streaming |
+| `CRM` | CRM client tenant (comptes, contacts, leads, opportunités — programme V0/V1, issue #5705+) |
 | `EdgeSync` | Synchronisation offline/mobile (structure spécialisée, hors squelette DDD standard) |
 | `Expense` | Notes de frais employés |
 | `Fleet` | Véhicules, trajets, affectations |


### PR DESCRIPTION
Closes #5707 (CRM-V0-03)

## Objectif
Créer le squelette DDD du module CRM client sans absorber Platform/Marketing et sans logique métier prématurée.

## Livrables
- **`api/app/Modules/CRM/`** : couches `Application/` `Domain/` `Infrastructure/` `Interfaces/` `Providers/` présentes (squelette, README par couche).
- **`CrmServiceProvider`** enregistré dans `api/bootstrap/providers.php` (section CRM client, après `CamerasServiceProvider`).
- **Aucun import vers `Platform`/`Marketing`** : garde d'isolation #5584 vérifiée (0 nouvel import croisé).
- **Docs d'architecture ×4 mises à jour** (parité #5589, module fantôme zéro) : `ARCHITECTURE.md` (19 modules actifs), `docs/ARCHITECTURE_STATUS.md` (ligne CRM 🆕), `docs/CONTRIBUTING_DDD.md`, `api/ARCHITECTURE.md` (ligne `Modules/CRM`, provider).
- CHANGELOG.md mis à jour.

## Vérifications locales
- check-architecture-docs-parity.sh : OK (19 modules ×4, 0 fantôme).
- check-module-isolation.sh : OK (0 nouvel import croisé).
- Structure : 5 couches présentes (Module Structure Validator compatible).

## DoD
- Aucune logique métier (squelette pur) — les migrations/models/controllers arrivent dans CRM-V0-04+.
- Le CRM commercial Leopardo (Platform/Marketing) n'est pas modifié (ADR-CRM-001/002).

---
[PM] Re-check mergeability (base branch updated after #5734 merge).