### PR TITLE
docs(governance): enregistre DEP-BC24 TRAVEL et DEP-BC25 RESTAURANT (index profondeur 23→25)

### DIFF
--- a/docs/architecture/BOUNDED-DEPTH-ISSUES-INDEX.json
+++ b/docs/architecture/BOUNDED-DEPTH-ISSUES-INDEX.json
@@ -161,6 +161,20 @@
       "status": "created",
       "number": 5899,
       "url": "https://github.com/kitokoh/leopardo-hr/issues/5899"
+    },
+    {
+      "key": "DEP-BC24",
+      "title": "[DEP-BC24] Deep maturity — BC-24 TRAVEL",
+      "status": "created",
+      "number": 6275,
+      "url": "https://github.com/kitokoh/leopardo-hr/issues/6275"
+    },
+    {
+      "key": "DEP-BC25",
+      "title": "[DEP-BC25] Deep maturity — BC-25 RESTAURANT",
+      "status": "created",
+      "number": 6276,
+      "url": "https://github.com/kitokoh/leopardo-hr/issues/6276"
     }
   ]
 }


### PR DESCRIPTION
## Contexte

L’index canonique `docs/architecture/BOUNDED-DEPTH-ISSUES-INDEX.json` ne couvrait que DEP-BC01..DEP-BC23. Les bounded contexts BC-24 TRAVEL et BC-25 RESTAURANT (verticales actives/conception) n’avaient **aucune issue-parapluie de profondeur**.

## Livrables

- Issues rédigées : **#6275 [DEP-BC24] Deep maturity — BC-24 TRAVEL**, **#6276 [DEP-BC25] Deep maturity — BC-25 RESTAURANT** (même format que DEP-BC01..23 : mission, critères 12 dimensions, DoD commune, dépendances registre/spec/PRs).
- Index mis à jour : 23 → 25 entrées.

## Non-régression

Docs uniquement (JSON) — aucun code de production touché. La CI fast-path docs couvre ce PR.