### PR TITLE
docs(governance): suivi pipeline DEP-BC24 TRAVEL (2026-08-30)

### DIFF
--- a/docs/architecture/maturity/DEP_BC24_TRAVEL_MATURITY.md
+++ b/docs/architecture/maturity/DEP_BC24_TRAVEL_MATURITY.md
@@ -1,9 +1,9 @@
 # DEP-BC24 — Rapport de maturité BC-24 TRAVEL
 
-> **Issue :** [TRAVEL-050 #5998](https://github.com/kitokoh/leopardo-hr/issues/5998)
+> **Issue :** [TRAVEL-050 #5998](https://github.com/kitokoh/leopardo-hr/issues/5998) + [DEP-BC24 #6275](https://github.com/kitokoh/leopardo-hr/issues/6275)
 > **Contexte :** BC-24 — TravelAgency (verticale agence de voyage : réseau, trajets, réservations, passagers, billets, paiements mobile money, locations, hôtels, rapports)
-> **Date :** 2026-08-29
-> **Statut :** **Planifié** — la solution n'est pas encore sur `main` ; maturité à mesurer à l'arrivée du code (issues TRAVEL-001..051).
+> **Date :** 2026-08-29 (mise à jour : 2026-08-30)
+> **Statut :** **Planifié** — la solution n'est pas encore sur `main` ; maturité à mesurer à l'arrivée du code (issues TRAVEL-001..051). Pipeline d'implémentation actif : voir §6.
 > **Spécification :** `docs/specifications/SOLUTION_TRAVEL_AGENCY.md`
 
 ## 1. Cartographie (état `main`)
@@ -40,6 +40,25 @@ GJ-TRAVEL-01, recette signée TRAVEL-051). **Aucun GO prématuré possible** (ga
 
 ## 5. Prochaine action
 
-Valider la spécification `SOLUTION_TRAVEL_AGENCY.md` (propriétaire), puis créer/implémenter
-TRAVEL-001 → TRAVEL-004 (fondations), livrer TRAVEL-010..014 (schéma), puis exécuter la scorecard
-12 dimensions + mettre à jour ce rapport à l'arrivée du code sur `main`.
+Valider la spécification `SOLUTION_TRAVEL_AGENCY.md` (propriétaire), merger les PRs de fondations
+(#6127), boutique/paiements/billets (#6273), UI admin (#6316) et extensions 8xx (#6340), puis
+exécuter la scorecard 12 dimensions et mettre à jour ce rapport à l'arrivée du code sur `main`.
+
+## 6. Suivi pipeline (2026-08-30)
+
+Le contexte est en cours d'implémentation par lots parallèles — branches `feat/travel-*` et
+`bc/bc24-*` ; aucune fusion sur `main` à ce jour (le code travel n'existe donc pas encore sur
+`main`) :
+
+| Lot | Branche / PR | Périmètre |
+|---|---|---|
+| Fondations | `feat/travel-101-202-foundations` (PR #6127) | TRAVEL-101..108 + 201..203 (squelette DDD, flag, manifest, onboarding, migrations pays/villes/stations/offices) |
+| Schéma & domaine | issues TRAVEL-204..217 (branches à venir) | Migrations réseau/routes/ventes/location/hôtels, enums, contracts, factories |
+| Boutique & paiements | `feat/travel-401-404-shop` (PR #6273) | TRAVEL-401..405 (shop, paiements cash/PVIT, billets PDF) |
+| UI admin | `bc/bc24-admin-screens` (PR #6316) | TRAVEL-601..609 + 1008 (navigation, écrans référentiel/réseau/réservations/check-in/billets/rapports/locations) |
+| Extensions 8xx | `bc/bc24-travel-extensions` (PR #6340) | TRAVEL-801..809 (sièges auto, aller-retour, groupe, recherche flexible, multi-devise…) |
+| Qualité & pilote | `bc/bc24-travel-qualite-pilote` (PR #6352) | TRAVEL-050/051 + DEP-BC24 : runbook, recette UAT, gates, audit RGPD, golden journey |
+
+Scorecard 12 dimensions : ⏳ Planifié — sera évaluée dimension par dimension à la fusion des lots
+ci-dessus (DoD commun `docs/architecture/BOUNDED-CONTEXT-DEEP-MATURITY-BACKLOG.md`). Les gates
+pilote (MAT-018) restent verrouillés (aucun GO prématuré, garde CI).


### PR DESCRIPTION
## DEP-BC24 (#6275) — Suivi pipeline de maturité BC-24 TRAVEL

- `docs/architecture/maturity/DEP_BC24_TRAVEL_MATURITY.md` actualisé (2026-08-30) : cartographie des 6 lots d'implémentation en cours (fondations #6127, boutique #6273, UI admin #6316, extensions #6340, qualité/pilote #6352) — aucun code travel sur `main` à ce jour, scorecard 12 dimensions ⏳ planifiée, gates pilote MAT-018 verrouillés.
- L'implémentation réelle des corrections suit via les PRs TRAVEL listées (fondations non mergées = blocage principal).

Note : ce rapport documente l'avancement (phase 1 DEP). La fermeture de #6275 interviendra quand les 12 dimensions seront évaluées sur le code réellement fusionné.