### PR TITLE
feat(travel): UI admin contenu & monétisation + contacts voyageurs — quiz, annonces, sites touristiques, formulaire/registre contacts (TRAVEL-911/912, Closes #6416, refs #6417)

### DIFF
--- a/front/admin-dashboard/e2e/travel-admin.spec.js
+++ b/front/admin-dashboard/e2e/travel-admin.spec.js
@@ -75,8 +75,105 @@ async function mockTravelApi(page, { pingStatus = 200 } = {}) {
       }),
     }),
   )
-}
+  // ── TRAVEL-911/912 (#6416/#6417) : quiz, annonces, sites, contacts ──
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/quizzes\/\d+\/results(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          { id: 1, participant_name: 'Awa', participant_email: 'awa@test.cm', score: 5, bonus: 1, submitted_at: '2026-08-30T10:00:00+00:00' },
+        ],
+      }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/quizzes\/\d+(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          id: 1,
+          title: 'Quiz vacances',
+          description: 'Questions de culture touristique',
+          status: 'active',
+          questions: [
+            { id: 1, question: 'Quelle est la capitale du Cameroun ?', options: ['Yaoundé', 'Douala'], points: 1 },
+          ],
+        },
+      }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/quizzes(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          { id: 1, title: 'Quiz vacances', status: 'active', starts_at: null, ends_at: null },
+        ],
+      }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/advert-types(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [{ id: 1, code: 'banner', label: 'Bannière' }] }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/advert-positions(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [{ id: 1, code: 'home', label: 'Accueil' }] }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/advert-prices(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/adverts(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          { id: 1, title: 'Annonce pilote', content: 'Visitez le Cameroun', price_minor: 500000, currency: 'XAF', expires_at: null },
+        ],
+      }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/tourist-sites(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [{ id: 1, name: 'Mont Cameroun', city_id: 1, status: 'active' }] }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/contacts(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          {
+            id: 1, first_name: 'Awa', last_name: 'Njoya', email: 'awa@test.cm', phone: '690000000',
+            email_consent_given: true, sms_consent_given: false, whatsapp_consent_given: false,
+          },
+        ],
+      }),
+    }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/contact(\?.*)?$/, (route) =>
+    route.fulfill({ status: 202, contentType: 'application/json', body: JSON.stringify({ status: 'received' }) }),
+  )
 
+
+}
 async function loginViaToken(page) {
   await page.addInitScript((token) => {
     sessionStorage.setItem('admin_token', token)
@@ -207,3 +304,86 @@ test.describe('TravelAgency — écrans (TRAVEL-602..608)', () => {
     await expect(page.getByRole('heading', { name: /Hôtels/i })).toBeVisible()
   })
 })
+
+
+test.describe('TravelAgency — contenu & monétisation (TRAVEL-911/#6416)', () => {
+  test.skip(!AUTHENTICATED, 'Skipped: requiert PLAYWRIGHT_AUTH_TOKEN (tests authentifiés)')
+  test.skip(LIVE, 'Skipped: BACKEND_LIVE=1 — tests mock désactivés')
+
+  test('onglet Quiz : liste, questions (bonne réponse jamais exposée), résultats', async ({ page }) => {
+    await loginViaToken(page)
+    await mockTravelApi(page)
+    await page.goto('/travel')
+
+    await page.getByRole('tab', { name: /Quiz/i }).click()
+    await expect(page.getByRole('heading', { name: /Quiz & jeux-concours/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Quiz vacances')).toBeVisible()
+
+    await page.getByRole('button', { name: /Questions/i }).click()
+    await expect(page.getByText('Quelle est la capitale du Cameroun ?')).toBeVisible({ timeout: 15_000 })
+    // La bonne réponse (correct_option_index) n'est jamais rendue par le mock ni l'API
+    await expect(page.getByText('correct_option_index')).toHaveCount(0)
+    await page.getByRole('button', { name: /Fermer/i }).click()
+
+    await page.getByRole('button', { name: /Résultats/i }).click()
+    await expect(page.getByText('awa@test.cm')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('onglet Annonces : référentiels types/positions + grille tarifaire + soumission', async ({ page }) => {
+    await loginViaToken(page)
+    await mockTravelApi(page)
+    await page.goto('/travel')
+
+    await page.getByRole('tab', { name: /Annonces/i }).click()
+    await expect(page.getByRole('tab', { name: /Types/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('tab', { name: /Emplacements/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /Grille tarifaire/i })).toBeVisible()
+
+    await page.getByRole('tab', { name: /Annonces/i }).last().click()
+    await expect(page.getByRole('heading', { name: /Annonces payantes/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Annonce pilote')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Renouveler/i })).toBeVisible()
+  })
+
+  test('onglet Sites touristiques : CRUD + filtre par ville', async ({ page }) => {
+    await loginViaToken(page)
+    await mockTravelApi(page)
+    await page.goto('/travel')
+
+    await page.getByRole('tab', { name: /Sites touristiques/i }).click()
+    await expect(page.getByRole('heading', { name: /Sites touristiques/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Mont Cameroun')).toBeVisible()
+    await expect(page.locator('#travel-sites-city-filter')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Créer/i })).toBeVisible()
+  })
+})
+
+test.describe('TravelAgency — contacts voyageurs (TRAVEL-912/#6417)', () => {
+  test.skip(!AUTHENTICATED, 'Skipped: requiert PLAYWRIGHT_AUTH_TOKEN (tests authentifiés)')
+  test.skip(LIVE, 'Skipped: BACKEND_LIVE=1 — tests mock désactivés')
+
+  test('onglet Contacts : formulaire (consentement) + registre + notification manuelle', async ({ page }) => {
+    await loginViaToken(page)
+    await mockTravelApi(page)
+    await page.goto('/travel')
+
+    await page.getByRole('tab', { name: /Contacts/i }).click()
+    await expect(page.getByRole('heading', { name: /Formulaire de contact/i })).toBeVisible({ timeout: 15_000 })
+
+    // Soumission avec consentement obligatoire
+    await page.locator('#travel-contact-email').fill('visiteur@test.cm')
+    await page.locator('#travel-contact-message').fill('Je souhaite des informations sur les safaris.')
+    await page.getByRole('checkbox').check()
+    await page.getByRole('button', { name: /Envoyer la demande/i }).click()
+    await expect(page.getByText(/Demande reçue/i)).toBeVisible({ timeout: 15_000 })
+
+    // Registre + consentements + notification manuelle
+    await expect(page.getByText('awa@test.cm')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Notifier/i })).toBeVisible()
+    await page.getByRole('button', { name: /Notifier/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15_000 })
+    await page.locator('#travel-notify-message').fill('Bonjour, votre agence vous informe…')
+    await page.getByRole('button', { name: /Envoyer/i }).click()
+  })
+})
+

--- a/front/admin-dashboard/e2e/travel-admin.spec.js
+++ b/front/admin-dashboard/e2e/travel-admin.spec.js
@@ -351,7 +351,7 @@ test.describe('TravelAgency — contenu & monétisation (TRAVEL-911/#6416)', () 
     await page.goto('/travel')
 
     await page.getByRole('tab', { name: /Sites touristiques/i }).click()
-    await expect(page.getByRole('heading', { name: /Sites touristiques/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('heading', { name: /Sites touristiques/i }).first()).toBeVisible({ timeout: 15_000 })
     await expect(page.getByText('Mont Cameroun')).toBeVisible()
     await expect(page.locator('#travel-sites-city-filter')).toBeVisible()
     await expect(page.getByRole('button', { name: /Créer/i })).toBeVisible()
@@ -383,7 +383,7 @@ test.describe('TravelAgency — contacts voyageurs (TRAVEL-912/#6417)', () => {
     await page.getByRole('button', { name: /Notifier/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15_000 })
     await page.locator('#travel-notify-message').fill('Bonjour, votre agence vous informe…')
-    await page.getByRole('button', { name: /Envoyer/i }).click()
+    await page.getByRole('button', { name: 'Envoyer', exact: true }).click()
   })
 })
 

--- a/front/admin-dashboard/src/components/travel/TravelCrudSection.vue
+++ b/front/admin-dashboard/src/components/travel/TravelCrudSection.vue
@@ -57,6 +57,7 @@
             {{ actionLabel(action) }}
           </button>
           <button
+            v-if="config.canEdit !== false"
             class="rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
             type="button"
             :aria-label="$t('travel.action.edit', 'Modifier')"

--- a/front/admin-dashboard/src/i18n/locales/ar.json
+++ b/front/admin-dashboard/src/i18n/locales/ar.json
@@ -4255,7 +4255,11 @@
       "checkin": "تسجيل الدخول",
       "tickets": "التذاكر",
       "reports": "التقارير",
-      "rentals": "الإيجارات والفنادق"
+      "rentals": "الإيجارات والفنادق",
+      "quizzes": "الاختبارات",
+      "adverts": "الإعلانات",
+      "sites": "المواقع السياحية",
+      "contacts": "جهات الاتصال"
     },
     "referentiel": {
       "tabsLabel": "الأقسام الفرعية للمرجع",
@@ -4289,7 +4293,11 @@
       "report": "ابحث في التقرير…",
       "rentalVehicle": "ابحث عن مركبة إيجار…",
       "rentalBooking": "ابحث عن حجز إيجار…",
-      "hotel": "ابحث عن فندق…"
+      "hotel": "ابحث عن فندق…",
+      "quiz": "ابحث عن اختبار…",
+      "advert": "ابحث عن إعلان…",
+      "site": "ابحث عن موقع…",
+      "contact": "ابحث عن جهة اتصال…"
     },
     "field": {
       "iso2": "كود ISO2",
@@ -4525,6 +4533,106 @@
     "form": {
       "selectPlaceholder": "— اختر —",
       "moneyMinor": "المبلغ بالعملة (1 = 100 وحدة صغيرة)"
+    },
+    "quiz": {
+      "title": "الاختبارات والمسابقات",
+      "subtitle": "أنشئ الاختبارات وأضف الأسئلة وراجع المشاركات.",
+      "questionsTitle": "أسئلة الاختبار",
+      "resultsTitle": "النتائج",
+      "field": {
+        "question": "السؤال",
+        "options": "الخيارات",
+        "points": "النقاط",
+        "correctIndex": "مؤشر الإجابة الصحيحة",
+        "maxParticipations": "الحد الأقصى للمشاركات لكل جهة اتصال",
+        "participantName": "الاسم",
+        "participantEmail": "البريد الإلكتروني",
+        "score": "النتيجة",
+        "bonus": "المكافأة",
+        "submittedAt": "أُرسل في"
+      },
+      "action": {
+        "questions": "الأسئلة",
+        "results": "النتائج",
+        "addQuestion": "إضافة سؤال"
+      },
+      "hint": {
+        "options": "خيار واحد في كل سطر.",
+        "correctIndex": "يبدأ من 0 (السطر الأول = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "مسودة",
+      "active": "نشط",
+      "closed": "مغلق"
+    },
+    "adverts": {
+      "tabsLabel": "أقسام الإعلانات الفرعية",
+      "tabTypes": "الأنواع",
+      "tabPositions": "المواضع",
+      "tabPrices": "جدول الأسعار",
+      "tabAdverts": "الإعلانات",
+      "title": "الإعلانات المدفوعة",
+      "subtitle": "أرسل إعلانًا وتابع الإعلانات المرئية.",
+      "createTitle": "إرسال إعلان",
+      "types": "أنواع الإعلانات",
+      "positions": "المواضع الإعلانية",
+      "prices": "جدول الأسعار",
+      "field": {
+        "type": "النوع",
+        "position": "الموضع",
+        "validityDays": "مدة الصلاحية (أيام)",
+        "content": "المحتوى",
+        "price": "السعر",
+        "pricePerImage": "السعر لكل صورة",
+        "pricePerCharacter": "السعر لكل حرف",
+        "expiresAt": "ينتهي في"
+      },
+      "action": {
+        "renew": "تجديد",
+        "submit": "إرسال"
+      }
+    },
+    "sites": {
+      "title": "المواقع السياحية",
+      "subtitle": "أماكن الاهتمام مع الموقع والبحث حسب المدينة.",
+      "filterCity": "تصفية حسب المدينة",
+      "allCities": "كل المدن",
+      "statusDisabled": "معطل",
+      "field": {
+        "latitude": "خط العرض",
+        "longitude": "خط الطول"
+      }
+    },
+    "contacts": {
+      "formTitle": "نموذج الاتصال",
+      "formSubtitle": "أرسل طلب اتصال — الموافقة على البريد الإلكتروني إلزامية.",
+      "registryTitle": "سجل جهات الاتصال",
+      "registrySubtitle": "الموافقات حسب القناة (اشتراك/إلغاء مختوم بالوقت) والإشعار اليدوي.",
+      "registryUnavailable": "السجل غير متاح — نقطة نهاية القائمة غير منشورة بعد على هذا النشر.",
+      "consentLabel": "أوافق على أن يتم التواصل معي عبر البريد الإلكتروني بشأن طلبي.",
+      "consentOn": "موافق",
+      "consentOff": "غير موافق",
+      "notifyTitle": "إشعار يدوي",
+      "notifyTarget": "المستلم",
+      "notifyHint": "يتم تجاهل القناة بدون موافقة؛ 422 إذا لم تكن هناك قناة موافق عليها.",
+      "channelApp": "التطبيق (موظف مرتبط)",
+      "success": "تم استلام الطلب — شكرًا، سنعاود التواصل معك.",
+      "field": {
+        "firstName": "الاسم الأول",
+        "lastName": "الاسم الأخير",
+        "email": "البريد الإلكتروني",
+        "phone": "الهاتف",
+        "message": "الرسالة",
+        "consents": "الموافقات",
+        "channels": "القنوات"
+      },
+      "action": {
+        "submit": "إرسال الطلب",
+        "toggleConsent": "تبديل الموافقة",
+        "notify": "إشعار",
+        "send": "إرسال"
+      }
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -4255,7 +4255,11 @@
       "checkin": "Check-in",
       "tickets": "Tickets",
       "reports": "Reports",
-      "rentals": "Rentals & Hotels"
+      "rentals": "Rentals & Hotels",
+      "quizzes": "Quiz",
+      "adverts": "Adverts",
+      "sites": "Tourist sites",
+      "contacts": "Contacts"
     },
     "referentiel": {
       "tabsLabel": "Referential sub-sections",
@@ -4289,7 +4293,11 @@
       "report": "Search in report…",
       "rentalVehicle": "Search a rental vehicle…",
       "rentalBooking": "Search a rental booking…",
-      "hotel": "Search a hotel…"
+      "hotel": "Search a hotel…",
+      "quiz": "Search a quiz…",
+      "advert": "Search an advert…",
+      "site": "Search a site…",
+      "contact": "Search a contact…"
     },
     "field": {
       "iso2": "ISO2",
@@ -4525,6 +4533,106 @@
     "form": {
       "selectPlaceholder": "— Select —",
       "moneyMinor": "Amount in currency (1 = 100 minor)"
+    },
+    "quiz": {
+      "title": "Quizzes & contests",
+      "subtitle": "Create quizzes, add questions and review participations.",
+      "questionsTitle": "Quiz questions",
+      "resultsTitle": "Results",
+      "field": {
+        "question": "Question",
+        "options": "Choices",
+        "points": "Points",
+        "correctIndex": "Correct answer index",
+        "maxParticipations": "Max participations per contact",
+        "participantName": "Name",
+        "participantEmail": "Email",
+        "score": "Score",
+        "bonus": "Bonus",
+        "submittedAt": "Submitted on"
+      },
+      "action": {
+        "questions": "Questions",
+        "results": "Results",
+        "addQuestion": "Add a question"
+      },
+      "hint": {
+        "options": "One option per line.",
+        "correctIndex": "Starts at 0 (first line = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Draft",
+      "active": "Active",
+      "closed": "Closed"
+    },
+    "adverts": {
+      "tabsLabel": "Advert sub-sections",
+      "tabTypes": "Types",
+      "tabPositions": "Positions",
+      "tabPrices": "Price grid",
+      "tabAdverts": "Adverts",
+      "title": "Paid adverts",
+      "subtitle": "Submit an advert and track visible ones.",
+      "createTitle": "Submit an advert",
+      "types": "Advert types",
+      "positions": "Advert positions",
+      "prices": "Price grid",
+      "field": {
+        "type": "Type",
+        "position": "Position",
+        "validityDays": "Validity (days)",
+        "content": "Content",
+        "price": "Price",
+        "pricePerImage": "Price per image",
+        "pricePerCharacter": "Price per character",
+        "expiresAt": "Expires on"
+      },
+      "action": {
+        "renew": "Renew",
+        "submit": "Submit"
+      }
+    },
+    "sites": {
+      "title": "Tourist sites",
+      "subtitle": "Points of interest with location and city search.",
+      "filterCity": "Filter by city",
+      "allCities": "All cities",
+      "statusDisabled": "Disabled",
+      "field": {
+        "latitude": "Latitude",
+        "longitude": "Longitude"
+      }
+    },
+    "contacts": {
+      "formTitle": "Contact form",
+      "formSubtitle": "Submit a contact request — email consent is required.",
+      "registryTitle": "Contact registry",
+      "registrySubtitle": "Per-channel consents (timestamped opt-in/opt-out) and manual notification.",
+      "registryUnavailable": "Registry unavailable — list endpoint not delivered on this deployment yet.",
+      "consentLabel": "I agree to be contacted by email about my request.",
+      "consentOn": "Consented",
+      "consentOff": "Not consented",
+      "notifyTitle": "Manual notification",
+      "notifyTarget": "Recipient",
+      "notifyHint": "A channel without consent is ignored; 422 if no channel is consented.",
+      "channelApp": "Application (linked employee)",
+      "success": "Request received — thank you, we will get back to you.",
+      "field": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "email": "Email",
+        "phone": "Phone",
+        "message": "Message",
+        "consents": "Consents",
+        "channels": "Channels"
+      },
+      "action": {
+        "submit": "Send request",
+        "toggleConsent": "Toggle consent",
+        "notify": "Notify",
+        "send": "Send"
+      }
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -4255,7 +4255,11 @@
       "checkin": "Check-in",
       "tickets": "Billets",
       "reports": "Rapports",
-      "rentals": "Locations & Hôtels"
+      "rentals": "Locations & Hôtels",
+      "quizzes": "Quiz",
+      "adverts": "Annonces",
+      "sites": "Sites touristiques",
+      "contacts": "Contacts"
     },
     "referentiel": {
       "tabsLabel": "Sous-sections du référentiel",
@@ -4289,7 +4293,11 @@
       "report": "Rechercher dans le rapport…",
       "rentalVehicle": "Rechercher un véhicule de location…",
       "rentalBooking": "Rechercher une réservation de location…",
-      "hotel": "Rechercher un hôtel…"
+      "hotel": "Rechercher un hôtel…",
+      "quiz": "Rechercher un quiz…",
+      "advert": "Rechercher une annonce…",
+      "site": "Rechercher un site…",
+      "contact": "Rechercher un contact…"
     },
     "field": {
       "iso2": "ISO2",
@@ -4525,6 +4533,106 @@
     "form": {
       "selectPlaceholder": "— Sélectionner —",
       "moneyMinor": "Montant en devises (1 = 100 minor)"
+    },
+    "quiz": {
+      "title": "Quiz & jeux-concours",
+      "subtitle": "Créez des quiz, ajoutez des questions et consultez les participations.",
+      "questionsTitle": "Questions du quiz",
+      "resultsTitle": "Résultats",
+      "field": {
+        "question": "Question",
+        "options": "Choix",
+        "points": "Points",
+        "correctIndex": "Index de la bonne réponse",
+        "maxParticipations": "Participations max. par contact",
+        "participantName": "Nom",
+        "participantEmail": "Email",
+        "score": "Score",
+        "bonus": "Bonus",
+        "submittedAt": "Soumis le"
+      },
+      "action": {
+        "questions": "Questions",
+        "results": "Résultats",
+        "addQuestion": "Ajouter une question"
+      },
+      "hint": {
+        "options": "Une option par ligne.",
+        "correctIndex": "Commence à 0 (première ligne = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Brouillon",
+      "active": "Actif",
+      "closed": "Clôturé"
+    },
+    "adverts": {
+      "tabsLabel": "Sous-sections annonces",
+      "tabTypes": "Types",
+      "tabPositions": "Emplacements",
+      "tabPrices": "Grille tarifaire",
+      "tabAdverts": "Annonces",
+      "title": "Annonces payantes",
+      "subtitle": "Soumettre une annonce et suivre les annonces visibles.",
+      "createTitle": "Soumettre une annonce",
+      "types": "Types d’annonces",
+      "positions": "Emplacements publicitaires",
+      "prices": "Grille tarifaire",
+      "field": {
+        "type": "Type",
+        "position": "Emplacement",
+        "validityDays": "Durée de validité (jours)",
+        "content": "Contenu",
+        "price": "Prix",
+        "pricePerImage": "Prix par image",
+        "pricePerCharacter": "Prix par caractère",
+        "expiresAt": "Expire le"
+      },
+      "action": {
+        "renew": "Renouveler",
+        "submit": "Soumettre"
+      }
+    },
+    "sites": {
+      "title": "Sites touristiques",
+      "subtitle": "Lieux d’intérêt avec localisation et recherche par ville.",
+      "filterCity": "Filtrer par ville",
+      "allCities": "Toutes les villes",
+      "statusDisabled": "Désactivé",
+      "field": {
+        "latitude": "Latitude",
+        "longitude": "Longitude"
+      }
+    },
+    "contacts": {
+      "formTitle": "Formulaire de contact",
+      "formSubtitle": "Saisir une demande de contact — le consentement email est obligatoire.",
+      "registryTitle": "Registre des contacts",
+      "registrySubtitle": "Consentements par canal (opt-in/opt-out horodaté) et notification manuelle.",
+      "registryUnavailable": "Registre indisponible — endpoint de liste non encore livré sur ce déploiement.",
+      "consentLabel": "J’accepte d’être contacté par email au sujet de ma demande.",
+      "consentOn": "Consenti",
+      "consentOff": "Non consenti",
+      "notifyTitle": "Notification manuelle",
+      "notifyTarget": "Destinataire",
+      "notifyHint": "Un canal sans consentement est ignoré ; 422 si aucun canal consenti.",
+      "channelApp": "Application (employé lié)",
+      "success": "Demande reçue — merci, nous reviendrons vers vous.",
+      "field": {
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "email": "Email",
+        "phone": "Téléphone",
+        "message": "Message",
+        "consents": "Consentements",
+        "channels": "Canaux"
+      },
+      "action": {
+        "submit": "Envoyer la demande",
+        "toggleConsent": "Basculer le consentement",
+        "notify": "Notifier",
+        "send": "Envoyer"
+      }
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/tr.json
+++ b/front/admin-dashboard/src/i18n/locales/tr.json
@@ -4255,7 +4255,11 @@
       "checkin": "Check-in",
       "tickets": "Biletler",
       "reports": "Raporlar",
-      "rentals": "Kiralama ve Oteller"
+      "rentals": "Kiralama ve Oteller",
+      "quizzes": "Quiz",
+      "adverts": "Reklamlar",
+      "sites": "Turistik yerler",
+      "contacts": "Kişiler"
     },
     "referentiel": {
       "tabsLabel": "Referans alt bölümleri",
@@ -4289,7 +4293,11 @@
       "report": "Raporda ara…",
       "rentalVehicle": "Kiralık araç ara…",
       "rentalBooking": "Kiralama rezervasyonu ara…",
-      "hotel": "Otel ara…"
+      "hotel": "Otel ara…",
+      "quiz": "Quiz ara…",
+      "advert": "Reklam ara…",
+      "site": "Yer ara…",
+      "contact": "Kişi ara…"
     },
     "field": {
       "iso2": "ISO2",
@@ -4525,6 +4533,106 @@
     "form": {
       "selectPlaceholder": "— Seçin —",
       "moneyMinor": "Para birimi cinsinden tutar (1 = 100 birim)"
+    },
+    "quiz": {
+      "title": "Quiz ve yarışmalar",
+      "subtitle": "Quiz oluşturun, soru ekleyin ve katılımları inceleyin.",
+      "questionsTitle": "Quiz soruları",
+      "resultsTitle": "Sonuçlar",
+      "field": {
+        "question": "Soru",
+        "options": "Seçenekler",
+        "points": "Puan",
+        "correctIndex": "Doğru cevap indeksi",
+        "maxParticipations": "Kişi başına maks. katılım",
+        "participantName": "Ad",
+        "participantEmail": "E-posta",
+        "score": "Puan",
+        "bonus": "Bonus",
+        "submittedAt": "Gönderim"
+      },
+      "action": {
+        "questions": "Sorular",
+        "results": "Sonuçlar",
+        "addQuestion": "Soru ekle"
+      },
+      "hint": {
+        "options": "Her satıra bir seçenek.",
+        "correctIndex": "0'dan başlar (ilk satır = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Taslak",
+      "active": "Aktif",
+      "closed": "Kapalı"
+    },
+    "adverts": {
+      "tabsLabel": "Reklam alt bölümleri",
+      "tabTypes": "Türler",
+      "tabPositions": "Konumlar",
+      "tabPrices": "Fiyat tablosu",
+      "tabAdverts": "Reklamlar",
+      "title": "Ücretli reklamlar",
+      "subtitle": "Reklam gönderin ve görünür olanları takip edin.",
+      "createTitle": "Reklam gönder",
+      "types": "Reklam türleri",
+      "positions": "Reklam konumları",
+      "prices": "Fiyat tablosu",
+      "field": {
+        "type": "Tür",
+        "position": "Konum",
+        "validityDays": "Geçerlilik (gün)",
+        "content": "İçerik",
+        "price": "Fiyat",
+        "pricePerImage": "Görsel başına fiyat",
+        "pricePerCharacter": "Karakter başına fiyat",
+        "expiresAt": "Bitiş"
+      },
+      "action": {
+        "renew": "Yenile",
+        "submit": "Gönder"
+      }
+    },
+    "sites": {
+      "title": "Turistik yerler",
+      "subtitle": "Konum ve şehir aramalı ilgi noktaları.",
+      "filterCity": "Şehre göre filtrele",
+      "allCities": "Tüm şehirler",
+      "statusDisabled": "Devre dışı",
+      "field": {
+        "latitude": "Enlem",
+        "longitude": "Boylam"
+      }
+    },
+    "contacts": {
+      "formTitle": "İletişim formu",
+      "formSubtitle": "İletişim talebi gönderin — e-posta onayı zorunludur.",
+      "registryTitle": "Kişi kayıtları",
+      "registrySubtitle": "Kanal bazında onaylar (zaman damgalı) ve manuel bildirim.",
+      "registryUnavailable": "Kayıtlar kullanılamıyor — liste ucu bu dağıtımda henüz yayınlanmadı.",
+      "consentLabel": "Talebimle ilgili e-posta ile iletişime geçilmesini kabul ediyorum.",
+      "consentOn": "Onaylı",
+      "consentOff": "Onaysız",
+      "notifyTitle": "Manuel bildirim",
+      "notifyTarget": "Alıcı",
+      "notifyHint": "Onaysız kanal yok sayılır; onaylı kanal yoksa 422.",
+      "channelApp": "Uygulama (bağlı çalışan)",
+      "success": "Talep alındı — teşekkürler, size dönüş yapacağız.",
+      "field": {
+        "firstName": "Ad",
+        "lastName": "Soyad",
+        "email": "E-posta",
+        "phone": "Telefon",
+        "message": "Mesaj",
+        "consents": "Onaylar",
+        "channels": "Kanallar"
+      },
+      "action": {
+        "submit": "Talebi gönder",
+        "toggleConsent": "Onayı değiştir",
+        "notify": "Bildir",
+        "send": "Gönder"
+      }
     }
   }
 }

--- a/front/admin-dashboard/src/views/travel/TravelAdvertsTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAdvertsTab.vue
@@ -93,10 +93,12 @@
           :error="formErrors.advert_type_id"
           required
         >
-          <select v-model="form.advert_type_id" class="form-input" required>
-            <option value="">{{ t('travel.form.selectPlaceholder', '— Sélectionner —') }}</option>
-            <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
-          </select>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <select :id="id" v-model="form.advert_type_id" class="form-input" required :aria-invalid="ariaInvalid" :aria-describedby="describedBy">
+              <option value="">{{ t('travel.form.selectPlaceholder', '— Sélectionner —') }}</option>
+              <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+            </select>
+          </template>
         </FormField>
         <FormField
           :id="'travel-advert-position'"
@@ -104,10 +106,12 @@
           :error="formErrors.advert_position_id"
           required
         >
-          <select v-model="form.advert_position_id" class="form-input" required>
-            <option value="">{{ t('travel.form.selectPlaceholder', '— Sélectionner —') }}</option>
-            <option v-for="opt in positionOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
-          </select>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <select :id="id" v-model="form.advert_position_id" class="form-input" required :aria-invalid="ariaInvalid" :aria-describedby="describedBy">
+              <option value="">{{ t('travel.form.selectPlaceholder', '— Sélectionner —') }}</option>
+              <option v-for="opt in positionOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+            </select>
+          </template>
         </FormField>
         <FormField
           :id="'travel-advert-title'"
@@ -115,14 +119,18 @@
           :error="formErrors.title"
           required
         >
-          <input v-model.trim="form.title" type="text" class="form-input" required maxlength="160" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input :id="id" v-model.trim="form.title" type="text" class="form-input" required maxlength="160" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" />
+          </template>
         </FormField>
         <FormField
           :id="'travel-advert-validity'"
           :label="t('travel.adverts.field.validityDays', 'Durée de validité (jours)')"
           :error="formErrors.validity_days"
         >
-          <input v-model.number="form.validity_days" type="number" class="form-input" min="1" max="365" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input :id="id" v-model.number="form.validity_days" type="number" class="form-input" min="1" max="365" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" />
+          </template>
         </FormField>
         <FormField
           :id="'travel-advert-content'"
@@ -131,7 +139,9 @@
           class="col-span-full"
           required
         >
-          <textarea v-model.trim="form.content" class="form-input" rows="4" required maxlength="2000"></textarea>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <textarea :id="id" v-model.trim="form.content" class="form-input" rows="4" required maxlength="2000" :aria-invalid="ariaInvalid" :aria-describedby="describedBy"></textarea>
+          </template>
         </FormField>
 
         <div v-if="globalError" class="col-span-full rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">

--- a/front/admin-dashboard/src/views/travel/TravelAdvertsTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAdvertsTab.vue
@@ -1,0 +1,347 @@
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-wrap gap-2" role="tablist" :aria-label="$t('travel.adverts.tabsLabel', 'Sous-sections annonces')">
+      <button
+        v-for="sub in subTabs"
+        :key="sub.key"
+        type="button"
+        role="tab"
+        :aria-selected="activeSub === sub.key"
+        :class="[
+          'rounded-md px-3.5 py-1.5 text-sm font-medium transition-colors',
+          activeSub === sub.key
+            ? 'bg-slate-900 text-white dark:bg-white dark:text-slate-900'
+            : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+        ]"
+        @click="selectSub(sub)"
+      >
+        {{ sub.label }}
+      </button>
+    </div>
+
+    <TravelCrudSection
+      v-if="activeSub === 'types'"
+      :config="typeConfig"
+    />
+    <TravelCrudSection
+      v-else-if="activeSub === 'positions'"
+      :config="positionConfig"
+    />
+    <TravelCrudSection
+      v-else-if="activeSub === 'prices'"
+      :config="priceConfig"
+      :lookups="{ types: typeOptions, positions: positionOptions }"
+      :column-display="priceDisplay"
+      @saved="loadReferenceLookups"
+    />
+
+    <!-- Annonces : soumission + annonces visibles (cycle complet : pay/validate/reject
+         via endpoint admin dédié — #6428) -->
+    <div v-else class="space-y-4">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-xl font-bold text-slate-900 dark:text-white">
+            {{ t('travel.adverts.title', 'Annonces payantes') }}
+          </h2>
+          <p class="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+            {{ t('travel.adverts.subtitle', 'Soumettre une annonce et suivre les annonces visibles.') }}
+          </p>
+        </div>
+        <button class="btn-primary" type="button" @click="openCreate">
+          <PlusIcon class="mr-2 h-4 w-4" />
+          {{ $t('travel.action.create', 'Créer') }}
+        </button>
+      </div>
+
+      <DataTable
+        :columns="advertColumns"
+        :rows="adverts"
+        :loading="loading"
+        :error="listError"
+        :search-keys="['title', 'content']"
+        :search-placeholder="t('travel.search.advert', 'Rechercher une annonce…')"
+        :caption="t('travel.adverts.title', 'Annonces payantes')"
+      >
+        <template #cell-price_minor="{ row, value }">
+          {{ formatMoney(value, row.currency || 'XAF') }}
+        </template>
+        <template #row-actions="{ row }">
+          <button
+            class="rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            type="button"
+            :aria-label="t('travel.adverts.action.renew', 'Renouveler')"
+            :title="t('travel.adverts.action.renew', 'Renouveler')"
+            @click="renew(row)"
+          >
+            {{ t('travel.adverts.action.renew', 'Renouveler') }}
+          </button>
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Formulaire de soumission d'annonce -->
+    <TravelModal
+      :open="createOpen"
+      :title="t('travel.adverts.createTitle', 'Soumettre une annonce')"
+      wide
+      @close="closeCreate"
+    >
+      <form class="grid grid-cols-1 gap-4 sm:grid-cols-2" @submit.prevent="submitAdvert">
+        <FormField
+          :id="'travel-advert-type'"
+          :label="t('travel.adverts.field.type', 'Type')"
+          :error="formErrors.advert_type_id"
+          required
+        >
+          <select v-model="form.advert_type_id" class="form-input" required>
+            <option value="">{{ t('travel.form.selectPlaceholder', '— Sélectionner —') }}</option>
+            <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </FormField>
+        <FormField
+          :id="'travel-advert-position'"
+          :label="t('travel.adverts.field.position', 'Emplacement')"
+          :error="formErrors.advert_position_id"
+          required
+        >
+          <select v-model="form.advert_position_id" class="form-input" required>
+            <option value="">{{ t('travel.form.selectPlaceholder', '— Sélectionner —') }}</option>
+            <option v-for="opt in positionOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </FormField>
+        <FormField
+          :id="'travel-advert-title'"
+          :label="t('travel.field.title', 'Titre')"
+          :error="formErrors.title"
+          required
+        >
+          <input v-model.trim="form.title" type="text" class="form-input" required maxlength="160" />
+        </FormField>
+        <FormField
+          :id="'travel-advert-validity'"
+          :label="t('travel.adverts.field.validityDays', 'Durée de validité (jours)')"
+          :error="formErrors.validity_days"
+        >
+          <input v-model.number="form.validity_days" type="number" class="form-input" min="1" max="365" />
+        </FormField>
+        <FormField
+          :id="'travel-advert-content'"
+          :label="t('travel.adverts.field.content', 'Contenu')"
+          :error="formErrors.content"
+          class="col-span-full"
+          required
+        >
+          <textarea v-model.trim="form.content" class="form-input" rows="4" required maxlength="2000"></textarea>
+        </FormField>
+
+        <div v-if="globalError" class="col-span-full rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {{ globalError }}
+        </div>
+
+        <div class="col-span-full flex justify-end gap-2 pt-2">
+          <button type="button" class="btn-secondary" @click="closeCreate">
+            {{ $t('common.cancel', 'Annuler') }}
+          </button>
+          <button type="submit" class="btn-primary" :disabled="saving">
+            {{ saving ? $t('common.busy', 'En cours…') : t('travel.adverts.action.submit', 'Soumettre') }}
+          </button>
+        </div>
+      </form>
+    </TravelModal>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { PlusIcon } from '@heroicons/vue/24/outline'
+import api from '@/services/api'
+import DataTable from '@/components/common/DataTable.vue'
+import FormField from '@/components/common/FormField.vue'
+import TravelCrudSection from '@/components/travel/TravelCrudSection.vue'
+import TravelModal from '@/components/travel/TravelModal.vue'
+import { useToast } from 'vue-toastification'
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale.js'
+
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
+const toast = useToast()
+
+const activeSub = ref('types')
+
+function selectSub(sub) {
+  activeSub.value = sub.key
+}
+
+const subTabs = computed(() => [
+  { key: 'types', label: t('travel.adverts.tabTypes', 'Types') },
+  { key: 'positions', label: t('travel.adverts.tabPositions', 'Emplacements') },
+  { key: 'prices', label: t('travel.adverts.tabPrices', 'Grille tarifaire') },
+  { key: 'adverts', label: t('travel.adverts.tabAdverts', 'Annonces') }
+])
+
+/* ── lookups types / positions ─────────────────────────────── */
+const advertTypes = ref([])
+const advertPositions = ref([])
+
+const typeOptions = computed(() => advertTypes.value.map((x) => ({ value: x.id, label: x.label || x.code })))
+const positionOptions = computed(() => advertPositions.value.map((x) => ({ value: x.id, label: x.label || x.code })))
+
+async function loadReferenceLookups() {
+  try {
+    const [types, positions] = await Promise.all([
+      api.get('/travel/advert-types', { params: { per_page: 100 }, _skipAuthRedirect: true }),
+      api.get('/travel/advert-positions', { params: { per_page: 100 }, _skipAuthRedirect: true })
+    ])
+    advertTypes.value = types.data?.data || []
+    advertPositions.value = positions.data?.data || []
+  } catch {
+    advertTypes.value = []
+    advertPositions.value = []
+  }
+}
+
+function lookupLabel(list, id) {
+  const item = list.find((x) => String(x.id) === String(id))
+  return item ? item.label || item.code : (id ?? '-')
+}
+
+/* ── types d'annonces ──────────────────────────────────────── */
+const referenceConfig = (resource, titleKey, titleFallback) => ({
+  resource,
+  titleKey,
+  titleFallback,
+  searchPlaceholderKey: 'travel.search.advert',
+  searchKeys: ['code', 'label'],
+  defaultSort: 'code',
+  canEdit: false,
+  columns: [
+    { key: 'code', label: 'travel.field.code', sortable: true },
+    { key: 'label', label: 'travel.field.label', sortable: true }
+  ],
+  fields: [
+    { key: 'code', label: 'travel.field.code', type: 'text', required: true, max: 40 },
+    { key: 'label', label: 'travel.field.label', type: 'text', required: true, max: 120 }
+  ],
+  defaults: {}
+})
+
+const typeConfig = computed(() => referenceConfig('advert-types', 'travel.adverts.types', 'Types d’annonces'))
+const positionConfig = computed(() => referenceConfig('advert-positions', 'travel.adverts.positions', 'Emplacements publicitaires'))
+
+/* ── grille tarifaire ──────────────────────────────────────── */
+const priceConfig = computed(() => ({
+  resource: 'advert-prices',
+  titleKey: 'travel.adverts.prices',
+  titleFallback: 'Grille tarifaire',
+  searchPlaceholderKey: 'travel.search.advert',
+  searchKeys: ['currency'],
+  defaultSort: 'id',
+  canEdit: false,
+  columns: [
+    { key: 'advert_type_id', label: 'travel.adverts.field.type', sortable: true },
+    { key: 'advert_position_id', label: 'travel.adverts.field.position', sortable: true },
+    { key: 'price_per_image_minor', label: 'travel.adverts.field.pricePerImage', type: 'money', sortable: true },
+    { key: 'price_per_character_minor', label: 'travel.adverts.field.pricePerCharacter', type: 'money', sortable: true },
+    { key: 'currency', label: 'travel.field.currency', sortable: true }
+  ],
+  fields: [
+    { key: 'advert_type_id', label: 'travel.adverts.field.type', type: 'select', source: 'types', required: true },
+    { key: 'advert_position_id', label: 'travel.adverts.field.position', type: 'select', source: 'positions', required: true },
+    { key: 'price_per_image_minor', label: 'travel.adverts.field.pricePerImage', type: 'money', required: true, min: 1 },
+    { key: 'price_per_character_minor', label: 'travel.adverts.field.pricePerCharacter', type: 'money', required: true, min: 1 },
+    { key: 'currency', label: 'travel.field.currency', type: 'text', required: true, min: 3, max: 3 }
+  ],
+  defaults: { currency: 'XAF' }
+}))
+
+const priceDisplay = computed(() => ({
+  advert_type_id: (row, value) => lookupLabel(advertTypes.value, value),
+  advert_position_id: (row, value) => lookupLabel(advertPositions.value, value)
+}))
+
+/* ── annonces ──────────────────────────────────────────────── */
+const adverts = ref([])
+const loading = ref(false)
+const listError = ref('')
+const createOpen = ref(false)
+const saving = ref(false)
+const form = ref({})
+const formErrors = ref({})
+const globalError = ref('')
+
+const advertColumns = computed(() => [
+  { key: 'title', label: t('travel.field.title', 'Titre'), sortable: true },
+  { key: 'price_minor', label: t('travel.adverts.field.price', 'Prix'), sortable: true },
+  { key: 'expires_at', label: t('travel.adverts.field.expiresAt', 'Expire le'), sortable: true }
+])
+
+function formatMoney(minor, currency) {
+  try {
+    return new Intl.NumberFormat(localeStore.current, { style: 'currency', currency }).format(Number(minor) / 100)
+  } catch {
+    return `${Number(minor) / 100} ${currency}`
+  }
+}
+
+async function loadAdverts() {
+  loading.value = true
+  listError.value = ''
+  try {
+    const res = await api.get('/travel/adverts', { params: { per_page: 100 }, _skipAuthRedirect: true })
+    adverts.value = res.data?.data || []
+  } catch (err) {
+    listError.value = err.response?.data?.message || t('travel.error.loadFailed', 'Impossible de charger les données.')
+  } finally {
+    loading.value = false
+  }
+}
+
+function openCreate() {
+  form.value = { validity_days: 30 }
+  formErrors.value = {}
+  globalError.value = ''
+  createOpen.value = true
+}
+
+function closeCreate() {
+  createOpen.value = false
+}
+
+async function submitAdvert() {
+  saving.value = true
+  formErrors.value = {}
+  globalError.value = ''
+  try {
+    await api.post('/travel/adverts', form.value, { _skipAuthRedirect: true })
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    createOpen.value = false
+    await loadAdverts()
+  } catch (err) {
+    const data = err.response?.data || {}
+    if (data.errors) {
+      formErrors.value = Object.fromEntries(
+        Object.entries(data.errors).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
+      )
+    }
+    globalError.value = data.message || data.localized_message || t('travel.error.saveFailed', "Échec de l'enregistrement.")
+  } finally {
+    saving.value = false
+  }
+}
+
+async function renew(row) {
+  try {
+    await api.post(`/travel/adverts/${row.id}/renew`, {}, { _skipAuthRedirect: true })
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    await loadAdverts()
+  } catch (err) {
+    toast.error(err.response?.data?.message || t('travel.error.saveFailed', "Échec de l'enregistrement."))
+  }
+}
+
+onMounted(() => {
+  loadReferenceLookups()
+  loadAdverts()
+})
+</script>

--- a/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
@@ -90,6 +90,10 @@ import TravelCheckInTab from '@/views/travel/TravelCheckInTab.vue'
 import TravelTicketsTab from '@/views/travel/TravelTicketsTab.vue'
 import TravelReportsTab from '@/views/travel/TravelReportsTab.vue'
 import TravelRentalsHotelsTab from '@/views/travel/TravelRentalsHotelsTab.vue'
+import TravelQuizTab from '@/views/travel/TravelQuizTab.vue'
+import TravelAdvertsTab from '@/views/travel/TravelAdvertsTab.vue'
+import TravelSitesTab from '@/views/travel/TravelSitesTab.vue'
+import TravelContactsTab from '@/views/travel/TravelContactsTab.vue'
 
 const localeStore = useLocaleStore()
 const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
@@ -107,7 +111,11 @@ const tabs = [
   { key: 'checkin', label: t('travel.tab.checkin', 'Check-in'), component: TravelCheckInTab },
   { key: 'tickets', label: t('travel.tab.tickets', 'Billets'), component: TravelTicketsTab },
   { key: 'reports', label: t('travel.tab.reports', 'Rapports'), component: TravelReportsTab },
-  { key: 'rentals', label: t('travel.tab.rentals', 'Locations & Hôtels'), component: TravelRentalsHotelsTab }
+  { key: 'rentals', label: t('travel.tab.rentals', 'Locations & Hôtels'), component: TravelRentalsHotelsTab },
+  { key: 'quizzes', label: t('travel.tab.quizzes', 'Quiz'), component: TravelQuizTab },
+  { key: 'adverts', label: t('travel.tab.adverts', 'Annonces'), component: TravelAdvertsTab },
+  { key: 'sites', label: t('travel.tab.sites', 'Sites touristiques'), component: TravelSitesTab },
+  { key: 'contacts', label: t('travel.tab.contacts', 'Contacts'), component: TravelContactsTab }
 ]
 
 const activeComponent = computed(() => tabs.find((tab) => tab.key === activeTab.value)?.component)

--- a/front/admin-dashboard/src/views/travel/TravelContactsTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelContactsTab.vue
@@ -15,14 +15,18 @@
           :label="t('travel.contacts.field.firstName', 'Prénom')"
           :error="contactErrors.first_name"
         >
-          <input v-model.trim="contactForm.first_name" type="text" class="form-input" maxlength="120" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input :id="id" v-model.trim="contactForm.first_name" type="text" class="form-input" maxlength="120" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" />
+          </template>
         </FormField>
         <FormField
           :id="'travel-contact-last'"
           :label="t('travel.contacts.field.lastName', 'Nom')"
           :error="contactErrors.last_name"
         >
-          <input v-model.trim="contactForm.last_name" type="text" class="form-input" maxlength="120" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input :id="id" v-model.trim="contactForm.last_name" type="text" class="form-input" maxlength="120" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" />
+          </template>
         </FormField>
         <FormField
           :id="'travel-contact-email'"
@@ -30,14 +34,18 @@
           :error="contactErrors.email"
           required
         >
-          <input v-model.trim="contactForm.email" type="email" class="form-input" required maxlength="190" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input :id="id" v-model.trim="contactForm.email" type="email" class="form-input" required maxlength="190" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" />
+          </template>
         </FormField>
         <FormField
           :id="'travel-contact-phone'"
           :label="t('travel.contacts.field.phone', 'Téléphone')"
           :error="contactErrors.phone"
         >
-          <input v-model.trim="contactForm.phone" type="tel" class="form-input" maxlength="40" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input :id="id" v-model.trim="contactForm.phone" type="tel" class="form-input" maxlength="40" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" />
+          </template>
         </FormField>
         <FormField
           :id="'travel-contact-message'"
@@ -46,7 +54,9 @@
           class="col-span-full"
           required
         >
-          <textarea v-model.trim="contactForm.message" class="form-input" rows="4" required maxlength="2000"></textarea>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <textarea :id="id" v-model.trim="contactForm.message" class="form-input" rows="4" required maxlength="2000" :aria-invalid="ariaInvalid" :aria-describedby="describedBy"></textarea>
+          </template>
         </FormField>
 
         <label class="col-span-full flex items-start gap-2 text-sm text-slate-600 dark:text-slate-300">
@@ -144,7 +154,9 @@
           :error="notifyErrors.message"
           required
         >
-          <textarea v-model.trim="notifyForm.message" class="form-input" rows="4" required maxlength="2000"></textarea>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <textarea :id="id" v-model.trim="notifyForm.message" class="form-input" rows="4" required maxlength="2000" :aria-invalid="ariaInvalid" :aria-describedby="describedBy"></textarea>
+          </template>
         </FormField>
 
         <fieldset>

--- a/front/admin-dashboard/src/views/travel/TravelContactsTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelContactsTab.vue
@@ -1,0 +1,332 @@
+<template>
+  <div class="space-y-6">
+    <!-- Formulaire de contact → lead CRM (TRAVEL-416/#6068) : consentement obligatoire. -->
+    <section class="glass-card rounded-2xl p-6">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
+        {{ t('travel.contacts.formTitle', 'Formulaire de contact') }}
+      </h2>
+      <p class="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+        {{ t('travel.contacts.formSubtitle', 'Saisir une demande de contact — le consentement email est obligatoire.') }}
+      </p>
+
+      <form class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2" @submit.prevent="submitContact">
+        <FormField
+          :id="'travel-contact-first'"
+          :label="t('travel.contacts.field.firstName', 'Prénom')"
+          :error="contactErrors.first_name"
+        >
+          <input v-model.trim="contactForm.first_name" type="text" class="form-input" maxlength="120" />
+        </FormField>
+        <FormField
+          :id="'travel-contact-last'"
+          :label="t('travel.contacts.field.lastName', 'Nom')"
+          :error="contactErrors.last_name"
+        >
+          <input v-model.trim="contactForm.last_name" type="text" class="form-input" maxlength="120" />
+        </FormField>
+        <FormField
+          :id="'travel-contact-email'"
+          :label="t('travel.contacts.field.email', 'Email')"
+          :error="contactErrors.email"
+          required
+        >
+          <input v-model.trim="contactForm.email" type="email" class="form-input" required maxlength="190" />
+        </FormField>
+        <FormField
+          :id="'travel-contact-phone'"
+          :label="t('travel.contacts.field.phone', 'Téléphone')"
+          :error="contactErrors.phone"
+        >
+          <input v-model.trim="contactForm.phone" type="tel" class="form-input" maxlength="40" />
+        </FormField>
+        <FormField
+          :id="'travel-contact-message'"
+          :label="t('travel.contacts.field.message', 'Message')"
+          :error="contactErrors.message"
+          class="col-span-full"
+          required
+        >
+          <textarea v-model.trim="contactForm.message" class="form-input" rows="4" required maxlength="2000"></textarea>
+        </FormField>
+
+        <label class="col-span-full flex items-start gap-2 text-sm text-slate-600 dark:text-slate-300">
+          <input v-model="contactForm.consent_email" type="checkbox" class="mt-0.5 h-4 w-4" required />
+          <span>{{ t('travel.contacts.consentLabel', 'J’accepte d’être contacté par email au sujet de ma demande.') }}</span>
+        </label>
+
+        <div v-if="contactGlobalError" class="col-span-full rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {{ contactGlobalError }}
+        </div>
+        <div v-if="contactSuccess" class="col-span-full rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700" role="status">
+          {{ contactSuccess }}
+        </div>
+
+        <div class="col-span-full flex justify-end gap-2">
+          <button type="submit" class="btn-primary" :disabled="contactSaving">
+            {{ contactSaving ? $t('common.busy', 'En cours…') : t('travel.contacts.action.submit', 'Envoyer la demande') }}
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <!-- Registre des contacts voyageurs + consentement par canal (TRAVEL-415/#6067,
+         TRAVEL-910/#6113) : endpoints liste/consentement livrés avec le batch
+         admin contacts — voir PR backend dédiée. -->
+    <section class="space-y-4">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-xl font-bold text-slate-900 dark:text-white">
+            {{ t('travel.contacts.registryTitle', 'Registre des contacts') }}
+          </h2>
+          <p class="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+            {{ t('travel.contacts.registrySubtitle', 'Consentements par canal (opt-in/opt-out horodaté) et notification manuelle.') }}
+          </p>
+        </div>
+      </div>
+
+      <div v-if="registryError" class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700" role="alert">
+        {{ registryError }}
+      </div>
+
+      <DataTable
+        :columns="registryColumns"
+        :rows="contacts"
+        :loading="registryLoading"
+        :error="registryError"
+        :search-keys="['first_name', 'last_name', 'email', 'phone']"
+        :search-placeholder="t('travel.search.contact', 'Rechercher un contact…')"
+        :caption="t('travel.contacts.registryTitle', 'Registre des contacts')"
+      >
+        <template #cell-consents="{ row }">
+          <div class="flex flex-wrap items-center gap-1.5">
+            <button
+              v-for="ch in consentChannels"
+              :key="ch.key"
+              type="button"
+              class="rounded-full px-2.5 py-1 text-xs font-medium transition-colors"
+              :class="row[`${ch.key}_consent_given`] ? consentOnClass : consentOffClass"
+              :aria-label="t('travel.contacts.action.toggleConsent', 'Basculer le consentement') + ' ' + ch.label"
+              :title="`${ch.label} — ${row[`${ch.key}_consent_given`] ? t('travel.contacts.consentOn', 'Consenti') : t('travel.contacts.consentOff', 'Non consenti')}`"
+              @click="toggleConsent(row, ch)"
+            >
+              {{ ch.label }}
+            </button>
+          </div>
+        </template>
+        <template #row-actions="{ row }">
+          <button
+            class="rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            type="button"
+            :aria-label="t('travel.contacts.action.notify', 'Notifier')"
+            :title="t('travel.contacts.action.notify', 'Notifier')"
+            @click="openNotify(row)"
+          >
+            {{ t('travel.contacts.action.notify', 'Notifier') }}
+          </button>
+        </template>
+      </DataTable>
+    </section>
+
+    <!-- Notification manuelle (TRAVEL-910/#6113) -->
+    <TravelModal
+      :open="notifyOpen"
+      :title="t('travel.contacts.notifyTitle', 'Notification manuelle')"
+      @close="closeNotify"
+    >
+      <form class="grid grid-cols-1 gap-4" @submit.prevent="sendNotify">
+        <p class="text-sm text-slate-600 dark:text-slate-300">
+          {{ t('travel.contacts.notifyTarget', 'Destinataire') }} :
+          <strong>{{ notifyTarget }}</strong>
+        </p>
+        <FormField
+          :id="'travel-notify-message'"
+          :label="t('travel.contacts.field.message', 'Message')"
+          :error="notifyErrors.message"
+          required
+        >
+          <textarea v-model.trim="notifyForm.message" class="form-input" rows="4" required maxlength="2000"></textarea>
+        </FormField>
+
+        <fieldset>
+          <legend class="text-sm font-medium text-slate-700 dark:text-slate-300">
+            {{ t('travel.contacts.field.channels', 'Canaux') }}
+          </legend>
+          <div class="mt-2 space-y-2">
+            <label v-for="ch in notifyChannels" :key="ch.key" class="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input v-model="notifyForm.channels" type="checkbox" :value="ch.key" class="h-4 w-4" />
+              {{ ch.label }}
+            </label>
+          </div>
+          <p class="mt-1 text-xs text-slate-400">
+            {{ t('travel.contacts.notifyHint', 'Un canal sans consentement est ignoré ; 422 si aucun canal consenti.') }}
+          </p>
+        </fieldset>
+
+        <div v-if="notifyError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {{ notifyError }}
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" class="btn-secondary" @click="closeNotify">
+            {{ $t('common.cancel', 'Annuler') }}
+          </button>
+          <button type="submit" class="btn-primary" :disabled="notifySaving">
+            {{ notifySaving ? $t('common.busy', 'En cours…') : t('travel.contacts.action.send', 'Envoyer') }}
+          </button>
+        </div>
+      </form>
+    </TravelModal>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import api from '@/services/api'
+import DataTable from '@/components/common/DataTable.vue'
+import FormField from '@/components/common/FormField.vue'
+import TravelModal from '@/components/travel/TravelModal.vue'
+import { useToast } from 'vue-toastification'
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale.js'
+
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
+const toast = useToast()
+
+/* ── formulaire de contact (public, POST /travel/contact) ─── */
+const contactForm = ref({ consent_email: false })
+const contactErrors = ref({})
+const contactGlobalError = ref('')
+const contactSuccess = ref('')
+const contactSaving = ref(false)
+
+async function submitContact() {
+  contactSaving.value = true
+  contactErrors.value = {}
+  contactGlobalError.value = ''
+  contactSuccess.value = ''
+  try {
+    await api.post('/travel/contact', contactForm.value, { _skipAuthRedirect: true })
+    contactSuccess.value = t('travel.contacts.success', 'Demande reçue — merci, nous reviendrons vers vous.')
+    contactForm.value = { consent_email: false }
+  } catch (err) {
+    const data = err.response?.data || {}
+    if (data.errors) {
+      contactErrors.value = Object.fromEntries(
+        Object.entries(data.errors).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
+      )
+    }
+    contactGlobalError.value = data.message || data.localized_message || t('travel.error.saveFailed', "Échec de l'enregistrement.")
+  } finally {
+    contactSaving.value = false
+  }
+}
+
+/* ── registre des contacts ─────────────────────────────────── */
+const consentChannels = [
+  { key: 'email', label: 'Email' },
+  { key: 'sms', label: 'SMS' },
+  { key: 'whatsapp', label: 'WhatsApp' }
+]
+
+const consentOnClass = 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
+const consentOffClass = 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+
+const contacts = ref([])
+const registryLoading = ref(false)
+const registryError = ref('')
+
+const registryColumns = computed(() => [
+  { key: 'last_name', label: t('travel.contacts.field.lastName', 'Nom') },
+  { key: 'first_name', label: t('travel.contacts.field.firstName', 'Prénom') },
+  { key: 'email', label: t('travel.contacts.field.email', 'Email') },
+  { key: 'phone', label: t('travel.contacts.field.phone', 'Téléphone') },
+  { key: 'consents', label: t('travel.contacts.field.consents', 'Consentements') }
+])
+
+async function loadContacts() {
+  registryLoading.value = true
+  registryError.value = ''
+  try {
+    const res = await api.get('/travel/contacts', { params: { per_page: 100 }, _skipAuthRedirect: true })
+    contacts.value = res.data?.data || []
+  } catch (err) {
+    const status = err.response?.status
+    registryError.value = status === 404 || status === 405
+      ? t('travel.contacts.registryUnavailable', 'Registre indisponible — endpoint de liste non encore livré sur ce déploiement.')
+      : (err.response?.data?.message || t('travel.error.loadFailed', 'Impossible de charger les données.'))
+  } finally {
+    registryLoading.value = false
+  }
+}
+
+async function toggleConsent(row, ch) {
+  try {
+    await api.patch(
+      `/travel/contacts/${row.id}`,
+      { channel: ch.key, consent: !row[`${ch.key}_consent_given`] },
+      { _skipAuthRedirect: true }
+    )
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    await loadContacts()
+  } catch (err) {
+    toast.error(err.response?.data?.message || t('travel.error.saveFailed', "Échec de l'enregistrement."))
+  }
+}
+
+/* ── notification manuelle ─────────────────────────────────── */
+const notifyChannels = [
+  { key: 'email', label: 'Email' },
+  { key: 'app', label: t('travel.contacts.channelApp', 'Application (employé lié)') }
+]
+
+const notifyOpen = ref(false)
+const notifyTarget = ref('')
+const notifyRow = ref(null)
+const notifyForm = ref({ message: '', channels: ['email'] })
+const notifyErrors = ref({})
+const notifyError = ref('')
+const notifySaving = ref(false)
+
+function openNotify(row) {
+  notifyRow.value = row
+  notifyTarget.value = [row.first_name, row.last_name].filter(Boolean).join(' ') || row.email || `#${row.id}`
+  notifyForm.value = { message: '', channels: ['email'] }
+  notifyErrors.value = {}
+  notifyError.value = ''
+  notifyOpen.value = true
+}
+
+function closeNotify() {
+  notifyOpen.value = false
+  notifyRow.value = null
+}
+
+async function sendNotify() {
+  if (!notifyRow.value) return
+  notifySaving.value = true
+  notifyErrors.value = {}
+  notifyError.value = ''
+  try {
+    await api.post(
+      `/travel/contacts/${notifyRow.value.id}/notify`,
+      { message: notifyForm.value.message, channels: notifyForm.value.channels },
+      { _skipAuthRedirect: true }
+    )
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    notifyOpen.value = false
+  } catch (err) {
+    const data = err.response?.data || {}
+    if (data.errors) {
+      notifyErrors.value = Object.fromEntries(
+        Object.entries(data.errors).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
+      )
+    }
+    notifyError.value = data.message || data.localized_message || t('travel.error.saveFailed', "Échec de l'enregistrement.")
+  } finally {
+    notifySaving.value = false
+  }
+}
+
+onMounted(loadContacts)
+</script>

--- a/front/admin-dashboard/src/views/travel/TravelQuizTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelQuizTab.vue
@@ -72,7 +72,18 @@
           :error="questionErrors.question"
           required
         >
-          <input v-model.trim="questionForm.question" type="text" class="form-input" required maxlength="500" />
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <input
+              :id="id"
+              v-model.trim="questionForm.question"
+              type="text"
+              class="form-input"
+              required
+              maxlength="500"
+              :aria-invalid="ariaInvalid"
+              :aria-describedby="describedBy"
+            />
+          </template>
         </FormField>
 
         <FormField
@@ -82,7 +93,17 @@
           :error="questionErrors.options"
           required
         >
-          <textarea v-model="questionForm.optionsText" class="form-input" rows="4" required></textarea>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <textarea
+              :id="id"
+              v-model="questionForm.optionsText"
+              class="form-input"
+              rows="4"
+              required
+              :aria-invalid="ariaInvalid"
+              :aria-describedby="describedBy"
+            ></textarea>
+          </template>
         </FormField>
 
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -93,14 +114,36 @@
             :error="questionErrors.correct_option_index"
             required
           >
-            <input v-model.number="questionForm.correct_option_index" type="number" class="form-input" min="0" required />
+            <template #default="{ id, ariaInvalid, describedBy }">
+              <input
+                :id="id"
+                v-model.number="questionForm.correct_option_index"
+                type="number"
+                class="form-input"
+                min="0"
+                required
+                :aria-invalid="ariaInvalid"
+                :aria-describedby="describedBy"
+              />
+            </template>
           </FormField>
           <FormField
             :id="'travel-quiz-points'"
             :label="t('travel.quiz.field.points', 'Points')"
             :error="questionErrors.points"
           >
-            <input v-model.number="questionForm.points" type="number" class="form-input" min="1" max="100" />
+            <template #default="{ id, ariaInvalid, describedBy }">
+              <input
+                :id="id"
+                v-model.number="questionForm.points"
+                type="number"
+                class="form-input"
+                min="1"
+                max="100"
+                :aria-invalid="ariaInvalid"
+                :aria-describedby="describedBy"
+              />
+            </template>
           </FormField>
         </div>
 

--- a/front/admin-dashboard/src/views/travel/TravelQuizTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelQuizTab.vue
@@ -1,0 +1,340 @@
+<template>
+  <div class="space-y-6">
+    <TravelCrudSection
+      :config="quizConfig"
+      :column-display="columnsDisplay"
+      @action="onRowAction"
+    />
+
+    <!-- Modale questions d'un quiz (TRAVEL-904/#6107) : la bonne réponse
+         (correct_option_index) n'est jamais exposée par l'API et n'est pas
+         affichée ici. -->
+    <TravelModal
+      :open="questionsOpen"
+      :title="t('travel.quiz.questionsTitle', 'Questions du quiz')"
+      wide
+      @close="closeQuestions"
+    >
+      <div v-if="questionsError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        {{ questionsError }}
+      </div>
+
+      <div class="overflow-x-auto rounded-lg border border-slate-200/50 dark:border-slate-800/50">
+        <table class="min-w-full divide-y divide-slate-200/50 text-sm dark:divide-slate-800/50">
+          <thead class="bg-slate-50/50 dark:bg-slate-800/50">
+            <tr>
+              <th class="px-4 py-2.5 text-left text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                {{ t('travel.quiz.field.question', 'Question') }}
+              </th>
+              <th class="px-4 py-2.5 text-left text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                {{ t('travel.quiz.field.options', 'Choix') }}
+              </th>
+              <th class="px-4 py-2.5 text-left text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                {{ t('travel.quiz.field.points', 'Points') }}
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+            <tr v-for="q in questions" :key="q.id" class="hover:bg-slate-50/70 dark:hover:bg-slate-800/70">
+              <td class="px-4 py-2 align-top font-medium text-slate-700 dark:text-slate-300">{{ q.question }}</td>
+              <td class="px-4 py-2 align-top text-slate-600 dark:text-slate-400">
+                <ol class="list-inside list-decimal space-y-0.5">
+                  <li v-for="(opt, i) in q.options" :key="i">{{ opt }}</li>
+                </ol>
+              </td>
+              <td class="whitespace-nowrap px-4 py-2 text-slate-700 dark:text-slate-300">{{ q.points }}</td>
+            </tr>
+            <tr v-if="questions.length === 0 && !questionsLoading">
+              <td :colspan="3" class="px-4 py-4 text-center text-xs text-slate-400">
+                {{ t('travel.table.emptyNested', 'Aucun élément.') }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <button type="button" class="btn-secondary mt-3 text-sm" @click="openAddQuestion">
+        <PlusIcon class="mr-1.5 h-4 w-4" />
+        {{ t('travel.quiz.action.addQuestion', 'Ajouter une question') }}
+      </button>
+    </TravelModal>
+
+    <!-- Ajout d'une question -->
+    <TravelModal
+      :open="addQuestionOpen"
+      :title="t('travel.quiz.action.addQuestion', 'Ajouter une question')"
+      @close="closeAddQuestion"
+    >
+      <form class="grid grid-cols-1 gap-4" @submit.prevent="saveQuestion">
+        <FormField
+          :id="'travel-quiz-question'"
+          :label="t('travel.quiz.field.question', 'Question')"
+          :error="questionErrors.question"
+          required
+        >
+          <input v-model.trim="questionForm.question" type="text" class="form-input" required maxlength="500" />
+        </FormField>
+
+        <FormField
+          :id="'travel-quiz-options'"
+          :label="t('travel.quiz.field.options', 'Choix')"
+          :hint="t('travel.quiz.hint.options', 'Une option par ligne.')"
+          :error="questionErrors.options"
+          required
+        >
+          <textarea v-model="questionForm.optionsText" class="form-input" rows="4" required></textarea>
+        </FormField>
+
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField
+            :id="'travel-quiz-correct'"
+            :label="t('travel.quiz.field.correctIndex', 'Index de la bonne réponse')"
+            :hint="t('travel.quiz.hint.correctIndex', 'Commence à 0 (première ligne = 0).')"
+            :error="questionErrors.correct_option_index"
+            required
+          >
+            <input v-model.number="questionForm.correct_option_index" type="number" class="form-input" min="0" required />
+          </FormField>
+          <FormField
+            :id="'travel-quiz-points'"
+            :label="t('travel.quiz.field.points', 'Points')"
+            :error="questionErrors.points"
+          >
+            <input v-model.number="questionForm.points" type="number" class="form-input" min="1" max="100" />
+          </FormField>
+        </div>
+
+        <div v-if="questionGlobalError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {{ questionGlobalError }}
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" class="btn-secondary" @click="closeAddQuestion">
+            {{ $t('common.cancel', 'Annuler') }}
+          </button>
+          <button type="submit" class="btn-primary" :disabled="questionSaving">
+            {{ questionSaving ? $t('common.busy', 'En cours…') : $t('travel.action.save', 'Enregistrer') }}
+          </button>
+        </div>
+      </form>
+    </TravelModal>
+
+    <!-- Résultats (triés par score, serveur) -->
+    <TravelModal
+      :open="resultsOpen"
+      :title="t('travel.quiz.resultsTitle', 'Résultats')"
+      wide
+      @close="closeResults"
+    >
+      <div v-if="resultsError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        {{ resultsError }}
+      </div>
+      <DataTable
+        :columns="resultsColumns"
+        :rows="results"
+        :loading="resultsLoading"
+        :caption="t('travel.quiz.resultsTitle', 'Résultats')"
+      />
+    </TravelModal>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { PlusIcon } from '@heroicons/vue/24/outline'
+import api from '@/services/api'
+import DataTable from '@/components/common/DataTable.vue'
+import FormField from '@/components/common/FormField.vue'
+import TravelCrudSection from '@/components/travel/TravelCrudSection.vue'
+import TravelModal from '@/components/travel/TravelModal.vue'
+import { useToast } from 'vue-toastification'
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale.js'
+
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
+const toast = useToast()
+
+/* ── statuts quiz ───────────────────────────────────────────── */
+const statusMap = {
+  draft: { labelKey: 'travel.quizStatus.draft', color: 'gray' },
+  active: { labelKey: 'travel.quizStatus.active', color: 'green' },
+  closed: { labelKey: 'travel.quizStatus.closed', color: 'blue' }
+}
+
+const quizConfig = computed(() => ({
+  resource: 'quizzes',
+  titleKey: 'travel.quiz.title',
+  titleFallback: 'Quiz & jeux-concours',
+  subtitleKey: 'travel.quiz.subtitle',
+  searchPlaceholderKey: 'travel.search.quiz',
+  searchKeys: ['title'],
+  defaultSort: 'id',
+  statusField: 'status',
+  statusMap,
+  canEdit: false,
+  canDelete: false,
+  columns: [
+    { key: 'title', label: 'travel.field.title', sortable: true },
+    { key: 'status', label: 'travel.field.status', sortable: true },
+    { key: 'starts_at', label: 'travel.field.startDate', sortable: true },
+    { key: 'ends_at', label: 'travel.field.endDate', sortable: true }
+  ],
+  fields: [
+    { key: 'title', label: 'travel.field.title', type: 'text', required: true, max: 160 },
+    { key: 'description', label: 'travel.field.description', type: 'textarea' },
+    { key: 'starts_at', label: 'travel.field.startDate', type: 'datetime-local' },
+    { key: 'ends_at', label: 'travel.field.endDate', type: 'datetime-local' },
+    { key: 'max_participations_per_contact', label: 'travel.quiz.field.maxParticipations', type: 'number', min: 1, max: 100 },
+    {
+      key: 'status', label: 'travel.field.status', type: 'select',
+      options: [
+        { value: 'draft', label: t('travel.quizStatus.draft', 'Brouillon') },
+        { value: 'active', label: t('travel.quizStatus.active', 'Actif') },
+        { value: 'closed', label: t('travel.quizStatus.closed', 'Clôturé') }
+      ]
+    }
+  ],
+  defaults: { status: 'draft', max_participations_per_contact: 1 },
+  rowActions: [
+    { key: 'questions', label: 'travel.quiz.action.questions', labelFallback: 'Questions' },
+    { key: 'results', label: 'travel.quiz.action.results', labelFallback: 'Résultats' }
+  ]
+}))
+
+const columnsDisplay = computed(() => ({
+  starts_at: (row, value) => formatDate(value),
+  ends_at: (row, value) => formatDate(value)
+}))
+
+function formatDate(iso) {
+  if (!iso) return '-'
+  try {
+    return new Date(iso).toLocaleString(localeStore.current)
+  } catch {
+    return String(iso)
+  }
+}
+
+/* ── actions de ligne : questions / résultats ─────────────── */
+const activeQuiz = ref(null)
+const questionsOpen = ref(false)
+const questions = ref([])
+const questionsLoading = ref(false)
+const questionsError = ref('')
+
+const addQuestionOpen = ref(false)
+const questionForm = ref({ question: '', optionsText: '', correct_option_index: 0, points: 1 })
+const questionErrors = ref({})
+const questionGlobalError = ref('')
+const questionSaving = ref(false)
+
+const resultsOpen = ref(false)
+const results = ref([])
+const resultsLoading = ref(false)
+const resultsError = ref('')
+
+const resultsColumns = computed(() => [
+  { key: 'participant_name', label: t('travel.quiz.field.participantName', 'Nom') },
+  { key: 'participant_email', label: t('travel.quiz.field.participantEmail', 'Email') },
+  { key: 'score', label: t('travel.quiz.field.score', 'Score') },
+  { key: 'bonus', label: t('travel.quiz.field.bonus', 'Bonus') },
+  { key: 'submitted_at', label: t('travel.quiz.field.submittedAt', 'Soumis le') }
+])
+
+function onRowAction({ key, row }) {
+  if (key === 'questions') {
+    openQuestions(row)
+  } else if (key === 'results') {
+    openResults(row)
+  }
+}
+
+async function openQuestions(row) {
+  activeQuiz.value = row
+  questionsOpen.value = true
+  questionsError.value = ''
+  questionsLoading.value = true
+  try {
+    const res = await api.get(`/travel/quizzes/${row.id}`, { _skipAuthRedirect: true })
+    questions.value = res.data?.data?.questions || []
+  } catch (err) {
+    questionsError.value = err.response?.data?.message || t('travel.error.loadFailed', 'Impossible de charger les données.')
+  } finally {
+    questionsLoading.value = false
+  }
+}
+
+function closeQuestions() {
+  questionsOpen.value = false
+  addQuestionOpen.value = false
+  activeQuiz.value = null
+}
+
+function openAddQuestion() {
+  questionForm.value = { question: '', optionsText: '', correct_option_index: 0, points: 1 }
+  questionErrors.value = {}
+  questionGlobalError.value = ''
+  addQuestionOpen.value = true
+}
+
+function closeAddQuestion() {
+  addQuestionOpen.value = false
+}
+
+async function saveQuestion() {
+  if (!activeQuiz.value) return
+  questionSaving.value = true
+  questionErrors.value = {}
+  questionGlobalError.value = ''
+  const options = (questionForm.value.optionsText || '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  try {
+    await api.post(
+      `/travel/quizzes/${activeQuiz.value.id}/questions`,
+      {
+        question: questionForm.value.question,
+        options,
+        correct_option_index: questionForm.value.correct_option_index,
+        points: questionForm.value.points ?? 1
+      },
+      { _skipAuthRedirect: true }
+    )
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    addQuestionOpen.value = false
+    await openQuestions(activeQuiz.value)
+  } catch (err) {
+    const data = err.response?.data || {}
+    if (data.errors) {
+      questionErrors.value = Object.fromEntries(
+        Object.entries(data.errors).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
+      )
+    }
+    questionGlobalError.value = data.message || data.localized_message || t('travel.error.saveFailed', "Échec de l'enregistrement.")
+  } finally {
+    questionSaving.value = false
+  }
+}
+
+async function openResults(row) {
+  activeQuiz.value = row
+  resultsOpen.value = true
+  resultsError.value = ''
+  resultsLoading.value = true
+  try {
+    const res = await api.get(`/travel/quizzes/${row.id}/results`, { _skipAuthRedirect: true })
+    results.value = res.data?.data || []
+  } catch (err) {
+    resultsError.value = err.response?.data?.message || t('travel.error.loadFailed', 'Impossible de charger les données.')
+  } finally {
+    resultsLoading.value = false
+  }
+}
+
+function closeResults() {
+  resultsOpen.value = false
+  activeQuiz.value = null
+}
+</script>

--- a/front/admin-dashboard/src/views/travel/TravelSitesTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelSitesTab.vue
@@ -14,10 +14,12 @@
           :id="'travel-sites-city-filter'"
           :label="t('travel.sites.filterCity', 'Filtrer par ville')"
         >
-          <select v-model="cityFilter" class="form-input" @change="refreshKey += 1">
-            <option value="">{{ t('travel.sites.allCities', 'Toutes les villes') }}</option>
-            <option v-for="opt in cityOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
-          </select>
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <select :id="id" v-model="cityFilter" class="form-input" :aria-invalid="ariaInvalid" :aria-describedby="describedBy" @change="refreshKey += 1">
+              <option value="">{{ t('travel.sites.allCities', 'Toutes les villes') }}</option>
+              <option v-for="opt in cityOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+            </select>
+          </template>
         </FormField>
       </div>
     </div>

--- a/front/admin-dashboard/src/views/travel/TravelSitesTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelSitesTab.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="space-y-4">
+    <div class="flex flex-wrap items-end gap-4">
+      <div>
+        <h2 class="text-xl font-bold text-slate-900 dark:text-white">
+          {{ t('travel.sites.title', 'Sites touristiques') }}
+        </h2>
+        <p class="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+          {{ t('travel.sites.subtitle', 'Lieux d’intérêt avec localisation et recherche par ville.') }}
+        </p>
+      </div>
+      <div class="ml-auto w-full sm:w-72">
+        <FormField
+          :id="'travel-sites-city-filter'"
+          :label="t('travel.sites.filterCity', 'Filtrer par ville')"
+        >
+          <select v-model="cityFilter" class="form-input" @change="refreshKey += 1">
+            <option value="">{{ t('travel.sites.allCities', 'Toutes les villes') }}</option>
+            <option v-for="opt in cityOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </FormField>
+      </div>
+    </div>
+
+    <TravelCrudSection
+      :key="`sites-${refreshKey}`"
+      :config="siteConfig"
+      :lookups="{ cities: cityOptions }"
+      :extra-params="extraParams"
+      :column-display="siteDisplay"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import api from '@/services/api'
+import FormField from '@/components/common/FormField.vue'
+import TravelCrudSection from '@/components/travel/TravelCrudSection.vue'
+import { translate } from '@/i18n/index.js'
+import { useLocaleStore } from '@/stores/locale.js'
+
+const localeStore = useLocaleStore()
+const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
+
+const cities = ref([])
+const cityFilter = ref('')
+const refreshKey = ref(0)
+
+const cityOptions = computed(() =>
+  cities.value.map((c) => ({ value: c.id, label: `${c.name}${c.country_iso2 ? ` (${c.country_iso2})` : ''}` }))
+)
+
+async function loadCities() {
+  try {
+    const res = await api.get('/travel/cities', { params: { per_page: 100 }, _skipAuthRedirect: true })
+    cities.value = res.data?.data || []
+  } catch {
+    cities.value = []
+  }
+}
+
+const extraParams = () => (cityFilter.value ? { city_id: cityFilter.value } : {})
+
+const statusMap = {
+  active: { labelKey: 'travel.status.active', color: 'green' },
+  disabled: { labelKey: 'travel.sites.statusDisabled', color: 'gray' }
+}
+
+const siteConfig = computed(() => ({
+  resource: 'tourist-sites',
+  titleKey: 'travel.sites.title',
+  titleFallback: 'Sites touristiques',
+  subtitleKey: 'travel.sites.subtitle',
+  searchPlaceholderKey: 'travel.search.site',
+  searchKeys: ['name', 'description'],
+  defaultSort: 'name',
+  statusField: 'status',
+  statusMap,
+  columns: [
+    { key: 'name', label: 'travel.field.name', sortable: true },
+    { key: 'city_id', label: 'travel.field.city', sortable: true },
+    { key: 'status', label: 'travel.field.status', sortable: true }
+  ],
+  fields: [
+    { key: 'name', label: 'travel.field.name', type: 'text', required: true, max: 160 },
+    { key: 'description', label: 'travel.field.description', type: 'textarea' },
+    { key: 'city_id', label: 'travel.field.city', type: 'select', source: 'cities' },
+    { key: 'latitude', label: 'travel.sites.field.latitude', type: 'number', step: 'any' },
+    { key: 'longitude', label: 'travel.sites.field.longitude', type: 'number', step: 'any' },
+    {
+      key: 'status', label: 'travel.field.status', type: 'select',
+      options: [
+        { value: 'active', label: t('travel.status.active', 'Actif') },
+        { value: 'disabled', label: t('travel.sites.statusDisabled', 'Désactivé') }
+      ]
+    }
+  ],
+  defaults: { status: 'active' }
+}))
+
+const siteDisplay = computed(() => ({
+  city_id: (row, value) => {
+    const opt = cityOptions.value.find((c) => String(c.value) === String(value))
+    return opt ? opt.label : (value ?? '-')
+  }
+}))
+
+onMounted(loadCities)
+</script>

--- a/front/web/src/lib/i18n/locales/ar.json
+++ b/front/web/src/lib/i18n/locales/ar.json
@@ -3653,7 +3653,11 @@
       "checkin": "تسجيل الدخول",
       "tickets": "التذاكر",
       "reports": "التقارير",
-      "rentals": "الإيجارات والفنادق"
+      "rentals": "الإيجارات والفنادق",
+      "quizzes": "الاختبارات",
+      "adverts": "الإعلانات",
+      "sites": "المواقع السياحية",
+      "contacts": "جهات الاتصال"
     },
     "referentiel": {
       "tabsLabel": "الأقسام الفرعية للمرجع",
@@ -3687,7 +3691,11 @@
       "report": "ابحث في التقرير…",
       "rentalVehicle": "ابحث عن مركبة إيجار…",
       "rentalBooking": "ابحث عن حجز إيجار…",
-      "hotel": "ابحث عن فندق…"
+      "hotel": "ابحث عن فندق…",
+      "quiz": "ابحث عن اختبار…",
+      "advert": "ابحث عن إعلان…",
+      "site": "ابحث عن موقع…",
+      "contact": "ابحث عن جهة اتصال…"
     },
     "field": {
       "iso2": "كود ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— اختر —",
       "moneyMinor": "المبلغ بالعملة (1 = 100 وحدة صغيرة)"
+    },
+    "quiz": {
+      "title": "الاختبارات والمسابقات",
+      "subtitle": "أنشئ الاختبارات وأضف الأسئلة وراجع المشاركات.",
+      "questionsTitle": "أسئلة الاختبار",
+      "resultsTitle": "النتائج",
+      "field": {
+        "question": "السؤال",
+        "options": "الخيارات",
+        "points": "النقاط",
+        "correctIndex": "مؤشر الإجابة الصحيحة",
+        "maxParticipations": "الحد الأقصى للمشاركات لكل جهة اتصال",
+        "participantName": "الاسم",
+        "participantEmail": "البريد الإلكتروني",
+        "score": "النتيجة",
+        "bonus": "المكافأة",
+        "submittedAt": "أُرسل في"
+      },
+      "action": {
+        "questions": "الأسئلة",
+        "results": "النتائج",
+        "addQuestion": "إضافة سؤال"
+      },
+      "hint": {
+        "options": "خيار واحد في كل سطر.",
+        "correctIndex": "يبدأ من 0 (السطر الأول = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "مسودة",
+      "active": "نشط",
+      "closed": "مغلق"
+    },
+    "adverts": {
+      "tabsLabel": "أقسام الإعلانات الفرعية",
+      "tabTypes": "الأنواع",
+      "tabPositions": "المواضع",
+      "tabPrices": "جدول الأسعار",
+      "tabAdverts": "الإعلانات",
+      "title": "الإعلانات المدفوعة",
+      "subtitle": "أرسل إعلانًا وتابع الإعلانات المرئية.",
+      "createTitle": "إرسال إعلان",
+      "types": "أنواع الإعلانات",
+      "positions": "المواضع الإعلانية",
+      "prices": "جدول الأسعار",
+      "field": {
+        "type": "النوع",
+        "position": "الموضع",
+        "validityDays": "مدة الصلاحية (أيام)",
+        "content": "المحتوى",
+        "price": "السعر",
+        "pricePerImage": "السعر لكل صورة",
+        "pricePerCharacter": "السعر لكل حرف",
+        "expiresAt": "ينتهي في"
+      },
+      "action": {
+        "renew": "تجديد",
+        "submit": "إرسال"
+      }
+    },
+    "sites": {
+      "title": "المواقع السياحية",
+      "subtitle": "أماكن الاهتمام مع الموقع والبحث حسب المدينة.",
+      "filterCity": "تصفية حسب المدينة",
+      "allCities": "كل المدن",
+      "statusDisabled": "معطل",
+      "field": {
+        "latitude": "خط العرض",
+        "longitude": "خط الطول"
+      }
+    },
+    "contacts": {
+      "formTitle": "نموذج الاتصال",
+      "formSubtitle": "أرسل طلب اتصال — الموافقة على البريد الإلكتروني إلزامية.",
+      "registryTitle": "سجل جهات الاتصال",
+      "registrySubtitle": "الموافقات حسب القناة (اشتراك/إلغاء مختوم بالوقت) والإشعار اليدوي.",
+      "registryUnavailable": "السجل غير متاح — نقطة نهاية القائمة غير منشورة بعد على هذا النشر.",
+      "consentLabel": "أوافق على أن يتم التواصل معي عبر البريد الإلكتروني بشأن طلبي.",
+      "consentOn": "موافق",
+      "consentOff": "غير موافق",
+      "notifyTitle": "إشعار يدوي",
+      "notifyTarget": "المستلم",
+      "notifyHint": "يتم تجاهل القناة بدون موافقة؛ 422 إذا لم تكن هناك قناة موافق عليها.",
+      "channelApp": "التطبيق (موظف مرتبط)",
+      "success": "تم استلام الطلب — شكرًا، سنعاود التواصل معك.",
+      "field": {
+        "firstName": "الاسم الأول",
+        "lastName": "الاسم الأخير",
+        "email": "البريد الإلكتروني",
+        "phone": "الهاتف",
+        "message": "الرسالة",
+        "consents": "الموافقات",
+        "channels": "القنوات"
+      },
+      "action": {
+        "submit": "إرسال الطلب",
+        "toggleConsent": "تبديل الموافقة",
+        "notify": "إشعار",
+        "send": "إرسال"
+      }
     }
   }
 }

--- a/front/web/src/lib/i18n/locales/en.json
+++ b/front/web/src/lib/i18n/locales/en.json
@@ -3653,7 +3653,11 @@
       "checkin": "Check-in",
       "tickets": "Tickets",
       "reports": "Reports",
-      "rentals": "Rentals & Hotels"
+      "rentals": "Rentals & Hotels",
+      "quizzes": "Quiz",
+      "adverts": "Adverts",
+      "sites": "Tourist sites",
+      "contacts": "Contacts"
     },
     "referentiel": {
       "tabsLabel": "Referential sub-sections",
@@ -3687,7 +3691,11 @@
       "report": "Search in report…",
       "rentalVehicle": "Search a rental vehicle…",
       "rentalBooking": "Search a rental booking…",
-      "hotel": "Search a hotel…"
+      "hotel": "Search a hotel…",
+      "quiz": "Search a quiz…",
+      "advert": "Search an advert…",
+      "site": "Search a site…",
+      "contact": "Search a contact…"
     },
     "field": {
       "iso2": "ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— Select —",
       "moneyMinor": "Amount in currency (1 = 100 minor)"
+    },
+    "quiz": {
+      "title": "Quizzes & contests",
+      "subtitle": "Create quizzes, add questions and review participations.",
+      "questionsTitle": "Quiz questions",
+      "resultsTitle": "Results",
+      "field": {
+        "question": "Question",
+        "options": "Choices",
+        "points": "Points",
+        "correctIndex": "Correct answer index",
+        "maxParticipations": "Max participations per contact",
+        "participantName": "Name",
+        "participantEmail": "Email",
+        "score": "Score",
+        "bonus": "Bonus",
+        "submittedAt": "Submitted on"
+      },
+      "action": {
+        "questions": "Questions",
+        "results": "Results",
+        "addQuestion": "Add a question"
+      },
+      "hint": {
+        "options": "One option per line.",
+        "correctIndex": "Starts at 0 (first line = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Draft",
+      "active": "Active",
+      "closed": "Closed"
+    },
+    "adverts": {
+      "tabsLabel": "Advert sub-sections",
+      "tabTypes": "Types",
+      "tabPositions": "Positions",
+      "tabPrices": "Price grid",
+      "tabAdverts": "Adverts",
+      "title": "Paid adverts",
+      "subtitle": "Submit an advert and track visible ones.",
+      "createTitle": "Submit an advert",
+      "types": "Advert types",
+      "positions": "Advert positions",
+      "prices": "Price grid",
+      "field": {
+        "type": "Type",
+        "position": "Position",
+        "validityDays": "Validity (days)",
+        "content": "Content",
+        "price": "Price",
+        "pricePerImage": "Price per image",
+        "pricePerCharacter": "Price per character",
+        "expiresAt": "Expires on"
+      },
+      "action": {
+        "renew": "Renew",
+        "submit": "Submit"
+      }
+    },
+    "sites": {
+      "title": "Tourist sites",
+      "subtitle": "Points of interest with location and city search.",
+      "filterCity": "Filter by city",
+      "allCities": "All cities",
+      "statusDisabled": "Disabled",
+      "field": {
+        "latitude": "Latitude",
+        "longitude": "Longitude"
+      }
+    },
+    "contacts": {
+      "formTitle": "Contact form",
+      "formSubtitle": "Submit a contact request — email consent is required.",
+      "registryTitle": "Contact registry",
+      "registrySubtitle": "Per-channel consents (timestamped opt-in/opt-out) and manual notification.",
+      "registryUnavailable": "Registry unavailable — list endpoint not delivered on this deployment yet.",
+      "consentLabel": "I agree to be contacted by email about my request.",
+      "consentOn": "Consented",
+      "consentOff": "Not consented",
+      "notifyTitle": "Manual notification",
+      "notifyTarget": "Recipient",
+      "notifyHint": "A channel without consent is ignored; 422 if no channel is consented.",
+      "channelApp": "Application (linked employee)",
+      "success": "Request received — thank you, we will get back to you.",
+      "field": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "email": "Email",
+        "phone": "Phone",
+        "message": "Message",
+        "consents": "Consents",
+        "channels": "Channels"
+      },
+      "action": {
+        "submit": "Send request",
+        "toggleConsent": "Toggle consent",
+        "notify": "Notify",
+        "send": "Send"
+      }
     }
   }
 }

--- a/front/web/src/lib/i18n/locales/fr.json
+++ b/front/web/src/lib/i18n/locales/fr.json
@@ -3653,7 +3653,11 @@
       "checkin": "Check-in",
       "tickets": "Billets",
       "reports": "Rapports",
-      "rentals": "Locations & Hôtels"
+      "rentals": "Locations & Hôtels",
+      "quizzes": "Quiz",
+      "adverts": "Annonces",
+      "sites": "Sites touristiques",
+      "contacts": "Contacts"
     },
     "referentiel": {
       "tabsLabel": "Sous-sections du référentiel",
@@ -3687,7 +3691,11 @@
       "report": "Rechercher dans le rapport…",
       "rentalVehicle": "Rechercher un véhicule de location…",
       "rentalBooking": "Rechercher une réservation de location…",
-      "hotel": "Rechercher un hôtel…"
+      "hotel": "Rechercher un hôtel…",
+      "quiz": "Rechercher un quiz…",
+      "advert": "Rechercher une annonce…",
+      "site": "Rechercher un site…",
+      "contact": "Rechercher un contact…"
     },
     "field": {
       "iso2": "ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— Sélectionner —",
       "moneyMinor": "Montant en devises (1 = 100 minor)"
+    },
+    "quiz": {
+      "title": "Quiz & jeux-concours",
+      "subtitle": "Créez des quiz, ajoutez des questions et consultez les participations.",
+      "questionsTitle": "Questions du quiz",
+      "resultsTitle": "Résultats",
+      "field": {
+        "question": "Question",
+        "options": "Choix",
+        "points": "Points",
+        "correctIndex": "Index de la bonne réponse",
+        "maxParticipations": "Participations max. par contact",
+        "participantName": "Nom",
+        "participantEmail": "Email",
+        "score": "Score",
+        "bonus": "Bonus",
+        "submittedAt": "Soumis le"
+      },
+      "action": {
+        "questions": "Questions",
+        "results": "Résultats",
+        "addQuestion": "Ajouter une question"
+      },
+      "hint": {
+        "options": "Une option par ligne.",
+        "correctIndex": "Commence à 0 (première ligne = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Brouillon",
+      "active": "Actif",
+      "closed": "Clôturé"
+    },
+    "adverts": {
+      "tabsLabel": "Sous-sections annonces",
+      "tabTypes": "Types",
+      "tabPositions": "Emplacements",
+      "tabPrices": "Grille tarifaire",
+      "tabAdverts": "Annonces",
+      "title": "Annonces payantes",
+      "subtitle": "Soumettre une annonce et suivre les annonces visibles.",
+      "createTitle": "Soumettre une annonce",
+      "types": "Types d’annonces",
+      "positions": "Emplacements publicitaires",
+      "prices": "Grille tarifaire",
+      "field": {
+        "type": "Type",
+        "position": "Emplacement",
+        "validityDays": "Durée de validité (jours)",
+        "content": "Contenu",
+        "price": "Prix",
+        "pricePerImage": "Prix par image",
+        "pricePerCharacter": "Prix par caractère",
+        "expiresAt": "Expire le"
+      },
+      "action": {
+        "renew": "Renouveler",
+        "submit": "Soumettre"
+      }
+    },
+    "sites": {
+      "title": "Sites touristiques",
+      "subtitle": "Lieux d’intérêt avec localisation et recherche par ville.",
+      "filterCity": "Filtrer par ville",
+      "allCities": "Toutes les villes",
+      "statusDisabled": "Désactivé",
+      "field": {
+        "latitude": "Latitude",
+        "longitude": "Longitude"
+      }
+    },
+    "contacts": {
+      "formTitle": "Formulaire de contact",
+      "formSubtitle": "Saisir une demande de contact — le consentement email est obligatoire.",
+      "registryTitle": "Registre des contacts",
+      "registrySubtitle": "Consentements par canal (opt-in/opt-out horodaté) et notification manuelle.",
+      "registryUnavailable": "Registre indisponible — endpoint de liste non encore livré sur ce déploiement.",
+      "consentLabel": "J’accepte d’être contacté par email au sujet de ma demande.",
+      "consentOn": "Consenti",
+      "consentOff": "Non consenti",
+      "notifyTitle": "Notification manuelle",
+      "notifyTarget": "Destinataire",
+      "notifyHint": "Un canal sans consentement est ignoré ; 422 si aucun canal consenti.",
+      "channelApp": "Application (employé lié)",
+      "success": "Demande reçue — merci, nous reviendrons vers vous.",
+      "field": {
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "email": "Email",
+        "phone": "Téléphone",
+        "message": "Message",
+        "consents": "Consentements",
+        "channels": "Canaux"
+      },
+      "action": {
+        "submit": "Envoyer la demande",
+        "toggleConsent": "Basculer le consentement",
+        "notify": "Notifier",
+        "send": "Envoyer"
+      }
     }
   }
 }

--- a/front/web/src/lib/i18n/locales/tr.json
+++ b/front/web/src/lib/i18n/locales/tr.json
@@ -3653,7 +3653,11 @@
       "checkin": "Check-in",
       "tickets": "Biletler",
       "reports": "Raporlar",
-      "rentals": "Kiralama ve Oteller"
+      "rentals": "Kiralama ve Oteller",
+      "quizzes": "Quiz",
+      "adverts": "Reklamlar",
+      "sites": "Turistik yerler",
+      "contacts": "Kişiler"
     },
     "referentiel": {
       "tabsLabel": "Referans alt bölümleri",
@@ -3687,7 +3691,11 @@
       "report": "Raporda ara…",
       "rentalVehicle": "Kiralık araç ara…",
       "rentalBooking": "Kiralama rezervasyonu ara…",
-      "hotel": "Otel ara…"
+      "hotel": "Otel ara…",
+      "quiz": "Quiz ara…",
+      "advert": "Reklam ara…",
+      "site": "Yer ara…",
+      "contact": "Kişi ara…"
     },
     "field": {
       "iso2": "ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— Seçin —",
       "moneyMinor": "Para birimi cinsinden tutar (1 = 100 birim)"
+    },
+    "quiz": {
+      "title": "Quiz ve yarışmalar",
+      "subtitle": "Quiz oluşturun, soru ekleyin ve katılımları inceleyin.",
+      "questionsTitle": "Quiz soruları",
+      "resultsTitle": "Sonuçlar",
+      "field": {
+        "question": "Soru",
+        "options": "Seçenekler",
+        "points": "Puan",
+        "correctIndex": "Doğru cevap indeksi",
+        "maxParticipations": "Kişi başına maks. katılım",
+        "participantName": "Ad",
+        "participantEmail": "E-posta",
+        "score": "Puan",
+        "bonus": "Bonus",
+        "submittedAt": "Gönderim"
+      },
+      "action": {
+        "questions": "Sorular",
+        "results": "Sonuçlar",
+        "addQuestion": "Soru ekle"
+      },
+      "hint": {
+        "options": "Her satıra bir seçenek.",
+        "correctIndex": "0'dan başlar (ilk satır = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Taslak",
+      "active": "Aktif",
+      "closed": "Kapalı"
+    },
+    "adverts": {
+      "tabsLabel": "Reklam alt bölümleri",
+      "tabTypes": "Türler",
+      "tabPositions": "Konumlar",
+      "tabPrices": "Fiyat tablosu",
+      "tabAdverts": "Reklamlar",
+      "title": "Ücretli reklamlar",
+      "subtitle": "Reklam gönderin ve görünür olanları takip edin.",
+      "createTitle": "Reklam gönder",
+      "types": "Reklam türleri",
+      "positions": "Reklam konumları",
+      "prices": "Fiyat tablosu",
+      "field": {
+        "type": "Tür",
+        "position": "Konum",
+        "validityDays": "Geçerlilik (gün)",
+        "content": "İçerik",
+        "price": "Fiyat",
+        "pricePerImage": "Görsel başına fiyat",
+        "pricePerCharacter": "Karakter başına fiyat",
+        "expiresAt": "Bitiş"
+      },
+      "action": {
+        "renew": "Yenile",
+        "submit": "Gönder"
+      }
+    },
+    "sites": {
+      "title": "Turistik yerler",
+      "subtitle": "Konum ve şehir aramalı ilgi noktaları.",
+      "filterCity": "Şehre göre filtrele",
+      "allCities": "Tüm şehirler",
+      "statusDisabled": "Devre dışı",
+      "field": {
+        "latitude": "Enlem",
+        "longitude": "Boylam"
+      }
+    },
+    "contacts": {
+      "formTitle": "İletişim formu",
+      "formSubtitle": "İletişim talebi gönderin — e-posta onayı zorunludur.",
+      "registryTitle": "Kişi kayıtları",
+      "registrySubtitle": "Kanal bazında onaylar (zaman damgalı) ve manuel bildirim.",
+      "registryUnavailable": "Kayıtlar kullanılamıyor — liste ucu bu dağıtımda henüz yayınlanmadı.",
+      "consentLabel": "Talebimle ilgili e-posta ile iletişime geçilmesini kabul ediyorum.",
+      "consentOn": "Onaylı",
+      "consentOff": "Onaysız",
+      "notifyTitle": "Manuel bildirim",
+      "notifyTarget": "Alıcı",
+      "notifyHint": "Onaysız kanal yok sayılır; onaylı kanal yoksa 422.",
+      "channelApp": "Uygulama (bağlı çalışan)",
+      "success": "Talep alındı — teşekkürler, size dönüş yapacağız.",
+      "field": {
+        "firstName": "Ad",
+        "lastName": "Soyad",
+        "email": "E-posta",
+        "phone": "Telefon",
+        "message": "Mesaj",
+        "consents": "Onaylar",
+        "channels": "Kanallar"
+      },
+      "action": {
+        "submit": "Talebi gönder",
+        "toggleConsent": "Onayı değiştir",
+        "notify": "Bildir",
+        "send": "Gönder"
+      }
     }
   }
 }

--- a/shared/i18n/locales/ar.json
+++ b/shared/i18n/locales/ar.json
@@ -3653,7 +3653,11 @@
       "checkin": "تسجيل الدخول",
       "tickets": "التذاكر",
       "reports": "التقارير",
-      "rentals": "الإيجارات والفنادق"
+      "rentals": "الإيجارات والفنادق",
+      "quizzes": "الاختبارات",
+      "adverts": "الإعلانات",
+      "sites": "المواقع السياحية",
+      "contacts": "جهات الاتصال"
     },
     "referentiel": {
       "tabsLabel": "الأقسام الفرعية للمرجع",
@@ -3687,7 +3691,11 @@
       "report": "ابحث في التقرير…",
       "rentalVehicle": "ابحث عن مركبة إيجار…",
       "rentalBooking": "ابحث عن حجز إيجار…",
-      "hotel": "ابحث عن فندق…"
+      "hotel": "ابحث عن فندق…",
+      "quiz": "ابحث عن اختبار…",
+      "advert": "ابحث عن إعلان…",
+      "site": "ابحث عن موقع…",
+      "contact": "ابحث عن جهة اتصال…"
     },
     "field": {
       "iso2": "كود ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— اختر —",
       "moneyMinor": "المبلغ بالعملة (1 = 100 وحدة صغيرة)"
+    },
+    "quiz": {
+      "title": "الاختبارات والمسابقات",
+      "subtitle": "أنشئ الاختبارات وأضف الأسئلة وراجع المشاركات.",
+      "questionsTitle": "أسئلة الاختبار",
+      "resultsTitle": "النتائج",
+      "field": {
+        "question": "السؤال",
+        "options": "الخيارات",
+        "points": "النقاط",
+        "correctIndex": "مؤشر الإجابة الصحيحة",
+        "maxParticipations": "الحد الأقصى للمشاركات لكل جهة اتصال",
+        "participantName": "الاسم",
+        "participantEmail": "البريد الإلكتروني",
+        "score": "النتيجة",
+        "bonus": "المكافأة",
+        "submittedAt": "أُرسل في"
+      },
+      "action": {
+        "questions": "الأسئلة",
+        "results": "النتائج",
+        "addQuestion": "إضافة سؤال"
+      },
+      "hint": {
+        "options": "خيار واحد في كل سطر.",
+        "correctIndex": "يبدأ من 0 (السطر الأول = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "مسودة",
+      "active": "نشط",
+      "closed": "مغلق"
+    },
+    "adverts": {
+      "tabsLabel": "أقسام الإعلانات الفرعية",
+      "tabTypes": "الأنواع",
+      "tabPositions": "المواضع",
+      "tabPrices": "جدول الأسعار",
+      "tabAdverts": "الإعلانات",
+      "title": "الإعلانات المدفوعة",
+      "subtitle": "أرسل إعلانًا وتابع الإعلانات المرئية.",
+      "createTitle": "إرسال إعلان",
+      "types": "أنواع الإعلانات",
+      "positions": "المواضع الإعلانية",
+      "prices": "جدول الأسعار",
+      "field": {
+        "type": "النوع",
+        "position": "الموضع",
+        "validityDays": "مدة الصلاحية (أيام)",
+        "content": "المحتوى",
+        "price": "السعر",
+        "pricePerImage": "السعر لكل صورة",
+        "pricePerCharacter": "السعر لكل حرف",
+        "expiresAt": "ينتهي في"
+      },
+      "action": {
+        "renew": "تجديد",
+        "submit": "إرسال"
+      }
+    },
+    "sites": {
+      "title": "المواقع السياحية",
+      "subtitle": "أماكن الاهتمام مع الموقع والبحث حسب المدينة.",
+      "filterCity": "تصفية حسب المدينة",
+      "allCities": "كل المدن",
+      "statusDisabled": "معطل",
+      "field": {
+        "latitude": "خط العرض",
+        "longitude": "خط الطول"
+      }
+    },
+    "contacts": {
+      "formTitle": "نموذج الاتصال",
+      "formSubtitle": "أرسل طلب اتصال — الموافقة على البريد الإلكتروني إلزامية.",
+      "registryTitle": "سجل جهات الاتصال",
+      "registrySubtitle": "الموافقات حسب القناة (اشتراك/إلغاء مختوم بالوقت) والإشعار اليدوي.",
+      "registryUnavailable": "السجل غير متاح — نقطة نهاية القائمة غير منشورة بعد على هذا النشر.",
+      "consentLabel": "أوافق على أن يتم التواصل معي عبر البريد الإلكتروني بشأن طلبي.",
+      "consentOn": "موافق",
+      "consentOff": "غير موافق",
+      "notifyTitle": "إشعار يدوي",
+      "notifyTarget": "المستلم",
+      "notifyHint": "يتم تجاهل القناة بدون موافقة؛ 422 إذا لم تكن هناك قناة موافق عليها.",
+      "channelApp": "التطبيق (موظف مرتبط)",
+      "success": "تم استلام الطلب — شكرًا، سنعاود التواصل معك.",
+      "field": {
+        "firstName": "الاسم الأول",
+        "lastName": "الاسم الأخير",
+        "email": "البريد الإلكتروني",
+        "phone": "الهاتف",
+        "message": "الرسالة",
+        "consents": "الموافقات",
+        "channels": "القنوات"
+      },
+      "action": {
+        "submit": "إرسال الطلب",
+        "toggleConsent": "تبديل الموافقة",
+        "notify": "إشعار",
+        "send": "إرسال"
+      }
     }
   }
 }

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -3653,7 +3653,11 @@
       "checkin": "Check-in",
       "tickets": "Tickets",
       "reports": "Reports",
-      "rentals": "Rentals & Hotels"
+      "rentals": "Rentals & Hotels",
+      "quizzes": "Quiz",
+      "adverts": "Adverts",
+      "sites": "Tourist sites",
+      "contacts": "Contacts"
     },
     "referentiel": {
       "tabsLabel": "Referential sub-sections",
@@ -3687,7 +3691,11 @@
       "report": "Search in report…",
       "rentalVehicle": "Search a rental vehicle…",
       "rentalBooking": "Search a rental booking…",
-      "hotel": "Search a hotel…"
+      "hotel": "Search a hotel…",
+      "quiz": "Search a quiz…",
+      "advert": "Search an advert…",
+      "site": "Search a site…",
+      "contact": "Search a contact…"
     },
     "field": {
       "iso2": "ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— Select —",
       "moneyMinor": "Amount in currency (1 = 100 minor)"
+    },
+    "quiz": {
+      "title": "Quizzes & contests",
+      "subtitle": "Create quizzes, add questions and review participations.",
+      "questionsTitle": "Quiz questions",
+      "resultsTitle": "Results",
+      "field": {
+        "question": "Question",
+        "options": "Choices",
+        "points": "Points",
+        "correctIndex": "Correct answer index",
+        "maxParticipations": "Max participations per contact",
+        "participantName": "Name",
+        "participantEmail": "Email",
+        "score": "Score",
+        "bonus": "Bonus",
+        "submittedAt": "Submitted on"
+      },
+      "action": {
+        "questions": "Questions",
+        "results": "Results",
+        "addQuestion": "Add a question"
+      },
+      "hint": {
+        "options": "One option per line.",
+        "correctIndex": "Starts at 0 (first line = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Draft",
+      "active": "Active",
+      "closed": "Closed"
+    },
+    "adverts": {
+      "tabsLabel": "Advert sub-sections",
+      "tabTypes": "Types",
+      "tabPositions": "Positions",
+      "tabPrices": "Price grid",
+      "tabAdverts": "Adverts",
+      "title": "Paid adverts",
+      "subtitle": "Submit an advert and track visible ones.",
+      "createTitle": "Submit an advert",
+      "types": "Advert types",
+      "positions": "Advert positions",
+      "prices": "Price grid",
+      "field": {
+        "type": "Type",
+        "position": "Position",
+        "validityDays": "Validity (days)",
+        "content": "Content",
+        "price": "Price",
+        "pricePerImage": "Price per image",
+        "pricePerCharacter": "Price per character",
+        "expiresAt": "Expires on"
+      },
+      "action": {
+        "renew": "Renew",
+        "submit": "Submit"
+      }
+    },
+    "sites": {
+      "title": "Tourist sites",
+      "subtitle": "Points of interest with location and city search.",
+      "filterCity": "Filter by city",
+      "allCities": "All cities",
+      "statusDisabled": "Disabled",
+      "field": {
+        "latitude": "Latitude",
+        "longitude": "Longitude"
+      }
+    },
+    "contacts": {
+      "formTitle": "Contact form",
+      "formSubtitle": "Submit a contact request — email consent is required.",
+      "registryTitle": "Contact registry",
+      "registrySubtitle": "Per-channel consents (timestamped opt-in/opt-out) and manual notification.",
+      "registryUnavailable": "Registry unavailable — list endpoint not delivered on this deployment yet.",
+      "consentLabel": "I agree to be contacted by email about my request.",
+      "consentOn": "Consented",
+      "consentOff": "Not consented",
+      "notifyTitle": "Manual notification",
+      "notifyTarget": "Recipient",
+      "notifyHint": "A channel without consent is ignored; 422 if no channel is consented.",
+      "channelApp": "Application (linked employee)",
+      "success": "Request received — thank you, we will get back to you.",
+      "field": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "email": "Email",
+        "phone": "Phone",
+        "message": "Message",
+        "consents": "Consents",
+        "channels": "Channels"
+      },
+      "action": {
+        "submit": "Send request",
+        "toggleConsent": "Toggle consent",
+        "notify": "Notify",
+        "send": "Send"
+      }
     }
   }
 }

--- a/shared/i18n/locales/fr.json
+++ b/shared/i18n/locales/fr.json
@@ -3653,7 +3653,11 @@
       "checkin": "Check-in",
       "tickets": "Billets",
       "reports": "Rapports",
-      "rentals": "Locations & Hôtels"
+      "rentals": "Locations & Hôtels",
+      "quizzes": "Quiz",
+      "adverts": "Annonces",
+      "sites": "Sites touristiques",
+      "contacts": "Contacts"
     },
     "referentiel": {
       "tabsLabel": "Sous-sections du référentiel",
@@ -3687,7 +3691,11 @@
       "report": "Rechercher dans le rapport…",
       "rentalVehicle": "Rechercher un véhicule de location…",
       "rentalBooking": "Rechercher une réservation de location…",
-      "hotel": "Rechercher un hôtel…"
+      "hotel": "Rechercher un hôtel…",
+      "quiz": "Rechercher un quiz…",
+      "advert": "Rechercher une annonce…",
+      "site": "Rechercher un site…",
+      "contact": "Rechercher un contact…"
     },
     "field": {
       "iso2": "ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— Sélectionner —",
       "moneyMinor": "Montant en devises (1 = 100 minor)"
+    },
+    "quiz": {
+      "title": "Quiz & jeux-concours",
+      "subtitle": "Créez des quiz, ajoutez des questions et consultez les participations.",
+      "questionsTitle": "Questions du quiz",
+      "resultsTitle": "Résultats",
+      "field": {
+        "question": "Question",
+        "options": "Choix",
+        "points": "Points",
+        "correctIndex": "Index de la bonne réponse",
+        "maxParticipations": "Participations max. par contact",
+        "participantName": "Nom",
+        "participantEmail": "Email",
+        "score": "Score",
+        "bonus": "Bonus",
+        "submittedAt": "Soumis le"
+      },
+      "action": {
+        "questions": "Questions",
+        "results": "Résultats",
+        "addQuestion": "Ajouter une question"
+      },
+      "hint": {
+        "options": "Une option par ligne.",
+        "correctIndex": "Commence à 0 (première ligne = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Brouillon",
+      "active": "Actif",
+      "closed": "Clôturé"
+    },
+    "adverts": {
+      "tabsLabel": "Sous-sections annonces",
+      "tabTypes": "Types",
+      "tabPositions": "Emplacements",
+      "tabPrices": "Grille tarifaire",
+      "tabAdverts": "Annonces",
+      "title": "Annonces payantes",
+      "subtitle": "Soumettre une annonce et suivre les annonces visibles.",
+      "createTitle": "Soumettre une annonce",
+      "types": "Types d’annonces",
+      "positions": "Emplacements publicitaires",
+      "prices": "Grille tarifaire",
+      "field": {
+        "type": "Type",
+        "position": "Emplacement",
+        "validityDays": "Durée de validité (jours)",
+        "content": "Contenu",
+        "price": "Prix",
+        "pricePerImage": "Prix par image",
+        "pricePerCharacter": "Prix par caractère",
+        "expiresAt": "Expire le"
+      },
+      "action": {
+        "renew": "Renouveler",
+        "submit": "Soumettre"
+      }
+    },
+    "sites": {
+      "title": "Sites touristiques",
+      "subtitle": "Lieux d’intérêt avec localisation et recherche par ville.",
+      "filterCity": "Filtrer par ville",
+      "allCities": "Toutes les villes",
+      "statusDisabled": "Désactivé",
+      "field": {
+        "latitude": "Latitude",
+        "longitude": "Longitude"
+      }
+    },
+    "contacts": {
+      "formTitle": "Formulaire de contact",
+      "formSubtitle": "Saisir une demande de contact — le consentement email est obligatoire.",
+      "registryTitle": "Registre des contacts",
+      "registrySubtitle": "Consentements par canal (opt-in/opt-out horodaté) et notification manuelle.",
+      "registryUnavailable": "Registre indisponible — endpoint de liste non encore livré sur ce déploiement.",
+      "consentLabel": "J’accepte d’être contacté par email au sujet de ma demande.",
+      "consentOn": "Consenti",
+      "consentOff": "Non consenti",
+      "notifyTitle": "Notification manuelle",
+      "notifyTarget": "Destinataire",
+      "notifyHint": "Un canal sans consentement est ignoré ; 422 si aucun canal consenti.",
+      "channelApp": "Application (employé lié)",
+      "success": "Demande reçue — merci, nous reviendrons vers vous.",
+      "field": {
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "email": "Email",
+        "phone": "Téléphone",
+        "message": "Message",
+        "consents": "Consentements",
+        "channels": "Canaux"
+      },
+      "action": {
+        "submit": "Envoyer la demande",
+        "toggleConsent": "Basculer le consentement",
+        "notify": "Notifier",
+        "send": "Envoyer"
+      }
     }
   }
 }

--- a/shared/i18n/locales/tr.json
+++ b/shared/i18n/locales/tr.json
@@ -3653,7 +3653,11 @@
       "checkin": "Check-in",
       "tickets": "Biletler",
       "reports": "Raporlar",
-      "rentals": "Kiralama ve Oteller"
+      "rentals": "Kiralama ve Oteller",
+      "quizzes": "Quiz",
+      "adverts": "Reklamlar",
+      "sites": "Turistik yerler",
+      "contacts": "Kişiler"
     },
     "referentiel": {
       "tabsLabel": "Referans alt bölümleri",
@@ -3687,7 +3691,11 @@
       "report": "Raporda ara…",
       "rentalVehicle": "Kiralık araç ara…",
       "rentalBooking": "Kiralama rezervasyonu ara…",
-      "hotel": "Otel ara…"
+      "hotel": "Otel ara…",
+      "quiz": "Quiz ara…",
+      "advert": "Reklam ara…",
+      "site": "Yer ara…",
+      "contact": "Kişi ara…"
     },
     "field": {
       "iso2": "ISO2",
@@ -3923,6 +3931,106 @@
     "form": {
       "selectPlaceholder": "— Seçin —",
       "moneyMinor": "Para birimi cinsinden tutar (1 = 100 birim)"
+    },
+    "quiz": {
+      "title": "Quiz ve yarışmalar",
+      "subtitle": "Quiz oluşturun, soru ekleyin ve katılımları inceleyin.",
+      "questionsTitle": "Quiz soruları",
+      "resultsTitle": "Sonuçlar",
+      "field": {
+        "question": "Soru",
+        "options": "Seçenekler",
+        "points": "Puan",
+        "correctIndex": "Doğru cevap indeksi",
+        "maxParticipations": "Kişi başına maks. katılım",
+        "participantName": "Ad",
+        "participantEmail": "E-posta",
+        "score": "Puan",
+        "bonus": "Bonus",
+        "submittedAt": "Gönderim"
+      },
+      "action": {
+        "questions": "Sorular",
+        "results": "Sonuçlar",
+        "addQuestion": "Soru ekle"
+      },
+      "hint": {
+        "options": "Her satıra bir seçenek.",
+        "correctIndex": "0'dan başlar (ilk satır = 0)."
+      }
+    },
+    "quizStatus": {
+      "draft": "Taslak",
+      "active": "Aktif",
+      "closed": "Kapalı"
+    },
+    "adverts": {
+      "tabsLabel": "Reklam alt bölümleri",
+      "tabTypes": "Türler",
+      "tabPositions": "Konumlar",
+      "tabPrices": "Fiyat tablosu",
+      "tabAdverts": "Reklamlar",
+      "title": "Ücretli reklamlar",
+      "subtitle": "Reklam gönderin ve görünür olanları takip edin.",
+      "createTitle": "Reklam gönder",
+      "types": "Reklam türleri",
+      "positions": "Reklam konumları",
+      "prices": "Fiyat tablosu",
+      "field": {
+        "type": "Tür",
+        "position": "Konum",
+        "validityDays": "Geçerlilik (gün)",
+        "content": "İçerik",
+        "price": "Fiyat",
+        "pricePerImage": "Görsel başına fiyat",
+        "pricePerCharacter": "Karakter başına fiyat",
+        "expiresAt": "Bitiş"
+      },
+      "action": {
+        "renew": "Yenile",
+        "submit": "Gönder"
+      }
+    },
+    "sites": {
+      "title": "Turistik yerler",
+      "subtitle": "Konum ve şehir aramalı ilgi noktaları.",
+      "filterCity": "Şehre göre filtrele",
+      "allCities": "Tüm şehirler",
+      "statusDisabled": "Devre dışı",
+      "field": {
+        "latitude": "Enlem",
+        "longitude": "Boylam"
+      }
+    },
+    "contacts": {
+      "formTitle": "İletişim formu",
+      "formSubtitle": "İletişim talebi gönderin — e-posta onayı zorunludur.",
+      "registryTitle": "Kişi kayıtları",
+      "registrySubtitle": "Kanal bazında onaylar (zaman damgalı) ve manuel bildirim.",
+      "registryUnavailable": "Kayıtlar kullanılamıyor — liste ucu bu dağıtımda henüz yayınlanmadı.",
+      "consentLabel": "Talebimle ilgili e-posta ile iletişime geçilmesini kabul ediyorum.",
+      "consentOn": "Onaylı",
+      "consentOff": "Onaysız",
+      "notifyTitle": "Manuel bildirim",
+      "notifyTarget": "Alıcı",
+      "notifyHint": "Onaysız kanal yok sayılır; onaylı kanal yoksa 422.",
+      "channelApp": "Uygulama (bağlı çalışan)",
+      "success": "Talep alındı — teşekkürler, size dönüş yapacağız.",
+      "field": {
+        "firstName": "Ad",
+        "lastName": "Soyad",
+        "email": "E-posta",
+        "phone": "Telefon",
+        "message": "Mesaj",
+        "consents": "Onaylar",
+        "channels": "Kanallar"
+      },
+      "action": {
+        "submit": "Talebi gönder",
+        "toggleConsent": "Onayı değiştir",
+        "notify": "Bildir",
+        "send": "Gönder"
+      }
     }
   }
 }

--- a/shared/i18n/versions/versions.json
+++ b/shared/i18n/versions/versions.json
@@ -25,22 +25,22 @@
   },
   "locales": {
     "fr": {
-      "checksum": "00ec8617b7beedad4c17730fff2b1241e4363c222cbf16991e70b389a92c450b",
+      "checksum": "e7a653843c1b59cab785c51ea88628846c78e275b5e48ca265c93cd775060a77",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     },
     "ar": {
-      "checksum": "7e23a774f94351151f060c706b4ea459f607f489b536164b67b5c74450e2ba1f",
+      "checksum": "c1dff0f14174bc8b593561fbbc71cd4d15ae175ba753e38b4cbf86f3ec4b0a5e",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     },
     "tr": {
-      "checksum": "5073983261b5a8650351b7eb4f2a04b9ae1ec6e7b0e26d9298707567e96c32ca",
+      "checksum": "b1a49d5e0be596b56ef4dcd63029a5615af58176f6653573ab3df3c227c0294d",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     },
     "en": {
-      "checksum": "1d79ce004a10c30f1a508f31809d2e338b3918020c81ed513d42e86c51780ecf",
+      "checksum": "76654cc10ce500e8fe6dfa07af8466f3fb2de2b978e8d342a858a9931670ce48",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     }
@@ -48,21 +48,21 @@
   "surfaces": {
     "web": {
       "checksums": {
-        "ar": "7e23a774f94351151f060c706b4ea459f607f489b536164b67b5c74450e2ba1f",
-        "en": "1d79ce004a10c30f1a508f31809d2e338b3918020c81ed513d42e86c51780ecf",
-        "fr": "00ec8617b7beedad4c17730fff2b1241e4363c222cbf16991e70b389a92c450b",
-        "tr": "5073983261b5a8650351b7eb4f2a04b9ae1ec6e7b0e26d9298707567e96c32ca"
+        "ar": "c1dff0f14174bc8b593561fbbc71cd4d15ae175ba753e38b4cbf86f3ec4b0a5e",
+        "en": "76654cc10ce500e8fe6dfa07af8466f3fb2de2b978e8d342a858a9931670ce48",
+        "fr": "e7a653843c1b59cab785c51ea88628846c78e275b5e48ca265c93cd775060a77",
+        "tr": "b1a49d5e0be596b56ef4dcd63029a5615af58176f6653573ab3df3c227c0294d"
       },
-      "updated_at": "2026-08-30T16:25:14.987Z"
+      "updated_at": "2026-08-30T17:12:51.008Z"
     },
     "admin": {
       "checksums": {
-        "ar": "2ce069e2bd5914fd02a9270450528e9d69c2f5d12ed9e1b4d3bde12238b953a1",
-        "en": "00ed9b11e1c62c1555941c0838a6dbe1383c39305df184b07fc39bc41b995b6b",
-        "fr": "aaaf9e4b5bfaaf68359a57ee9d35b27188557de03ab89ad3e836b38a7224100d",
-        "tr": "298d6177290152cbb5cbb5cdb31c8d205393bd29e4704f4de4f1f772fa973228"
+        "ar": "6d5615d65717370a61f0485a15f7ec97a1cb3553e066caebf52cef1981f34233",
+        "en": "a320d4d38116edd3e83505b36aed4b1166862054029faf0c8ac33d9dd4dae06b",
+        "fr": "b7bd236b0233a5e2155f39b805c914306fdc76897335964b32da7e6fe5364138",
+        "tr": "31ad53ad80dd7546f74868845da8d86d7864f44134f4b96ec878c6d8cd4f984c"
       },
-      "updated_at": "2026-08-30T16:25:15.022Z"
+      "updated_at": "2026-08-30T17:12:51.057Z"
     }
   }
 }


### PR DESCRIPTION
## Lot UI admin web BC-24 TRAVEL — TRAVEL-911 (#6416) + TRAVEL-912 (#6417)

Branche de lot \`bc/bc24-travel-ui-contenu-monetisation\` empilée sur \`bc/bc24-travel-admin-ui\` (lot TRAVEL-601..609, PR #6389) — un commit par issue livrée.

### Livré

| Issue | Contenu |
|---|---|
| #6416 (TRAVEL-911) | Onglet **Quiz** : liste/création, questions (la bonne réponse \`correct_option_index\` n'est **jamais** exposée par l'API ni rendue), résultats triés par score. Onglet **Annonces** : référentiels types/emplacements, grille tarifaire (minor units, devise tenant), soumission + annonces visibles + renouvellement. Onglet **Sites touristiques** : CRUD + filtre par ville/recherche |
| #6417 (TRAVEL-912) | Onglet **Contacts** : formulaire de contact → \`POST /travel/contact\` (consentement obligatoire, accusé 202) + registre des contacts (consentements par canal opt-in/opt-out, notification manuelle \`POST /travel/contacts/{id}/notify\` — 422 si aucun canal consenti) |

### Endpoints backend manquants découverts → issues séparées (règle « pas d'endpoint inventé »)

- #6426 (TRAVEL-913) : liste admin des contacts — implémenté dans la PR backend dédiée
- #6427 (TRAVEL-914) : mise à jour du consentement par canal — implémenté dans la PR backend dédiée
- #6428 (TRAVEL-915) : liste admin des annonces tous statuts (l'index actuel ne montre que les annonces visibles) — implémenté dans la PR backend dédiée

### Composants

- \`TravelQuizTab\`, \`TravelAdvertsTab\`, \`TravelSitesTab\`, \`TravelContactsTab\` (patterns \`TravelCrudSection\` / \`TravelModal\` existants)
- \`TravelCrudSection\` : option \`canEdit: false\` (ressources sans PUT — quiz, référentiels annonces, grille)
- i18n : clés \`travel.quiz/adverts/sites/contacts\` sur les 4 locales (fr source de vérité) + sync-web

### Validation locale

- \`eslint\` ✅ 0 erreur · \`vite build\` ✅ · \`playwright e2e/travel-admin.spec.js\` ✅ **14/14 verts** (mock API) · \`validate-and-sync\` ✅

### DoD

CI : coverage/PHPStan/Module Structure/Frontend ESLint+TS/actionlint/i18n attendus verts (changements frontend + i18n uniquement).

Refs #6417 (registre complet une fois la PR backend #6430 mergée).

Closes #6416