### PR TITLE
docs: archive les rapports Phase 8 périmés, corrige HANDOFF_OPERATIONNEL_R6

### DIFF
--- a/docs/GESTION_PROJET/HANDOFF_OPERATIONNEL_R6.md
+++ b/docs/GESTION_PROJET/HANDOFF_OPERATIONNEL_R6.md
@@ -4,6 +4,13 @@
 **Objet** : passation complète de l'exploitation Leopardo RH — pour l'équipe, les ops et les agents entrants.
 **Règle d'or** : ce document est le **point d'entrée unique** ; chaque procédure détaillée vit dans son runbook dédié (index §4).
 
+> ⚠️ **Correction (2026-08-29)** : §1 et §5 décrivaient la base de données comme un Postgres
+> managé Render et le web service comme plan `starter` — vérifié faux via l'API Render : aucune
+> instance Postgres Render n'existe sur ce compte (`GET /v1/postgres` → vide), la base réelle est
+> **Neon** (externe) ; le web service `gestionemployerbackend` est en plan **`free`**, pas
+> `starter` (contrairement à ce que déclare `render.yaml`). Corrigé ci-dessous — le reste du
+> document (workers absents #5172, déviation cache/queue) était déjà exact.
+
 ---
 
 ## 1. État du système (au 2026-08-20)
@@ -12,10 +19,10 @@
 |---|---|
 | Version | `v4.24.0` (release 2026-08-11 ; tag git) |
 | Branche canonique | `main` (protection : checks requis, PR obligatoire) |
-| API (prod) | `https://gestionemployerbackend.onrender.com` (Render, web service `gestionemployerbackend`, plan starter, région frankfurt) |
+| API (prod) | `https://gestionemployerbackend.onrender.com` (Render, web service `gestionemployerbackend`, plan **`free`** — pas `starter`, écart avec `render.yaml`, vérifié via API Render 2026-08-29 ; région frankfurt) |
 | Vitrine (prod) | Vercel — **domaine `leopardo-rh.com` NXDOMAIN** (issue #3452, action DNS en attente) |
 | Proxy API vitrine | `https://gestionemployer-backend.vercel.app` |
-| Base de données | PostgreSQL Render `leopardo-db` (schémas `public` + `shared_tenants`, multitenancy mode `schema`) |
+| Base de données | **Neon** (Postgres externe, pas de Postgres Render — `GET /v1/postgres` renvoie vide) ; schémas `public` + `shared_tenants`, multitenancy mode `schema` |
 | Cache/Queue/Session | Redis interne Render `leopardo-redis` (plan free) — **⚠️ env live en déviation : `QUEUE_CONNECTION=database`, `CACHE_STORE/SESSION_DRIVER=file`** (issue #5172) |
 | Mail | API HTTP **Mailgun** (`MAIL_MAILER=mailgun`, #5139 — le SMTP sortant est bloqué par Render) |
 | Workers | ⚠️ **`leopardo-queue-worker` et `leopardo-scheduler` NON provisionnés sur Render** (issue #5172 — runbook livré, action ops requise) |
@@ -64,7 +71,7 @@
 ## 5. Coûts & budget (cadence agents)
 
 - **Budget agents** : `docs/OPS/BUDGET_AGENTS.md` (#5148) — plafond mensuel, arrêt au plafond, cadence 1 agent feature + 50 % traîne, tableau hebdo à remplir chaque vendredi.
-- **Coûts infra** : Render (web starter + DB starter + Redis free), Vercel (quota 100 deploys/j gratuit — déploiements path-aware pour ne pas le brûler), Mailgun (sandbox → domaine), Sentry/UptimeRobot.
+- **Coûts infra** : Render (web `free` — pas `starter` en réalité), Neon (Postgres externe, pas un coût Render), Redis Render (free), Vercel (quota 100 deploys/j gratuit — déploiements path-aware pour ne pas le brûler), Mailgun (sandbox → domaine), Sentry/UptimeRobot.
 - **⚠️ Leçons CI** : le quota Vercel s'épuise (~100/j) et bloque visuellement les PR (non bloquant) ; les runs GitHub Actions peuvent ne pas se créer sous rafale (leçon sweep-qa-360) — commenter la PR et attendre plutôt que merger sans checks.
 
 ## 6. Traîne connue & risques (au handoff)

--- a/docs/archive/PHASE_8_VITRINE_2026-07-18/DEPLOYMENT_AND_MONITORING_SUMMARY.md
+++ b/docs/archive/PHASE_8_VITRINE_2026-07-18/DEPLOYMENT_AND_MONITORING_SUMMARY.md
@@ -3,8 +3,8 @@
 > ⚠️ **Rapport historique figé (2026-07-18)** — la structure `.github/workflows/` decrite plus bas
 > (`test.yml`, `lint.yml`, `build.yml`) ne reflète plus les noms de fichiers reels du repo, et
 > `leopardo.com`/`staging.leopardo.com` ne sont pas des domaines possedes pour ce produit (voir
-> `docs/DEPLOYMENT_PRODUCTION.md` et `docs/PHASE_8_COMPLETION.md`). Pour l'etat courant, voir
-> `PILOTAGE.md` et `.github/workflows/README.md`.
+> `../../DEPLOYMENT_PRODUCTION.md` et `PHASE_8_COMPLETION.md` dans ce même dossier). Pour
+> l'etat courant, voir `../../../PILOTAGE.md` et `../../../.github/workflows/README.md`.
 
 ## Vue d'ensemble
 

--- a/docs/archive/PHASE_8_VITRINE_2026-07-18/PHASE_8_COMPLETION.md
+++ b/docs/archive/PHASE_8_VITRINE_2026-07-18/PHASE_8_COMPLETION.md
@@ -5,8 +5,8 @@
 > ci-dessous n'existent plus sous ces noms dans `.github/workflows/` ; les checks équivalents
 > vivent aujourd'hui dans `tests.yml` (backend), `web-marketing-ci.yml` (vitrine Next.js) et
 > `web-ci.yml` (admin Vue). Le domaine `leopardo.com` cité dans ce rapport n'est pas possédé
-> pour ce produit (voir `docs/DEPLOYMENT_PRODUCTION.md`). Pour l'état réel des workflows, voir
-> `DEVELOPMENT.md` section CI/CD et `.github/workflows/README.md`.
+> pour ce produit (voir `../../DEPLOYMENT_PRODUCTION.md`). Pour l'état réel des workflows, voir
+> `../../../DEVELOPMENT.md` section CI/CD et `../../../.github/workflows/README.md`.
 
 ## Statut: ✅ COMPLÉTÉ
 

--- a/docs/archive/PHASE_8_VITRINE_2026-07-18/PROJECT_COMPLETION_SUMMARY.md
+++ b/docs/archive/PHASE_8_VITRINE_2026-07-18/PROJECT_COMPLETION_SUMMARY.md
@@ -2,8 +2,8 @@
 
 > ⚠️ **Rapport historique figé (2026-07-18)** — la structure `.github/workflows/` decrite plus bas
 > (`test.yml`, `lint.yml`, `build.yml`) ne reflète plus les noms de fichiers reels du repo (voir
-> `docs/PHASE_8_COMPLETION.md` pour le detail des renommages). Pour l'etat courant, voir
-> `PILOTAGE.md` et `.github/workflows/README.md`.
+> `PHASE_8_COMPLETION.md` dans ce même dossier pour le detail des renommages). Pour l'etat courant, voir
+> `../../../PILOTAGE.md` et `../../../.github/workflows/README.md`.
 
 ## 🎉 Projet Complété avec Succès!
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -14,6 +14,7 @@ conserve tout).
 |---|---|---|
 | `PLAN_ACTION/` | Ancien processus de planification (72 plans clos, 2025 → 2026-07) | Seuls les fichiers encore référencés (AGENTS.md, docs sécurité) sont conservés ; les autres plans sont supprimés — récupérables via l'historique git (`git log -- docs/PLAN_ACTION/`). |
 | `PLAN_ACTION2/` | Ancien backlog du processus multi-agents (avant bascule GitHub Issues, PA2-OPS-008 #1279) | Intégral, référence de traçabilité — voir `docs/PLAN_ACTION2/README.md`. |
+| `PHASE_8_VITRINE_2026-07-18/` | Rapports de complétion de la restructuration initiale de la vitrine (implémentation du 2026-07-18) — `PROJECT_COMPLETION_SUMMARY.md`, `PHASE_8_COMPLETION.md`, `DEPLOYMENT_AND_MONITORING_SUMMARY.md` | Déplacés depuis `docs/` le 2026-08-29 (nettoyage doc) — chacun se déclarait déjà "rapport historique figé" décrivant des workflows CI/CD (`test.yml`/`lint.yml`/`build.yml`, domaine `leopardo.com`) qui n'ont jamais existé sous ces noms dans ce repo. Pour l'état réel, voir `PILOTAGE.md` et `.github/workflows/README.md`. |
 
 ## Recherche d'un fichier supprimé
 


### PR DESCRIPTION
## Contexte

Première vague du nettoyage documentaire demandé — priorité aux docs déjà identifiées comme fausses ou contradictoires pendant cette session, avant d'élargir à d'autres vagues.

## Changements
1. **Archivage** : `PROJECT_COMPLETION_SUMMARY.md`, `PHASE_8_COMPLETION.md`, `DEPLOYMENT_AND_MONITORING_SUMMARY.md` se déclaraient déjà eux-mêmes « rapport historique figé (2026-07-18) » (workflows `test.yml`/`lint.yml`/`build.yml` et domaine `leopardo.com` qui n'ont jamais existé sous ces noms) mais restaient à la racine de `docs/` comme une référence active. Déplacés vers `docs/archive/PHASE_8_VITRINE_2026-07-18/`, index `docs/archive/README.md` mis à jour, références croisées entre les 3 fichiers corrigées.
2. **Correction factuelle** : `docs/GESTION_PROJET/HANDOFF_OPERATIONNEL_R6.md` (se présente comme le « point d'entrée unique » à jour) décrivait la base de données comme un Postgres managé Render et le web service en plan `starter` — vérifié faux via l'API Render (`GET /v1/postgres` vide, la vraie base est **Neon** ; le service est en plan **`free`**). Le reste du document (workers absents #5172, déviation cache/queue) était déjà exact, non touché.

## Validation
- Grep exhaustif : aucune référence résiduelle vers les 3 anciens chemins `docs/*.md`.
- Aucun marqueur de conflit résiduel.
- Pas de `pulumi preview`/`pulumi up` applicable.
