### PR TITLE
chore(governance): protocole de branches par lot BC (réduit la fragmentation CI)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## 📝 Pull Request Overview
 
-**Issue Reference:** Fixes #
-> ⚠️ **Obligatoire (PA2-OPS-008) :** cette PR doit obligatoirement inclure `Closes #XXX` (ou `Fixes #XXX` / `Resolves #XXX`) dans son titre ou sa description, sauf si elle est explicitement typee `docs:`/`chore:`. Un garde CI bloquant (`.github/workflows/pr-issue-guard.yml`, `dev-hub/tools/check-pr-closes-issue.sh`) refuse toute PR qui ne le fait pas.
+**Issue Reference(s):** Fixes # <!-- une ligne "Fixes #N" / "Closes #N" par issue si cette PR livre un lot BC (docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md) -->
+> ⚠️ **Obligatoire (PA2-OPS-008) :** cette PR doit obligatoirement inclure `Closes #XXX` (ou `Fixes #XXX` / `Resolves #XXX`) dans son titre ou sa description, sauf si elle est explicitement typee `docs:`/`chore:`. Un garde CI bloquant (`.github/workflows/pr-issue-guard.yml`, `dev-hub/tools/check-pr-closes-issue.sh`) refuse toute PR qui ne le fait pas. Pour une PR de lot BC (branche `bc/<code>-*`), répéter le mot-clé pour CHAQUE issue fermée.
 **Category:** [Feature / Bug Fix / Documentation / Refactor]
 
 ---

--- a/.github/workflows/bc-batch-branch-protocol.yml
+++ b/.github/workflows/bc-batch-branch-protocol.yml
@@ -1,0 +1,72 @@
+name: BC Batch Branch Protocol Guard
+
+# Garde du protocole de branches par lot BC (docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md).
+# Vérifie sur le dépôt : une seule branche bc/<code>-* active par BC, claim
+# markers orphelins, PRs bc/* sans `Closes #N` (#2512), cohérence de label BC,
+# taille des PRs (budget proportionnel au nombre d'issues fermées), collisions
+# de migrations inter-PR (#1962) et état de `main`.
+# Rôle = RAPPORT (comme branch-hygiene.yml / crm-branch-protocol.yml) : les
+# violations sont publiées en artefact pour arbitrage manuel ; le mode
+# --strict (sortie 1) n'est utilisé que via workflow_dispatch.
+#
+# Référence : docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md
+
+on:
+  schedule:
+    # Quotidien à 05:37 UTC (décalé des autres gardes de gouvernance).
+    - cron: "37 5 * * *"
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Mode strict (sortie 1 sur violation)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  actions: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: bc-batch-branch-protocol
+  cancel-in-progress: false
+
+jobs:
+  check-protocol:
+    timeout-minutes: 15
+    name: BC batch branch protocol
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: false
+
+      - name: Run BC batch branch protocol guard
+        id: guard
+        shell: bash
+        run: |
+          chmod +x dev-hub/tools/check-bc-batch-branch-protocol.sh
+          if [ "${{ github.event.inputs.strict }}" = "true" ]; then
+            dev-hub/tools/check-bc-batch-branch-protocol.sh "${{ github.repository }}" --strict 2>&1 | tee /tmp/bc-batch-branch-protocol-report.txt
+          else
+            dev-hub/tools/check-bc-batch-branch-protocol.sh "${{ github.repository }}" 2>&1 | tee /tmp/bc-batch-branch-protocol-report.txt
+          fi
+          echo "report_file=/tmp/bc-batch-branch-protocol-report.txt" >> "$GITHUB_OUTPUT"
+        # Le rapport est publié même quand des violations sont détectées
+        # (le script sort 0 par défaut ; --strict peut sortir 1).
+        continue-on-error: true
+
+      - name: Publier le rapport en artefact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bc-batch-branch-protocol-report
+          path: /tmp/bc-batch-branch-protocol-report.txt
+          if-no-files-found: warn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,16 @@ canonique. Toute issue ouverte est etiquettee avec son BC (`BC-01 PLATFORM`,
    reste la regle anti-doublon ci-dessus (`fix/<issue>-<slug>` + claim
    marker) : si une branche existe deja pour une issue du BC, contribuer
    dessus ou s'arreter.
+2bis. **Lot d'issues d'un meme BC : une branche par lot, pas une par issue**
+   (`docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md`, 2026-08-29) — quand
+   plusieurs issues du meme BC sont confiees a un agent, il ouvre UNE branche
+   `bc/<code-bc>-<slug>` et y accumule un commit par issue livree, puis ferme
+   toutes les issues du lot dans une seule PR (`Closes #N` repete par issue).
+   Objectif : reduire le nombre de branches/PRs/runs CI par lot (constat
+   `docs/infra/02_alignement/CI_SATURATION.md`). Le protocole `fix/<issue>-*`
+   (une branche par issue) reste la norme pour une issue isolee hors lot, un
+   hotfix, ou le programme CRM qui garde son protocole dedie plus strict
+   (`CRM_BRANCH_PROTOCOL.md`, une issue = une branche = une PR).
 3. **Nouvelle issue sans label BC** : verifier le registre
    `bounded-context-registry.json` (chemin racine -> BC) et ajouter le
    label avant de commencer.

--- a/dev-hub/tools/check-bc-batch-branch-protocol.sh
+++ b/dev-hub/tools/check-bc-batch-branch-protocol.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# check-bc-batch-branch-protocol.sh — Garde du protocole de branches par lot BC.
+#
+# Vérifie sur le dépôt les règles de `docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md` :
+#   - une seule branche bc/<code-bc>-* active par BC (pas deux lots parallèles sur le même BC) ;
+#   - claim markers orphelins (branche « claim marker BC-<code> » sans PR, âgée) ;
+#   - PRs ouvertes sur bc/* sans aucun mot-clé Closes/Fixes/Resolves #N ;
+#   - cohérence de label : toute issue fermée par une PR bc/<code-bc>-* porte le label BC-<code> ;
+#   - PRs au-delà du budget proportionnel (~15 fichiers / ~1000 lignes par issue fermée) ;
+#   - collisions de préfixes de migrations inter-PR (#1962, --remote) ;
+#   - main rouge : dernier SHA de main avec un check requis en échec.
+#
+# Usage : check-bc-batch-branch-protocol.sh <owner/repo> [--strict] [--max-age-days N]
+#   --strict        : sortie 1 dès qu'une violation est détectée (défaut : rapport).
+#   --max-age-days N: âge à partir duquel un claim marker orphelin est signalé (défaut 2).
+#
+# Nécessite `gh` authentifié (GITHUB_TOKEN : branches, pulls, issues, commits, statuses) et `jq`.
+# Rôle = rapport par défaut, comme les autres gardes de gouvernance
+# (check-crm-branch-protocol.sh, check-issues-closed-without-merge.sh).
+set -uo pipefail
+
+REPO="${1:?usage: check-bc-batch-branch-protocol.sh <owner/repo> [--strict] [--max-age-days N]}"
+STRICT=0
+MAX_AGE=2
+for opt in "${@:2}"; do
+  case "$opt" in
+    --strict) STRICT=1 ;;
+    --max-age-days=*) MAX_AGE="${opt#*=}" ;;
+  esac
+done
+
+VIOLATIONS=0
+now=$(date +%s)
+
+say()  { printf '%s\n' "$*"; }
+warn() { printf '::warning::%s\n' "$*"; }
+err()  { printf '::error::%s\n' "$*"; VIOLATIONS=$((VIOLATIONS + 1)); }
+
+say "== Garde protocole branches par lot BC — ${REPO} =="
+
+branch_list=$(gh api "repos/${REPO}/branches" --paginate --jq '.[].name' 2>/dev/null) || {
+  err "impossible de lister les branches (gh api branches)"
+  branch_list=""
+}
+open_prs_json=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
+  --jq '[.[] | {number, title, body: (.body // ""), head: .head.ref}]' 2>/dev/null)
+[ -z "$open_prs_json" ] && open_prs_json="[]"
+open_heads=$(printf '%s' "$open_prs_json" | jq -r '.[].head' 2>/dev/null)
+
+# Seules les branches bc/<code>-<slug> relèvent de ce protocole (pas fix/<issue>-*, feat/*, etc.).
+bc_branches=$(printf '%s\n' "$branch_list" | grep -E '^bc/[a-z0-9]+-' || true)
+
+# ── 1. une seule branche bc/* active par BC ───────────────────────────────────
+say ""
+say "── 1. Une seule branche active par BC ──"
+bc_codes=$(printf '%s\n' "$bc_branches" | sed -nE 's#^bc/([a-z0-9]+)-.*$#\1#p' | sort -u)
+dup_found=0
+for code in $bc_codes; do
+  [ -z "$code" ] && continue
+  branches=$(printf '%s\n' "$bc_branches" | grep -E "^bc/${code}-" || true)
+  count=$(printf '%s\n' "$branches" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$count" -le 1 ] && continue
+  branches_with_pr=""
+  orphans=""
+  for b in $branches; do
+    if printf '%s\n' "$open_heads" | grep -qx "$b"; then
+      branches_with_pr="$branches_with_pr $b"
+    else
+      orphans="$orphans $b"
+    fi
+  done
+  if [ -n "$branches_with_pr" ] && [ -n "$orphans" ]; then
+    err "BC ${code} : branche(s) canonique(s)$branches_with_pr ET branche(s) sans PR$orphans — un seul lot actif par BC"
+    dup_found=1
+  elif [ "$count" -gt 1 ] && [ -z "$branches_with_pr" ]; then
+    err "BC ${code} : plusieurs branches sans PR ($branches) — conserver un seul lot, purger les autres"
+    dup_found=1
+  fi
+done
+[ "$dup_found" -eq 0 ] && say "  OK — au plus une branche active par BC."
+
+# ── 2. claim markers orphelins ────────────────────────────────────────────────
+say ""
+say "── 2. Claim markers orphelins (âge > ${MAX_AGE} j) ──"
+orphan_claims=0
+while IFS= read -r br; do
+  [ -z "$br" ] && continue
+  if printf '%s\n' "$open_heads" | grep -qx "$br"; then
+    continue
+  fi
+  last_msg=$(gh api "repos/${REPO}/commits/${br}" --jq '.commit.message // ""' 2>/dev/null || true)
+  case "$last_msg" in
+    "claim marker BC-"*)
+      last_date=$(gh api "repos/${REPO}/commits/${br}" --jq '.commit.committer.date // ""' 2>/dev/null || true)
+      if [ -n "$last_date" ]; then
+        last_ts=$(date -u -d "$last_date" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_date" +%s 2>/dev/null || echo 0)
+        age_days=$(( (now - last_ts) / 86400 ))
+        if [ "$age_days" -ge "$MAX_AGE" ]; then
+          err "claim marker orphelin : ${br} (dernier commit claim il y a ${age_days} j, aucune PR) — libérer ou matérialiser"
+          orphan_claims=$((orphan_claims + 1))
+        else
+          warn "claim marker récent (< ${MAX_AGE} j) : ${br} — lot en cours probable"
+        fi
+      fi
+      ;;
+  esac
+done <<EOF
+$(printf '%s\n' "$bc_branches")
+EOF
+[ "$orphan_claims" -eq 0 ] && say "  OK — aucun claim marker orphelin."
+
+# ── 3. PRs bc/* sans Closes/Fixes/Resolves ────────────────────────────────────
+say ""
+say "── 3. PRs bc/* sans mot-clé Closes/Fixes/Resolves #N ──"
+pr_missing_close=0
+bc_prs_json=$(printf '%s' "$open_prs_json" | jq -c '[.[] | select(.head | test("^bc/[a-z0-9]+-"))]')
+while IFS=$'\t' read -r num title body; do
+  [ -z "$num" ] && continue
+  if ! printf '%s' "$body" | grep -qiE '(clos(es|ed|ing)|fix(es|ed|ing)|resolv(es|ed|ing))[[:space:]]*:?[[:space:]]*#[0-9]+'; then
+    err "PR #${num} (« ${title} ») : aucun mot-clé Closes/Fixes/Resolves #N dans le body"
+    pr_missing_close=$((pr_missing_close + 1))
+  fi
+done < <(printf '%s' "$bc_prs_json" | jq -r '.[] | [.number, .title, .body] | @tsv')
+[ "$pr_missing_close" -eq 0 ] && say "  OK — toutes les PRs bc/* déclarent au moins une issue à fermer."
+
+# ── 4. cohérence de label BC ───────────────────────────────────────────────────
+say ""
+say "── 4. Cohérence de label BC (une PR bc/<code>-* ne ferme que des issues BC-<code>) ──"
+label_mismatch=0
+while IFS=$'\t' read -r num head body; do
+  [ -z "$num" ] && continue
+  code=$(printf '%s' "$head" | sed -nE 's#^bc/([a-z0-9]+)-.*$#\1#p')
+  [ -z "$code" ] && continue
+  bc_num=$(printf '%s' "$code" | sed -nE 's#^bc([0-9]+)$#\1#p')
+  [ -z "$bc_num" ] && continue
+  expected_label="BC-${bc_num}"
+  closed_issues=$(printf '%s' "$body" | grep -oiE '(clos(es|ed|ing)|fix(es|ed|ing)|resolv(es|ed|ing))[[:space:]]*:?[[:space:]]*#[0-9]+' \
+    | grep -oE '[0-9]+')
+  for issue in $closed_issues; do
+    labels=$(gh api "repos/${REPO}/issues/${issue}" --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+    if [ -n "$labels" ] && ! printf '%s' "$labels" | grep -q "$expected_label"; then
+      err "PR #${num} (branche ${head}) ferme #${issue} mais son label (${labels:-aucun}) ne contient pas ${expected_label} attendu"
+      label_mismatch=$((label_mismatch + 1))
+    fi
+  done
+done < <(printf '%s' "$bc_prs_json" | jq -r '.[] | [.number, .head, .body] | @tsv')
+[ "$label_mismatch" -eq 0 ] && say "  OK — toutes les issues fermées portent le label BC attendu."
+
+# ── 5. budget de taille proportionnel (~15 fichiers / ~1000 lignes par issue) ─
+say ""
+say "── 5. Taille des PRs bc/* (budget ~15 fichiers / ~1000 lignes par issue fermée) ──"
+pr_too_big=0
+while IFS=$'\t' read -r num title body; do
+  [ -z "$num" ] && continue
+  n_issues=$(printf '%s' "$body" | grep -oiE '(clos(es|ed|ing)|fix(es|ed|ing)|resolv(es|ed|ing))[[:space:]]*:?[[:space:]]*#[0-9]+' | wc -l | tr -d ' ')
+  [ "${n_issues:-0}" -eq 0 ] && n_issues=1
+  budget_files=$((n_issues * 15))
+  budget_lines=$((n_issues * 1000))
+  stats=$(gh api "repos/${REPO}/pulls/${num}" --jq '.additions, .deletions, .changed_files' 2>/dev/null || true)
+  [ -z "$stats" ] && continue
+  additions=$(printf '%s\n' "$stats" | sed -n 1p)
+  files=$(printf '%s\n' "$stats" | sed -n 3p)
+  if [ "${files:-0}" -gt "$budget_files" ] || [ "${additions:-0}" -gt "$budget_lines" ]; then
+    warn "PR #${num} (« ${title} ») : ${files} fichiers/+${additions} lignes pour ${n_issues} issue(s) — budget ${budget_files}f/${budget_lines}l dépassé, envisager de découper"
+    pr_too_big=$((pr_too_big + 1))
+  fi
+done < <(printf '%s' "$bc_prs_json" | jq -r '.[] | [.number, .title, .body] | @tsv')
+[ "$pr_too_big" -eq 0 ] && say "  OK — aucune PR bc/* au-delà de son budget proportionnel."
+
+# ── 6. collisions de préfixes de migrations inter-PR (#1962) ─────────────────
+say ""
+say "── 6. Collisions de migrations inter-PR (#1962) ──"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [ -x "${ROOT}/dev-hub/tools/check-migration-basename-collisions.sh" ]; then
+  if ! bash "${ROOT}/dev-hub/tools/check-migration-basename-collisions.sh" "${ROOT}/api/database/migrations" --remote >/tmp/bc-batch-migration-guard.out 2>&1; then
+    err "collision de préfixes/basenames de migrations inter-PR détectée — voir le log ci-dessous"
+    sed 's/^/    /' /tmp/bc-batch-migration-guard.out | tail -20
+  else
+    say "  OK — aucune collision de migrations."
+  fi
+else
+  warn "check-migration-basename-collisions.sh absent — garde #1962 non exécutée"
+fi
+
+# ── 7. main rouge (checks requis) ─────────────────────────────────────────────
+say ""
+say "── 7. État de main (arrêt si rouge) ──"
+required_checks="Backend Coverage (PHP 8.4 + PostgreSQL 16)
+PHPStan — Strict (Core/Modules/Shared, level 8)
+Module Structure Validator
+Frontend — ESLint + TypeScript
+actionlint (+ shellcheck)"
+main_sha=$(gh api "repos/${REPO}/commits/main" --jq '.sha' 2>/dev/null || true)
+if [ -n "$main_sha" ]; then
+  main_red=0
+  while IFS= read -r check; do
+    [ -z "$check" ] && continue
+    state=$(gh api "repos/${REPO}/commits/${main_sha}/check-runs" --jq \
+      --arg name "$check" '.check_runs[] | select(.name == $name) | .conclusion' 2>/dev/null | sort -u | tr '\n' ' ')
+    if [ -n "$state" ] && printf '%s' "$state" | grep -qE 'failure|timed_out|action_required|cancelled'; then
+      err "MAIN ROUGE : check requis « ${check} » en échec sur ${main_sha:0:7} — ne pas merger tant que main n'est pas vert"
+      main_red=1
+    fi
+  done <<EOF
+${required_checks}
+EOF
+  [ "$main_red" -eq 0 ] && say "  OK — aucun check requis en échec sur main (${main_sha:0:7})."
+else
+  warn "impossible de lire main — étape 7 ignorée"
+fi
+
+# ── conclusion ────────────────────────────────────────────────────────────────
+say ""
+if [ "$VIOLATIONS" -eq 0 ]; then
+  say "✅ Protocole branches par lot BC : aucune violation détectée."
+  exit 0
+fi
+say "⚠️  ${VIOLATIONS} violation(s) détectée(s)."
+if [ "$STRICT" -eq 1 ]; then
+  say "Mode --strict : sortie 1."
+  exit 1
+fi
+say "Mode rapport (défaut) : sortie 0 — arbitrage manuel requis."
+exit 0

--- a/dev-hub/tools/check-issue-claim-unique.sh
+++ b/dev-hub/tools/check-issue-claim-unique.sh
@@ -12,6 +12,12 @@
 # ouvertes référencent la MÊME issue → ::error + exit 1 (la PR en doublon doit
 # être fermée, protocole #2400 : 1 PR = 1 issue, renvoi vers la PR canonique).
 #
+# Exception (docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md, 2026-08-29) : une PR
+# `bc/<code>-*` peut légitimement fermer PLUSIEURS issues d'un même lot BC —
+# cette garde reste valide sans modification, elle interdit seulement qu'une
+# MÊME issue soit référencée par 2+ PR ouvertes différentes, indépendamment du
+# nombre d'issues qu'une seule PR ferme.
+#
 # Usage : dev-hub/tools/check-issue-claim-unique.sh <owner/repo>
 # Requiert `gh` authentifié (GITHUB_TOKEN/GH_TOKEN suffit : lecture PRs).
 set -uo pipefail

--- a/docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md
+++ b/docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md
@@ -1,0 +1,129 @@
+# Protocole de branches par lot — Bounded Context (batch BC)
+
+- **Statut :** actif — protocole par défaut pour tout travail multi-issues sur un même BC
+- **Date :** 2026-08-29
+- **Portée :** toutes les issues affectées par lot à un agent sur un même bounded context
+  (label `BC-XX <NOM>`, registre `dev-hub/governance/bounded-context-registry.json`), **hors
+  programme CRM** qui garde son protocole dédié plus strict (`CRM_BRANCH_PROTOCOL.md`, #5746,
+  une issue = une branche = une PR) tant qu'il n'a pas été explicitement révisé.
+- **Règles source :** `AGENTS.md` (§ Affectation par Bounded Context #5859, § anti-doublon
+  #2400, § garde migrations #1962/#5431, § procédure PR et merge), `BRANCH_PROTECTION_REQUIRED.md`.
+
+## Pourquoi ce protocole
+
+`AGENTS.md` affecte déjà le travail par BC (« un seul agent par BC à la fois »), mais le
+protocole anti-doublon #2400 imposait quand même **une branche + une PR par issue**. Résultat :
+un agent qui traite 8 issues d'un même BC ouvre 8 branches et 8 PRs, chacune déclenchant sa
+propre vague de CI — exactement le facteur multiplicateur documenté dans
+`docs/infra/02_alignement/CI_SATURATION.md` et gardé sous surveillance par
+`merge-quota-guard.yml` (25 merges/jour). Puisqu'un seul agent travaille déjà le BC à la fois
+(aucun risque de collision concurrente sur le même BC), rien n'oblige à fragmenter son travail
+en plusieurs branches — regrouper les commits d'un même BC sur une branche unique, avec une PR
+qui ferme plusieurs issues à la fois, réduit le nombre de branches/PRs/runs CI sans perdre la
+traçabilité issue-par-issue (chaque commit référence son issue).
+
+## 1. Prise de tâche (claim)
+
+1. **Le fondateur/chef de projet affecte un lot d'issues d'un même BC** à un agent (ex. « traite
+   les issues BC-24 TRAVEL #6015 à #6037 »). L'agent sélectionne uniquement des issues de ce BC.
+2. **Vérifier l'absence de branche BC déjà active** avant de commencer :
+   ```bash
+   gh api "repos/kitokoh/leopardo-hr/branches" --paginate --jq '.[].name' | grep -i "^bc/<code-bc>-"
+   gh pr list --state open --json number,title,headRefName
+   ```
+   Une branche `bc/<code-bc>-*` existante = le BC est déjà en cours de traitement → contribuer
+   dessus (même agent reprenant son propre lot) ou s'arrêter (règle « un seul agent par BC à la
+   fois », `AGENTS.md`).
+3. **Nommage de branche** : `bc/<code-bc-minuscule>-<slug-du-lot>` (ex. `bc/bc24-travel-fondations`,
+   `bc/bc16-edu-notifications`). Un seul préfixe `bc/<code-bc>-` actif à la fois par BC — pas de
+   variantes parallèles pour le même lot.
+4. **Self-assign** sur chaque issue traitée au fil du lot (`gh issue edit <N> --add-assignee @me`)
+   — la trace d'assignation reste par issue, seule la branche/PR se regroupe.
+5. **Marker branch immédiate** : dès le début du lot, pousser `bc/<code-bc>-<slug>` depuis
+   `origin/main` à jour avec un commit vide `claim marker BC-<code>`.
+
+## 2. Vie de la branche
+
+- **Base = `origin/main` à jour** : rebaser dès que `main` a bougé (mode de synchronisation
+  canonique, pas de merge de `main` dans la branche) — comme pour toute branche du dépôt.
+- **Un commit par issue livrée**, message au format `<type>(<scope>): <résumé> (#<issue>)` —
+  chaque commit reste attribuable à son issue même si la PR en ferme plusieurs.
+- **Taille de PR** : le plafond CRM (40 fichiers / +2 500 lignes) ne s'applique pas tel quel à
+  une PR multi-issues — utiliser un budget proportionnel : **~15 fichiers et ~1 000 lignes par
+  issue fermée**, à ajuster au jugement (une PR qui livre 5 petites issues peut légitimement
+  dépasser une seule grosse limite fixe). Si le lot grossit trop, le découper en plusieurs PRs
+  successives sur la même branche plutôt qu'en branches parallèles.
+- **Jobs CI ciblés** : les path filters existants (`tests.yml`, `web-ci.yml`, …) s'appliquent
+  sans changement — un push sur `bc/*` ne déclenche que les workflows pertinents aux fichiers
+  modifiés.
+- **Migrations** (toute PR qui ajoute/renomme une migration) : inchangé —
+  ```bash
+  bash dev-hub/tools/check-migration-basename-collisions.sh
+  bash dev-hub/tools/check-migration-basename-collisions.sh --remote
+  ```
+  Préfixe `YYYY_MM_DD_0000NN_<issue>_<slug>.php` (règle #5431) — chaque migration garde la
+  référence de SON issue même groupée dans une PR multi-issues.
+
+## 3. Checks requis
+
+Inchangés — mêmes 5 checks bloquants que sur toute PR (source : `BRANCH_PROTECTION_REQUIRED.md`) :
+
+| Check | Workflow |
+|---|---|
+| `Backend Coverage (PHP 8.4 + PostgreSQL 16)` | `coverage-gate.yml` |
+| `PHPStan — Strict (Core/Modules/Shared, level 8)` | `phpstan-baseline.yml` |
+| `Module Structure Validator` | `architecture-check.yml` |
+| `Frontend — ESLint + TypeScript` | `web-ci.yml` |
+| `actionlint (+ shellcheck)` | `actionlint.yml` |
+
+## 4. Merge — le body de la PR doit fermer TOUTES les issues livrées
+
+- Le body **doit** contenir un mot-clé de fermeture par issue livrée dans ce lot :
+  ```
+  Closes #6015
+  Closes #6019
+  Closes #6031
+  ```
+  (mot-clé explicite par issue — garde #2512 ; le garde `check-pr-closes-issue.sh` exige au
+  moins une occurrence, mais toutes les issues du lot doivent être listées pour se fermer au
+  merge — sinon elles restent ouvertes à tort, cf. garde de gouvernance `issue-governance-guard.yml`
+  qui détecte les « ghost close »).
+- **Toutes les issues référencées doivent porter le même label `BC-XX`** que la branche — une
+  PR `bc/bc24-travel-*` ne doit fermer que des issues `BC-24 TRAVEL` (garde §6 ci-dessous).
+- Jamais d'auto-merge d'une PR rouge ; arrêt si `main` est rouge sur un check requis (règles
+  inchangées, cf. `CRM_BRANCH_PROTOCOL.md` §4 pour le détail identique).
+- Merger : `gh pr merge <N> --merge --delete-branch`, puis vérifier `gh pr view <N> --json
+  state,mergedAt` et l'absence de la branche distante.
+- **Lot suivant du même BC** : si le fondateur confie de nouvelles issues du même BC après le
+  merge, ouvrir une **nouvelle** branche `bc/<code-bc>-<nouveau-slug>` (ne pas rouvrir l'ancienne,
+  déjà supprimée) — même principe qu'une nouvelle vague de travail.
+
+## 5. Reprise après conflit
+
+Identique au protocole général (`AGENTS.md`) : `git fetch origin main && git rebase
+origin/main`, résoudre en gardant la version la plus récente de `main` pour tout fichier déjà
+modifié par une autre PR mergée, puis `git diff origin/main...HEAD` pour valider que la branche
+n'apporte que le périmètre des issues de son lot.
+
+## 6. Capacité CI — vérification automatique
+
+Le garde `dev-hub/tools/check-bc-batch-branch-protocol.sh <owner/repo>` (workflow
+`bc-batch-branch-protocol.yml`, quotidien) vérifie :
+
+- une seule branche `bc/<code-bc>-*` active par BC (pas deux lots parallèles sur le même BC) ;
+- claim markers orphelins (branche `claim marker BC-<code>` sans PR, âgée) ;
+- PRs ouvertes sur `bc/*` sans aucun mot-clé `Closes #N` ;
+- **cohérence de label** : toute issue fermée par une PR `bc/<code-bc>-*` porte bien le label
+  `BC-<code>` correspondant (évite qu'un lot BC-24 ferme discrètement une issue BC-11) ;
+- taille de PR au-delà du budget proportionnel (~15 fichiers / ~1 000 lignes par issue fermée) ;
+- collisions de préfixes de migrations inter-PR (réutilise `check-migration-basename-collisions.sh --remote`) ;
+- `main` rouge sur un check requis.
+
+Comme les autres gardes de gouvernance (`check-crm-branch-protocol.sh`,
+`check-issues-closed-without-merge.sh`), rôle **rapport par défaut** (`exit 0`), `--strict` pour
+sortir en erreur.
+
+## 7. Nettoyage
+
+Identique au protocole général : `--delete-branch` au merge, purge des branches locales/orphelines
+via `branch-hygiene.yml` (#5506, dry-run par défaut).


### PR DESCRIPTION
## Contexte

Le travail est déjà affecté par bounded context (un seul agent par BC à la fois, #5859), mais le protocole anti-doublon #2400 imposait quand même une branche + une PR par issue individuelle. Un agent qui traite 8 issues d'un même BC ouvrait donc 8 branches et 8 PRs, chacune déclenchant sa propre vague de CI — le facteur multiplicateur documenté dans `docs/infra/02_alignement/CI_SATURATION.md` et surveillé par `merge-quota-guard.yml` (25 merges/jour).

## Ce qui change
- Nouveau protocole **optionnel** : `docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md`. Quand plusieurs issues d'un même BC sont confiées à un agent, il ouvre **une** branche `bc/<code>-<slug>` et y accumule un commit par issue livrée, puis ferme toutes les issues du lot dans **une seule PR** (`Closes #N` répété par issue).
- Le protocole `fix/<issue>-*` (une branche par issue) **reste la norme** pour une issue isolée, un hotfix, ou le programme CRM qui garde son protocole dédié plus strict (`CRM_BRANCH_PROTOCOL.md`, non modifié).
- Nouveau garde `dev-hub/tools/check-bc-batch-branch-protocol.sh` (workflow `bc-batch-branch-protocol.yml`, quotidien, rôle rapport comme `check-crm-branch-protocol.sh`) : une seule branche `bc/*` active par BC, claim markers orphelins, PRs sans `Closes`, **cohérence de label BC** (une PR `bc/<code>-*` ne doit fermer que des issues `BC-<code>`), budget de taille proportionnel au nombre d'issues fermées, collisions de migrations, état de `main`.
- `AGENTS.md` et `PULL_REQUEST_TEMPLATE.md` mis à jour pour documenter l'alternative.

## Ce qui NE change PAS (vérifié avant d'écrire le moindre code)
`check-issue-claim-unique.sh` (anti-doublon #5442) et `check-pr-closes-issue.sh` (PA2-OPS-008) fonctionnent déjà correctement avec plusieurs `Closes #N` dans une même PR — logique inchangée, juste un commentaire clarifié sur `check-issue-claim-unique.sh` pour éviter toute confusion future.

## Validation
- YAML du nouveau workflow valide (`yaml.safe_load`).
- Scripts shell valides (`bash -n`) — `shellcheck` indisponible dans cet environnement.
- Aucun marqueur de conflit résiduel (`git grep`).
- Pas de `pulumi preview`/`pulumi up` applicable : ce repo n'utilise pas Pulumi.
