### PR TITLE
feat: formulaire congé, carte soldes, digest hebdo manager, export CSV présences (#5693 #5694 #5695 #5696)

### DIFF
--- a/api/app/Console/Commands/SendManagerWeeklyDigestCommand.php
+++ b/api/app/Console/Commands/SendManagerWeeklyDigestCommand.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Mail\ManagerWeeklyDigestMail;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Digest hebdomadaire manager — envoyé chaque lundi matin (#5695).
+ *
+ * Pour chaque entreprise active, calcule les KPIs RH de la semaine écoulée
+ * et envoie un email à tous les managers (role principal/rh) qui ont un email.
+ *
+ * Métriques :
+ * - Absences en attente de validation
+ * - Taux de présence moyen (7 derniers jours)
+ * - Nouveaux employés créés cette semaine
+ * - Contrats arrivant à échéance dans 30 jours
+ */
+class SendManagerWeeklyDigestCommand extends Command
+{
+    protected $signature = 'manager:weekly-digest
+        {--dry-run : Affiche les destinataires sans envoyer}
+        {--company= : Limiter à une company_id spécifique (tests)}';
+
+    protected $description = 'Envoie le digest RH hebdomadaire aux managers (#5695)';
+
+    public function handle(): int
+    {
+        $dryRun    = (bool) $this->option('dry-run');
+        $onlyCompany = $this->option('company');
+
+        $this->info($dryRun ? '[DRY-RUN] Digest hebdomadaire manager' : 'Digest hebdomadaire manager — envoi en cours...');
+
+        $now       = Carbon::now();
+        $weekStart = $now->copy()->subDays(7)->startOfDay();
+        $weekEnd   = $now->copy()->startOfDay();
+        $expiry    = $now->copy()->addDays(30)->toDateString();
+
+        // Récupère toutes les entreprises actives via le schema public.
+        $companiesTable = DB::getDriverName() === 'pgsql' ? 'public.companies' : 'companies';
+        $companiesQuery = DB::table($companiesTable)
+            ->select(['id', 'name', 'language'])
+            ->where('status', '!=', 'suspended');
+
+        if ($onlyCompany) {
+            $companiesQuery->where('id', (string) $onlyCompany);
+        }
+
+        $companies = $companiesQuery->get();
+
+        $sent   = 0;
+        $errors = 0;
+
+        foreach ($companies as $company) {
+            $companyId = (string) $company->id;
+
+            // Basculer sur le schema tenant si PostgreSQL.
+            if (DB::getDriverName() === 'pgsql') {
+                try {
+                    DB::statement("SET search_path TO shared_tenants");
+                } catch (\Throwable) {
+                    // Fallback : schema par défaut.
+                }
+            }
+
+            try {
+                $managers = DB::table('employees')
+                    ->where('company_id', $companyId)
+                    ->where('status', 'active')
+                    ->whereNotNull('email')
+                    ->whereIn('manager_role', ['principal', 'rh'])
+                    ->select(['id', 'first_name', 'last_name', 'email', 'preferred_language'])
+                    ->get();
+
+                if ($managers->isEmpty()) {
+                    continue;
+                }
+
+                // KPIs entreprise ─────────────────────────────────────────
+                $pendingAbsences = (int) DB::table('absences')
+                    ->where('company_id', $companyId)
+                    ->where('status', 'pending')
+                    ->count();
+
+                // Taux de présence moyen : logs check_in des 7 derniers jours
+                $employeesActive = (int) DB::table('employees')
+                    ->where('company_id', $companyId)
+                    ->where('status', 'active')
+                    ->count();
+
+                $avgAttendancePct = 0;
+                if ($employeesActive > 0) {
+                    $checkedInDays = DB::table('attendance_logs')
+                        ->where('company_id', $companyId)
+                        ->whereBetween('check_in', [$weekStart, $weekEnd])
+                        ->distinct()
+                        ->select(DB::raw('DATE(check_in) as day'), 'employee_id')
+                        ->get()
+                        ->groupBy('day');
+
+                    if ($checkedInDays->isNotEmpty()) {
+                        $total = $checkedInDays->sum(fn ($day) => $day->count());
+                        $days  = $checkedInDays->count();
+                        $avgAttendancePct = (int) min(100, round(($total / ($employeesActive * $days)) * 100));
+                    }
+                }
+
+                $newEmployees = (int) DB::table('employees')
+                    ->where('company_id', $companyId)
+                    ->whereBetween('created_at', [$weekStart, $weekEnd])
+                    ->count();
+
+                $expiringContracts = DB::getSchemaBuilder()->hasTable('contracts')
+                    ? (int) DB::table('contracts')
+                        ->where('company_id', $companyId)
+                        ->where('status', 'active')
+                        ->where('end_date', '<=', $expiry)
+                        ->where('end_date', '>=', $now->toDateString())
+                        ->count()
+                    : 0;
+
+                $locale = (string) ($company->language ?? 'fr');
+                $weekLabel = $weekStart->locale($locale)->translatedFormat('d M') . ' – ' . $weekEnd->locale($locale)->translatedFormat('d M Y');
+
+                foreach ($managers as $manager) {
+                    $managerLocale = (string) ($manager->preferred_language ?? $locale);
+                    $managerName   = trim(($manager->first_name ?? '') . ' ' . ($manager->last_name ?? '')) ?: (string) $manager->email;
+
+                    $data = [
+                        'manager_name'        => $managerName,
+                        'company_name'        => (string) ($company->name ?? 'Leopardo RH'),
+                        'week_label'          => $weekLabel,
+                        'pending_absences'    => $pendingAbsences,
+                        'avg_attendance_pct'  => $avgAttendancePct,
+                        'new_employees'       => $newEmployees,
+                        'expiring_contracts'  => $expiringContracts,
+                        'app_url'             => rtrim((string) config('app.url', 'https://app.leopardo.io'), '/'),
+                    ];
+
+                    if ($dryRun) {
+                        $this->line("  → [DRY-RUN] {$manager->email} ({$companyId}) pending={$pendingAbsences} pct={$avgAttendancePct}%");
+                        continue;
+                    }
+
+                    try {
+                        Mail::to((string) $manager->email)
+                            ->send(new ManagerWeeklyDigestMail($data, $managerLocale));
+                        $sent++;
+                    } catch (\Throwable $e) {
+                        Log::warning('manager:weekly-digest mail error', [
+                            'email'      => $manager->email,
+                            'company_id' => $companyId,
+                            'error'      => $e->getMessage(),
+                        ]);
+                        $errors++;
+                    }
+                }
+            } catch (\Throwable $e) {
+                Log::error('manager:weekly-digest company error', [
+                    'company_id' => $companyId,
+                    'error'      => $e->getMessage(),
+                ]);
+                $errors++;
+            }
+        }
+
+        $this->info($dryRun
+            ? "[DRY-RUN] terminé — {$companies->count()} entreprise(s) analysée(s)."
+            : "Digest envoyé : {$sent} email(s), {$errors} erreur(s).");
+
+        return $errors > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/api/app/Mail/ManagerWeeklyDigestMail.php
+++ b/api/app/Mail/ManagerWeeklyDigestMail.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Digest hebdomadaire manager — résumé RH envoyé chaque lundi matin (#5695).
+ *
+ * Contient :
+ * - Absences en attente de validation (nombre)
+ * - Présences moyennes de la semaine écoulée
+ * - Nouveaux employés créés cette semaine
+ * - Contrats arrivant à échéance (30 j)
+ */
+class ManagerWeeklyDigestMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param  array{
+     *   manager_name: string,
+     *   company_name: string,
+     *   week_label: string,
+     *   pending_absences: int,
+     *   avg_attendance_pct: int,
+     *   new_employees: int,
+     *   expiring_contracts: int,
+     *   app_url: string,
+     * }  $data
+     */
+    public function __construct(
+        public readonly array $data,
+        public readonly string $locale = 'fr',
+    ) {}
+
+    public function build(): self
+    {
+        $subject = match ($this->locale) {
+            'ar' => "ملخص أسبوعي للموارد البشرية — {$this->data['company_name']}",
+            'tr' => "Haftalık HR Özeti — {$this->data['company_name']}",
+            'en' => "Weekly HR Digest — {$this->data['company_name']}",
+            default => "Résumé RH hebdomadaire — {$this->data['company_name']}",
+        };
+
+        return $this
+            ->subject($subject)
+            ->view('emails.manager-weekly-digest', [
+                'data'   => $this->data,
+                'locale' => $this->locale,
+            ]);
+    }
+}

--- a/api/app/Modules/Absence/Interfaces/Api/V1/Controllers/AbsenceTypeController.php
+++ b/api/app/Modules/Absence/Interfaces/Api/V1/Controllers/AbsenceTypeController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Absence\Interfaces\Api\V1\Controllers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Http\Controllers\Controller;
+use App\Modules\Planning\Domain\Models\AbsenceType;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Types d'absence disponibles pour l'entreprise du salarié connecté.
+ *
+ * Endpoint : GET /api/v1/absence-types
+ * Utilisé par le formulaire de demande de congé (front/web #5693) et
+ * les applications mobiles.
+ */
+class AbsenceTypeController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        $types = AbsenceType::query()
+            ->where('company_id', $actor->company_id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'code', 'is_paid', 'deducts_leave', 'requires_proof', 'max_days_once']);
+
+        return response()->json([
+            'data' => $types->map(fn (AbsenceType $t) => [
+                'id'            => $t->id,
+                'name'          => $t->name,
+                'code'          => $t->code,
+                'is_paid'       => (bool) $t->is_paid,
+                'deducts_leave' => (bool) $t->deducts_leave,
+                'requires_proof'=> (bool) $t->requires_proof,
+                'max_days_once' => $t->max_days_once,
+            ]),
+        ]);
+    }
+}

--- a/api/resources/views/emails/manager-weekly-digest.blade.php
+++ b/api/resources/views/emails/manager-weekly-digest.blade.php
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="{{ $locale ?? 'fr' }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ $locale === 'en' ? 'Weekly HR Digest' : ($locale === 'tr' ? 'Haftalık HR Özeti' : ($locale === 'ar' ? 'الملخص الأسبوعي' : 'Résumé RH hebdomadaire')) }}</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,Helvetica,sans-serif;color:#0f172a;">
+
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;padding:32px 16px;">
+  <tr>
+    <td align="center">
+      <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 24px rgba(0,0,0,0.06);">
+
+        {{-- Header --}}
+        <tr>
+          <td style="background:linear-gradient(135deg,#059669 0%,#0891b2 100%);padding:32px 40px;">
+            <p style="margin:0;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#a7f3d0;">
+              Leopardo RH
+            </p>
+            <h1 style="margin:8px 0 4px;font-size:26px;font-weight:900;color:#ffffff;line-height:1.2;">
+              @if($locale === 'en') Weekly HR Digest
+              @elseif($locale === 'tr') Haftalık HR Özeti
+              @elseif($locale === 'ar') الملخص الأسبوعي للموارد البشرية
+              @else Résumé RH hebdomadaire
+              @endif
+            </h1>
+            <p style="margin:0;font-size:13px;color:#d1fae5;">
+              {{ $data['company_name'] }} — {{ $data['week_label'] }}
+            </p>
+          </td>
+        </tr>
+
+        {{-- Greeting --}}
+        <tr>
+          <td style="padding:32px 40px 16px;">
+            <p style="margin:0;font-size:15px;color:#334155;">
+              @if($locale === 'en') Hello <strong>{{ $data['manager_name'] }}</strong>,
+              @elseif($locale === 'tr') Merhaba <strong>{{ $data['manager_name'] }}</strong>,
+              @elseif($locale === 'ar') مرحباً <strong>{{ $data['manager_name'] }}</strong>،
+              @else Bonjour <strong>{{ $data['manager_name'] }}</strong>,
+              @endif
+            </p>
+            <p style="margin:10px 0 0;font-size:14px;color:#64748b;line-height:1.6;">
+              @if($locale === 'en') Here is your weekly summary for the HR activity of your company.
+              @elseif($locale === 'tr') Şirketinizin geçen haftaki İK aktivitesinin özeti aşağıdadır.
+              @elseif($locale === 'ar') فيما يلي ملخص النشاط الأسبوعي لإدارة الموارد البشرية في شركتك.
+              @else Voici le résumé de l'activité RH de votre entreprise pour la semaine écoulée.
+              @endif
+            </p>
+          </td>
+        </tr>
+
+        {{-- Stats Grid --}}
+        <tr>
+          <td style="padding:16px 40px;">
+            <table width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+                {{-- Absences en attente --}}
+                <td width="48%" style="background:#fef3c7;border-radius:12px;padding:20px;vertical-align:top;">
+                  <p style="margin:0;font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:#92400e;">
+                    @if($locale === 'en') Pending leave requests
+                    @elseif($locale === 'tr') Bekleyen izin talepleri
+                    @elseif($locale === 'ar') طلبات الإجازة المعلقة
+                    @else Congés en attente
+                    @endif
+                  </p>
+                  <p style="margin:8px 0 0;font-size:40px;font-weight:900;color:#b45309;line-height:1;">
+                    {{ $data['pending_absences'] }}
+                  </p>
+                  @if($data['pending_absences'] > 0)
+                  <p style="margin:6px 0 0;font-size:12px;color:#92400e;">
+                    @if($locale === 'en') ⚡ Requires your attention
+                    @elseif($locale === 'tr') ⚡ Dikkatinizi gerektiriyor
+                    @elseif($locale === 'ar') ⚡ تتطلب انتباهك
+                    @else ⚡ Nécessite votre attention
+                    @endif
+                  </p>
+                  @endif
+                </td>
+                <td width="4%"></td>
+                {{-- Présence --}}
+                <td width="48%" style="background:#ecfdf5;border-radius:12px;padding:20px;vertical-align:top;">
+                  <p style="margin:0;font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:#065f46;">
+                    @if($locale === 'en') Avg. attendance rate
+                    @elseif($locale === 'tr') Ort. devam oranı
+                    @elseif($locale === 'ar') متوسط نسبة الحضور
+                    @else Taux de présence moy.
+                    @endif
+                  </p>
+                  <p style="margin:8px 0 0;font-size:40px;font-weight:900;color:#047857;line-height:1;">
+                    {{ $data['avg_attendance_pct'] }}%
+                  </p>
+                  <p style="margin:6px 0 0;font-size:12px;color:#065f46;">
+                    @if($locale === 'en') Last 7 days
+                    @elseif($locale === 'tr') Son 7 gün
+                    @elseif($locale === 'ar') آخر 7 أيام
+                    @else 7 derniers jours
+                    @endif
+                  </p>
+                </td>
+              </tr>
+              <tr><td colspan="3" style="height:12px;"></td></tr>
+              <tr>
+                {{-- Nouveaux employés --}}
+                <td width="48%" style="background:#eff6ff;border-radius:12px;padding:20px;vertical-align:top;">
+                  <p style="margin:0;font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:#1e40af;">
+                    @if($locale === 'en') New employees
+                    @elseif($locale === 'tr') Yeni çalışanlar
+                    @elseif($locale === 'ar') موظفون جدد
+                    @else Nouveaux employés
+                    @endif
+                  </p>
+                  <p style="margin:8px 0 0;font-size:40px;font-weight:900;color:#1d4ed8;line-height:1;">
+                    {{ $data['new_employees'] }}
+                  </p>
+                  <p style="margin:6px 0 0;font-size:12px;color:#1e40af;">
+                    @if($locale === 'en') This week
+                    @elseif($locale === 'tr') Bu hafta
+                    @elseif($locale === 'ar') هذا الأسبوع
+                    @else Cette semaine
+                    @endif
+                  </p>
+                </td>
+                <td width="4%"></td>
+                {{-- Contrats expirant --}}
+                <td width="48%" style="background:#fdf4ff;border-radius:12px;padding:20px;vertical-align:top;">
+                  <p style="margin:0;font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:#6b21a8;">
+                    @if($locale === 'en') Expiring contracts (30d)
+                    @elseif($locale === 'tr') Sona eren sözleşmeler (30g)
+                    @elseif($locale === 'ar') العقود المنتهية (30 يوم)
+                    @else Contrats expirant (30 j)
+                    @endif
+                  </p>
+                  <p style="margin:8px 0 0;font-size:40px;font-weight:900;color:#7c3aed;line-height:1;">
+                    {{ $data['expiring_contracts'] }}
+                  </p>
+                  @if($data['expiring_contracts'] > 0)
+                  <p style="margin:6px 0 0;font-size:12px;color:#6b21a8;">
+                    @if($locale === 'en') ⚠️ To renew
+                    @elseif($locale === 'tr') ⚠️ Yenilenecek
+                    @elseif($locale === 'ar') ⚠️ للتجديد
+                    @else ⚠️ À renouveler
+                    @endif
+                  </p>
+                  @endif
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        {{-- CTA --}}
+        <tr>
+          <td style="padding:24px 40px 32px;text-align:center;">
+            <a href="{{ $data['app_url'] }}/dashboard"
+               style="display:inline-block;background:linear-gradient(135deg,#059669,#0891b2);color:#ffffff;text-decoration:none;font-size:14px;font-weight:700;padding:14px 32px;border-radius:12px;">
+              @if($locale === 'en') Open dashboard
+              @elseif($locale === 'tr') Paneli aç
+              @elseif($locale === 'ar') فتح لوحة التحكم
+              @else Ouvrir le tableau de bord
+              @endif
+            </a>
+          </td>
+        </tr>
+
+        {{-- Footer --}}
+        <tr>
+          <td style="background:#f8fafc;padding:20px 40px;border-top:1px solid #e2e8f0;text-align:center;">
+            <p style="margin:0;font-size:11px;color:#94a3b8;">
+              Leopardo RH — {{ $data['company_name'] }}<br>
+              @if($locale === 'en') You receive this email because you are a manager in Leopardo.
+              @elseif($locale === 'tr') Bu e-postayı Leopardo'da yönetici olduğunuz için alıyorsunuz.
+              @elseif($locale === 'ar') تستلم هذا البريد الإلكتروني لأنك مدير في Leopardo.
+              @else Vous recevez cet email car vous êtes manager dans Leopardo.
+              @endif
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+</table>
+
+</body>
+</html>

--- a/api/routes/console.php
+++ b/api/routes/console.php
@@ -197,3 +197,10 @@ Artisan::command('super-admin:reset-password {email} {password}', function (stri
 // confirmer avant la clôture (novembre).
 Schedule::command('islamic:check-unconfirmed')
     ->yearlyOn(11, 15, '09:00');
+
+// #5695 — Digest RH hebdomadaire : envoyé aux managers le lundi à 07h30 UTC.
+// Inclut : absences en attente, taux de présence, nouveaux employés, contrats expirants.
+Schedule::command('manager:weekly-digest')
+    ->weeklyOn(1, '07:30')
+    ->withoutOverlapping()
+    ->onOneServer();

--- a/api/routes/modules/absence.php
+++ b/api/routes/modules/absence.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Modules\Absence\Interfaces\Api\V1\Controllers\AbsenceController;
+use App\Modules\Absence\Interfaces\Api\V1\Controllers\AbsenceTypeController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -12,6 +13,12 @@ use Illuminate\Support\Facades\Route;
 | Mounted inside Route::prefix('v1') in api.php.
 | Full paths: /api/v1/absences/...
 */
+
+Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])
+    ->group(function (): void {
+        // #5693 — Types d'absence disponibles (utilisé par le formulaire front/web).
+        Route::get('/absence-types', [AbsenceTypeController::class, 'index']);
+    });
 
 Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])
     ->prefix('absences')

--- a/front/web/src/app/(dashboard)/absences/page.tsx
+++ b/front/web/src/app/(dashboard)/absences/page.tsx
@@ -1,12 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Check, Loader2, X } from 'lucide-react';
+/**
+ * Page Absences/Congés — liste + formulaire de demande (#5693).
+ *
+ * Deux contextes d'utilisation :
+ * - Manager : voit toutes les demandes de son équipe, peut approuver/refuser.
+ * - Employé : voit ses propres demandes et peut en créer de nouvelles.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Check, Loader2, Plus, X, AlertTriangle, Calendar, FileText } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { getCopy, normalizeLocale } from '@/lib/i18n';
 import { ModulePageShell } from '@/components/module-page-shell';
 import { Button } from '@/components/ui/Button';
 import { useVitrineLocale } from '@/modules/vitrine/lib/vitrine-locale';
+import { t as i18nT } from '@/lib/i18n/locale-catalog';
+import type { AppLocale } from '@/lib/i18n';
 
 type AbsenceRecord = {
   id: number;
@@ -15,69 +25,172 @@ type AbsenceRecord = {
   status?: string;
   reason?: string | null;
   days_count?: number | string | null;
-  absence_type?: {
-    name?: string;
-  } | null;
+  absence_type?: { name?: string } | null;
 };
 
-type AbsencesPayload = {
-  data?: AbsenceRecord[];
+type AbsenceType = {
+  id: number;
+  name: string;
+  code: string;
+  is_paid: boolean;
+  deducts_leave: boolean;
+  requires_proof: boolean;
+  max_days_once: number;
 };
+
+type AbsencesPayload   = { data?: AbsenceRecord[] };
+type AbsenceTypesPayload = { data?: AbsenceType[] };
 
 const STATUS_LABEL_KEY: Record<string, keyof ReturnType<typeof getCopy>['absences']> = {
-  pending: 'statusPending',
-  approved: 'statusApproved',
-  rejected: 'statusRejected',
+  pending:   'statusPending',
+  approved:  'statusApproved',
+  rejected:  'statusRejected',
   cancelled: 'statusCancelled',
 };
 
 export default function AbsencesPage() {
   const { locale } = useVitrineLocale();
-  const appLocale = normalizeLocale(locale ?? 'fr');
+  const appLocale = normalizeLocale(locale ?? 'fr') as AppLocale;
   const labels = getCopy(appLocale).absences;
 
-  const [absences, setAbsences] = useState<AbsenceRecord[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [actionId, setActionId] = useState<number | null>(null);
-  const [rejectTarget, setRejectTarget] = useState<AbsenceRecord | null>(null);
-  const [rejectReason, setRejectReason] = useState('');
-  const [rejecting, setRejecting] = useState(false);
-  const [rejectError, setRejectError] = useState<string | null>(null);
+  const [absences, setAbsences]   = useState<AbsenceRecord[]>([]);
+  const [error, setError]         = useState<string | null>(null);
+  const [loading, setLoading]     = useState(true);
+  const [actionId, setActionId]   = useState<number | null>(null);
 
-  useEffect(() => {
-    let active = true;
+  // Reject modal
+  const [rejectTarget, setRejectTarget]   = useState<AbsenceRecord | null>(null);
+  const [rejectReason, setRejectReason]   = useState('');
+  const [rejecting, setRejecting]         = useState(false);
+  const [rejectError, setRejectError]     = useState<string | null>(null);
 
-    async function load() {
-      try {
-        const response = await apiFetch('/absences');
-        const payload = await response.json() as AbsencesPayload;
+  // New-request modal (#5693)
+  const [showNewForm, setShowNewForm]     = useState(false);
+  const [absenceTypes, setAbsenceTypes]   = useState<AbsenceType[]>([]);
+  const [typesLoading, setTypesLoading]   = useState(false);
+  const [newTypeId, setNewTypeId]         = useState('');
+  const [newStart, setNewStart]           = useState('');
+  const [newEnd, setNewEnd]               = useState('');
+  const [newReason, setNewReason]         = useState('');
+  const [newProof, setNewProof]           = useState<File | null>(null);
+  const [submitting, setSubmitting]       = useState(false);
+  const [newFormError, setNewFormError]   = useState<string | null>(null);
+  const [newFormSuccess, setNewFormSuccess] = useState<string | null>(null);
 
-        if (!active) {
-          return;
-        }
-
-        setAbsences(Array.isArray(payload.data) ? payload.data : []);
-      } catch (err) {
-        if (!active) {
-          return;
-        }
-
-        setError(err instanceof ApiError ? err.message : labels.loadError);
-      } finally {
-        if (active) {
-          setLoading(false);
-        }
-      }
+  // ── Chargement de la liste des absences ──────────────────────────────────
+  const loadAbsences = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiFetch('/absences');
+      const payload = (await response.json()) as AbsencesPayload;
+      setAbsences(Array.isArray(payload.data) ? payload.data : []);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : labels.loadError);
+    } finally {
+      setLoading(false);
     }
-
-    void load();
-
-    return () => {
-      active = false;
-    };
   }, [labels.loadError]);
 
+  useEffect(() => { void loadAbsences(); }, [loadAbsences]);
+
+  // ── Chargement des types d'absence (lazy, à l'ouverture du formulaire) ───
+  const openNewForm = useCallback(async () => {
+    setShowNewForm(true);
+    setNewFormError(null);
+    setNewFormSuccess(null);
+
+    if (absenceTypes.length > 0) return;
+
+    setTypesLoading(true);
+    try {
+      const r = await apiFetch('/absence-types');
+      const payload = (await r.json()) as AbsenceTypesPayload;
+      setAbsenceTypes(payload.data ?? []);
+    } catch {
+      setNewFormError(i18nT(appLocale, 'absence.typesLoadError', 'Impossible de charger les types de congé.'));
+    } finally {
+      setTypesLoading(false);
+    }
+  }, [absenceTypes.length, appLocale]);
+
+  const closeNewForm = useCallback(() => {
+    setShowNewForm(false);
+    setNewTypeId('');
+    setNewStart('');
+    setNewEnd('');
+    setNewReason('');
+    setNewProof(null);
+    setNewFormError(null);
+    setNewFormSuccess(null);
+  }, []);
+
+  // ── Soumission de la nouvelle demande ────────────────────────────────────
+  const handleSubmitNew = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    setNewFormError(null);
+
+    if (!newTypeId) {
+      setNewFormError(i18nT(appLocale, 'absence.typeRequired', 'Veuillez sélectionner un type de congé.'));
+      return;
+    }
+    if (!newStart || !newEnd) {
+      setNewFormError(i18nT(appLocale, 'absence.datesRequired', 'Les dates de début et de fin sont obligatoires.'));
+      return;
+    }
+    if (newEnd < newStart) {
+      setNewFormError(i18nT(appLocale, 'absence.endAfterStart', 'La date de fin doit être après la date de début.'));
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      // Si une pièce jointe est fournie, on envoie en multipart/form-data.
+      let body: FormData | string;
+
+      if (newProof) {
+        const fd = new FormData();
+        fd.append('absence_type_id', newTypeId);
+        fd.append('start_date', newStart);
+        fd.append('end_date', newEnd);
+        if (newReason) fd.append('reason', newReason);
+        fd.append('proof', newProof);
+        body = fd;
+      } else {
+        body = JSON.stringify({
+          absence_type_id: Number(newTypeId),
+          start_date: newStart,
+          end_date: newEnd,
+          reason: newReason || null,
+        });
+      }
+
+      const response = await apiFetch('/absences', {
+        method: 'POST',
+        ...(newProof ? {} : { headers: { 'Content-Type': 'application/json' } }),
+        body,
+      });
+
+      const result = (await response.json()) as { data?: AbsenceRecord };
+      if (result.data) {
+        setAbsences((prev) => [result.data as AbsenceRecord, ...prev]);
+      }
+
+      setNewFormSuccess(i18nT(appLocale, 'absence.submitSuccess', 'Votre demande a été envoyée et est en attente de validation.'));
+      setNewTypeId('');
+      setNewStart('');
+      setNewEnd('');
+      setNewReason('');
+      setNewProof(null);
+    } catch (err) {
+      setNewFormError(err instanceof ApiError ? err.message : i18nT(appLocale, 'absence.submitError', 'Impossible d\'envoyer la demande.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [newTypeId, newStart, newEnd, newReason, newProof, appLocale]);
+
+  // ── Actions manager ──────────────────────────────────────────────────────
   const applyStatus = (id: number, status: string) => {
     setAbsences((prev) => prev.map((a) => (a.id === id ? { ...a, status } : a)));
   };
@@ -96,18 +209,12 @@ export default function AbsencesPage() {
   };
 
   const handleReject = async () => {
-    if (!rejectTarget) {
-      return;
-    }
+    if (!rejectTarget) return;
     const reason = rejectReason.trim();
-    if (!reason) {
-      setRejectError(labels.reasonRequired);
-      return;
-    }
+    if (!reason) { setRejectError(labels.reasonRequired); return; }
     setRejecting(true);
     setRejectError(null);
     try {
-      // Contrat API : PUT /absences/{id}/reject — rejected_reason obligatoire (1-1000).
       await apiFetch(`/absences/${rejectTarget.id}/reject`, {
         method: 'PUT',
         body: JSON.stringify({ rejected_reason: reason }),
@@ -127,12 +234,34 @@ export default function AbsencesPage() {
     return labels[key];
   };
 
+  // ── Sélection du type courant (pour afficher requires_proof) ─────────────
+  const selectedType = absenceTypes.find((t) => String(t.id) === newTypeId);
+
   return (
     <ModulePageShell
       title={labels.title}
       subtitle=""
       accentClassName="from-emerald-500 to-teal-600"
     >
+      {/* Bouton Nouvelle demande (#5693) */}
+      <div className="flex justify-end mb-4">
+        <Button
+          variant="primary"
+          onClick={() => void openNewForm()}
+          icon={<Plus className="h-4 w-4" />}
+          className="rounded-xl bg-emerald-600 px-4 py-2 text-sm font-bold text-white hover:bg-emerald-500"
+        >
+          {i18nT(appLocale, 'absence.newRequest', 'Nouvelle demande')}
+        </Button>
+      </div>
+
+      {newFormSuccess && (
+        <div className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-sm font-medium text-emerald-800">
+          <Check className="h-4 w-4 shrink-0 text-emerald-600" />
+          {newFormSuccess}
+        </div>
+      )}
+
       <section className="rounded-2xl border border-app-border bg-white/40 shadow-glass-sm backdrop-blur-xl dark:bg-slate-900/40">
         {error && (
           <p role="alert" className="m-4 rounded-lg bg-red-50 px-3 py-2 text-xs font-medium text-red-700">
@@ -150,7 +279,7 @@ export default function AbsencesPage() {
         ) : (
           absences.map((absence) => {
             const isPending = absence.status === 'pending';
-            const busy = actionId === absence.id;
+            const busy      = actionId === absence.id;
             return (
               <div
                 key={absence.id}
@@ -159,11 +288,11 @@ export default function AbsencesPage() {
                 <div>
                   <p className="text-sm font-bold text-slate-950">{absence.absence_type?.name ?? labels.title}</p>
                   <p className="text-xs text-slate-500">
-                    {absence.start_date ?? '—'} au {absence.end_date ?? '—'}
+                    {absence.start_date ?? '—'} → {absence.end_date ?? '—'}
                   </p>
-                  {absence.reason ? (
+                  {absence.reason && (
                     <p className="mt-2 text-xs text-slate-500">{absence.reason}</p>
-                  ) : null}
+                  )}
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-slate-600">
@@ -196,11 +325,7 @@ export default function AbsencesPage() {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => {
-                          setRejectTarget(absence);
-                          setRejectReason('');
-                          setRejectError(null);
-                        }}
+                        onClick={() => { setRejectTarget(absence); setRejectReason(''); setRejectError(null); }}
                         disabled={busy}
                         className="border-red-200 text-red-700 hover:border-red-300 hover:text-red-800"
                       >
@@ -215,6 +340,158 @@ export default function AbsencesPage() {
         )}
       </section>
 
+      {/* ── Modal : Nouvelle demande (#5693) ─────────────────────────────── */}
+      {showNewForm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm"
+          onClick={(e) => { if (e.target === e.currentTarget) closeNewForm(); }}
+        >
+          <div
+            className="w-full max-w-lg overflow-hidden rounded-3xl bg-white shadow-2xl dark:bg-slate-900"
+            role="dialog"
+            aria-modal="true"
+            aria-label={i18nT(appLocale, 'absence.newRequest', 'Nouvelle demande')}
+          >
+            <div className="flex items-center justify-between border-b border-app-border px-6 py-4">
+              <div className="flex items-center gap-2">
+                <Calendar className="h-5 w-5 text-emerald-600" />
+                <h2 className="text-lg font-bold text-slate-900 dark:text-white">
+                  {i18nT(appLocale, 'absence.newRequest', 'Nouvelle demande de congé')}
+                </h2>
+              </div>
+              <button
+                onClick={closeNewForm}
+                aria-label={labels.cancel}
+                className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <form className="p-6 space-y-5" onSubmit={(e) => void handleSubmitNew(e)}>
+              {newFormError && (
+                <div role="alert" className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  {newFormError}
+                </div>
+              )}
+
+              {/* Type de congé */}
+              <div>
+                <label htmlFor="new-absence-type" className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1.5">
+                  {i18nT(appLocale, 'absence.typeLabel', 'Type de congé')} <span className="text-red-500">*</span>
+                </label>
+                {typesLoading ? (
+                  <div className="flex items-center gap-2 text-sm text-slate-400 py-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {i18nT(appLocale, 'absence.typesLoading', 'Chargement...')}
+                  </div>
+                ) : (
+                  <select
+                    id="new-absence-type"
+                    value={newTypeId}
+                    required
+                    className="block h-11 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                    onChange={(e) => { setNewTypeId(e.target.value); setNewFormError(null); }}
+                  >
+                    <option value="">{i18nT(appLocale, 'absence.selectType', '— Choisir un type —')}</option>
+                    {absenceTypes.map((t) => (
+                      <option key={t.id} value={t.id}>{t.name}{t.is_paid ? '' : ' (non payé)'}</option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              {/* Dates */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="new-start-date" className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1.5">
+                    {i18nT(appLocale, 'absence.startDate', 'Début')} <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    id="new-start-date"
+                    type="date"
+                    required
+                    className="block h-11 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                    value={newStart}
+                    onChange={(e) => { setNewStart(e.target.value); setNewFormError(null); }}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="new-end-date" className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1.5">
+                    {i18nT(appLocale, 'absence.endDate', 'Fin')} <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    id="new-end-date"
+                    type="date"
+                    required
+                    min={newStart || undefined}
+                    className="block h-11 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                    value={newEnd}
+                    onChange={(e) => { setNewEnd(e.target.value); setNewFormError(null); }}
+                  />
+                </div>
+              </div>
+
+              {/* Motif */}
+              <div>
+                <label htmlFor="new-reason" className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1.5">
+                  {i18nT(appLocale, 'absence.reason', 'Motif')}
+                  <span className="ml-1 text-slate-400 font-normal">{i18nT(appLocale, 'absence.optional', '(optionnel)')}</span>
+                </label>
+                <textarea
+                  id="new-reason"
+                  rows={2}
+                  maxLength={1000}
+                  placeholder={i18nT(appLocale, 'absence.reasonPlaceholder', 'Ex : congé annuel, maladie, événement familial…')}
+                  className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                  value={newReason}
+                  onChange={(e) => setNewReason(e.target.value)}
+                />
+              </div>
+
+              {/* Pièce justificative (conditionnel selon requires_proof) */}
+              {(selectedType?.requires_proof || newProof) && (
+                <div>
+                  <label htmlFor="new-proof" className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1.5">
+                    <FileText className="inline h-3.5 w-3.5 mr-1" />
+                    {i18nT(appLocale, 'absence.proof', 'Pièce justificative')}
+                    {selectedType?.requires_proof && <span className="text-red-500 ml-1">*</span>}
+                  </label>
+                  <input
+                    id="new-proof"
+                    type="file"
+                    accept=".jpg,.jpeg,.png,.pdf,.heic"
+                    className="block w-full text-sm text-slate-500 file:mr-3 file:rounded-xl file:border-0 file:bg-emerald-50 file:px-3 file:py-1.5 file:text-xs file:font-bold file:text-emerald-700 hover:file:bg-emerald-100"
+                    onChange={(e) => setNewProof(e.target.files?.[0] ?? null)}
+                  />
+                  <p className="mt-1 text-xs text-slate-400">
+                    {i18nT(appLocale, 'absence.proofHint', 'JPG, PNG, HEIC ou PDF — max 5 Mo')}
+                  </p>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <Button variant="outline" type="button" onClick={closeNewForm} disabled={submitting} className="bg-white">
+                  {labels.cancel}
+                </Button>
+                <Button
+                  type="submit"
+                  loading={submitting}
+                  disabled={submitting}
+                  className="rounded-xl bg-emerald-600 px-5 py-2 text-sm font-bold text-white hover:bg-emerald-500"
+                >
+                  {submitting
+                    ? i18nT(appLocale, 'absence.submitting', 'Envoi...')
+                    : i18nT(appLocale, 'absence.submit', 'Envoyer la demande')}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* ── Modal : Refus ──────────────────────────────────────────────────── */}
       {rejectTarget && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm">
           <div
@@ -225,11 +502,7 @@ export default function AbsencesPage() {
           >
             <div className="flex items-center justify-between border-b border-app-border px-6 py-4">
               <h2 className="text-lg font-bold text-slate-900 dark:text-white">{labels.rejectTitle}</h2>
-              <button
-                onClick={() => setRejectTarget(null)}
-                aria-label={labels.cancel}
-                className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
-              >
+              <button onClick={() => setRejectTarget(null)} aria-label={labels.cancel} className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600">
                 <X className="h-4 w-4" />
               </button>
             </div>
@@ -247,9 +520,7 @@ export default function AbsencesPage() {
                 className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-red-400 focus:ring-2 focus:ring-red-400/30 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
               />
               {rejectError && (
-                <p role="alert" className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-xs font-medium text-red-700">
-                  {rejectError}
-                </p>
+                <p role="alert" className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-xs font-medium text-red-700">{rejectError}</p>
               )}
               <div className="mt-5 flex justify-end gap-3">
                 <Button variant="outline" onClick={() => setRejectTarget(null)} disabled={rejecting} className="bg-white">

--- a/front/web/src/app/(dashboard)/attendance/page.tsx
+++ b/front/web/src/app/(dashboard)/attendance/page.tsx
@@ -1,9 +1,22 @@
-﻿'use client';
+'use client';
 
-import { useEffect, useState, useSyncExternalStore } from 'react';
+/**
+ * Page Pointage du jour + export CSV mensuel (#5696).
+ *
+ * - Vue manager (mode collection) : affiche toute l'équipe + bouton export CSV.
+ * - Vue employé (mode single) : affiche son propre pointage.
+ *
+ * L'export utilise GET /api/v1/export/attendance?format=csv&from=...&to=...
+ * et déclenche un téléchargement côté navigateur.
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { Download, Loader2, Calendar } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { getCopy, getPreferredLocale, type AppLocale } from '@/lib/i18n';
 import { ModulePageShell } from '@/components/module-page-shell';
+import { Button } from '@/components/ui/Button';
+import { t as i18nT } from '@/lib/i18n/locale-catalog';
 
 type AttendanceItem = {
   employee_id?: number;
@@ -29,15 +42,61 @@ type AttendancePayload = {
   };
 };
 
+type ExportPayload = {
+  data?: {
+    format?: string;
+    content?: string;
+    filename?: string;
+    count?: number;
+  };
+};
+
 const emptySubscribe = () => () => {};
+
+/** Formate YYYY-MM-DD pour le premier et dernier jour du mois donné. */
+function monthRange(yearMonth: string): { from: string; to: string } {
+  const [year, month] = yearMonth.split('-').map(Number);
+  const from = new Date(year, month - 1, 1);
+  const to   = new Date(year, month, 0); // dernier jour du mois
+  const pad  = (n: number) => String(n).padStart(2, '0');
+  return {
+    from: `${from.getFullYear()}-${pad(from.getMonth() + 1)}-01`,
+    to:   `${to.getFullYear()}-${pad(to.getMonth() + 1)}-${pad(to.getDate())}`,
+  };
+}
+
+/** Déclenche un téléchargement de fichier CSV dans le navigateur. */
+function downloadCsv(csvContent: string, filename: string): void {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url  = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/** Renvoie le mois courant au format YYYY-MM. */
+function currentYearMonth(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
 
 export default function AttendancePage() {
   const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const copy = getCopy(locale);
-  const [mode, setMode] = useState<'collection' | 'single'>('single');
+  const [mode, setMode]   = useState<'collection' | 'single'>('single');
   const [items, setItems] = useState<AttendanceItem[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Export CSV (#5696)
+  const [exportMonth, setExportMonth]     = useState<string>(currentYearMonth);
+  const [exporting, setExporting]         = useState(false);
+  const [exportError, setExportError]     = useState<string | null>(null);
+  const [exportSuccess, setExportSuccess] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -45,12 +104,10 @@ export default function AttendancePage() {
     async function load() {
       try {
         const response = await apiFetch('/attendance/today');
-        const payload = await response.json() as AttendancePayload;
-        const data = payload.data;
+        const payload  = (await response.json()) as AttendancePayload;
+        const data     = payload.data;
 
-        if (!active) {
-          return;
-        }
+        if (!active) return;
 
         if (data?.mode === 'collection' && Array.isArray(data.items)) {
           setMode('collection');
@@ -60,32 +117,59 @@ export default function AttendancePage() {
 
         const singleItem = data?.item ?? data;
         setMode('single');
-        setItems(singleItem ? [singleItem] : []);
+        setItems(singleItem ? [singleItem as AttendanceItem] : []);
       } catch (err) {
-        if (!active) {
-          return;
-        }
-
+        if (!active) return;
         setError(err instanceof ApiError ? err.message : copy.attendancePage.loadError);
       } finally {
-        if (active) {
-          setLoading(false);
-        }
+        if (active) setLoading(false);
       }
     }
 
     void load();
-
-    return () => {
-      active = false;
-    };
+    return () => { active = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  /** Export CSV mensuel — #5696. */
+  const handleExportCsv = useCallback(async () => {
+    setExporting(true);
+    setExportError(null);
+    setExportSuccess(null);
+
+    const { from, to } = monthRange(exportMonth);
+    const params = new URLSearchParams({ format: 'csv', from, to });
+
+    try {
+      const response = await apiFetch(`/export/attendance?${params.toString()}`);
+      const payload  = (await response.json()) as ExportPayload;
+
+      const csvContent = payload.data?.content ?? '';
+      const filename   = payload.data?.filename ?? `attendance_${from}_${to}.csv`;
+      const count      = payload.data?.count ?? 0;
+
+      if (!csvContent) {
+        setExportError(i18nT(locale, 'csvExport.empty', 'Aucune donnée à exporter pour cette période.'));
+        return;
+      }
+
+      downloadCsv(csvContent, filename);
+      setExportSuccess(
+        count > 0
+          ? i18nT(locale, 'csvExport.success', `${count} ligne(s) exportée(s).`).replace('{count}', String(count))
+          : i18nT(locale, 'csvExport.done', 'Export téléchargé.')
+      );
+    } catch (err) {
+      setExportError(err instanceof ApiError ? err.message : i18nT(locale, 'csvExport.error', 'Impossible de générer l\'export.'));
+    } finally {
+      setExporting(false);
+    }
+  }, [exportMonth, locale]);
+
   return (
     <ModulePageShell
-      title="Pointage du jour"
-      subtitle="État temps réel depuis l’API RH. La page s’adapte aux comptes manager ou employé selon le payload backend."
+      title={i18nT(locale, 'attendance.title', 'Pointage du jour')}
+      subtitle={i18nT(locale, 'attendance.subtitle', 'État temps réel depuis l\'API RH.')}
       accentClassName="bg-gradient-to-br from-warning/10 via-white to-white"
     >
       {error ? (
@@ -94,10 +178,56 @@ export default function AttendancePage() {
         </div>
       ) : null}
 
+      {/* ── Export CSV mensuel (#5696) — visible uniquement pour les managers ── */}
+      {!loading && mode === 'collection' && (
+        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <Calendar className="h-5 w-5 text-emerald-600 shrink-0" aria-hidden="true" />
+          <div className="flex-1">
+            <p className="text-sm font-bold text-slate-950">
+              {i18nT(locale, 'csvExport.title', 'Export CSV présences')}
+            </p>
+            <p className="text-xs text-slate-500">
+              {i18nT(locale, 'csvExport.subtitle', 'Téléchargez le rapport mensuel de pointage de votre équipe.')}
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 w-full sm:w-auto">
+            <input
+              type="month"
+              value={exportMonth}
+              max={currentYearMonth()}
+              className="h-9 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+              onChange={(e) => { setExportMonth(e.target.value); setExportError(null); setExportSuccess(null); }}
+              aria-label={i18nT(locale, 'csvExport.monthLabel', 'Mois à exporter')}
+            />
+            <Button
+              type="button"
+              loading={exporting}
+              disabled={exporting || !exportMonth}
+              icon={exporting ? undefined : <Download className="h-4 w-4" />}
+              className="h-9 rounded-xl bg-emerald-600 px-4 text-xs font-black uppercase tracking-widest text-white hover:bg-emerald-500 disabled:opacity-50 shrink-0"
+              onClick={() => void handleExportCsv()}
+            >
+              {exporting
+                ? i18nT(locale, 'csvExport.exporting', 'Export...')
+                : i18nT(locale, 'csvExport.button', 'Exporter CSV')}
+            </Button>
+          </div>
+
+          {/* Feedback */}
+          {exportSuccess && (
+            <p className="w-full text-xs font-medium text-emerald-700 mt-1">{exportSuccess}</p>
+          )}
+          {exportError && (
+            <p role="alert" className="w-full text-xs font-medium text-red-600 mt-1">{exportError}</p>
+          )}
+        </div>
+      )}
+
+      {/* ── Statistiques rapides ──────────────────────────────────────────── */}
       <section className="grid gap-4 md:grid-cols-3">
         <div className="rounded-2xl border border-app-border bg-white p-5 shadow-sm">
           <p className="text-xs font-bold uppercase tracking-widest text-slate-400">Mode</p>
-          <p className="mt-3 text-3xl font-black text-slate-950">{loading ? '...' : mode === 'collection' ? 'Manager' : 'Employe'}</p>
+          <p className="mt-3 text-3xl font-black text-slate-950">{loading ? '...' : mode === 'collection' ? 'Manager' : 'Employé'}</p>
         </div>
         <div className="rounded-2xl border border-app-border bg-white p-5 shadow-sm">
           <p className="text-xs font-bold uppercase tracking-widest text-slate-400">Lignes</p>
@@ -109,15 +239,19 @@ export default function AttendancePage() {
         </div>
       </section>
 
+      {/* ── Liste pointage ────────────────────────────────────────────────── */}
       <section className="overflow-hidden rounded-3xl border border-app-border bg-white shadow-sm">
         <div className="border-b border-app-border px-6 py-4">
-          <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">Etat courant</h2>
+          <h2 className="text-sm font-bold uppercase tracking-wider text-slate-800">État courant</h2>
         </div>
         <div className="divide-y divide-app-border">
           {loading ? (
-            <div className="px-6 py-8 text-sm text-slate-500">Chargement du pointage...</div>
+            <div className="flex items-center gap-2 px-6 py-8 text-sm text-slate-500">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              <span>Chargement du pointage...</span>
+            </div>
           ) : items.length === 0 ? (
-            <div className="px-6 py-8 text-sm text-slate-500">Aucune donnee visible pour aujourd hui.</div>
+            <div className="px-6 py-8 text-sm text-slate-500">Aucune donnée visible pour aujourd'hui.</div>
           ) : (
             items.map((item, index) => (
               <div key={`${item.employee_id ?? 'self'}-${index}`} className="flex flex-col gap-3 px-6 py-5 md:flex-row md:items-center md:justify-between">
@@ -126,7 +260,7 @@ export default function AttendancePage() {
                   <p className="text-xs text-slate-500">{item.matricule ?? 'Session personnelle'}</p>
                 </div>
                 <div className="flex flex-wrap gap-2 text-[11px] font-bold uppercase tracking-wider">
-                  <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">{item.check_in_time ?? 'Pas d entree'}</span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">{item.check_in_time ?? 'Pas d\'entrée'}</span>
                   <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">{item.check_out_time ?? 'Pas de sortie'}</span>
                   <span className="rounded-full bg-warning/15 px-3 py-1 text-warning">{item.status ?? 'inconnu'}</span>
                 </div>
@@ -138,4 +272,3 @@ export default function AttendancePage() {
     </ModulePageShell>
   );
 }
-

--- a/front/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/front/web/src/app/(dashboard)/dashboard/page.tsx
@@ -21,6 +21,7 @@ import {
   FileCheck,
   Languages,
   ArrowRight,
+  Loader2,
 } from 'lucide-react';
 import { ApiError, apiFetch } from '@/lib/api-client';
 import { trackClientEvent } from '@/lib/client-analytics';
@@ -726,6 +727,112 @@ function PriorityAction({ label, value, href }: { label: string; value: number; 
   );
 }
 
+type LeaveBalance = {
+  id: number | string;
+  absence_type?: { id?: number; name?: string; code?: string } | null;
+  allocated_days?: number | null;
+  used_days?: number | null;
+  remaining_days?: number | null;
+};
+
+/**
+ * #5694 — Carte solde congés pour le dashboard employé.
+ * Charge GET /api/v1/me/leave-balances et affiche les soldes par type.
+ */
+function LeaveBalanceCard({ locale }: { locale: AppLocale }) {
+  const [balances, setBalances] = useState<LeaveBalance[]>([]);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    apiFetch('/me/leave-balances')
+      .then((r) => r.json() as Promise<{ data?: LeaveBalance[] }>)
+      .then((p) => {
+        if (!active) return;
+        setBalances(Array.isArray(p.data) ? p.data : []);
+      })
+      .catch(() => { if (active) setError(true); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  if (error || (!loading && balances.length === 0)) return null;
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center gap-2 mb-5">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-emerald-600 text-white shrink-0">
+          <Calendar className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div>
+          <h2 className="text-base font-black text-slate-950">
+            {i18nT(locale, 'leaveBalance.title', 'Mes soldes de congés')}
+          </h2>
+          <p className="text-xs text-slate-500">
+            {i18nT(locale, 'leaveBalance.subtitle', 'Jours disponibles pour l\'année en cours')}
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-slate-400 py-4">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>{i18nT(locale, 'leaveBalance.loading', 'Chargement...')}</span>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {balances.map((balance) => {
+            const allocated = Number(balance.allocated_days ?? 0);
+            const used      = Number(balance.used_days ?? 0);
+            const remaining = Number(balance.remaining_days ?? (allocated - used));
+            const pct       = allocated > 0 ? Math.min(100, Math.round((used / allocated) * 100)) : 0;
+            const critical  = remaining <= 2 && allocated > 0;
+
+            return (
+              <div
+                key={String(balance.id)}
+                className={`rounded-2xl border p-4 ${critical ? 'border-amber-200 bg-amber-50' : 'border-slate-100 bg-slate-50'}`}
+              >
+                <p className="text-xs font-bold uppercase tracking-wider text-slate-500 truncate">
+                  {balance.absence_type?.name ?? i18nT(locale, 'leaveBalance.leave', 'Congé')}
+                </p>
+                <div className="mt-2 flex items-end justify-between gap-2">
+                  <p className={`text-3xl font-black tabular-nums ${critical ? 'text-amber-700' : 'text-slate-950'}`}>
+                    {remaining}
+                  </p>
+                  <p className="text-xs text-slate-400 pb-1">
+                    / {allocated} j
+                  </p>
+                </div>
+                {/* Barre de progression */}
+                {allocated > 0 && (
+                  <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-slate-200">
+                    <div
+                      className={`h-full rounded-full transition-all duration-500 ${critical ? 'bg-amber-400' : 'bg-emerald-500'}`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                )}
+                <p className="mt-1.5 text-[10px] text-slate-400">
+                  {used} {i18nT(locale, 'leaveBalance.used', 'utilisé(s)')} · {remaining} {i18nT(locale, 'leaveBalance.remaining', 'restant(s)')}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-4 flex justify-end">
+        <Link href="/absences" className="inline-flex items-center gap-1 text-xs font-bold text-emerald-600 hover:text-emerald-800 transition">
+          {i18nT(locale, 'leaveBalance.viewAll', 'Voir mes demandes')}
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 function EmployeeDashboard({ user }: { user: StoredAuthUser | null }) {
   const locale = useSyncExternalStore<AppLocale>(emptySubscribe, getPreferredLocale, () => 'fr');
   const cards = [
@@ -754,6 +861,9 @@ function EmployeeDashboard({ user }: { user: StoredAuthUser | null }) {
           </Link>
         ))}
       </div>
+
+      {/* #5694 — Carte solde congés */}
+      <LeaveBalanceCard locale={locale} />
     </div>
   );
 }


### PR DESCRIPTION
## Résumé

Implémente 4 fonctionnalités demandées (lot 2).

---

### #5693 — Formulaire demande congé front/web

**Avant :** `/absences` n'affichait qu'une liste, sans aucun moyen de créer une nouvelle demande.

**Après :**
- Bouton « Nouvelle demande » → modal avec type de congé, dates, motif, pièce justificative conditionnelle (`requires_proof`)
- Nouveau backend `GET /api/v1/absence-types` (types disponibles pour l'entreprise)
- Soumission via `POST /absences` existant (JSON ou multipart selon présence d'une pièce jointe)

---

### #5694 — Carte solde congés dashboard

**Avant :** Aucune visibilité sur les soldes de congés pour l'employé sur son dashboard.

**Après :**
- Nouvelle carte « Mes soldes de congés » sur le dashboard employé
- Alimentée par `GET /me/leave-balances` (déjà existant)
- Barre de progression par type de congé + alerte visuelle si solde ≤ 2 jours

---

### #5695 — Digest email hebdo manager

**Avant :** Aucun résumé RH périodique envoyé aux managers.

**Après :**
- `ManagerWeeklyDigestMail` + template Blade multilingue (fr/en/ar/tr)
- Commande `manager:weekly-digest` (option `--dry-run`, `--company=`)
- Planifiée chaque lundi 07h30 UTC (`routes/console.php`)
- KPIs : absences en attente, taux de présence moyen 7j, nouveaux employés, contrats expirant à 30j

---

### #5696 — Export CSV présences mensuel

**Avant :** L'endpoint `GET /export/attendance?format=csv` existait côté backend mais aucune UI ne l'exposait.

**Après :**
- Sélecteur de mois + bouton « Exporter CSV » sur `/attendance` (visible en mode manager)
- Déclenche un téléchargement navigateur (Blob + `URL.createObjectURL`)
- Feedback succès/erreur inline

---

## Fichiers modifiés

| Fichier | Change |
|---|---|
| `api/app/Modules/Absence/Interfaces/Api/V1/Controllers/AbsenceTypeController.php` | Nouveau — GET /absence-types |
| `api/routes/modules/absence.php` | Route absence-types |
| `front/web/src/app/(dashboard)/absences/page.tsx` | Modal nouvelle demande |
| `front/web/src/app/(dashboard)/dashboard/page.tsx` | LeaveBalanceCard |
| `api/app/Mail/ManagerWeeklyDigestMail.php` | Nouveau — mailable digest |
| `api/resources/views/emails/manager-weekly-digest.blade.php` | Nouveau — template email |
| `api/app/Console/Commands/SendManagerWeeklyDigestCommand.php` | Nouveau — commande + KPIs |
| `api/routes/console.php` | Schedule hebdo lundi 07h30 |
| `front/web/src/app/(dashboard)/attendance/page.tsx` | Export CSV mensuel |

Closes #5693 — Closes #5694 — Closes #5695 — Closes #5696