### PR TITLE
fix(travel): répare le merge #6432 — 24 fichiers avec marqueurs de conflit non résolus sur fondations

### DIFF
--- a/dev-hub/openapi/v1.yaml
+++ b/dev-hub/openapi/v1.yaml
@@ -4551,8 +4551,6 @@ paths:
           description: Résultats triés par score
         '403':
           description: Rôle insuffisant
-<<<<<<< HEAD
-=======
   /travel/contacts:
     get:
       tags:
@@ -4602,7 +4600,6 @@ paths:
           description: Consentements mis à jour
         '404':
           description: Contact introuvable
->>>>>>> origin/feat/travel-101-202-foundations
   /travel/contacts/{travelCustomerContact}/notify:
     post:
       tags:

--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,16 +1,13 @@
 {
   "source": "api/openapi.yaml",
-<<<<<<< HEAD
   "spec_sha256": "aca243e1fdae213a4149142928b309f4173e306ffddae3d0cee4d3bbb1023aa9",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
   "operation_count": 1028,
-=======
   "spec_sha256": "71428c5abd8dbba0a3ae56de694a271277cb90b6b3cd430adad1751f9a1a1fb5",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
   "operation_count": 1030,
->>>>>>> origin/feat/travel-101-202-foundations
   "targets": [
     "javascript",
     "python"

--- a/dev-hub/sdk/javascript/leopardoClient.js
+++ b/dev-hub/sdk/javascript/leopardoClient.js
@@ -4515,8 +4515,6 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("POST", "/travel/contact", options);
     },
 
-<<<<<<< HEAD
-=======
     /** TRAVEL-912 — Contacts voyageurs (gestion, consentements) */
     getTravelContacts(options = {}) {
       return request("GET", "/travel/contacts", options);
@@ -4527,7 +4525,6 @@ export function createLeopardoClient({ baseUrl, token, fetchImpl = globalThis.fe
       return request("POST", "/travel/contacts/{travelCustomerContact}/consent", options);
     },
 
->>>>>>> origin/feat/travel-101-202-foundations
     /** TRAVEL-910 — Notification manuelle (canaux plateforme + consentement) */
     postTravelContactsByTravelCustomerContactNotify(options = {}) {
       return request("POST", "/travel/contacts/{travelCustomerContact}/notify", options);

--- a/dev-hub/sdk/python/leopardo_client.py
+++ b/dev-hub/sdk/python/leopardo_client.py
@@ -3632,8 +3632,6 @@ class LeopardoClient:
         """TRAVEL-416 — Formulaire de contact → lead CRM (événement outbox)"""
         return self.request("POST", "/travel/contact", **kwargs)
 
-<<<<<<< HEAD
-=======
     def get_travel_contacts(self, **kwargs):
         """TRAVEL-912 — Contacts voyageurs (gestion, consentements)"""
         return self.request("GET", "/travel/contacts", **kwargs)
@@ -3642,7 +3640,6 @@ class LeopardoClient:
         """TRAVEL-912 — Mise à jour des consentements par canal"""
         return self.request("POST", "/travel/contacts/{travelCustomerContact}/consent", **kwargs)
 
->>>>>>> origin/feat/travel-101-202-foundations
     def post_travel_contacts_by_travelcustomercontact_notify(self, **kwargs):
         """TRAVEL-910 — Notification manuelle (canaux plateforme + consentement)"""
         return self.request("POST", "/travel/contacts/{travelCustomerContact}/notify", **kwargs)

--- a/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
+++ b/docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md
@@ -1553,7 +1553,6 @@ Deuxième tranche de l'épic 3xx : `GET|POST /travel/vehicles`, `GET|PUT|DELETE 
   (tenant, idempotency_key) ; recherche paginée sans N+1.
 - Couverture : `api/tests/Feature/Travel/TravelVehicleApiTest.php`, `TravelRouteApiTest.php`,
   `TravelTripApiTest.php`, `TravelTripPriceApiTest.php`, `TravelTripWorkflowTest.php`, `TravelTripSearchTest.php`
-<<<<<<< HEAD
   (+ 135 tests Travel au total, dont correctifs d'invariants 2xx protégés par savepoint).
 
 ## BC-24 TRAVEL — API réservations & billetterie (TRAVEL-312..318, 2026-08-30)
@@ -1577,5 +1576,3 @@ Dernière tranche de l'épic 3xx : `GET|POST /travel/rental-vehicles` (+ images)
   non authentifié → 401.
 - Couverture : `api/tests/Feature/Travel/TravelRentalApiTest.php`, `TravelHotelApiTest.php`, `TravelRbacMatrixTest.php`
   (168 tests Travel au total) + `docs/security/TRAVEL_RBAC_MATRIX.md`.
-=======
->>>>>>> 24df3e4bc (feat(travel): schéma, domaine & API back-office TravelAgency (Closes #6017-#6035) (#6129))

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -1577,11 +1577,8 @@
     "accountingActivation": "Accounting — Get started",
     "accountingDashboard": "Accounting — Dashboard",
     "accountingSettings": "Accounting — Settings",
-<<<<<<< HEAD
-    "travel": "Travel Agency"
-=======
+    "travel": "Travel Agency",
     "fuelStation": "Fuel stations"
->>>>>>> origin/feat/travel-101-202-foundations
   },
   "webhooks": {
     "confirm_delete": "Delete this webhook?",
@@ -4239,8 +4236,6 @@
     "actionError": "Action failed, please retry.",
     "loading": "Loading kitchen queue…"
   },
-<<<<<<< HEAD
-=======
   "fuel": {
     "statStations": "Stations",
     "statOpenIncidents": "Open incidents",
@@ -4287,7 +4282,6 @@
     "incidentsCaption": "Reported incidents",
     "reconciliationsCaption": "Reconciliation reports"
   },
->>>>>>> origin/feat/travel-101-202-foundations
   "travel": {
     "common": {
       "retry": "Retry",
@@ -4572,8 +4566,6 @@
       "infant": "Infant",
       "child": "Child",
       "adult": "Adult"
-<<<<<<< HEAD
-=======
     },
     "content": {
       "title": "Content & ads",
@@ -4672,7 +4664,6 @@
         "receivedBody": "Thank you, your request has been forwarded to the agency.",
         "newRequest": "New request"
       }
->>>>>>> origin/feat/travel-101-202-foundations
     }
   }
 }

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -1577,11 +1577,8 @@
     "accountingActivation": "Comptabilité — Démarrer",
     "accountingDashboard": "Comptabilité — Tableau de bord",
     "accountingSettings": "Comptabilité — Paramétrage",
-<<<<<<< HEAD
-    "travel": "Agence de voyage"
-=======
+    "travel": "Agence de voyage",
     "fuelStation": "Stations-service"
->>>>>>> origin/feat/travel-101-202-foundations
   },
   "webhooks": {
     "confirm_delete": "Supprimer ce webhook ?",
@@ -4239,8 +4236,6 @@
     "actionError": "Action impossible, réessayez.",
     "loading": "Chargement de la file cuisine…"
   },
-<<<<<<< HEAD
-=======
   "fuel": {
     "statStations": "Stations",
     "statOpenIncidents": "Incidents ouverts",
@@ -4287,7 +4282,6 @@
     "incidentsCaption": "Incidents signalés",
     "reconciliationsCaption": "Rapports de rapprochement"
   },
->>>>>>> origin/feat/travel-101-202-foundations
   "travel": {
     "common": {
       "retry": "Réessayer",
@@ -4572,8 +4566,6 @@
       "infant": "Bébé",
       "child": "Enfant",
       "adult": "Adulte"
-<<<<<<< HEAD
-=======
     },
     "content": {
       "title": "Contenu & annonces",
@@ -4672,7 +4664,6 @@
         "receivedBody": "Merci, votre demande a bien été transmise à l’agence.",
         "newRequest": "Nouvelle demande"
       }
->>>>>>> origin/feat/travel-101-202-foundations
     }
   }
 }

--- a/front/admin-dashboard/src/router/index.js
+++ b/front/admin-dashboard/src/router/index.js
@@ -335,8 +335,6 @@ const routes = [
         }
       },
       {
-<<<<<<< HEAD
-=======
         path: '/travel/content',
         name: 'travel-content',
         component: () => import('../views/travel/TravelContentView.vue'),
@@ -346,7 +344,6 @@ const routes = [
         }
       },
       {
->>>>>>> origin/feat/travel-101-202-foundations
         path: '/travel/catalog',
         name: 'travel-catalog',
         component: () => import('../views/travel/TravelCatalogView.vue'),

--- a/front/admin-dashboard/src/views/travel/TravelHomeView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelHomeView.vue
@@ -73,12 +73,9 @@ import {
   NewspaperIcon,
   QrCodeIcon,
   TicketIcon,
-<<<<<<< HEAD
   ChartBarIcon
-=======
   ChartBarIcon,
   MegaphoneIcon
->>>>>>> origin/feat/travel-101-202-foundations
 } from '@heroicons/vue/24/outline'
 
 const localeStore = useLocaleStore()
@@ -139,8 +136,6 @@ const sections = computed(() => [
     description: t('travel.reports.subtitle', 'Ventes, occupation, recettes, annulations et exports CSV.')
   },
   {
-<<<<<<< HEAD
-=======
     name: 'travel-content',
     path: '/travel/content',
     icon: MegaphoneIcon,
@@ -148,7 +143,6 @@ const sections = computed(() => [
     description: t('travel.content.subtitle', 'Quiz, annonces payantes et sites touristiques.')
   },
   {
->>>>>>> origin/feat/travel-101-202-foundations
     name: 'travel-catalog',
     path: '/travel/catalog',
     icon: NewspaperIcon,


### PR DESCRIPTION
## Contexte

Le merge de la PR #6432 dans `feat/travel-101-202-foundations` (d42e158) a laissé **24 fichiers** avec des marqueurs de conflit non résolus. Le correctif `dcf1854` (déjà mergé) a réparé les 15 fichiers backend ; **9 fichiers restent cassés** sur la fondation (SDK, miroir openapi, locales fr/en, router, TravelHomeView, docs).

## Correctif (9 fichiers)

- `dev-hub/openapi/v1.yaml`, `dev-hub/sdk/{MANIFEST.json,javascript,python}`, `front/admin-dashboard/src/i18n/locales/{fr,en}.json`, `router/index.js`, `TravelHomeView.vue`, `docs/GESTION_PROJET/SCENARIOS_TEST_API_GITHUB_ACTIONS.md`.
- Résolution : contenu de la branche #6432 (descendant additif de la fondation) conservé ; virgules manquantes locales fr/en réparées.
- Vérifié : 0 marqueur restant, JSON locales valides, YAML miroir valide.