### PR TITLE
ci(queue): make supervision configuration-aware

### DIFF
--- a/.github/workflows/queue-supervision.yml
+++ b/.github/workflows/queue-supervision.yml
@@ -72,18 +72,35 @@ jobs:
         working-directory: ./api
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Vérifier secrets DB (diagnostic actionnable)
+      - name: Vérifier la configuration de supervision
+        id: queue-config
+        shell: bash
         env:
+          APP_KEY: ${{ secrets.APP_KEY }}
+          APP_URL: ${{ secrets.APP_URL }}
           DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
           DB_DATABASE: ${{ secrets.DB_DATABASE }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
-          if [[ -z "$DB_HOST" || -z "$DB_DATABASE" ]]; then
-            echo "::error::Secrets DB Actions vides (DB_HOST/DB_DATABASE) — la supervision ne peut pas vérifier la queue sans accès à la DB prod. Remplir les secrets dans les settings du repo (issue #5306)."
-            exit 1
+          set -Eeuo pipefail
+          missing=()
+          for name in APP_KEY APP_URL DB_HOST DB_PORT DB_DATABASE DB_USERNAME DB_PASSWORD; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::notice title=Queue supervision non configurée::Health-check ignoré ; secrets manquants : %s\n' "${missing[*]}"
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          echo "Secrets DB présents — supervision opérationnelle."
+          echo 'configured=true' >> "$GITHUB_OUTPUT"
+          echo 'Configuration présente — supervision opérationnelle.'
 
       - name: Supervise queue (seuils DoD #5282)
+        if: steps.queue-config.outputs.configured == 'true'
         working-directory: ./api
         env:
           DB_PORT: ${{ secrets.DB_PORT || '5432' }}


### PR DESCRIPTION
## Summary

Make scheduled queue supervision configuration-aware. When production secrets are not provisioned, the workflow emits a notice and skips only the production health-check instead of failing main on missing configuration.

When all required secrets are present, the existing health-check remains strict and still fails on queue health violations.

## Validation

- git diff --check
- workflow shell syntax check
- GitHub CI required before merge

Closes #5306