### PR TITLE
feat(crm): migrations tenant leads/pipelines/opportunities (#5709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- **feat(crm): tables tenant-scoped leads / pipelines / opportunités (issue #5709) — company_id uuid non nullable, contraintes CHECK (status/source/score), index scope tenant d'abord, softDeletes (archivage), zero FK inter-lots (découplage #5708 en cours).** Gardes migrations (collision #1962 + convention #1613) verts ; tests fresh + rollback 6/6.
+
 - **fix(ci): garde inter-PR des préfixes de migrations (#5437) — faux positif sur push main : baseSha vide faisait considérer toutes les migrations de main comme nouvelles et les comparer aux PRs ouvertes (collision fantôme dès quune PR est ouverte).** Le contrôle ne sapplique plus quaux PRs ouvertes ; bug latent du mode --local (currentNewNames) corrigé au passage — tests 8/8.
 - **docs(api): note ops — healthcheck (GET /api/v1/health, match PROGRAM_VERSION, uptime < 900 s), CORS E2E (origine 127.0.0.1:4173 whitelistée, déploiement requis), incident Redis (healthcheck fail-closed).**
 

--- a/api/database/migrations/tenant/2026_08_28_000001_5709_create_crm_leads_table.php
+++ b/api/database/migrations/tenant/2026_08_28_000001_5709_create_crm_leads_table.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #5709 — CRM V0 : table tenant-scoped des leads client.
+ *
+ * Le CRM client (espaces client / API tenant) est distinct du CRM commercial
+ * Leopardo (Platform/Marketing, schéma public) — voir ADR-CRM-DUAL-CONTEXTS.
+ *
+ * Isolation tenant :
+ * - `company_id` uuid NON nullable, indexé — toute donnée client appartient
+ *   à une entreprise ; le filtrage cross-tenant est garanti par
+ *   BelongsToCompany + Policies (aucune requête sans tenant).
+ * - Aucune relation cross-tenant possible : pas de FK vers des tables hors
+ *   périmètre, les références d'owner (users) sont par uuid sans FK.
+ *
+ * PII : email/phone sont des données personnelles. La stratégie HMAC
+ * (lookup exact irréversible) et le chiffrement AES-256 au repos sont
+ * documentés dans docs/security/CRM_PII_HMAC.md (issue #5713) — les
+ * colonnes restent en clair pour l'exploitation tant que la stratégie
+ * n'est pas appliquée (consolidation programmée avec le module CRM).
+ *
+ * Archivage : softDeletes (une donnée client archivée reste récupérable
+ * sous contrôle, et l'audit RGPD exige la traçabilité des suppressions).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! schemaTableExists('crm_leads')) {
+            Schema::create('crm_leads', function (Blueprint $table): void {
+                $table->id();
+                $table->uuid('company_id');
+                // Rattachement futur à un compte (#5708) — colonne uuid sans
+                // FK tant que les tables accounts/contacts ne sont pas livrées
+                // (découplage : aucune relation cross-tenant possible).
+                $table->uuid('account_id')->nullable();
+                // Owner (utilisateur) — uuid sans FK, résolu par l'application.
+                $table->uuid('owner_id')->nullable();
+
+                $table->string('first_name', 120)->nullable();
+                $table->string('last_name', 120)->nullable();
+                // PII — voir docs/security/CRM_PII_HMAC.md (#5713).
+                $table->string('email', 255)->nullable();
+                $table->string('phone', 40)->nullable();
+                $table->string('company_name', 255)->nullable();
+                $table->string('title', 255)->nullable();
+                // web | referral | import | manual | other
+                $table->string('source', 20)->default('manual');
+                // new | contacted | qualified | converted | rejected
+                $table->string('status', 20)->default('new');
+                $table->unsignedSmallInteger('score')->default(0);
+                $table->json('tags')->nullable();
+                $table->text('notes')->nullable();
+                $table->timestamp('converted_at')->nullable();
+                $table->timestamps();
+                $table->softDeletes();
+
+                // Index de requêtage : scope tenant d'abord (préfixe company_id).
+                $table->index(['company_id', 'status'], 'crm_leads_company_status_idx');
+                $table->index(['company_id', 'owner_id'], 'crm_leads_company_owner_idx');
+                $table->index(['company_id', 'created_at'], 'crm_leads_company_created_idx');
+                $table->index(['company_id', 'email'], 'crm_leads_company_email_idx');
+            });
+        }
+
+        // Contraintes de domaine CHECK (PostgreSQL — pattern DB::statement du
+        // repo, cf. backfill #5588). Résolution du schéma via search_path.
+        $schema = resolveTableSchema('crm_leads');
+        if ($schema !== null) {
+            $qualified = "{$schema}.crm_leads";
+            DB::statement("ALTER TABLE {$qualified} ADD CONSTRAINT crm_leads_status_check CHECK (status IN ('new', 'contacted', 'qualified', 'converted', 'rejected'))");
+            DB::statement("ALTER TABLE {$qualified} ADD CONSTRAINT crm_leads_source_check CHECK (source IN ('web', 'referral', 'import', 'manual', 'other'))");
+            DB::statement("ALTER TABLE {$qualified} ADD CONSTRAINT crm_leads_score_check CHECK (score BETWEEN 0 AND 100)");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('crm_leads');
+    }
+};

--- a/api/database/migrations/tenant/2026_08_28_000002_5709_create_crm_pipelines_table.php
+++ b/api/database/migrations/tenant/2026_08_28_000002_5709_create_crm_pipelines_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #5709 — CRM V0 : table tenant-scoped des pipelines commerciaux.
+ *
+ * Un pipeline est un jeu d'étapes (stages) ordonné, propre à une entreprise.
+ * Les opportunités (#5709) s'y rattachent par `pipeline_id` (uuid, sans FK —
+ * découplage tant que le module CRM complet n'est pas livré).
+ *
+ * Isolation tenant : `company_id` uuid NON nullable ; unicité du nom PAR
+ * entreprise (`crm_pipelines_company_name_unique`) — deux entreprises
+ * peuvent avoir un pipeline « Ventes » sans collision.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! schemaTableExists('crm_pipelines')) {
+            Schema::create('crm_pipelines', function (Blueprint $table): void {
+                $table->id();
+                $table->uuid('company_id');
+                $table->string('name', 120);
+                // Pipeline par défaut de l'entreprise (un seul possible).
+                $table->boolean('is_default')->default(false);
+                // Étapes ordonnées : json [{"key":"prospection","label":"Prospection","probability":10}, ...]
+                $table->json('stages');
+                $table->timestamps();
+                $table->softDeletes();
+
+                $table->unique(['company_id', 'name'], 'crm_pipelines_company_name_unique');
+                $table->index(['company_id', 'is_default'], 'crm_pipelines_company_default_idx');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('crm_pipelines');
+    }
+};

--- a/api/database/migrations/tenant/2026_08_28_000003_5709_create_crm_opportunities_table.php
+++ b/api/database/migrations/tenant/2026_08_28_000003_5709_create_crm_opportunities_table.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #5709 — CRM V0 : table tenant-scoped des opportunités.
+ *
+ * Une opportunité est une affaire en cours rattachée à un pipeline et
+ * (optionnellement) à un lead. `amount` est le montant attendu, `stage`
+ * l'étape courante du pipeline, `status` l'état final de l'affaire.
+ *
+ * Isolation tenant : `company_id` uuid NON nullable, en tête de tous les
+ * index composés (scope tenant d'abord). Références pipeline/lead/owner par
+ * uuid SANS FK (découplage inter-lots : tables #5708 / module CRM en cours).
+ *
+ * Archivage : softDeletes.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! schemaTableExists('crm_opportunities')) {
+            Schema::create('crm_opportunities', function (Blueprint $table): void {
+                $table->id();
+                $table->uuid('company_id');
+                $table->uuid('pipeline_id')->nullable();
+                $table->uuid('lead_id')->nullable();
+                $table->uuid('owner_id')->nullable();
+
+                $table->string('name', 255);
+                $table->string('stage', 80)->default('prospection');
+                $table->decimal('amount', 14, 2)->nullable();
+                $table->char('currency', 3)->nullable();
+                $table->date('expected_close_date')->nullable();
+                // open | won | lost
+                $table->string('status', 10)->default('open');
+                $table->text('notes')->nullable();
+                $table->timestamps();
+                $table->softDeletes();
+
+                // Index de requêtage pipeline/stage/owner/date (critère #5709).
+                $table->index(['company_id', 'pipeline_id', 'stage'], 'crm_opp_company_pipeline_stage_idx');
+                $table->index(['company_id', 'owner_id'], 'crm_opp_company_owner_idx');
+                $table->index(['company_id', 'expected_close_date'], 'crm_opp_company_close_date_idx');
+                $table->index(['company_id', 'status'], 'crm_opp_company_status_idx');
+            });
+        }
+
+        $schema = resolveTableSchema('crm_opportunities');
+        if ($schema !== null) {
+            DB::statement("ALTER TABLE {$schema}.crm_opportunities ADD CONSTRAINT crm_opportunities_status_check CHECK (status IN ('open', 'won', 'lost'))");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('crm_opportunities');
+    }
+};

--- a/api/tests/Feature/CRM/CrmV0MigrationsTest.php
+++ b/api/tests/Feature/CRM/CrmV0MigrationsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CRM;
+
+use Illuminate\Support\Facades\DB;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/** Contrat minimal des migrations testées (up/down). */
+interface CrmV0DownableMigration
+{
+    public function up(): void;
+
+    public function down(): void;
+}
+
+/**
+ * Issue #5709 — CRM V0 : migrations tenant leads / pipelines / opportunités.
+ *
+ * Vérifie, sur base fraîche (RefreshTenantDatabase) :
+ *   1. le placement des tables dans le schéma tenant (search_path) ;
+ *   2. les colonnes obligatoires (company_id non nullable) ;
+ *   3. les contraintes de domaine CHECK (status, source, score) ;
+ *   4. les index de requêtage (scope tenant d'abord) ;
+ *   5. le rollback (down) qui supprime les tables.
+ */
+class CrmV0MigrationsTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private const TABLES = [
+        'crm_leads',
+        'crm_pipelines',
+        'crm_opportunities',
+    ];
+
+    private function tenantSchema(): string
+    {
+        // Les migrations tenant résolvent le schéma via le search_path
+        // (convention #1613) ; en CI locale le schéma tenant est
+        // `shared_tenants` (config search_path de test).
+        $row = DB::selectOne(
+            "SELECT current_schemas(false) AS schemas"
+        );
+
+        $schemas = $row ? (string) $row->schemas : '';
+
+        return str_contains($schemas, 'shared_tenants') ? 'shared_tenants' : 'public';
+    }
+
+    public function test_crm_tables_are_created_in_tenant_schema(): void
+    {
+        $schema = $this->tenantSchema();
+
+        foreach (self::TABLES as $table) {
+            $row = DB::selectOne(
+                'SELECT 1 FROM information_schema.tables
+                 WHERE table_schema = ? AND table_name = ?',
+                [$schema, $table]
+            );
+            $this->assertNotNull($row, "table {$table} absente du schéma tenant {$schema}");
+        }
+    }
+
+    public function test_leads_columns_company_id_not_nullable(): void
+    {
+        $schema = $this->tenantSchema();
+
+        // company_id : colonne uuid NON nullable (isolation tenant obligatoire).
+        $row = DB::selectOne(
+            'SELECT is_nullable FROM information_schema.columns
+             WHERE table_schema = ? AND table_name = ? AND column_name = ?',
+            [$schema, 'crm_leads', 'company_id']
+        );
+        $this->assertNotNull($row);
+        $this->assertSame('NO', (string) $row->is_nullable);
+
+        // Colonnes PII présentes (la stratégie HMAC #5713 s'appliquera à elles).
+        foreach (['email', 'phone', 'first_name', 'last_name'] as $col) {
+            $c = DB::selectOne(
+                'SELECT 1 FROM information_schema.columns
+                 WHERE table_schema = ? AND table_name = ? AND column_name = ?',
+                [$schema, 'crm_leads', $col]
+            );
+            $this->assertNotNull($c, "colonne {$col} absente de crm_leads");
+        }
+    }
+
+    public function test_leads_check_constraints_are_enforced(): void
+    {
+        $schema = $this->tenantSchema();
+
+        $checks = DB::select(
+            'SELECT conname FROM pg_constraint
+             WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname = ?)
+               AND contype = \'c\'
+               AND conrelid = (SELECT oid FROM pg_class
+                               WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = ?)
+                                 AND relname = ?)',
+            [$schema, $schema, 'crm_leads']
+        );
+        $names = array_map(static fn ($r) => (string) $r->conname, $checks);
+
+        $this->assertContains('crm_leads_status_check', $names);
+        $this->assertContains('crm_leads_source_check', $names);
+        $this->assertContains('crm_leads_score_check', $names);
+    }
+
+    public function test_opportunities_check_constraint_status(): void
+    {
+        $schema = $this->tenantSchema();
+
+        $check = DB::selectOne(
+            'SELECT 1 FROM pg_constraint
+             WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname = ?)
+               AND contype = \'c\'
+               AND conname = ?',
+            [$schema, 'crm_opportunities_status_check']
+        );
+        $this->assertNotNull($check);
+    }
+
+    public function test_crm_indexes_are_present(): void
+    {
+        $schema = $this->tenantSchema();
+
+        $expected = [
+            'crm_leads_company_status_idx',
+            'crm_leads_company_owner_idx',
+            'crm_leads_company_created_idx',
+            'crm_leads_company_email_idx',
+            'crm_pipelines_company_name_unique',
+            'crm_pipelines_company_default_idx',
+            'crm_opp_company_pipeline_stage_idx',
+            'crm_opp_company_owner_idx',
+            'crm_opp_company_close_date_idx',
+            'crm_opp_company_status_idx',
+        ];
+
+        $rows = DB::select(
+            'SELECT indexname FROM pg_indexes WHERE schemaname = ?',
+            [$schema]
+        );
+        $names = array_map(static fn ($r) => (string) $r->indexname, $rows);
+
+        foreach ($expected as $index) {
+            $this->assertContains($index, $names, "index {$index} absent");
+        }
+    }
+
+    public function test_rollback_drops_crm_tables(): void
+    {
+        $schema = $this->tenantSchema();
+
+        // Le runner global `migrate:rollback --path=tenant` est fragile ici :
+        // le repo `migrations` de shared_tenants contient des entrées dont les
+        // fichiers vivent dans public/ (état historique) → « Migration not
+        // found ». On teste donc le down() de chaque migration directement,
+        // ce qui est le contrat réel du rollback (#5709 : fresh + rollback
+        // testés).
+        $files = [
+            '2026_08_28_000001_5709_create_crm_leads_table.php',
+            '2026_08_28_000002_5709_create_crm_pipelines_table.php',
+            '2026_08_28_000003_5709_create_crm_opportunities_table.php',
+        ];
+
+        foreach ($files as $file) {
+            /** @var CrmV0DownableMigration $migration */
+            $migration = require database_path('migrations/tenant/'.$file);
+            $migration->down();
+        }
+
+        foreach (self::TABLES as $table) {
+            $row = DB::selectOne(
+                'SELECT 1 FROM information_schema.tables
+                 WHERE table_schema = ? AND table_name = ?',
+                [$schema, $table]
+            );
+            $this->assertNull($row, "table {$table} devrait être supprimée par down()");
+
+            // Restaurer pour ne pas laisser la base fraîche des tests suivants
+            // sans les tables (les down() ci-dessus sortent du runner).
+            /** @var CrmV0DownableMigration $migration */
+            $migration = require database_path('migrations/tenant/'.$files[array_search($table, self::TABLES, true)]);
+            $migration->up();
+        }
+    }
+}


### PR DESCRIPTION
## Issue #5709 — migrations tenant CRM leads / pipelines / opportunités

Tables tenant-scoped du CRM client (espaces client / API tenant — distinct du CRM commercial Platform/Marketing) :

- **crm_leads** : `company_id` uuid **non nullable**, PII email/phone (stratégie HMAC #5713 documentée dans le fichier), statut/source/score avec **contraintes CHECK PostgreSQL** (`DB::statement` — pattern repo #5588), 4 indexes composés scope-tenant, `softDeletes` (archivage traçable RGPD).
- **crm_pipelines** : jeux d'étapes (stages json) par entreprise, `unique(company_id, name)`, pipeline par défaut.
- **crm_opportunities** : affaires liées pipeline/lead par uuid **sans FK** (découplage inter-lots : tables accounts/contacts #5708 livrées par un autre lot — aucune relation cross-tenant possible), CHECK `status IN (open|won|lost)`, indexes pipeline/stage/owner/date.

## Critères d'acceptation
- [x] États et contraintes CHECK documentés (docblocks + contraintes nommées)
- [x] Relations cross-tenant impossibles (company_id partout, aucun FK hors périmètre)
- [x] Indexes pipeline/stage/owner/date présents (scope tenant d'abord)
- [x] Migration collision guard vert (basenames + préfixes #1962, convention #1613)

## Vérification
- Tests écrits avant implémentation : `CrmV0MigrationsTest` (placement schéma tenant, colonnes non nullables, CHECK, indexes, rollback `down()`) — **6/6 verts** en local
- PHPStan strict : 0 erreur
- `check-migration-basename-collisions.sh` ✅, `check-migrations-tenant-schema.sh` ✅

Closes #5709