### PR TITLE
fix(travel): échappement apostrophes COMMENT ON TABLE — migrations articles/commentaires (TRAVEL-901..903)

### DIFF
--- a/api/database/migrations/tenant/2026_08_30_000916_6104_create_travel_articles_tables.php
+++ b/api/database/migrations/tenant/2026_08_30_000916_6104_create_travel_articles_tables.php
@@ -25,7 +25,7 @@ return new class extends Migration
                 $table->unique(['company_id', 'slug'], 'travel_article_categories_company_slug_unique');
             });
 
-            DB::statement("COMMENT ON TABLE travel_article_categories IS 'Catégories d'articles éditoriaux (TRAVEL-901/#6104).'");
+            DB::statement("COMMENT ON TABLE travel_article_categories IS 'Catégories d''articles éditoriaux (TRAVEL-901/#6104).'");
         }
 
         if (! schemaTableExists('travel_articles')) {

--- a/api/database/migrations/tenant/2026_08_30_000917_6105_create_travel_comments_engagement_tables.php
+++ b/api/database/migrations/tenant/2026_08_30_000917_6105_create_travel_comments_engagement_tables.php
@@ -31,7 +31,7 @@ return new class extends Migration
                 $table->index(['company_id', 'article_id'], 'travel_comments_company_article_idx');
             });
 
-            DB::statement("COMMENT ON TABLE travel_comments IS 'Commentaires d'articles - modération (TRAVEL-902/#6105).'");
+            DB::statement("COMMENT ON TABLE travel_comments IS 'Commentaires d''articles - modération (TRAVEL-902/#6105).'");
         }
 
         if (! schemaTableExists('travel_likes')) {
@@ -45,7 +45,7 @@ return new class extends Migration
                 $table->unique(['company_id', 'article_id', 'actor_type', 'actor_id'], 'travel_likes_company_article_actor_unique');
             });
 
-            DB::statement("COMMENT ON TABLE travel_likes IS 'Likes d'articles - unicite (tenant, article, acteur) (TRAVEL-903/#6106).'");
+            DB::statement("COMMENT ON TABLE travel_likes IS 'Likes d''articles - unicite (tenant, article, acteur) (TRAVEL-903/#6106).'");
         }
 
         if (! schemaTableExists('travel_shares')) {
@@ -60,7 +60,7 @@ return new class extends Migration
                 $table->index(['company_id', 'article_id'], 'travel_shares_company_article_idx');
             });
 
-            DB::statement("COMMENT ON TABLE travel_shares IS 'Partages d'articles (canal) (TRAVEL-903/#6106).'");
+            DB::statement("COMMENT ON TABLE travel_shares IS 'Partages d''articles (canal) (TRAVEL-903/#6106).'");
         }
 
         if (! schemaTableExists('travel_ratings')) {
@@ -75,7 +75,7 @@ return new class extends Migration
                 $table->unique(['company_id', 'article_id', 'actor_type', 'actor_id'], 'travel_ratings_company_article_actor_unique');
             });
 
-            DB::statement("COMMENT ON TABLE travel_ratings IS 'Notes d'articles 1..5 - unicite (tenant, article, acteur) (TRAVEL-903/#6106).'");
+            DB::statement("COMMENT ON TABLE travel_ratings IS 'Notes d''articles 1..5 - unicite (tenant, article, acteur) (TRAVEL-903/#6106).'");
         }
     }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29111,6 +29111,22 @@ components:
       required: true
       schema:
         type: string
+    TravelReportPeriod:
+      name: period_from
+      in: query
+      description: Début de période (YYYY-MM-DD) — agrégation des rapports TRAVEL-501..504.
+      required: false
+      schema:
+        type: string
+        format: date
+    TravelReportPeriodTo:
+      name: period_to
+      in: query
+      description: Fin de période (YYYY-MM-DD) — agrégation des rapports TRAVEL-501..504.
+      required: false
+      schema:
+        type: string
+        format: date
   headers:
     XRequestId:
       description: Identifiant de correlation a fournir au support en cas d'incident.

--- a/api/tests/Feature/Travel/TravelBookingApiTest.php
+++ b/api/tests/Feature/Travel/TravelBookingApiTest.php
@@ -179,6 +179,60 @@ class TravelBookingApiTest extends TestCase
         ])->assertStatus(409);
     }
 
+    public function test_only_one_booking_wins_the_last_seat_under_race(): void
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'CM', 'currency' => 'XAF']);
+        $this->activateTravel($company);
+        $this->principal($company);
+
+        // Trajet avec UN SEUL siège libre : la course porte sur ce siège.
+        ['trip' => $trip, 'class' => $class] = app(TenantManager::class)->withinTenant($company, function (): array {
+            $trip = TravelTrip::factory()->create(['status' => 'published', 'total_seats' => 1]);
+            app(GenerateTripSeatsAction::class)->execute($trip);
+
+            $class = TravelClass::factory()->create();
+            TravelTripPrice::factory()->create([
+                'trip_id' => $trip->id,
+                'class_id' => $class->id,
+                'adult_price_minor' => 15000,
+            ]);
+
+            return ['trip' => $trip->refresh(), 'class' => $class];
+        });
+
+        $passenger = ['full_name' => 'Jean Dupont', 'age_category' => 'adult', 'class_id' => $class->id];
+
+        // Première réservation : gagne le dernier siège (statut 201).
+        $first = $this->postJson('/api/v1/travel/bookings', [
+            'trip_id' => $trip->id,
+            'booking_source' => 'office',
+            'idempotency_key' => 'race-001',
+            'passengers' => [$passenger],
+        ])->assertStatus(201)
+            ->assertJsonPath('data.passengers.0.seat_number', 1);
+
+        // Seconde réservation (clé d'idempotence différente) : le verrou
+        // transactionnel a sérialisé l'accès → 409 SEATS_UNAVAILABLE.
+        $this->postJson('/api/v1/travel/bookings', [
+            'trip_id' => $trip->id,
+            'booking_source' => 'office',
+            'idempotency_key' => 'race-002',
+            'passengers' => [$passenger],
+        ])->assertStatus(409);
+
+        // Une seule réservation existe sur ce trajet, et elle possède le siège.
+        [$bookingCount, $seatBookingId] = app(TenantManager::class)->withinTenant($company, function () use ($trip): array {
+            return [
+                TravelBooking::query()->where('trip_id', $trip->id)->count(),
+                TravelTripSeat::query()->where('trip_id', $trip->id)->value('booking_id'),
+            ];
+        });
+
+        $this->assertSame(1, $bookingCount);
+        $this->assertSame($first->json('data.id'), $seatBookingId);
+    }
+
     public function test_booking_of_another_tenant_returns_404(): void
     {
         /** @var Company $companyA */


### PR DESCRIPTION
## Correctif bloquant — migrations tenant travel

**Symptôme** : `COMMENT ON TABLE travel_article_categories IS 'Catégories d'articles...'` (et 4 autres dans 000916/000917) contient une apostrophe non échappée → `SQLSTATE 42601` au `leopardo:migrate`, cassant TOUTE la chaîne de migrations tenant. Vérifié par exécution locale de la suite Travel : **175 tests en échec au bootstrap (0 assertion)**.

**Correctif** : échappement SQL `''` (pattern PostgreSQL) sur les 5 chaînes.

**Vérification** : suite Travel relancée après correctif (attente CI locale + GitHub Actions).

Périmètre strict BC-24 TRAVEL.

Closes #6418