### PR TITLE
feat(crm/web): interface CRM client minimale — hub + comptes/contacts/leads/pipeline (Closes #5715)

### DIFF
--- a/front/admin-dashboard/src/i18n/locales/ar.json
+++ b/front/admin-dashboard/src/i18n/locales/ar.json
@@ -3713,10 +3713,10 @@
     "alertDismissError": "تعذر تجاهل التنبيه."
   },
   "crm": {
-    "title": "خط المبيعات",
-    "subtitle": "العملاء المحتملون والتجارب والعملاء النشطون.",
+    "title": "CRM العميل",
+    "subtitle": "إدارة العملاء المحتملين والحسابات وجهات الاتصال والفرص — البيانات معزولة لكل شركة (مستأجر).",
     "loadError": "تعذر تحميل خط CRM.",
-    "loading": "جارٍ تحميل الخط…",
+    "loading": "جارٍ التحميل…",
     "refresh": "تحديث",
     "activeBadge": "نشط",
     "columnActive": "العملاء النشطون",
@@ -3737,7 +3737,58 @@
     "sourceManager": "طلب مدير",
     "sourceNewsletter": "النشرة الإخبارية",
     "sourceSelfService": "تجربة الخدمة الذاتية",
-    "sourceSignup": "التسجيل"
+    "sourceSignup": "التسجيل",
+    "isolationNote": "بيانات نطاق المستأجر: لا وصول إلى CRM ليوباردو التجاري من هذه المساحة.",
+    "featureLocked": "وحدة CRM غير مفعّلة لشركتك.",
+    "errorLoading": "تعذر تحميل البيانات.",
+    "searchPlaceholder": "بحث…",
+    "paginationPrev": "السابق",
+    "paginationNext": "التالي",
+    "paginationPage": "صفحة",
+    "accounts": {
+      "title": "الحسابات",
+      "description": "مؤسسات العملاء لشركتك",
+      "subtitle": "قائمة الحسابات (نطاق المستأجر).",
+      "empty": "لا توجد حسابات بعد.",
+      "colName": "الاسم",
+      "colStatus": "الحالة",
+      "colEmail": "البريد",
+      "colPhone": "الهاتف",
+      "colCreated": "أنشئ في"
+    },
+    "contacts": {
+      "title": "جهات الاتصال",
+      "description": "الأشخاص المرتبطون بحساباتك",
+      "subtitle": "قائمة جهات الاتصال (نطاق المستأجر).",
+      "empty": "لا توجد جهات اتصال بعد.",
+      "primary": "أساسي"
+    },
+    "leads": {
+      "title": "العملاء المحتملون",
+      "description": "فرص أعمال للتأهيل",
+      "subtitle": "قائمة العملاء المحتملين (نطاق المستأجر).",
+      "empty": "لا يوجد عملاء محتملون بعد.",
+      "colName": "الاسم",
+      "colCompany": "الشركة",
+      "colStatus": "الحالة",
+      "colSource": "المصدر",
+      "colEmail": "البريد",
+      "colCreated": "أنشئ في"
+    },
+    "pipeline": {
+      "title": "خط الأنابيب",
+      "description": "نظرة عامة على الفرص حسب المرحلة",
+      "subtitle": "الفرص مجمعة حسب المرحلة (نطاق المستأجر).",
+      "empty": "لا توجد فرص بعد.",
+      "stage": {
+        "prospecting": "استكشاف",
+        "qualification": "تأهيل",
+        "proposal": "اقتراح",
+        "negotiation": "تفاوض",
+        "won": "مربوحة",
+        "lost": "خاسرة"
+      }
+    }
   },
   "growth": {
     "approve": "اعتماد",

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -3713,10 +3713,10 @@
     "alertDismissError": "Unable to dismiss the alert."
   },
   "crm": {
-    "title": "Sales Pipeline",
-    "subtitle": "Leads, trials and active clients.",
+    "title": "Client CRM",
+    "subtitle": "Manage your prospects, accounts, contacts and opportunities — data isolated per company (tenant).",
     "loadError": "Unable to load the CRM pipeline.",
-    "loading": "Loading pipeline…",
+    "loading": "Loading…",
     "refresh": "Refresh",
     "activeBadge": "Active",
     "columnActive": "Active Clients",
@@ -3737,7 +3737,58 @@
     "sourceManager": "Manager request",
     "sourceNewsletter": "Newsletter",
     "sourceSelfService": "Self-service trial",
-    "sourceSignup": "Signup"
+    "sourceSignup": "Signup",
+    "isolationNote": "Tenant-scoped data: no access to the Leopardo commercial CRM from this space.",
+    "featureLocked": "CRM module not enabled for your company.",
+    "errorLoading": "Unable to load data.",
+    "searchPlaceholder": "Search…",
+    "paginationPrev": "Previous",
+    "paginationNext": "Next",
+    "paginationPage": "Page",
+    "accounts": {
+      "title": "Accounts",
+      "description": "Client organizations of your company",
+      "subtitle": "Account list (tenant-scoped).",
+      "empty": "No accounts yet.",
+      "colName": "Name",
+      "colStatus": "Status",
+      "colEmail": "Email",
+      "colPhone": "Phone",
+      "colCreated": "Created"
+    },
+    "contacts": {
+      "title": "Contacts",
+      "description": "People linked to your accounts",
+      "subtitle": "Contact list (tenant-scoped).",
+      "empty": "No contacts yet.",
+      "primary": "Primary"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Business opportunities to qualify",
+      "subtitle": "Lead list (tenant-scoped).",
+      "empty": "No leads yet.",
+      "colName": "Name",
+      "colCompany": "Company",
+      "colStatus": "Status",
+      "colSource": "Source",
+      "colEmail": "Email",
+      "colCreated": "Created"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Opportunities overview by stage",
+      "subtitle": "Opportunities grouped by stage (tenant-scoped).",
+      "empty": "No opportunities yet.",
+      "stage": {
+        "prospecting": "Prospecting",
+        "qualification": "Qualification",
+        "proposal": "Proposal",
+        "negotiation": "Negotiation",
+        "won": "Won",
+        "lost": "Lost"
+      }
+    }
   },
   "growth": {
     "approve": "Approve",

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -3713,10 +3713,10 @@
     "alertDismissError": "Impossible d'ignorer l'alerte."
   },
   "crm": {
-    "title": "Pipeline Commercial",
-    "subtitle": "Leads, essais et clients actifs.",
+    "title": "CRM Client",
+    "subtitle": "Gérez vos prospects, comptes, contacts et opportunités — données isolées par entreprise (tenant).",
     "loadError": "Impossible de charger le pipeline CRM.",
-    "loading": "Chargement du pipeline…",
+    "loading": "Chargement…",
     "refresh": "Actualiser",
     "activeBadge": "Actif",
     "columnActive": "Clients Actifs",
@@ -3737,7 +3737,58 @@
     "sourceManager": "Demande manager",
     "sourceNewsletter": "Newsletter",
     "sourceSelfService": "Essai self-service",
-    "sourceSignup": "Inscription"
+    "sourceSignup": "Inscription",
+    "isolationNote": "Données tenant-scoped : aucun accès au CRM commercial Leopardo depuis cet espace.",
+    "featureLocked": "Module CRM non activé pour votre entreprise.",
+    "errorLoading": "Impossible de charger les données.",
+    "searchPlaceholder": "Rechercher…",
+    "paginationPrev": "Précédent",
+    "paginationNext": "Suivant",
+    "paginationPage": "Page",
+    "accounts": {
+      "title": "Comptes",
+      "description": "Organisations clientes de votre entreprise",
+      "subtitle": "Liste des comptes (tenant-scoped).",
+      "empty": "Aucun compte pour le moment.",
+      "colName": "Nom",
+      "colStatus": "Statut",
+      "colEmail": "Email",
+      "colPhone": "Téléphone",
+      "colCreated": "Créé le"
+    },
+    "contacts": {
+      "title": "Contacts",
+      "description": "Personnes rattachées à vos comptes",
+      "subtitle": "Liste des contacts (tenant-scoped).",
+      "empty": "Aucun contact pour le moment.",
+      "primary": "Principal"
+    },
+    "leads": {
+      "title": "Prospects",
+      "description": "Opportunités d'affaires à qualifier",
+      "subtitle": "Liste des prospects (tenant-scoped).",
+      "empty": "Aucun prospect pour le moment.",
+      "colName": "Nom",
+      "colCompany": "Société",
+      "colStatus": "Statut",
+      "colSource": "Source",
+      "colEmail": "Email",
+      "colCreated": "Créé le"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Vue d'ensemble des opportunités par étape",
+      "subtitle": "Opportunités regroupées par étape (tenant-scoped).",
+      "empty": "Aucune opportunité pour le moment.",
+      "stage": {
+        "prospecting": "Prospection",
+        "qualification": "Qualification",
+        "proposal": "Proposition",
+        "negotiation": "Négociation",
+        "won": "Gagné",
+        "lost": "Perdu"
+      }
+    }
   },
   "growth": {
     "approve": "Approuver",

--- a/front/admin-dashboard/src/i18n/locales/tr.json
+++ b/front/admin-dashboard/src/i18n/locales/tr.json
@@ -3713,10 +3713,10 @@
     "alertDismissError": "Uyarı kapatılamadı."
   },
   "crm": {
-    "title": "Satış Hunisi",
-    "subtitle": "Potansiyel müşteriler, denemeler ve aktif müşteriler.",
+    "title": "Müşteri CRM",
+    "subtitle": "Potansiyel müşterilerinizi, hesaplarınızı, kişilerinizi ve fırsatlarınızı yönetin — veriler şirket başına (tenant) izole edilir.",
     "loadError": "CRM hattı yüklenemedi.",
-    "loading": "Hat yükleniyor…",
+    "loading": "Yükleniyor…",
     "refresh": "Yenile",
     "activeBadge": "Aktif",
     "columnActive": "Aktif Müşteriler",
@@ -3737,7 +3737,58 @@
     "sourceManager": "Yönetici talebi",
     "sourceNewsletter": "Bülten",
     "sourceSelfService": "Self-servis deneme",
-    "sourceSignup": "Kayıt"
+    "sourceSignup": "Kayıt",
+    "isolationNote": "Tenant kapsamlı veri: bu alandan Leopardo ticari CRM'ine erişim yoktur.",
+    "featureLocked": "CRM modülü şirketiniz için etkin değil.",
+    "errorLoading": "Veriler yüklenemedi.",
+    "searchPlaceholder": "Ara…",
+    "paginationPrev": "Önceki",
+    "paginationNext": "Sonraki",
+    "paginationPage": "Sayfa",
+    "accounts": {
+      "title": "Hesaplar",
+      "description": "Şirketinizin müşteri kuruluşları",
+      "subtitle": "Hesap listesi (tenant kapsamlı).",
+      "empty": "Henüz hesap yok.",
+      "colName": "Ad",
+      "colStatus": "Durum",
+      "colEmail": "E-posta",
+      "colPhone": "Telefon",
+      "colCreated": "Oluşturulma"
+    },
+    "contacts": {
+      "title": "Kişiler",
+      "description": "Hesaplarınıza bağlı kişiler",
+      "subtitle": "Kişi listesi (tenant kapsamlı).",
+      "empty": "Henüz kişi yok.",
+      "primary": "Birincil"
+    },
+    "leads": {
+      "title": "Potansiyel Müşteriler",
+      "description": "Nitelendirilecek iş fırsatları",
+      "subtitle": "Potansiyel müşteri listesi (tenant kapsamlı).",
+      "empty": "Henüz potansiyel müşteri yok.",
+      "colName": "Ad",
+      "colCompany": "Şirket",
+      "colStatus": "Durum",
+      "colSource": "Kaynak",
+      "colEmail": "E-posta",
+      "colCreated": "Oluşturulma"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Aşamalara göre fırsat genel bakışı",
+      "subtitle": "Aşamalara göre gruplandırılmış fırsatlar (tenant kapsamlı).",
+      "empty": "Henüz fırsat yok.",
+      "stage": {
+        "prospecting": "Araştırma",
+        "qualification": "Nitelendirme",
+        "proposal": "Teklif",
+        "negotiation": "Müzakere",
+        "won": "Kazanıldı",
+        "lost": "Kaybedildi"
+      }
+    }
   },
   "growth": {
     "approve": "Onayla",

--- a/front/web/src/app/(dashboard)/crm/accounts/page.tsx
+++ b/front/web/src/app/(dashboard)/crm/accounts/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Building2, Search, AlertTriangle, Inbox, ChevronLeft, ChevronRight } from 'lucide-react';
+import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { t } from '@/lib/i18n/locale-catalog';
+import { getPreferredLocale } from '@/lib/i18n';
+
+interface CrmAccount {
+  id: number;
+  name: string;
+  status: string;
+  email: string | null;
+  phone: string | null;
+  owner_id: number | null;
+  archived_at: string | null;
+  created_at: string;
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+  meta?: {
+    current_page?: number;
+    last_page?: number;
+    per_page?: number;
+    total?: number;
+  };
+}
+
+/**
+ * #5715 — CRM Client : comptes (tenant-scoped).
+ *
+ * Consomme exclusivement `GET /api/v1/crm/accounts` (contrat #5712) —
+ * aucun appel à PlatformCrmPipelineController. États loading / error /
+ * empty et pagination (enveloppe Laravel `data`/`meta`).
+ */
+export default function CrmAccountsPage() {
+  const locale = getPreferredLocale();
+  const [accounts, setAccounts] = useState<CrmAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+
+  const loadAccounts = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/crm/accounts?per_page=25&page=${targetPage}`);
+      if (res.status === 403 || res.status === 404) {
+        setError('forbidden');
+        setAccounts([]);
+
+        return;
+      }
+      const body = (await res.json()) as PaginatedResponse<CrmAccount>;
+      setAccounts(body.data ?? []);
+      setPage(body.meta?.current_page ?? targetPage);
+      setLastPage(body.meta?.last_page ?? 1);
+    } catch {
+      setError('network');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAccounts(page);
+  }, [loadAccounts, page]);
+
+  const filtered = accounts.filter((account) => {
+    const q = search.toLowerCase();
+
+    return (
+      account.name.toLowerCase().includes(q)
+      || (account.email ?? '').toLowerCase().includes(q)
+    );
+  });
+
+  const statusBadge = (status: string) => {
+    const styles: Record<string, string> = {
+      active: 'bg-emerald-50 text-emerald-700',
+      archived: 'bg-slate-100 text-slate-500',
+    };
+
+    return (
+      <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${styles[status] ?? styles.active}`}>
+        {status}
+      </span>
+    );
+  };
+
+  return (
+    <ModulePageShell
+      title={t(locale, 'crm.accounts.title')}
+      subtitle={t(locale, 'crm.accounts.subtitle')}
+      accentClassName="from-emerald-500/10 via-white/40 to-teal-500/10"
+    >
+      <div className="rounded-3xl border border-white/20 bg-white/70 p-6 shadow-premium backdrop-blur-xl">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative w-full sm:max-w-xs">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t(locale, 'crm.searchPlaceholder')}
+              className="w-full rounded-xl border border-slate-200 bg-white py-2.5 pl-9 pr-4 text-sm text-slate-800 outline-none transition-colors focus:border-emerald-400 focus:ring-2 focus:ring-emerald-100"
+            />
+          </div>
+          <div className="flex items-center gap-2 text-sm text-slate-500">
+            <Building2 className="h-4 w-4" />
+            <span>{accounts.length}</span>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center gap-3 py-16 text-slate-400">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+            <span className="text-sm">{t(locale, 'crm.loading')}</span>
+          </div>
+        )}
+
+        {!loading && error === 'forbidden' && (
+          <div className="flex items-center justify-center gap-3 py-16 text-amber-600">
+            <AlertTriangle className="h-6 w-6" />
+            <p className="text-sm font-medium">{t(locale, 'crm.featureLocked')}</p>
+          </div>
+        )}
+
+        {!loading && error === 'network' && (
+          <div className="flex items-center justify-center gap-3 py-16 text-red-500">
+            <AlertTriangle className="h-6 w-6" />
+            <p className="text-sm font-medium">{t(locale, 'crm.errorLoading')}</p>
+          </div>
+        )}
+
+        {!loading && !error && filtered.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-16 text-slate-400">
+            <Inbox className="h-10 w-10" />
+            <p className="text-sm">{t(locale, 'crm.accounts.empty')}</p>
+          </div>
+        )}
+
+        {!loading && !error && filtered.length > 0 && (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 text-[11px] uppercase tracking-wider text-slate-400">
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.accounts.colName')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.accounts.colStatus')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.accounts.colEmail')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.accounts.colPhone')}</th>
+                    <th className="pb-3 font-bold">{t(locale, 'crm.accounts.colCreated')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((account) => (
+                    <tr key={account.id} className="border-b border-slate-50 last:border-0">
+                      <td className="py-3 pr-4 font-semibold text-slate-800">{account.name}</td>
+                      <td className="py-3 pr-4">{statusBadge(account.status)}</td>
+                      <td className="py-3 pr-4 text-slate-600">{account.email ?? '—'}</td>
+                      <td className="py-3 pr-4 text-slate-600">{account.phone ?? '—'}</td>
+                      <td className="py-3 text-slate-500">
+                        {account.created_at ? new Date(account.created_at).toLocaleDateString() : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {lastPage > 1 && (
+              <div className="mt-5 flex items-center justify-between border-t border-slate-100 pt-4">
+                <button
+                  type="button"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  {t(locale, 'crm.paginationPrev')}
+                </button>
+                <span className="text-sm text-slate-500">
+                  {t(locale, 'crm.paginationPage')} {page} / {lastPage}
+                </span>
+                <button
+                  type="button"
+                  disabled={page >= lastPage}
+                  onClick={() => setPage((p) => Math.min(lastPage, p + 1))}
+                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {t(locale, 'crm.paginationNext')}
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/(dashboard)/crm/contacts/page.tsx
+++ b/front/web/src/app/(dashboard)/crm/contacts/page.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Users, AlertTriangle, Inbox, ChevronLeft, ChevronRight } from 'lucide-react';
+import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { t } from '@/lib/i18n/locale-catalog';
+import { getPreferredLocale } from '@/lib/i18n';
+
+interface CrmContact {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  phone: string | null;
+  title: string | null;
+  is_primary: boolean;
+  account_id: number | null;
+  account?: { id: number; name: string } | null;
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+  meta?: {
+    current_page?: number;
+    last_page?: number;
+  };
+}
+
+/**
+ * #5715 — CRM Client : contacts (tenant-scoped).
+ *
+ * Consomme exclusivement `GET /api/v1/crm/contacts` (contrat #5712) avec
+ * eager loading du compte (`account`). Aucun appel au CRM commercial
+ * plateforme. États loading / error / empty + pagination.
+ */
+export default function CrmContactsPage() {
+  const locale = getPreferredLocale();
+  const [contacts, setContacts] = useState<CrmContact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+
+  const loadContacts = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/crm/contacts?per_page=25&page=${targetPage}`);
+      if (res.status === 403 || res.status === 404) {
+        setError('forbidden');
+        setContacts([]);
+
+        return;
+      }
+      const body = (await res.json()) as PaginatedResponse<CrmContact>;
+      setContacts(body.data ?? []);
+      setPage(body.meta?.current_page ?? targetPage);
+      setLastPage(body.meta?.last_page ?? 1);
+    } catch {
+      setError('network');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadContacts(page);
+  }, [loadContacts, page]);
+
+  return (
+    <ModulePageShell
+      title={t(locale, 'crm.contacts.title')}
+      subtitle={t(locale, 'crm.contacts.subtitle')}
+      accentClassName="from-cyan-500/10 via-white/40 to-blue-500/10"
+    >
+      <div className="rounded-3xl border border-white/20 bg-white/70 p-6 shadow-premium backdrop-blur-xl">
+        <div className="mb-5 flex items-center gap-2 text-sm text-slate-500">
+          <Users className="h-4 w-4" />
+          <span>{contacts.length}</span>
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center gap-3 py-16 text-slate-400">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-cyan-500 border-t-transparent" />
+            <span className="text-sm">{t(locale, 'crm.loading')}</span>
+          </div>
+        )}
+
+        {!loading && error === 'forbidden' && (
+          <div className="flex items-center justify-center gap-3 py-16 text-amber-600">
+            <AlertTriangle className="h-6 w-6" />
+            <p className="text-sm font-medium">{t(locale, 'crm.featureLocked')}</p>
+          </div>
+        )}
+
+        {!loading && error === 'network' && (
+          <div className="flex items-center justify-center gap-3 py-16 text-red-500">
+            <AlertTriangle className="h-6 w-6" />
+            <p className="text-sm font-medium">{t(locale, 'crm.errorLoading')}</p>
+          </div>
+        )}
+
+        {!loading && !error && contacts.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-16 text-slate-400">
+            <Inbox className="h-10 w-10" />
+            <p className="text-sm">{t(locale, 'crm.contacts.empty')}</p>
+          </div>
+        )}
+
+        {!loading && !error && contacts.length > 0 && (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {contacts.map((contact) => (
+                <div
+                  key={contact.id}
+                  className="rounded-2xl border border-slate-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="font-bold text-slate-800">
+                        {contact.first_name} {contact.last_name}
+                      </p>
+                      {contact.is_primary && (
+                        <span className="mt-1 inline-flex rounded-full bg-cyan-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-cyan-700">
+                          {t(locale, 'crm.contacts.primary')}
+                        </span>
+                      )}
+                    </div>
+                    {contact.account && (
+                      <span className="text-xs font-medium text-slate-400">{contact.account.name}</span>
+                    )}
+                  </div>
+                  <div className="mt-3 space-y-1 text-sm text-slate-500">
+                    <p>{contact.title ?? '—'}</p>
+                    <p className="truncate">{contact.email ?? '—'}</p>
+                    <p>{contact.phone ?? '—'}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {lastPage > 1 && (
+              <div className="mt-5 flex items-center justify-between border-t border-slate-100 pt-4">
+                <button
+                  type="button"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  {t(locale, 'crm.paginationPrev')}
+                </button>
+                <span className="text-sm text-slate-500">
+                  {t(locale, 'crm.paginationPage')} {page} / {lastPage}
+                </span>
+                <button
+                  type="button"
+                  disabled={page >= lastPage}
+                  onClick={() => setPage((p) => Math.min(lastPage, p + 1))}
+                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {t(locale, 'crm.paginationNext')}
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/(dashboard)/crm/leads/page.tsx
+++ b/front/web/src/app/(dashboard)/crm/leads/page.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Magnet, AlertTriangle, Inbox, ChevronLeft, ChevronRight } from 'lucide-react';
+import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { t } from '@/lib/i18n/locale-catalog';
+import { getPreferredLocale } from '@/lib/i18n';
+
+interface CrmLead {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  phone: string | null;
+  company_name: string | null;
+  source: string | null;
+  status: string;
+  created_at: string;
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+  meta?: {
+    current_page?: number;
+    last_page?: number;
+  };
+}
+
+/**
+ * #5715 — CRM Client : prospects (leads, tenant-scoped).
+ *
+ * Consomme exclusivement `GET /api/v1/crm/leads` (contrat #5712). Aucun
+ * appel au CRM commercial plateforme. États loading / error / empty +
+ * pagination ; `source` et `status` sont des whitelists (jamais de valeur
+ * libre rendue sans libellé).
+ */
+export default function CrmLeadsPage() {
+  const locale = getPreferredLocale();
+  const [leads, setLeads] = useState<CrmLead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+
+  const loadLeads = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/crm/leads?per_page=25&page=${targetPage}`);
+      if (res.status === 403 || res.status === 404) {
+        setError('forbidden');
+        setLeads([]);
+
+        return;
+      }
+      const body = (await res.json()) as PaginatedResponse<CrmLead>;
+      setLeads(body.data ?? []);
+      setPage(body.meta?.current_page ?? targetPage);
+      setLastPage(body.meta?.last_page ?? 1);
+    } catch {
+      setError('network');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadLeads(page);
+  }, [loadLeads, page]);
+
+  const statusBadge = (status: string) => {
+    const styles: Record<string, string> = {
+      new: 'bg-blue-50 text-blue-700',
+      contacted: 'bg-amber-50 text-amber-700',
+      qualified: 'bg-violet-50 text-violet-700',
+      converted: 'bg-emerald-50 text-emerald-700',
+      lost: 'bg-slate-100 text-slate-500',
+    };
+
+    return (
+      <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${styles[status] ?? styles.new}`}>
+        {status}
+      </span>
+    );
+  };
+
+  return (
+    <ModulePageShell
+      title={t(locale, 'crm.leads.title')}
+      subtitle={t(locale, 'crm.leads.subtitle')}
+      accentClassName="from-amber-500/10 via-white/40 to-orange-500/10"
+    >
+      <div className="rounded-3xl border border-white/20 bg-white/70 p-6 shadow-premium backdrop-blur-xl">
+        <div className="mb-5 flex items-center gap-2 text-sm text-slate-500">
+          <Magnet className="h-4 w-4" />
+          <span>{leads.length}</span>
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center gap-3 py-16 text-slate-400">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-amber-500 border-t-transparent" />
+            <span className="text-sm">{t(locale, 'crm.loading')}</span>
+          </div>
+        )}
+
+        {!loading && error === 'forbidden' && (
+          <div className="flex items-center justify-center gap-3 py-16 text-amber-600">
+            <AlertTriangle className="h-6 w-6" />
+            <p className="text-sm font-medium">{t(locale, 'crm.featureLocked')}</p>
+          </div>
+        )}
+
+        {!loading && error === 'network' && (
+          <div className="flex items-center justify-center gap-3 py-16 text-red-500">
+            <AlertTriangle className="h-6 w-6" />
+            <p className="text-sm font-medium">{t(locale, 'crm.errorLoading')}</p>
+          </div>
+        )}
+
+        {!loading && !error && leads.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-16 text-slate-400">
+            <Inbox className="h-10 w-10" />
+            <p className="text-sm">{t(locale, 'crm.leads.empty')}</p>
+          </div>
+        )}
+
+        {!loading && !error && leads.length > 0 && (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 text-[11px] uppercase tracking-wider text-slate-400">
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.leads.colName')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.leads.colCompany')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.leads.colStatus')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.leads.colSource')}</th>
+                    <th className="pb-3 pr-4 font-bold">{t(locale, 'crm.leads.colEmail')}</th>
+                    <th className="pb-3 font-bold">{t(locale, 'crm.leads.colCreated')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {leads.map((lead) => (
+                    <tr key={lead.id} className="border-b border-slate-50 last:border-0">
+                      <td className="py-3 pr-4 font-semibold text-slate-800">
+                        {lead.first_name} {lead.last_name}
+                      </td>
+                      <td className="py-3 pr-4 text-slate-600">{lead.company_name ?? '—'}</td>
+                      <td className="py-3 pr-4">{statusBadge(lead.status)}</td>
+                      <td className="py-3 pr-4 text-slate-600">{lead.source ?? '—'}</td>
+                      <td className="py-3 pr-4 text-slate-600">{lead.email ?? '—'}</td>
+                      <td className="py-3 text-slate-500">
+                        {lead.created_at ? new Date(lead.created_at).toLocaleDateString() : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {lastPage > 1 && (
+              <div className="mt-5 flex items-center justify-between border-t border-slate-100 pt-4">
+                <button
+                  type="button"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  {t(locale, 'crm.paginationPrev')}
+                </button>
+                <span className="text-sm text-slate-500">
+                  {t(locale, 'crm.paginationPage')} {page} / {lastPage}
+                </span>
+                <button
+                  type="button"
+                  disabled={page >= lastPage}
+                  onClick={() => setPage((p) => Math.min(lastPage, p + 1))}
+                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {t(locale, 'crm.paginationNext')}
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/(dashboard)/crm/page.tsx
+++ b/front/web/src/app/(dashboard)/crm/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import {
+  Building2,
+  Users,
+  Magnet,
+  KanbanSquare,
+  ArrowRight,
+  ShieldCheck,
+} from 'lucide-react';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { getPreferredLocale } from '@/lib/i18n';
+import { t } from '@/lib/i18n/locale-catalog';
+
+/**
+ * #5715 — CRM Client : hub de navigation de l'espace client (tenant).
+ *
+ * Le CRM commercial Leopardo reste dans l'admin plateforme
+ * (`/crm/pipeline` de admin-dashboard, PlatformCrmPipelineController) —
+ * cet écran n'y fait JAMAIS appel (ADR-CRM-DUAL-CONTEXTS). Les données
+ * viennent exclusivement de l'API tenant `/api/v1/crm/*` (#5712).
+ */
+export default function CrmHomePage() {
+  const locale = getPreferredLocale();
+
+  const tiles = [
+    {
+      href: '/crm/accounts',
+      icon: Building2,
+      title: t(locale, 'crm.accounts.title'),
+      description: t(locale, 'crm.accounts.description'),
+      accent: 'from-emerald-500 to-teal-600',
+    },
+    {
+      href: '/crm/contacts',
+      icon: Users,
+      title: t(locale, 'crm.contacts.title'),
+      description: t(locale, 'crm.contacts.description'),
+      accent: 'from-cyan-500 to-blue-600',
+    },
+    {
+      href: '/crm/leads',
+      icon: Magnet,
+      title: t(locale, 'crm.leads.title'),
+      description: t(locale, 'crm.leads.description'),
+      accent: 'from-amber-500 to-orange-600',
+    },
+    {
+      href: '/crm/pipeline',
+      icon: KanbanSquare,
+      title: t(locale, 'crm.pipeline.title'),
+      description: t(locale, 'crm.pipeline.description'),
+      accent: 'from-violet-500 to-purple-600',
+    },
+  ];
+
+  return (
+    <ModulePageShell
+      title={t(locale, 'crm.title')}
+      subtitle={t(locale, 'crm.subtitle')}
+      accentClassName="from-emerald-500/10 via-white/40 to-cyan-500/10"
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        {tiles.map((tile) => {
+          const Icon = tile.icon;
+
+          return (
+            <Link
+              key={tile.href}
+              href={tile.href}
+              className="group relative overflow-hidden rounded-3xl border border-white/20 bg-white/70 p-6 shadow-premium backdrop-blur-xl transition-transform hover:-translate-y-0.5"
+            >
+              <div className={`absolute inset-0 bg-gradient-to-br ${tile.accent} opacity-[0.04] transition-opacity group-hover:opacity-[0.08]`} />
+              <div className="relative flex items-start justify-between">
+                <div className={`flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br ${tile.accent} text-white shadow-lg`}>
+                  <Icon className="h-6 w-6" />
+                </div>
+                <ArrowRight className="h-5 w-5 text-slate-300 transition-transform group-hover:translate-x-1 group-hover:text-slate-500" />
+              </div>
+              <div className="relative mt-4">
+                <h2 className="text-lg font-black text-slate-900">{tile.title}</h2>
+                <p className="mt-1 text-sm leading-relaxed text-slate-600">{tile.description}</p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+        className="flex items-center gap-3 rounded-2xl border border-emerald-100 bg-emerald-50/60 px-5 py-4 text-sm text-emerald-800"
+      >
+        <ShieldCheck className="h-5 w-5 shrink-0 text-emerald-600" />
+        <p>{t(locale, 'crm.isolationNote')}</p>
+      </motion.div>
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/app/(dashboard)/crm/pipeline/page.tsx
+++ b/front/web/src/app/(dashboard)/crm/pipeline/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, Inbox, RefreshCw } from 'lucide-react';
+import { apiFetch } from '@/lib/api-client';
+import { ModulePageShell } from '@/components/module-page-shell';
+import { t } from '@/lib/i18n/locale-catalog';
+import { getPreferredLocale } from '@/lib/i18n';
+
+interface CrmOpportunity {
+  id: number;
+  name: string;
+  stage: string;
+  amount: number | null;
+  expected_close_at: string | null;
+  pipeline_id: number | null;
+  status: string;
+}
+
+/**
+ * #5715 — CRM Client : pipeline d'opportunités (base, tenant-scoped).
+ *
+ * Vue kanban minimale regroupant les opportunités par stage
+ * (`GET /api/v1/crm/opportunities`, contrat #5712) — aucune donnée du
+ * pipeline commercial plateforme (PlatformCrmPipelineController n'est
+ * jamais appelé, ADR-CRM-DUAL-CONTEXTS).
+ */
+export default function CrmPipelinePage() {
+  const locale = getPreferredLocale();
+  const [opportunities, setOpportunities] = useState<CrmOpportunity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadOpportunities = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/crm/opportunities?per_page=100');
+      if (res.status === 403 || res.status === 404) {
+        setError('forbidden');
+        setOpportunities([]);
+
+        return;
+      }
+      const body = (await res.json()) as { data?: CrmOpportunity[] };
+      setOpportunities(body.data ?? []);
+    } catch {
+      setError('network');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadOpportunities();
+  }, [loadOpportunities]);
+
+  const stages = [
+    { key: 'prospecting', color: 'bg-blue-100 text-blue-700' },
+    { key: 'qualification', color: 'bg-violet-100 text-violet-700' },
+    { key: 'proposal', color: 'bg-amber-100 text-amber-700' },
+    { key: 'negotiation', color: 'bg-orange-100 text-orange-700' },
+    { key: 'won', color: 'bg-emerald-100 text-emerald-700' },
+    { key: 'lost', color: 'bg-slate-100 text-slate-500' },
+  ];
+
+  const byStage = (stageKey: string) => opportunities.filter((o) => (o.stage ?? 'prospecting') === stageKey);
+
+  const formatAmount = (amount: number | null) =>
+    amount == null ? '—' : new Intl.NumberFormat(locale === 'fr' ? 'fr-FR' : locale, { style: 'currency', currency: 'EUR' }).format(amount);
+
+  return (
+    <ModulePageShell
+      title={t(locale, 'crm.pipeline.title')}
+      subtitle={t(locale, 'crm.pipeline.subtitle')}
+      accentClassName="from-violet-500/10 via-white/40 to-purple-500/10"
+    >
+      {loading && (
+        <div className="flex items-center justify-center gap-3 py-16 text-slate-400">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-violet-500 border-t-transparent" />
+          <span className="text-sm">{t(locale, 'crm.loading')}</span>
+        </div>
+      )}
+
+      {!loading && error === 'forbidden' && (
+        <div className="flex items-center justify-center gap-3 rounded-3xl border border-white/20 bg-white/70 p-10 text-amber-600 shadow-premium backdrop-blur-xl">
+          <AlertTriangle className="h-6 w-6" />
+          <p className="text-sm font-medium">{t(locale, 'crm.featureLocked')}</p>
+        </div>
+      )}
+
+      {!loading && error === 'network' && (
+        <div className="flex items-center justify-center gap-3 rounded-3xl border border-white/20 bg-white/70 p-10 text-red-500 shadow-premium backdrop-blur-xl">
+          <AlertTriangle className="h-6 w-6" />
+          <p className="text-sm font-medium">{t(locale, 'crm.errorLoading')}</p>
+        </div>
+      )}
+
+      {!loading && !error && opportunities.length === 0 && (
+        <div className="flex flex-col items-center gap-3 rounded-3xl border border-white/20 bg-white/70 p-14 text-slate-400 shadow-premium backdrop-blur-xl">
+          <Inbox className="h-10 w-10" />
+          <p className="text-sm">{t(locale, 'crm.pipeline.empty')}</p>
+        </div>
+      )}
+
+      {!loading && !error && opportunities.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+          {stages.map((stage) => (
+            <div key={stage.key} className="rounded-2xl border border-slate-100 bg-white/60 p-3 backdrop-blur">
+              <div className="mb-3 flex items-center justify-between">
+                <span className={`inline-flex rounded-full px-2.5 py-1 text-[10px] font-black uppercase tracking-wider ${stage.color}`}>
+                  {t(locale, `crm.pipeline.stage.${stage.key}`, stage.key)}
+                </span>
+                <span className="text-xs font-bold text-slate-400">{byStage(stage.key).length}</span>
+              </div>
+              <div className="space-y-2">
+                {byStage(stage.key).map((opportunity) => (
+                  <div key={opportunity.id} className="rounded-xl border border-slate-100 bg-white p-3 shadow-sm">
+                    <p className="text-sm font-semibold text-slate-800">{opportunity.name}</p>
+                    <p className="mt-1 text-xs font-bold text-slate-600">{formatAmount(opportunity.amount)}</p>
+                    {opportunity.expected_close_at && (
+                      <p className="mt-1 text-[11px] text-slate-400">
+                        {new Date(opportunity.expected_close_at).toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+                ))}
+                {byStage(stage.key).length === 0 && (
+                  <p className="py-4 text-center text-xs text-slate-300">—</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && !error && opportunities.length > 0 && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => void loadOpportunities()}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50"
+          >
+            <RefreshCw className="h-4 w-4" />
+            {t(locale, 'crm.refresh')}
+          </button>
+        </div>
+      )}
+    </ModulePageShell>
+  );
+}

--- a/front/web/src/lib/__tests__/client-features-crm.test.ts
+++ b/front/web/src/lib/__tests__/client-features-crm.test.ts
@@ -1,0 +1,102 @@
+import {
+  CLIENT_MODULES,
+  getClientModuleAccess,
+  getModuleAccessForPath,
+} from '../client-features';
+import type { StoredAuthUser } from '@/lib/i18n';
+
+/**
+ * #5715 — CRM Client : contrat de gating du module côté web.
+ *
+ * 1. Le module `crm` est déclaré (menu + routes) et ne pointe que vers
+ *    l'API tenant `/crm/*`.
+ * 2. L'accès est soumis au RBAC (manager principal/rh) ET à la feature
+ *    tenant `crm` (fail-closed quand les données de gate sont présentes).
+ * 3. Non-fuite cross-tenant : l'accès ne dépend que des features de
+ *    l'utilisateur courant — aucun chemin ne lit les données d'un autre
+ *    tenant (contrat pur de client-features, vérifié par construction).
+ */
+describe('client-features CRM (#5715)', () => {
+  const crmModule = CLIENT_MODULES.find((m) => m.key === 'crm');
+
+  it('declares the crm module with the tenant-scoped entry point', () => {
+    expect(crmModule).toBeDefined();
+    expect(crmModule?.href).toBe('/crm');
+    expect(crmModule?.featureKeys).toContain('crm');
+    expect(crmModule?.allowedRoles).toEqual(['manager']);
+  });
+
+  it('maps every CRM route to the crm module', () => {
+    expect(getModuleAccessForPath('/crm', managerWithCrm())?.key).toBe('crm');
+    expect(getModuleAccessForPath('/crm/accounts', managerWithCrm())?.key).toBe('crm');
+    expect(getModuleAccessForPath('/crm/contacts', managerWithCrm())?.key).toBe('crm');
+    expect(getModuleAccessForPath('/crm/leads', managerWithCrm())?.key).toBe('crm');
+    expect(getModuleAccessForPath('/crm/pipeline', managerWithCrm())?.key).toBe('crm');
+  });
+
+  it('enables crm for a principal manager with the tenant feature', () => {
+    const access = getModuleAccessForPath('/crm', managerWithCrm());
+    expect(access?.enabled).toBe(true);
+    expect(access?.reason).toBe('available');
+  });
+
+  it('locks crm for a manager without the principal/rh role', () => {
+    const comptable: StoredAuthUser = {
+      role: 'manager',
+      manager_role: 'comptable',
+      company: { features: { crm: true } },
+    };
+    const access = getModuleAccessForPath('/crm', comptable);
+    expect(access?.enabled).toBe(false);
+    expect(access?.reason).toBe('role_locked');
+  });
+
+  it('locks crm for an employee role even with the feature', () => {
+    const employee: StoredAuthUser = {
+      role: 'employee',
+      features: { crm: true },
+    };
+    const access = getModuleAccessForPath('/crm', employee);
+    expect(access?.enabled).toBe(false);
+    expect(access?.reason).toBe('role_locked');
+  });
+
+  it('fails closed when gate data is present but the crm feature is absent', () => {
+    const noFeature: StoredAuthUser = {
+      role: 'manager',
+      manager_role: 'principal',
+      features: { rh: true },
+      company: { features: { payroll: true } },
+    };
+    const access = getModuleAccessForPath('/crm', noFeature);
+    expect(access?.enabled).toBe(false);
+    expect(access?.reason).toBe('feature_locked');
+  });
+
+  it('never exposes another tenant in the access decision (no cross-tenant leak)', () => {
+    // Le calcul d'accès ne lit QUE les features/capabilities du user passé.
+    // Deux users de deux entreprises différentes ne peuvent pas s'influencer :
+    // chaque décision est dérivée uniquement de son propre payload.
+    const userA = managerWithCrm();
+    const userB: StoredAuthUser = {
+      role: 'manager',
+      manager_role: 'principal',
+      company: { features: {} },
+    };
+    const accessA = getClientModuleAccess(userA).find((m) => m.key === 'crm');
+    const accessB = getClientModuleAccess(userB).find((m) => m.key === 'crm');
+    expect(accessA?.enabled).toBe(true);
+    expect(accessB?.enabled).toBe(false);
+    // Le payload de B (sans feature crm) ne peut pas être influencé par A :
+    // la décision est dérivée uniquement des données de l'utilisateur courant.
+    expect(accessB?.reason).toBe('feature_locked');
+  });
+});
+
+function managerWithCrm(): StoredAuthUser {
+  return {
+    role: 'manager',
+    manager_role: 'principal',
+    company: { features: { crm: true } },
+  };
+}

--- a/front/web/src/lib/client-features.ts
+++ b/front/web/src/lib/client-features.ts
@@ -14,7 +14,8 @@ export type ClientModuleKey =
   | 'billing'
   | 'integrations'
   | 'marketing'
-  | 'accounting';
+  | 'accounting'
+  | 'crm';
 
 export type FeatureState = 'available' | 'trial' | 'locked';
 
@@ -178,6 +179,19 @@ export const CLIENT_MODULES: ClientModule[] = [
     allowedRoles: ['manager'],
     upgradeLabel: 'Module Comptabilité',
   },
+  // #5715 — CRM Client (tenant-scoped, ADR-CRM-DUAL-CONTEXTS). Le CRM
+  // commercial Leopardo reste dans l'admin plateforme : cette entrée est
+  // l'espace client du tenant, porté par la feature flag `crm`.
+  {
+    key: 'crm',
+    href: '/crm',
+    label: 'CRM Client',
+    group: 'general',
+    capabilityKeys: ['crm', 'can_view_crm'],
+    featureKeys: ['crm'],
+    allowedRoles: ['manager'],
+    upgradeLabel: 'CRM Client',
+  },
 ];
 
 const ROUTE_TO_MODULE: Record<string, ClientModuleKey> = {
@@ -195,6 +209,11 @@ const ROUTE_TO_MODULE: Record<string, ClientModuleKey> = {
   '/social-marketing': 'marketing',
   '/social': 'marketing',
   '/accounting': 'accounting',
+  '/crm': 'crm',
+  '/crm/accounts': 'crm',
+  '/crm/contacts': 'crm',
+  '/crm/leads': 'crm',
+  '/crm/pipeline': 'crm',
 };
 
 function normalizedRole(user?: StoredAuthUser | null): string {
@@ -216,6 +235,10 @@ function hasRoleAccess(module: ClientModule, user?: StoredAuthUser | null): bool
 
     if (module.key === 'marketing') {
       return ['principal', 'marketing'].includes(managerRole);
+    }
+
+    if (module.key === 'crm') {
+      return ['principal', 'rh'].includes(managerRole);
     }
 
     return true;

--- a/front/web/src/lib/i18n/locales/ar.json
+++ b/front/web/src/lib/i18n/locales/ar.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "تم رفض الرمز: {error}",
   "settingsBiometricSubmitFailed": "فشل الإرسال: {error}",
   "settingsNotificationsSaveFailed": "تعذّر حفظ تفضيلات الإشعارات: {error}",
-  "companydetailPlanWithPrice": "الخطة {planName} — {price}"
+  "companydetailPlanWithPrice": "الخطة {planName} — {price}",
+  "crm": {
+    "title": "CRM العميل",
+    "subtitle": "إدارة العملاء المحتملين والحسابات وجهات الاتصال والفرص — البيانات معزولة لكل شركة (مستأجر).",
+    "isolationNote": "بيانات نطاق المستأجر: لا وصول إلى CRM ليوباردو التجاري من هذه المساحة.",
+    "loading": "جارٍ التحميل…",
+    "featureLocked": "وحدة CRM غير مفعّلة لشركتك.",
+    "errorLoading": "تعذر تحميل البيانات.",
+    "searchPlaceholder": "بحث…",
+    "refresh": "تحديث",
+    "paginationPrev": "السابق",
+    "paginationNext": "التالي",
+    "paginationPage": "صفحة",
+    "accounts": {
+      "title": "الحسابات",
+      "description": "مؤسسات العملاء لشركتك",
+      "subtitle": "قائمة الحسابات (نطاق المستأجر).",
+      "empty": "لا توجد حسابات بعد.",
+      "colName": "الاسم",
+      "colStatus": "الحالة",
+      "colEmail": "البريد",
+      "colPhone": "الهاتف",
+      "colCreated": "أنشئ في"
+    },
+    "contacts": {
+      "title": "جهات الاتصال",
+      "description": "الأشخاص المرتبطون بحساباتك",
+      "subtitle": "قائمة جهات الاتصال (نطاق المستأجر).",
+      "empty": "لا توجد جهات اتصال بعد.",
+      "primary": "أساسي"
+    },
+    "leads": {
+      "title": "العملاء المحتملون",
+      "description": "فرص أعمال للتأهيل",
+      "subtitle": "قائمة العملاء المحتملين (نطاق المستأجر).",
+      "empty": "لا يوجد عملاء محتملون بعد.",
+      "colName": "الاسم",
+      "colCompany": "الشركة",
+      "colStatus": "الحالة",
+      "colSource": "المصدر",
+      "colEmail": "البريد",
+      "colCreated": "أنشئ في"
+    },
+    "pipeline": {
+      "title": "خط الأنابيب",
+      "description": "نظرة عامة على الفرص حسب المرحلة",
+      "subtitle": "الفرص مجمعة حسب المرحلة (نطاق المستأجر).",
+      "empty": "لا توجد فرص بعد.",
+      "stage": {
+        "prospecting": "استكشاف",
+        "qualification": "تأهيل",
+        "proposal": "اقتراح",
+        "negotiation": "تفاوض",
+        "won": "مربوحة",
+        "lost": "خاسرة"
+      }
+    }
+  }
 }

--- a/front/web/src/lib/i18n/locales/en.json
+++ b/front/web/src/lib/i18n/locales/en.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "QR rejected: {error}",
   "settingsBiometricSubmitFailed": "Submission failed: {error}",
   "settingsNotificationsSaveFailed": "Failed to save notification preferences: {error}",
-  "companydetailPlanWithPrice": "{planName} — {price}"
+  "companydetailPlanWithPrice": "{planName} — {price}",
+  "crm": {
+    "title": "Client CRM",
+    "subtitle": "Manage your prospects, accounts, contacts and opportunities — data isolated per company (tenant).",
+    "isolationNote": "Tenant-scoped data: no access to the Leopardo commercial CRM from this space.",
+    "loading": "Loading…",
+    "featureLocked": "CRM module not enabled for your company.",
+    "errorLoading": "Unable to load data.",
+    "searchPlaceholder": "Search…",
+    "refresh": "Refresh",
+    "paginationPrev": "Previous",
+    "paginationNext": "Next",
+    "paginationPage": "Page",
+    "accounts": {
+      "title": "Accounts",
+      "description": "Client organizations of your company",
+      "subtitle": "Account list (tenant-scoped).",
+      "empty": "No accounts yet.",
+      "colName": "Name",
+      "colStatus": "Status",
+      "colEmail": "Email",
+      "colPhone": "Phone",
+      "colCreated": "Created"
+    },
+    "contacts": {
+      "title": "Contacts",
+      "description": "People linked to your accounts",
+      "subtitle": "Contact list (tenant-scoped).",
+      "empty": "No contacts yet.",
+      "primary": "Primary"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Business opportunities to qualify",
+      "subtitle": "Lead list (tenant-scoped).",
+      "empty": "No leads yet.",
+      "colName": "Name",
+      "colCompany": "Company",
+      "colStatus": "Status",
+      "colSource": "Source",
+      "colEmail": "Email",
+      "colCreated": "Created"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Opportunities overview by stage",
+      "subtitle": "Opportunities grouped by stage (tenant-scoped).",
+      "empty": "No opportunities yet.",
+      "stage": {
+        "prospecting": "Prospecting",
+        "qualification": "Qualification",
+        "proposal": "Proposal",
+        "negotiation": "Negotiation",
+        "won": "Won",
+        "lost": "Lost"
+      }
+    }
+  }
 }

--- a/front/web/src/lib/i18n/locales/fr.json
+++ b/front/web/src/lib/i18n/locales/fr.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "QR rejeté : {error}",
   "settingsBiometricSubmitFailed": "Échec de l'envoi : {error}",
   "settingsNotificationsSaveFailed": "Échec de l’enregistrement des préférences : {error}",
-  "companydetailPlanWithPrice": "{planName} — {price}"
+  "companydetailPlanWithPrice": "{planName} — {price}",
+  "crm": {
+    "title": "CRM Client",
+    "subtitle": "Gérez vos prospects, comptes, contacts et opportunités — données isolées par entreprise (tenant).",
+    "isolationNote": "Données tenant-scoped : aucun accès au CRM commercial Leopardo depuis cet espace.",
+    "loading": "Chargement…",
+    "featureLocked": "Module CRM non activé pour votre entreprise.",
+    "errorLoading": "Impossible de charger les données.",
+    "searchPlaceholder": "Rechercher…",
+    "refresh": "Actualiser",
+    "paginationPrev": "Précédent",
+    "paginationNext": "Suivant",
+    "paginationPage": "Page",
+    "accounts": {
+      "title": "Comptes",
+      "description": "Organisations clientes de votre entreprise",
+      "subtitle": "Liste des comptes (tenant-scoped).",
+      "empty": "Aucun compte pour le moment.",
+      "colName": "Nom",
+      "colStatus": "Statut",
+      "colEmail": "Email",
+      "colPhone": "Téléphone",
+      "colCreated": "Créé le"
+    },
+    "contacts": {
+      "title": "Contacts",
+      "description": "Personnes rattachées à vos comptes",
+      "subtitle": "Liste des contacts (tenant-scoped).",
+      "empty": "Aucun contact pour le moment.",
+      "primary": "Principal"
+    },
+    "leads": {
+      "title": "Prospects",
+      "description": "Opportunités d'affaires à qualifier",
+      "subtitle": "Liste des prospects (tenant-scoped).",
+      "empty": "Aucun prospect pour le moment.",
+      "colName": "Nom",
+      "colCompany": "Société",
+      "colStatus": "Statut",
+      "colSource": "Source",
+      "colEmail": "Email",
+      "colCreated": "Créé le"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Vue d'ensemble des opportunités par étape",
+      "subtitle": "Opportunités regroupées par étape (tenant-scoped).",
+      "empty": "Aucune opportunité pour le moment.",
+      "stage": {
+        "prospecting": "Prospection",
+        "qualification": "Qualification",
+        "proposal": "Proposition",
+        "negotiation": "Négociation",
+        "won": "Gagné",
+        "lost": "Perdu"
+      }
+    }
+  }
 }

--- a/front/web/src/lib/i18n/locales/tr.json
+++ b/front/web/src/lib/i18n/locales/tr.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "QR reddedildi: {error}",
   "settingsBiometricSubmitFailed": "Gönderim başarısız: {error}",
   "settingsNotificationsSaveFailed": "Bildirim tercihleri kaydedilemedi: {error}",
-  "companydetailPlanWithPrice": "{planName} — {price}"
+  "companydetailPlanWithPrice": "{planName} — {price}",
+  "crm": {
+    "title": "Müşteri CRM",
+    "subtitle": "Potansiyel müşterilerinizi, hesaplarınızı, kişilerinizi ve fırsatlarınızı yönetin — veriler şirket başına (tenant) izole edilir.",
+    "isolationNote": "Tenant kapsamlı veri: bu alandan Leopardo ticari CRM'ine erişim yoktur.",
+    "loading": "Yükleniyor…",
+    "featureLocked": "CRM modülü şirketiniz için etkin değil.",
+    "errorLoading": "Veriler yüklenemedi.",
+    "searchPlaceholder": "Ara…",
+    "refresh": "Yenile",
+    "paginationPrev": "Önceki",
+    "paginationNext": "Sonraki",
+    "paginationPage": "Sayfa",
+    "accounts": {
+      "title": "Hesaplar",
+      "description": "Şirketinizin müşteri kuruluşları",
+      "subtitle": "Hesap listesi (tenant kapsamlı).",
+      "empty": "Henüz hesap yok.",
+      "colName": "Ad",
+      "colStatus": "Durum",
+      "colEmail": "E-posta",
+      "colPhone": "Telefon",
+      "colCreated": "Oluşturulma"
+    },
+    "contacts": {
+      "title": "Kişiler",
+      "description": "Hesaplarınıza bağlı kişiler",
+      "subtitle": "Kişi listesi (tenant kapsamlı).",
+      "empty": "Henüz kişi yok.",
+      "primary": "Birincil"
+    },
+    "leads": {
+      "title": "Potansiyel Müşteriler",
+      "description": "Nitelendirilecek iş fırsatları",
+      "subtitle": "Potansiyel müşteri listesi (tenant kapsamlı).",
+      "empty": "Henüz potansiyel müşteri yok.",
+      "colName": "Ad",
+      "colCompany": "Şirket",
+      "colStatus": "Durum",
+      "colSource": "Kaynak",
+      "colEmail": "E-posta",
+      "colCreated": "Oluşturulma"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Aşamalara göre fırsat genel bakışı",
+      "subtitle": "Aşamalara göre gruplandırılmış fırsatlar (tenant kapsamlı).",
+      "empty": "Henüz fırsat yok.",
+      "stage": {
+        "prospecting": "Araştırma",
+        "qualification": "Nitelendirme",
+        "proposal": "Teklif",
+        "negotiation": "Müzakere",
+        "won": "Kazanıldı",
+        "lost": "Kaybedildi"
+      }
+    }
+  }
 }

--- a/shared/i18n/locales/ar.json
+++ b/shared/i18n/locales/ar.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "تم رفض الرمز: {error}",
   "settingsBiometricSubmitFailed": "فشل الإرسال: {error}",
   "settingsNotificationsSaveFailed": "تعذّر حفظ تفضيلات الإشعارات: {error}",
-  "companydetailPlanWithPrice": "الخطة {planName} — {price}"
+  "companydetailPlanWithPrice": "الخطة {planName} — {price}",
+  "crm": {
+    "title": "CRM العميل",
+    "subtitle": "إدارة العملاء المحتملين والحسابات وجهات الاتصال والفرص — البيانات معزولة لكل شركة (مستأجر).",
+    "isolationNote": "بيانات نطاق المستأجر: لا وصول إلى CRM ليوباردو التجاري من هذه المساحة.",
+    "loading": "جارٍ التحميل…",
+    "featureLocked": "وحدة CRM غير مفعّلة لشركتك.",
+    "errorLoading": "تعذر تحميل البيانات.",
+    "searchPlaceholder": "بحث…",
+    "refresh": "تحديث",
+    "paginationPrev": "السابق",
+    "paginationNext": "التالي",
+    "paginationPage": "صفحة",
+    "accounts": {
+      "title": "الحسابات",
+      "description": "مؤسسات العملاء لشركتك",
+      "subtitle": "قائمة الحسابات (نطاق المستأجر).",
+      "empty": "لا توجد حسابات بعد.",
+      "colName": "الاسم",
+      "colStatus": "الحالة",
+      "colEmail": "البريد",
+      "colPhone": "الهاتف",
+      "colCreated": "أنشئ في"
+    },
+    "contacts": {
+      "title": "جهات الاتصال",
+      "description": "الأشخاص المرتبطون بحساباتك",
+      "subtitle": "قائمة جهات الاتصال (نطاق المستأجر).",
+      "empty": "لا توجد جهات اتصال بعد.",
+      "primary": "أساسي"
+    },
+    "leads": {
+      "title": "العملاء المحتملون",
+      "description": "فرص أعمال للتأهيل",
+      "subtitle": "قائمة العملاء المحتملين (نطاق المستأجر).",
+      "empty": "لا يوجد عملاء محتملون بعد.",
+      "colName": "الاسم",
+      "colCompany": "الشركة",
+      "colStatus": "الحالة",
+      "colSource": "المصدر",
+      "colEmail": "البريد",
+      "colCreated": "أنشئ في"
+    },
+    "pipeline": {
+      "title": "خط الأنابيب",
+      "description": "نظرة عامة على الفرص حسب المرحلة",
+      "subtitle": "الفرص مجمعة حسب المرحلة (نطاق المستأجر).",
+      "empty": "لا توجد فرص بعد.",
+      "stage": {
+        "prospecting": "استكشاف",
+        "qualification": "تأهيل",
+        "proposal": "اقتراح",
+        "negotiation": "تفاوض",
+        "won": "مربوحة",
+        "lost": "خاسرة"
+      }
+    }
+  }
 }

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "QR rejected: {error}",
   "settingsBiometricSubmitFailed": "Submission failed: {error}",
   "settingsNotificationsSaveFailed": "Failed to save notification preferences: {error}",
-  "companydetailPlanWithPrice": "{planName} — {price}"
+  "companydetailPlanWithPrice": "{planName} — {price}",
+  "crm": {
+    "title": "Client CRM",
+    "subtitle": "Manage your prospects, accounts, contacts and opportunities — data isolated per company (tenant).",
+    "isolationNote": "Tenant-scoped data: no access to the Leopardo commercial CRM from this space.",
+    "loading": "Loading…",
+    "featureLocked": "CRM module not enabled for your company.",
+    "errorLoading": "Unable to load data.",
+    "searchPlaceholder": "Search…",
+    "refresh": "Refresh",
+    "paginationPrev": "Previous",
+    "paginationNext": "Next",
+    "paginationPage": "Page",
+    "accounts": {
+      "title": "Accounts",
+      "description": "Client organizations of your company",
+      "subtitle": "Account list (tenant-scoped).",
+      "empty": "No accounts yet.",
+      "colName": "Name",
+      "colStatus": "Status",
+      "colEmail": "Email",
+      "colPhone": "Phone",
+      "colCreated": "Created"
+    },
+    "contacts": {
+      "title": "Contacts",
+      "description": "People linked to your accounts",
+      "subtitle": "Contact list (tenant-scoped).",
+      "empty": "No contacts yet.",
+      "primary": "Primary"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Business opportunities to qualify",
+      "subtitle": "Lead list (tenant-scoped).",
+      "empty": "No leads yet.",
+      "colName": "Name",
+      "colCompany": "Company",
+      "colStatus": "Status",
+      "colSource": "Source",
+      "colEmail": "Email",
+      "colCreated": "Created"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Opportunities overview by stage",
+      "subtitle": "Opportunities grouped by stage (tenant-scoped).",
+      "empty": "No opportunities yet.",
+      "stage": {
+        "prospecting": "Prospecting",
+        "qualification": "Qualification",
+        "proposal": "Proposal",
+        "negotiation": "Negotiation",
+        "won": "Won",
+        "lost": "Lost"
+      }
+    }
+  }
 }

--- a/shared/i18n/locales/fr.json
+++ b/shared/i18n/locales/fr.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "QR rejeté : {error}",
   "settingsBiometricSubmitFailed": "Échec de l'envoi : {error}",
   "settingsNotificationsSaveFailed": "Échec de l’enregistrement des préférences : {error}",
-  "companydetailPlanWithPrice": "{planName} — {price}"
+  "companydetailPlanWithPrice": "{planName} — {price}",
+  "crm": {
+    "title": "CRM Client",
+    "subtitle": "Gérez vos prospects, comptes, contacts et opportunités — données isolées par entreprise (tenant).",
+    "isolationNote": "Données tenant-scoped : aucun accès au CRM commercial Leopardo depuis cet espace.",
+    "loading": "Chargement…",
+    "featureLocked": "Module CRM non activé pour votre entreprise.",
+    "errorLoading": "Impossible de charger les données.",
+    "searchPlaceholder": "Rechercher…",
+    "refresh": "Actualiser",
+    "paginationPrev": "Précédent",
+    "paginationNext": "Suivant",
+    "paginationPage": "Page",
+    "accounts": {
+      "title": "Comptes",
+      "description": "Organisations clientes de votre entreprise",
+      "subtitle": "Liste des comptes (tenant-scoped).",
+      "empty": "Aucun compte pour le moment.",
+      "colName": "Nom",
+      "colStatus": "Statut",
+      "colEmail": "Email",
+      "colPhone": "Téléphone",
+      "colCreated": "Créé le"
+    },
+    "contacts": {
+      "title": "Contacts",
+      "description": "Personnes rattachées à vos comptes",
+      "subtitle": "Liste des contacts (tenant-scoped).",
+      "empty": "Aucun contact pour le moment.",
+      "primary": "Principal"
+    },
+    "leads": {
+      "title": "Prospects",
+      "description": "Opportunités d'affaires à qualifier",
+      "subtitle": "Liste des prospects (tenant-scoped).",
+      "empty": "Aucun prospect pour le moment.",
+      "colName": "Nom",
+      "colCompany": "Société",
+      "colStatus": "Statut",
+      "colSource": "Source",
+      "colEmail": "Email",
+      "colCreated": "Créé le"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Vue d'ensemble des opportunités par étape",
+      "subtitle": "Opportunités regroupées par étape (tenant-scoped).",
+      "empty": "Aucune opportunité pour le moment.",
+      "stage": {
+        "prospecting": "Prospection",
+        "qualification": "Qualification",
+        "proposal": "Proposition",
+        "negotiation": "Négociation",
+        "won": "Gagné",
+        "lost": "Perdu"
+      }
+    }
+  }
 }

--- a/shared/i18n/locales/tr.json
+++ b/shared/i18n/locales/tr.json
@@ -3544,5 +3544,62 @@
   "settingsQrRejected": "QR reddedildi: {error}",
   "settingsBiometricSubmitFailed": "Gönderim başarısız: {error}",
   "settingsNotificationsSaveFailed": "Bildirim tercihleri kaydedilemedi: {error}",
-  "companydetailPlanWithPrice": "{planName} — {price}"
+  "companydetailPlanWithPrice": "{planName} — {price}",
+  "crm": {
+    "title": "Müşteri CRM",
+    "subtitle": "Potansiyel müşterilerinizi, hesaplarınızı, kişilerinizi ve fırsatlarınızı yönetin — veriler şirket başına (tenant) izole edilir.",
+    "isolationNote": "Tenant kapsamlı veri: bu alandan Leopardo ticari CRM'ine erişim yoktur.",
+    "loading": "Yükleniyor…",
+    "featureLocked": "CRM modülü şirketiniz için etkin değil.",
+    "errorLoading": "Veriler yüklenemedi.",
+    "searchPlaceholder": "Ara…",
+    "refresh": "Yenile",
+    "paginationPrev": "Önceki",
+    "paginationNext": "Sonraki",
+    "paginationPage": "Sayfa",
+    "accounts": {
+      "title": "Hesaplar",
+      "description": "Şirketinizin müşteri kuruluşları",
+      "subtitle": "Hesap listesi (tenant kapsamlı).",
+      "empty": "Henüz hesap yok.",
+      "colName": "Ad",
+      "colStatus": "Durum",
+      "colEmail": "E-posta",
+      "colPhone": "Telefon",
+      "colCreated": "Oluşturulma"
+    },
+    "contacts": {
+      "title": "Kişiler",
+      "description": "Hesaplarınıza bağlı kişiler",
+      "subtitle": "Kişi listesi (tenant kapsamlı).",
+      "empty": "Henüz kişi yok.",
+      "primary": "Birincil"
+    },
+    "leads": {
+      "title": "Potansiyel Müşteriler",
+      "description": "Nitelendirilecek iş fırsatları",
+      "subtitle": "Potansiyel müşteri listesi (tenant kapsamlı).",
+      "empty": "Henüz potansiyel müşteri yok.",
+      "colName": "Ad",
+      "colCompany": "Şirket",
+      "colStatus": "Durum",
+      "colSource": "Kaynak",
+      "colEmail": "E-posta",
+      "colCreated": "Oluşturulma"
+    },
+    "pipeline": {
+      "title": "Pipeline",
+      "description": "Aşamalara göre fırsat genel bakışı",
+      "subtitle": "Aşamalara göre gruplandırılmış fırsatlar (tenant kapsamlı).",
+      "empty": "Henüz fırsat yok.",
+      "stage": {
+        "prospecting": "Araştırma",
+        "qualification": "Nitelendirme",
+        "proposal": "Teklif",
+        "negotiation": "Müzakere",
+        "won": "Kazanıldı",
+        "lost": "Kaybedildi"
+      }
+    }
+  }
 }

--- a/shared/i18n/versions/versions.json
+++ b/shared/i18n/versions/versions.json
@@ -25,22 +25,22 @@
   },
   "locales": {
     "fr": {
-      "checksum": "84e80fa071d515bb629467f70fbc556ef868d663fab9e910def986040b1d2aa8",
+      "checksum": "6624c4562fefa8f7563f2699ab5ea56331e33262aa97879495d01a4545c4f532",
       "version": "1.0.0",
       "updated_at": "2026-08-25T00:00:00Z"
     },
     "ar": {
-      "checksum": "d65b052e8bdfabe05922d6e30d1f661d4ec9e1a2271a155c39714fe11df124e7",
+      "checksum": "e2bf7ff33469ee2ada579172ecdbd2b1170a8607d8db5f3d9081588f5130e789",
       "version": "1.0.0",
       "updated_at": "2026-08-25T00:00:00Z"
     },
     "tr": {
-      "checksum": "91829624e2eb359923edbaad183d7beada6cc2fbc8a7ae489fc7adea4039161e",
+      "checksum": "a80c7108baf2c08115580b19030075b9d3dbf2595902a28ea602dbe16970df99",
       "version": "1.0.0",
       "updated_at": "2026-08-25T00:00:00Z"
     },
     "en": {
-      "checksum": "8bdc18c17e8264fd0ef5ea78f7476bdb0fc159a809943714c74c4b2875e220f1",
+      "checksum": "72382abdb24a407c9818a396041d666a576a75d34b67c500a80193093c7e3c72",
       "version": "1.0.0",
       "updated_at": "2026-08-25T00:00:00Z"
     }
@@ -48,21 +48,21 @@
   "surfaces": {
     "web": {
       "checksums": {
-        "ar": "d65b052e8bdfabe05922d6e30d1f661d4ec9e1a2271a155c39714fe11df124e7",
-        "en": "8bdc18c17e8264fd0ef5ea78f7476bdb0fc159a809943714c74c4b2875e220f1",
-        "fr": "84e80fa071d515bb629467f70fbc556ef868d663fab9e910def986040b1d2aa8",
-        "tr": "91829624e2eb359923edbaad183d7beada6cc2fbc8a7ae489fc7adea4039161e"
+        "ar": "e2bf7ff33469ee2ada579172ecdbd2b1170a8607d8db5f3d9081588f5130e789",
+        "en": "72382abdb24a407c9818a396041d666a576a75d34b67c500a80193093c7e3c72",
+        "fr": "6624c4562fefa8f7563f2699ab5ea56331e33262aa97879495d01a4545c4f532",
+        "tr": "a80c7108baf2c08115580b19030075b9d3dbf2595902a28ea602dbe16970df99"
       },
-      "updated_at": "2026-08-27T08:48:29.651Z"
+      "updated_at": "2026-08-28T02:04:08.547Z"
     },
     "admin": {
       "checksums": {
-        "ar": "50e652e8d9e99502e05fb07222dec90779a8c9d833e2c0e96b79ca0ac77d3db8",
-        "en": "9a4a1448f8f3febb98531119ef679aade21fc9b5df192609f18162c3af89a3e9",
-        "fr": "db9e99c82d243acd3832c7242516a5b4d4013b72fd2c8d2575a0d3f1e4b1e1ed",
-        "tr": "ce267968212d149586d8be13a53ad0b04f2be3bad11c85b8a828925c540a4772"
+        "ar": "3cb3fc7982351d78d7c03f8cc2858777454f2424f82b0d81dd9107cc30311a3f",
+        "en": "66cfcfd26d80b1144f2c06cf91c63c01668364c4f1347596661d940110468333",
+        "fr": "3dd8bc2ec4e14dc90b679e99e82dee6c6d321565265477df0a1eacdaeb4a0d59",
+        "tr": "1ef8a2645a99db38f8534849db6ea050375f0832fcc3085965f9f86b32f301cc"
       },
-      "updated_at": "2026-08-27T08:48:29.675Z"
+      "updated_at": "2026-08-28T02:04:08.574Z"
     }
   }
 }


### PR DESCRIPTION
Closes #5715 (CRM-V0-11)

## Objectif
Interface web CRM client minimale dans les espaces client : comptes, contacts, leads et pipeline de base — sans réutiliser l'écran Platform CRM.

## Livrables
- **Menu + router tenant/RBAC** : entrée « CRM Client » dans la sidebar (client-features.ts) — visible pour `manager` (principal/rh) et gated par la feature tenant `crm` (fail-closed quand les données de gate sont présentes, ADR-CRM-004). Routes `/crm`, `/crm/accounts`, `/crm/contacts`, `/crm/leads`, `/crm/pipeline` mappées au module.
- **5 pages** dans `front/web/src/app/(dashboard)/crm/` : hub de navigation (tiles) + listes comptes/contacts/leads (recherche, statuts, pagination) + kanban pipeline (opportunités par étape).
- **États loading / error / empty + pagination** sur chaque liste (enveloppe Laravel `data`/`meta`).
- **Zéro appel à `PlatformCrmPipelineController`** : les pages consomment exclusivement l'API tenant `/api/v1/crm/*` (contrat #5712).
- **i18n** : bloc `crm` ajouté ×4 locales (fr/en/tr/ar, 45 clés, parité vérifiée).
- **Test jest** `client-features-crm.test.ts` : gating RBAC + feature, fail-closed, mapping des routes, et **non-fuite cross-tenant** (l'accès est dérivé uniquement du payload de l'utilisateur courant).

## Notes
- Le backend `/api/v1/crm/*` arrive avec #5712 (en cours dans le swarm) : les pages gèrent 403/404 proprement (état « feature locked ») en attendant.
- L'écran `/crm/pipeline` de l'admin plateforme (CRM commercial) reste intact — ADR-CRM-002.
