### PR TITLE
fix(travel): alignement registre contacts (POST /consent) + cycle de vie complet annonces en admin (TRAVEL-911/912, #6416/#6417)

### DIFF
--- a/front/admin-dashboard/e2e/travel-admin.spec.js
+++ b/front/admin-dashboard/e2e/travel-admin.spec.js
@@ -142,7 +142,9 @@ async function mockTravelApi(page, { pingStatus = 200 } = {}) {
       contentType: 'application/json',
       body: JSON.stringify({
         data: [
-          { id: 1, title: 'Annonce pilote', content: 'Visitez le Cameroun', price_minor: 500000, currency: 'XAF', expires_at: null },
+          { id: 1, title: 'Annonce soumise', content: 'Nouvelle campagne', status: 'submitted', price_minor: 250000, currency: 'XAF', expires_at: null },
+          { id: 2, title: 'Annonce pilote', content: 'Visitez le Cameroun', status: 'paid', price_minor: 500000, currency: 'XAF', expires_at: null },
+          { id: 3, title: 'Annonce active', content: 'Offre spéciale', status: 'validated', price_minor: 300000, currency: 'XAF', expires_at: '2026-12-31T00:00:00+00:00' },
         ],
       }),
     }),
@@ -341,8 +343,20 @@ test.describe('TravelAgency — contenu & monétisation (TRAVEL-911/#6416)', () 
 
     await page.getByRole('tab', { name: /Annonces/i }).last().click()
     await expect(page.getByRole('heading', { name: /Annonces payantes/i })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Annonce soumise')).toBeVisible()
     await expect(page.getByText('Annonce pilote')).toBeVisible()
-    await expect(page.getByRole('button', { name: /Renouveler/i })).toBeVisible()
+    // Cycle de vie (mode gestion) : pay sur submitted, validate sur paid, renew sur validated
+    const submittedRow = page.locator('tr', { hasText: 'Annonce soumise' })
+    await expect(submittedRow.getByRole('button', { name: /Encaisser/i })).toBeVisible()
+    const paidRow = page.locator('tr', { hasText: 'Annonce pilote' })
+    await expect(paidRow.getByRole('button', { name: /Valider/i })).toBeVisible()
+    const activeRow = page.locator('tr', { hasText: 'Annonce active' })
+    await expect(activeRow.getByRole('button', { name: /Renouveler/i })).toBeVisible()
+    // Rejet avec motif (mock POST /reject via catch-all)
+    await paidRow.getByRole('button', { name: /Rejeter/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15_000 })
+    await page.locator('#travel-advert-reject-reason').fill('Contenu non conforme')
+    await page.getByRole('dialog').getByRole('button', { name: 'Rejeter', exact: true }).click()
   })
 
   test('onglet Sites touristiques : CRUD + filtre par ville', async ({ page }) => {
@@ -377,8 +391,10 @@ test.describe('TravelAgency — contacts voyageurs (TRAVEL-912/#6417)', () => {
     await page.getByRole('button', { name: /Envoyer la demande/i }).click()
     await expect(page.getByText(/Demande reçue/i)).toBeVisible({ timeout: 15_000 })
 
-    // Registre + consentements + notification manuelle
+    // Registre + consentements (POST /consent) + notification manuelle
     await expect(page.getByText('awa@test.cm')).toBeVisible()
+    const consentSms = page.getByRole('button', { name: /SMS/i })
+    await consentSms.click()
     await expect(page.getByRole('button', { name: /Notifier/i })).toBeVisible()
     await page.getByRole('button', { name: /Notifier/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15_000 })

--- a/front/admin-dashboard/src/i18n/locales/ar.json
+++ b/front/admin-dashboard/src/i18n/locales/ar.json
@@ -4573,7 +4573,7 @@
       "tabPrices": "جدول الأسعار",
       "tabAdverts": "الإعلانات",
       "title": "الإعلانات المدفوعة",
-      "subtitle": "أرسل إعلانًا وتابع الإعلانات المرئية.",
+      "subtitle": "أرسل، تحصّل الدفع، صدّق/ارفض وجدّد الإعلانات.",
       "createTitle": "إرسال إعلان",
       "types": "أنواع الإعلانات",
       "positions": "المواضع الإعلانية",
@@ -4586,12 +4586,18 @@
         "price": "السعر",
         "pricePerImage": "السعر لكل صورة",
         "pricePerCharacter": "السعر لكل حرف",
-        "expiresAt": "ينتهي في"
+        "expiresAt": "ينتهي في",
+        "rejectReason": "سبب الرفض"
       },
       "action": {
         "renew": "تجديد",
-        "submit": "إرسال"
-      }
+        "submit": "إرسال",
+        "pay": "تحصيل الدفع",
+        "validate": "تصديق",
+        "reject": "رفض"
+      },
+      "rejectTitle": "رفض الإعلان",
+      "rejectTarget": "الإعلان"
     },
     "sites": {
       "title": "المواقع السياحية",
@@ -4633,6 +4639,15 @@
         "notify": "إشعار",
         "send": "إرسال"
       }
+    },
+    "advertStatus": {
+      "draft": "مسودة",
+      "submitted": "مقدمة",
+      "paid": "مدفوعة",
+      "validated": "مُصدَّقة",
+      "rejected": "مرفوضة",
+      "expired": "منتهية",
+      "archived": "مؤرشفة"
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -4573,7 +4573,7 @@
       "tabPrices": "Price grid",
       "tabAdverts": "Adverts",
       "title": "Paid adverts",
-      "subtitle": "Submit an advert and track visible ones.",
+      "subtitle": "Submit, collect payment, validate/reject and renew adverts.",
       "createTitle": "Submit an advert",
       "types": "Advert types",
       "positions": "Advert positions",
@@ -4586,12 +4586,18 @@
         "price": "Price",
         "pricePerImage": "Price per image",
         "pricePerCharacter": "Price per character",
-        "expiresAt": "Expires on"
+        "expiresAt": "Expires on",
+        "rejectReason": "Rejection reason"
       },
       "action": {
         "renew": "Renew",
-        "submit": "Submit"
-      }
+        "submit": "Submit",
+        "pay": "Collect payment",
+        "validate": "Validate",
+        "reject": "Reject"
+      },
+      "rejectTitle": "Reject advert",
+      "rejectTarget": "Advert"
     },
     "sites": {
       "title": "Tourist sites",
@@ -4633,6 +4639,15 @@
         "notify": "Notify",
         "send": "Send"
       }
+    },
+    "advertStatus": {
+      "draft": "Draft",
+      "submitted": "Submitted",
+      "paid": "Paid",
+      "validated": "Validated",
+      "rejected": "Rejected",
+      "expired": "Expired",
+      "archived": "Archived"
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -4573,7 +4573,7 @@
       "tabPrices": "Grille tarifaire",
       "tabAdverts": "Annonces",
       "title": "Annonces payantes",
-      "subtitle": "Soumettre une annonce et suivre les annonces visibles.",
+      "subtitle": "Soumettre, encaisser, valider/rejeter et renouveler les annonces.",
       "createTitle": "Soumettre une annonce",
       "types": "Types d’annonces",
       "positions": "Emplacements publicitaires",
@@ -4586,12 +4586,18 @@
         "price": "Prix",
         "pricePerImage": "Prix par image",
         "pricePerCharacter": "Prix par caractère",
-        "expiresAt": "Expire le"
+        "expiresAt": "Expire le",
+        "rejectReason": "Motif du rejet"
       },
       "action": {
         "renew": "Renouveler",
-        "submit": "Soumettre"
-      }
+        "submit": "Soumettre",
+        "pay": "Encaisser",
+        "validate": "Valider",
+        "reject": "Rejeter"
+      },
+      "rejectTitle": "Rejeter l’annonce",
+      "rejectTarget": "Annonce"
     },
     "sites": {
       "title": "Sites touristiques",
@@ -4633,6 +4639,15 @@
         "notify": "Notifier",
         "send": "Envoyer"
       }
+    },
+    "advertStatus": {
+      "draft": "Brouillon",
+      "submitted": "Soumise",
+      "paid": "Payée",
+      "validated": "Validée",
+      "rejected": "Rejetée",
+      "expired": "Expirée",
+      "archived": "Archivée"
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/tr.json
+++ b/front/admin-dashboard/src/i18n/locales/tr.json
@@ -4573,7 +4573,7 @@
       "tabPrices": "Fiyat tablosu",
       "tabAdverts": "Reklamlar",
       "title": "Ücretli reklamlar",
-      "subtitle": "Reklam gönderin ve görünür olanları takip edin.",
+      "subtitle": "Reklam gönderin, ödemeyi tahsil edin, onaylayın/reddedin ve yenileyin.",
       "createTitle": "Reklam gönder",
       "types": "Reklam türleri",
       "positions": "Reklam konumları",
@@ -4586,12 +4586,18 @@
         "price": "Fiyat",
         "pricePerImage": "Görsel başına fiyat",
         "pricePerCharacter": "Karakter başına fiyat",
-        "expiresAt": "Bitiş"
+        "expiresAt": "Bitiş",
+        "rejectReason": "Reddetme nedeni"
       },
       "action": {
         "renew": "Yenile",
-        "submit": "Gönder"
-      }
+        "submit": "Gönder",
+        "pay": "Tahsil et",
+        "validate": "Onayla",
+        "reject": "Reddet"
+      },
+      "rejectTitle": "Reklamı reddet",
+      "rejectTarget": "Reklam"
     },
     "sites": {
       "title": "Turistik yerler",
@@ -4633,6 +4639,15 @@
         "notify": "Bildir",
         "send": "Gönder"
       }
+    },
+    "advertStatus": {
+      "draft": "Taslak",
+      "submitted": "Gönderildi",
+      "paid": "Ödendi",
+      "validated": "Onaylandı",
+      "rejected": "Reddedildi",
+      "expired": "Süresi doldu",
+      "archived": "Arşivlendi"
     }
   }
 }

--- a/front/admin-dashboard/src/views/travel/TravelAdvertsTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAdvertsTab.vue
@@ -35,8 +35,8 @@
       @saved="loadReferenceLookups"
     />
 
-    <!-- Annonces : soumission + annonces visibles (cycle complet : pay/validate/reject
-         via endpoint admin dédié — #6428) -->
+    <!-- Annonces : soumission + cycle de vie complet (mode gestion — l'index
+         renvoie tous les statuts pour les rôles moderateur, #6428) -->
     <div v-else class="space-y-4">
       <div class="flex items-center justify-between gap-4">
         <div>
@@ -44,7 +44,7 @@
             {{ t('travel.adverts.title', 'Annonces payantes') }}
           </h2>
           <p class="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
-            {{ t('travel.adverts.subtitle', 'Soumettre une annonce et suivre les annonces visibles.') }}
+            {{ t('travel.adverts.subtitle', 'Soumettre, encaisser, valider/rejeter et renouveler les annonces.') }}
           </p>
         </div>
         <button class="btn-primary" type="button" @click="openCreate">
@@ -62,11 +62,45 @@
         :search-placeholder="t('travel.search.advert', 'Rechercher une annonce…')"
         :caption="t('travel.adverts.title', 'Annonces payantes')"
       >
+        <template #cell-status="{ value }">
+          <StatusBadge :status="value" :map="advertStatusMap" />
+        </template>
         <template #cell-price_minor="{ row, value }">
           {{ formatMoney(value, row.currency || 'XAF') }}
         </template>
         <template #row-actions="{ row }">
           <button
+            v-if="['submitted', 'draft'].includes(row.status)"
+            class="rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            type="button"
+            :aria-label="t('travel.adverts.action.pay', 'Encaisser')"
+            :title="t('travel.adverts.action.pay', 'Encaisser')"
+            @click="pay(row)"
+          >
+            {{ t('travel.adverts.action.pay', 'Encaisser') }}
+          </button>
+          <button
+            v-if="row.status === 'paid'"
+            class="rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            type="button"
+            :aria-label="t('travel.adverts.action.validate', 'Valider')"
+            :title="t('travel.adverts.action.validate', 'Valider')"
+            @click="validate(row)"
+          >
+            {{ t('travel.adverts.action.validate', 'Valider') }}
+          </button>
+          <button
+            v-if="['submitted', 'paid', 'validated'].includes(row.status)"
+            class="rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-slate-400 dark:hover:bg-red-900/20 dark:hover:text-red-300"
+            type="button"
+            :aria-label="t('travel.adverts.action.reject', 'Rejeter')"
+            :title="t('travel.adverts.action.reject', 'Rejeter')"
+            @click="openReject(row)"
+          >
+            {{ t('travel.adverts.action.reject', 'Rejeter') }}
+          </button>
+          <button
+            v-if="['validated', 'expired'].includes(row.status)"
             class="rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
             type="button"
             :aria-label="t('travel.adverts.action.renew', 'Renouveler')"
@@ -78,6 +112,50 @@
         </template>
       </DataTable>
     </div>
+
+    <!-- Rejet avec motif obligatoire (TRAVEL-908/#6111) -->
+    <TravelModal
+      :open="rejectOpen"
+      :title="t('travel.adverts.rejectTitle', 'Rejeter l’annonce')"
+      @close="closeReject"
+    >
+      <form class="grid grid-cols-1 gap-4" @submit.prevent="confirmReject">
+        <p class="text-sm text-slate-600 dark:text-slate-300">
+          {{ t('travel.adverts.rejectTarget', 'Annonce') }} :
+          <strong>{{ rejectRow?.title }}</strong>
+        </p>
+        <FormField
+          :id="'travel-advert-reject-reason'"
+          :label="t('travel.adverts.field.rejectReason', 'Motif du rejet')"
+          :error="rejectErrors.reason"
+          required
+        >
+          <template #default="{ id, ariaInvalid, describedBy }">
+            <textarea
+              :id="id"
+              v-model.trim="rejectForm.reason"
+              class="form-input"
+              rows="3"
+              required
+              maxlength="500"
+              :aria-invalid="ariaInvalid"
+              :aria-describedby="describedBy"
+            ></textarea>
+          </template>
+        </FormField>
+        <div v-if="rejectError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {{ rejectError }}
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" class="btn-secondary" @click="closeReject">
+            {{ $t('common.cancel', 'Annuler') }}
+          </button>
+          <button type="submit" class="btn-primary" :disabled="rejectSaving">
+            {{ rejectSaving ? $t('common.busy', 'En cours…') : t('travel.adverts.action.reject', 'Rejeter') }}
+          </button>
+        </div>
+      </form>
+    </TravelModal>
 
     <!-- Formulaire de soumission d'annonce -->
     <TravelModal
@@ -167,6 +245,7 @@ import { PlusIcon } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import DataTable from '@/components/common/DataTable.vue'
 import FormField from '@/components/common/FormField.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import TravelCrudSection from '@/components/travel/TravelCrudSection.vue'
 import TravelModal from '@/components/travel/TravelModal.vue'
 import { useToast } from 'vue-toastification'
@@ -279,9 +358,26 @@ const saving = ref(false)
 const form = ref({})
 const formErrors = ref({})
 const globalError = ref('')
+const rejectOpen = ref(false)
+const rejectRow = ref(null)
+const rejectForm = ref({ reason: '' })
+const rejectErrors = ref({})
+const rejectError = ref('')
+const rejectSaving = ref(false)
+
+const advertStatusMap = computed(() => ({
+  draft: { labelKey: 'travel.advertStatus.draft', color: 'gray' },
+  submitted: { labelKey: 'travel.advertStatus.submitted', color: 'yellow' },
+  paid: { labelKey: 'travel.advertStatus.paid', color: 'blue' },
+  validated: { labelKey: 'travel.advertStatus.validated', color: 'green' },
+  rejected: { labelKey: 'travel.advertStatus.rejected', color: 'red' },
+  expired: { labelKey: 'travel.advertStatus.expired', color: 'gray' },
+  archived: { labelKey: 'travel.advertStatus.archived', color: 'gray' }
+}))
 
 const advertColumns = computed(() => [
   { key: 'title', label: t('travel.field.title', 'Titre'), sortable: true },
+  { key: 'status', label: t('travel.field.status', 'Statut'), sortable: true },
   { key: 'price_minor', label: t('travel.adverts.field.price', 'Prix'), sortable: true },
   { key: 'expires_at', label: t('travel.adverts.field.expiresAt', 'Expire le'), sortable: true }
 ])
@@ -347,6 +443,66 @@ async function renew(row) {
     await loadAdverts()
   } catch (err) {
     toast.error(err.response?.data?.message || t('travel.error.saveFailed', "Échec de l'enregistrement."))
+  }
+}
+
+async function pay(row) {
+  try {
+    await api.post(`/travel/adverts/${row.id}/pay`, {}, { _skipAuthRedirect: true })
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    await loadAdverts()
+  } catch (err) {
+    toast.error(err.response?.data?.message || t('travel.error.saveFailed', "Échec de l'enregistrement."))
+  }
+}
+
+async function validate(row) {
+  try {
+    await api.post(`/travel/adverts/${row.id}/validate`, {}, { _skipAuthRedirect: true })
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    await loadAdverts()
+  } catch (err) {
+    toast.error(err.response?.data?.message || t('travel.error.saveFailed', "Échec de l'enregistrement."))
+  }
+}
+
+function openReject(row) {
+  rejectRow.value = row
+  rejectForm.value = { reason: '' }
+  rejectErrors.value = {}
+  rejectError.value = ''
+  rejectOpen.value = true
+}
+
+function closeReject() {
+  rejectOpen.value = false
+  rejectRow.value = null
+}
+
+async function confirmReject() {
+  if (!rejectRow.value) return
+  rejectSaving.value = true
+  rejectErrors.value = {}
+  rejectError.value = ''
+  try {
+    await api.post(
+      `/travel/adverts/${rejectRow.value.id}/reject`,
+      { reason: rejectForm.value.reason },
+      { _skipAuthRedirect: true }
+    )
+    toast.success(t('travel.toast.saved', 'Enregistré.'))
+    rejectOpen.value = false
+    await loadAdverts()
+  } catch (err) {
+    const data = err.response?.data || {}
+    if (data.errors) {
+      rejectErrors.value = Object.fromEntries(
+        Object.entries(data.errors).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
+      )
+    }
+    rejectError.value = data.message || data.localized_message || t('travel.error.saveFailed', "Échec de l'enregistrement.")
+  } finally {
+    rejectSaving.value = false
   }
 }
 

--- a/front/admin-dashboard/src/views/travel/TravelContactsTab.vue
+++ b/front/admin-dashboard/src/views/travel/TravelContactsTab.vue
@@ -274,9 +274,11 @@ async function loadContacts() {
 
 async function toggleConsent(row, ch) {
   try {
-    await api.patch(
-      `/travel/contacts/${row.id}`,
-      { channel: ch.key, consent: !row[`${ch.key}_consent_given`] },
+    // Contrat backend (TRAVEL-914/#6427) : POST /contacts/{id}/consent,
+    // un booléen par canal ({email_consent|sms_consent|whatsapp_consent}).
+    await api.post(
+      `/travel/contacts/${row.id}/consent`,
+      { [`${ch.key}_consent`]: !row[`${ch.key}_consent_given`] },
       { _skipAuthRedirect: true }
     )
     toast.success(t('travel.toast.saved', 'Enregistré.'))

--- a/front/web/src/lib/i18n/locales/ar.json
+++ b/front/web/src/lib/i18n/locales/ar.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "جدول الأسعار",
       "tabAdverts": "الإعلانات",
       "title": "الإعلانات المدفوعة",
-      "subtitle": "أرسل إعلانًا وتابع الإعلانات المرئية.",
+      "subtitle": "أرسل، تحصّل الدفع، صدّق/ارفض وجدّد الإعلانات.",
       "createTitle": "إرسال إعلان",
       "types": "أنواع الإعلانات",
       "positions": "المواضع الإعلانية",
@@ -3984,12 +3984,18 @@
         "price": "السعر",
         "pricePerImage": "السعر لكل صورة",
         "pricePerCharacter": "السعر لكل حرف",
-        "expiresAt": "ينتهي في"
+        "expiresAt": "ينتهي في",
+        "rejectReason": "سبب الرفض"
       },
       "action": {
         "renew": "تجديد",
-        "submit": "إرسال"
-      }
+        "submit": "إرسال",
+        "pay": "تحصيل الدفع",
+        "validate": "تصديق",
+        "reject": "رفض"
+      },
+      "rejectTitle": "رفض الإعلان",
+      "rejectTarget": "الإعلان"
     },
     "sites": {
       "title": "المواقع السياحية",
@@ -4031,6 +4037,15 @@
         "notify": "إشعار",
         "send": "إرسال"
       }
+    },
+    "advertStatus": {
+      "draft": "مسودة",
+      "submitted": "مقدمة",
+      "paid": "مدفوعة",
+      "validated": "مُصدَّقة",
+      "rejected": "مرفوضة",
+      "expired": "منتهية",
+      "archived": "مؤرشفة"
     }
   }
 }

--- a/front/web/src/lib/i18n/locales/en.json
+++ b/front/web/src/lib/i18n/locales/en.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "Price grid",
       "tabAdverts": "Adverts",
       "title": "Paid adverts",
-      "subtitle": "Submit an advert and track visible ones.",
+      "subtitle": "Submit, collect payment, validate/reject and renew adverts.",
       "createTitle": "Submit an advert",
       "types": "Advert types",
       "positions": "Advert positions",
@@ -3984,12 +3984,18 @@
         "price": "Price",
         "pricePerImage": "Price per image",
         "pricePerCharacter": "Price per character",
-        "expiresAt": "Expires on"
+        "expiresAt": "Expires on",
+        "rejectReason": "Rejection reason"
       },
       "action": {
         "renew": "Renew",
-        "submit": "Submit"
-      }
+        "submit": "Submit",
+        "pay": "Collect payment",
+        "validate": "Validate",
+        "reject": "Reject"
+      },
+      "rejectTitle": "Reject advert",
+      "rejectTarget": "Advert"
     },
     "sites": {
       "title": "Tourist sites",
@@ -4031,6 +4037,15 @@
         "notify": "Notify",
         "send": "Send"
       }
+    },
+    "advertStatus": {
+      "draft": "Draft",
+      "submitted": "Submitted",
+      "paid": "Paid",
+      "validated": "Validated",
+      "rejected": "Rejected",
+      "expired": "Expired",
+      "archived": "Archived"
     }
   }
 }

--- a/front/web/src/lib/i18n/locales/fr.json
+++ b/front/web/src/lib/i18n/locales/fr.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "Grille tarifaire",
       "tabAdverts": "Annonces",
       "title": "Annonces payantes",
-      "subtitle": "Soumettre une annonce et suivre les annonces visibles.",
+      "subtitle": "Soumettre, encaisser, valider/rejeter et renouveler les annonces.",
       "createTitle": "Soumettre une annonce",
       "types": "Types d’annonces",
       "positions": "Emplacements publicitaires",
@@ -3984,12 +3984,18 @@
         "price": "Prix",
         "pricePerImage": "Prix par image",
         "pricePerCharacter": "Prix par caractère",
-        "expiresAt": "Expire le"
+        "expiresAt": "Expire le",
+        "rejectReason": "Motif du rejet"
       },
       "action": {
         "renew": "Renouveler",
-        "submit": "Soumettre"
-      }
+        "submit": "Soumettre",
+        "pay": "Encaisser",
+        "validate": "Valider",
+        "reject": "Rejeter"
+      },
+      "rejectTitle": "Rejeter l’annonce",
+      "rejectTarget": "Annonce"
     },
     "sites": {
       "title": "Sites touristiques",
@@ -4031,6 +4037,15 @@
         "notify": "Notifier",
         "send": "Envoyer"
       }
+    },
+    "advertStatus": {
+      "draft": "Brouillon",
+      "submitted": "Soumise",
+      "paid": "Payée",
+      "validated": "Validée",
+      "rejected": "Rejetée",
+      "expired": "Expirée",
+      "archived": "Archivée"
     }
   }
 }

--- a/front/web/src/lib/i18n/locales/tr.json
+++ b/front/web/src/lib/i18n/locales/tr.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "Fiyat tablosu",
       "tabAdverts": "Reklamlar",
       "title": "Ücretli reklamlar",
-      "subtitle": "Reklam gönderin ve görünür olanları takip edin.",
+      "subtitle": "Reklam gönderin, ödemeyi tahsil edin, onaylayın/reddedin ve yenileyin.",
       "createTitle": "Reklam gönder",
       "types": "Reklam türleri",
       "positions": "Reklam konumları",
@@ -3984,12 +3984,18 @@
         "price": "Fiyat",
         "pricePerImage": "Görsel başına fiyat",
         "pricePerCharacter": "Karakter başına fiyat",
-        "expiresAt": "Bitiş"
+        "expiresAt": "Bitiş",
+        "rejectReason": "Reddetme nedeni"
       },
       "action": {
         "renew": "Yenile",
-        "submit": "Gönder"
-      }
+        "submit": "Gönder",
+        "pay": "Tahsil et",
+        "validate": "Onayla",
+        "reject": "Reddet"
+      },
+      "rejectTitle": "Reklamı reddet",
+      "rejectTarget": "Reklam"
     },
     "sites": {
       "title": "Turistik yerler",
@@ -4031,6 +4037,15 @@
         "notify": "Bildir",
         "send": "Gönder"
       }
+    },
+    "advertStatus": {
+      "draft": "Taslak",
+      "submitted": "Gönderildi",
+      "paid": "Ödendi",
+      "validated": "Onaylandı",
+      "rejected": "Reddedildi",
+      "expired": "Süresi doldu",
+      "archived": "Arşivlendi"
     }
   }
 }

--- a/shared/i18n/locales/ar.json
+++ b/shared/i18n/locales/ar.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "جدول الأسعار",
       "tabAdverts": "الإعلانات",
       "title": "الإعلانات المدفوعة",
-      "subtitle": "أرسل إعلانًا وتابع الإعلانات المرئية.",
+      "subtitle": "أرسل، تحصّل الدفع، صدّق/ارفض وجدّد الإعلانات.",
       "createTitle": "إرسال إعلان",
       "types": "أنواع الإعلانات",
       "positions": "المواضع الإعلانية",
@@ -3984,12 +3984,18 @@
         "price": "السعر",
         "pricePerImage": "السعر لكل صورة",
         "pricePerCharacter": "السعر لكل حرف",
-        "expiresAt": "ينتهي في"
+        "expiresAt": "ينتهي في",
+        "rejectReason": "سبب الرفض"
       },
       "action": {
         "renew": "تجديد",
-        "submit": "إرسال"
-      }
+        "submit": "إرسال",
+        "pay": "تحصيل الدفع",
+        "validate": "تصديق",
+        "reject": "رفض"
+      },
+      "rejectTitle": "رفض الإعلان",
+      "rejectTarget": "الإعلان"
     },
     "sites": {
       "title": "المواقع السياحية",
@@ -4031,6 +4037,15 @@
         "notify": "إشعار",
         "send": "إرسال"
       }
+    },
+    "advertStatus": {
+      "draft": "مسودة",
+      "submitted": "مقدمة",
+      "paid": "مدفوعة",
+      "validated": "مُصدَّقة",
+      "rejected": "مرفوضة",
+      "expired": "منتهية",
+      "archived": "مؤرشفة"
     }
   }
 }

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "Price grid",
       "tabAdverts": "Adverts",
       "title": "Paid adverts",
-      "subtitle": "Submit an advert and track visible ones.",
+      "subtitle": "Submit, collect payment, validate/reject and renew adverts.",
       "createTitle": "Submit an advert",
       "types": "Advert types",
       "positions": "Advert positions",
@@ -3984,12 +3984,18 @@
         "price": "Price",
         "pricePerImage": "Price per image",
         "pricePerCharacter": "Price per character",
-        "expiresAt": "Expires on"
+        "expiresAt": "Expires on",
+        "rejectReason": "Rejection reason"
       },
       "action": {
         "renew": "Renew",
-        "submit": "Submit"
-      }
+        "submit": "Submit",
+        "pay": "Collect payment",
+        "validate": "Validate",
+        "reject": "Reject"
+      },
+      "rejectTitle": "Reject advert",
+      "rejectTarget": "Advert"
     },
     "sites": {
       "title": "Tourist sites",
@@ -4031,6 +4037,15 @@
         "notify": "Notify",
         "send": "Send"
       }
+    },
+    "advertStatus": {
+      "draft": "Draft",
+      "submitted": "Submitted",
+      "paid": "Paid",
+      "validated": "Validated",
+      "rejected": "Rejected",
+      "expired": "Expired",
+      "archived": "Archived"
     }
   }
 }

--- a/shared/i18n/locales/fr.json
+++ b/shared/i18n/locales/fr.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "Grille tarifaire",
       "tabAdverts": "Annonces",
       "title": "Annonces payantes",
-      "subtitle": "Soumettre une annonce et suivre les annonces visibles.",
+      "subtitle": "Soumettre, encaisser, valider/rejeter et renouveler les annonces.",
       "createTitle": "Soumettre une annonce",
       "types": "Types d’annonces",
       "positions": "Emplacements publicitaires",
@@ -3984,12 +3984,18 @@
         "price": "Prix",
         "pricePerImage": "Prix par image",
         "pricePerCharacter": "Prix par caractère",
-        "expiresAt": "Expire le"
+        "expiresAt": "Expire le",
+        "rejectReason": "Motif du rejet"
       },
       "action": {
         "renew": "Renouveler",
-        "submit": "Soumettre"
-      }
+        "submit": "Soumettre",
+        "pay": "Encaisser",
+        "validate": "Valider",
+        "reject": "Rejeter"
+      },
+      "rejectTitle": "Rejeter l’annonce",
+      "rejectTarget": "Annonce"
     },
     "sites": {
       "title": "Sites touristiques",
@@ -4031,6 +4037,15 @@
         "notify": "Notifier",
         "send": "Envoyer"
       }
+    },
+    "advertStatus": {
+      "draft": "Brouillon",
+      "submitted": "Soumise",
+      "paid": "Payée",
+      "validated": "Validée",
+      "rejected": "Rejetée",
+      "expired": "Expirée",
+      "archived": "Archivée"
     }
   }
 }

--- a/shared/i18n/locales/tr.json
+++ b/shared/i18n/locales/tr.json
@@ -3971,7 +3971,7 @@
       "tabPrices": "Fiyat tablosu",
       "tabAdverts": "Reklamlar",
       "title": "Ücretli reklamlar",
-      "subtitle": "Reklam gönderin ve görünür olanları takip edin.",
+      "subtitle": "Reklam gönderin, ödemeyi tahsil edin, onaylayın/reddedin ve yenileyin.",
       "createTitle": "Reklam gönder",
       "types": "Reklam türleri",
       "positions": "Reklam konumları",
@@ -3984,12 +3984,18 @@
         "price": "Fiyat",
         "pricePerImage": "Görsel başına fiyat",
         "pricePerCharacter": "Karakter başına fiyat",
-        "expiresAt": "Bitiş"
+        "expiresAt": "Bitiş",
+        "rejectReason": "Reddetme nedeni"
       },
       "action": {
         "renew": "Yenile",
-        "submit": "Gönder"
-      }
+        "submit": "Gönder",
+        "pay": "Tahsil et",
+        "validate": "Onayla",
+        "reject": "Reddet"
+      },
+      "rejectTitle": "Reklamı reddet",
+      "rejectTarget": "Reklam"
     },
     "sites": {
       "title": "Turistik yerler",
@@ -4031,6 +4037,15 @@
         "notify": "Bildir",
         "send": "Gönder"
       }
+    },
+    "advertStatus": {
+      "draft": "Taslak",
+      "submitted": "Gönderildi",
+      "paid": "Ödendi",
+      "validated": "Onaylandı",
+      "rejected": "Reddedildi",
+      "expired": "Süresi doldu",
+      "archived": "Arşivlendi"
     }
   }
 }

--- a/shared/i18n/versions/versions.json
+++ b/shared/i18n/versions/versions.json
@@ -25,22 +25,22 @@
   },
   "locales": {
     "fr": {
-      "checksum": "e7a653843c1b59cab785c51ea88628846c78e275b5e48ca265c93cd775060a77",
+      "checksum": "118aacac3999bf4ab0501abe5c8952e216a6e2b43d5b06db3ad1d0d9f3ce2e29",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     },
     "ar": {
-      "checksum": "c1dff0f14174bc8b593561fbbc71cd4d15ae175ba753e38b4cbf86f3ec4b0a5e",
+      "checksum": "102dccaac72bdb124a71914a1cf58ede6c1d066999134ed7595b9d19bc29cf01",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     },
     "tr": {
-      "checksum": "b1a49d5e0be596b56ef4dcd63029a5615af58176f6653573ab3df3c227c0294d",
+      "checksum": "bf56e371d1df63080653d828fc0c9c52f5d99966efb7b14a76c029350a8ff1d3",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     },
     "en": {
-      "checksum": "76654cc10ce500e8fe6dfa07af8466f3fb2de2b978e8d342a858a9931670ce48",
+      "checksum": "cefcc0dd410f6d96596a116ac32fea29dd61dba95b165dc5f8b245a842bd88d6",
       "version": "1.0.0",
       "updated_at": "2026-08-30T12:00:00Z"
     }
@@ -48,21 +48,21 @@
   "surfaces": {
     "web": {
       "checksums": {
-        "ar": "c1dff0f14174bc8b593561fbbc71cd4d15ae175ba753e38b4cbf86f3ec4b0a5e",
-        "en": "76654cc10ce500e8fe6dfa07af8466f3fb2de2b978e8d342a858a9931670ce48",
-        "fr": "e7a653843c1b59cab785c51ea88628846c78e275b5e48ca265c93cd775060a77",
-        "tr": "b1a49d5e0be596b56ef4dcd63029a5615af58176f6653573ab3df3c227c0294d"
+        "ar": "102dccaac72bdb124a71914a1cf58ede6c1d066999134ed7595b9d19bc29cf01",
+        "en": "cefcc0dd410f6d96596a116ac32fea29dd61dba95b165dc5f8b245a842bd88d6",
+        "fr": "118aacac3999bf4ab0501abe5c8952e216a6e2b43d5b06db3ad1d0d9f3ce2e29",
+        "tr": "bf56e371d1df63080653d828fc0c9c52f5d99966efb7b14a76c029350a8ff1d3"
       },
-      "updated_at": "2026-08-30T17:12:51.008Z"
+      "updated_at": "2026-08-30T17:42:48.424Z"
     },
     "admin": {
       "checksums": {
-        "ar": "6d5615d65717370a61f0485a15f7ec97a1cb3553e066caebf52cef1981f34233",
-        "en": "a320d4d38116edd3e83505b36aed4b1166862054029faf0c8ac33d9dd4dae06b",
-        "fr": "b7bd236b0233a5e2155f39b805c914306fdc76897335964b32da7e6fe5364138",
-        "tr": "31ad53ad80dd7546f74868845da8d86d7864f44134f4b96ec878c6d8cd4f984c"
+        "ar": "2f07cfe2e9fefd9d64db16225b66c5bfd1fe8c9b03ebde1a60f8a3a632841d60",
+        "en": "8c8c5e8061cf7817449fcd98a8659f6cafd44031ab1c4833819ebdd0ddfbdd82",
+        "fr": "46b7364c006784cea4a086ac11e7e7b9a7eb8f07f59195ee2bac35b905b54ee7",
+        "tr": "1dc553add63d5d48ff46b6cf20313ccf074a2b183519ec3c82e7a2c91d335392"
       },
-      "updated_at": "2026-08-30T17:12:51.057Z"
+      "updated_at": "2026-08-30T17:42:48.461Z"
     }
   }
 }


### PR DESCRIPTION
## Correctifs du lot UI TRAVEL-911/912 (suite #6435)

Branche empilée sur \`bc/bc24-travel-admin-ui\` (qui contient déjà le lot #6435 mergé).

### Pourquoi

Le backend \`feat/travel-101-202-foundations\` a été reconstruit (force-push) et expose désormais :
- **POST /travel/contacts/{id}/consent** avec payload \`{email_consent|sms_consent|whatsapp_consent}\` (≠ mon PATCH initial — adopté) ;
- **GET /travel/adverts mode gestion** : tous les statuts pour les rôles moderateur (filtre \`?status=\`) — le cycle pay/validate/reject/renew devient pilotable.

### Livré

| Commit | Contenu |
|---|---|
| 9388eabb | Registre contacts : bascule consentement via \`POST /contacts/{id}/consent\` (contrat réel, aucun mock) |
| b0e56a25 | Annonces : colonne statut (badges), actions par statut Encaisser / Valider / Rejeter (motif obligatoire) / Renouveler |

### Validation

\`eslint\` ✅ · \`vite build\` ✅ · \`playwright e2e/travel-admin.spec.js\` ✅ **14/14** (mocks alignés sur le nouveau contrat).

### Notes

- PR backend #6436 fermée comme redondante (le backend reconstruit couvre #6426/#6427/#6428).
- Issues #6426/#6427/#6428 : implémentées dans \`feat/travel-101-202-foundations\` — clôture à prévoir au merge de #6127 sur main.

Refs #6416, #6417