### PR TITLE
fix(ci): déblocage checks requis pendant l'épuisement du budget Git LFS

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29) : actionlint/shellcheck n'ont pas
+          # besoin des assets LFS — checkout sans LFS.
+          lfs: false
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@e0207a28405ecad11953ba625a95d92f7889572a # v1

--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -79,7 +79,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29, budget mensuel) : les jobs
+          # backend/architecture n'ont pas besoin des assets LFS (design,
+          # icônes mobiles) — checkout sans LFS pour débloquer les checks
+          # requis. Les workflows mobiles/web gardent lfs:true.
+          lfs: false
           # check-app-version-sync.sh / check-duplicate-routes.sh comparent
           # GITHUB_BASE_SHA..HEAD — il faut l'historique complet (#5698).
           fetch-depth: 0
@@ -167,7 +171,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29, budget mensuel) : les jobs
+          # backend/architecture n'ont pas besoin des assets LFS (design,
+          # icônes mobiles) — checkout sans LFS pour débloquer les checks
+          # requis. Les workflows mobiles/web gardent lfs:true.
+          lfs: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -207,7 +215,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29, budget mensuel) : les jobs
+          # backend/architecture n'ont pas besoin des assets LFS (design,
+          # icônes mobiles) — checkout sans LFS pour débloquer les checks
+          # requis. Les workflows mobiles/web gardent lfs:true.
+          lfs: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -233,7 +245,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29, budget mensuel) : les jobs
+          # backend/architecture n'ont pas besoin des assets LFS (design,
+          # icônes mobiles) — checkout sans LFS pour débloquer les checks
+          # requis. Les workflows mobiles/web gardent lfs:true.
+          lfs: false
           # Issue #5629 : le checkout par défaut (depth 1) ne contient pas le
           # base_sha des PRs à base ancienne → les gardes de diff (cross-module
           # imports, strict_types, accented messages, baseline PHPStan)
@@ -436,7 +452,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29, budget mensuel) : les jobs
+          # backend/architecture n'ont pas besoin des assets LFS (design,
+          # icônes mobiles) — checkout sans LFS pour débloquer les checks
+          # requis. Les workflows mobiles/web gardent lfs:true.
+          lfs: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -121,7 +121,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          lfs: true
+          # Quota Git LFS épuisé (2026-08-29, budget mensuel) : les jobs
+          # backend/architecture n'ont pas besoin des assets LFS (design,
+          # icônes mobiles) — checkout sans LFS pour débloquer les checks
+          # requis. Les workflows mobiles/web gardent lfs:true.
+          lfs: false
 
       - name: Setup backend (PHP + Composer + multi-tenant DB)
         uses: ./.github/actions/setup-backend-db


### PR DESCRIPTION
## Déblocage CI — budget Git LFS épuisé

**Contexte (constat 2026-08-29 ~05:15Z)** : le budget LFS mensuel du repo est épuisé — `batch response: This repository exceeded its LFS budget.` Tout checkout avec `lfs: true` échoue au fetch → **main rouge sur les 5 checks requis** et toutes les PRs bloquées au checkout (le swarm a brûlé la bande passante mensuelle).

**Correctif** : les 6 checkouts des jobs portant les **checks requis** passent en `lfs: false` :
- `.github/workflows/architecture-check.yml` (5) : PHPStan Strict, PHPStan Modules, Module Structure Validator, actionlint, Frontend ESLint ;
- `.github/workflows/coverage-gate.yml` (1) : Backend Coverage.

Ces jobs analysent le code PHP + gardes + lint frontend admin : **aucun besoin des assets LFS** (`assets/**`, icônes mobiles). Les workflows mobiles/web qui exigent les vrais binaires LFS restent en `lfs: true` — leur déblocage nécessite que le propriétaire **augmente le budget LFS** (Settings → Storage & bandwidth) ou attende le reset mensuel.

**Action propriétaire requise** : augmenter le budget LFS (ou retirer `assets/**` du LFS). Dès que le quota est rétabli, remettre `lfs: true` (reversible).

Closes — aucun issue dédiée : fix infra direct.