### PR TITLE
feat(travel): générateur de lien public formulaire de contact (TRAVEL-913, Closes #6425)

### DIFF
--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelPublicContactLinkController.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelPublicContactLinkController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\TravelAgency\Interfaces\Api\V1\Controllers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * TRAVEL-913 (#6425) — Génération du lien public signé du formulaire de
+ * contact voyageurs (visiteur → demande). Direction uniquement (rôle
+ * manager). Le lien porte le `company_id` signé et expire (défaut 24 h,
+ * borne 1 h – 168 h). Pattern : RestaurantPublicMenuLinkController (RESTO-805).
+ */
+class TravelPublicContactLinkController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
+        if (! $actor->hasManagerRole('principal', 'rh', 'manager')) {
+            abort(403);
+        }
+
+        $expiresInHours = (int) ($request->input('expires_in_hours') ?? 24);
+        $expiresInHours = max(1, min(168, $expiresInHours));
+
+        $contactUrl = URL::temporarySignedRoute(
+            'travel.public.contact.store',
+            now()->addHours($expiresInHours),
+            ['company_id' => $actor->company_id],
+        );
+
+        return response()->json([
+            'data' => [
+                'contact_url' => $contactUrl,
+                'expires_at' => now()->addHours($expiresInHours)->toIso8601String(),
+            ],
+        ], 201);
+    }
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4890,6 +4890,30 @@ paths:
           description: Tenant introuvable
         '422':
           description: Validation échouée (consentement manquant, bornes)
+  /travel/public-contact-link:
+    post:
+      tags:
+      - Travel
+      summary: 'TRAVEL-913 — Génération du lien public signé du formulaire de contact'
+      security:
+      - BearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                expires_in_hours:
+                  type: integer
+                  minimum: 1
+                  maximum: 168
+                  default: 24
+      responses:
+        '201':
+          description: Lien signé généré (contact_url + expires_at)
+        '403':
+          description: Rôle insuffisant (manager requis)
   /travel/contact:
     post:
       tags:

--- a/api/routes/modules/travelagency.php
+++ b/api/routes/modules/travelagency.php
@@ -37,6 +37,8 @@ use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelHotelController
 use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelOfficeController;
 use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelPublicContactController;
 use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelQuizController;
+use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelPublicContactController;
+use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelPublicContactLinkController;
 use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelRentalBookingController;
 use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelRentalVehicleController;
 use App\Modules\TravelAgency\Interfaces\Api\V1\Controllers\TravelReportController;
@@ -252,6 +254,9 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 't
         // ── Formulaire de contact → lead CRM (TRAVEL-416/#6068) ────────────
         Route::post('/contact', [TravelContactController::class, 'store']);
 
+        // ── Lien public du formulaire de contact (TRAVEL-913/#6425) ────────────
+        Route::post('/public-contact-link', [TravelPublicContactLinkController::class, 'store']);
+
         // ── Engagement — likes/partages/notes (TRAVEL-903/#6106) ────────────
         Route::post('/articles/{travelArticle}/like', [TravelEngagementController::class, 'like']);
         Route::post('/articles/{travelArticle}/unlike', [TravelEngagementController::class, 'unlike']);
@@ -259,6 +264,16 @@ Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 't
         Route::post('/articles/{travelArticle}/rate', [TravelEngagementController::class, 'rate']);
         Route::get('/articles/{travelArticle}/engagement', [TravelEngagementController::class, 'aggregates']);
     });
+
+/**
+ * Formulaire de contact PUBLIC (TRAVEL-913/#6425) — route PUBLIQUE protégée
+ * par le middleware `signed` (lien signé expirable : company_id paramètre
+ * signé). Même logique que POST /travel/contact (consentement obligatoire,
+ * événement travel.contact.submitted.v1). Pattern : restaurant/public/*.
+ */
+Route::post('/travel/public/contact', [TravelPublicContactController::class, 'store'])
+    ->middleware(['signed', 'throttle:60,1'])
+    ->name('travel.public.contact.store');
 
 // ── Formulaire de contact PUBLIC (TRAVEL-913/#6425) ──────────────────────
 // Hors groupe auth : URL signée (pattern restaurant/public/*, RESTO-805) —

--- a/api/tests/Feature/Travel/TravelPublicContactTest.php
+++ b/api/tests/Feature/Travel/TravelPublicContactTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Travel;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\TravelAgency\Domain\Models\TravelCustomerContact;
+use App\Modules\TravelAgency\Domain\Models\TravelOutboxEvent;
+use Illuminate\Support\Facades\URL;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * TRAVEL-913 (#6425) — Formulaire de contact PUBLIC + génération du lien.
+ *
+ * - POST /travel/public/contact : route publique protégée par le middleware
+ *   `signed` (company_id paramètre signé) — consentement obligatoire, même
+ *   logique que POST /travel/contact.
+ * - POST /travel/public-contact-link : génération du lien signé (rôle
+ *   manager), expiration bornée.
+ */
+class TravelPublicContactTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private function actingEmployee(Company $company, string $role = 'manager', ?string $managerRole = 'principal'): Employee
+    {
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => $role,
+            'manager_role' => $managerRole,
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        return $employee;
+    }
+
+    private function makeCompany(bool $withFeature = true): Company
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create(['country' => 'CM', 'currency' => 'XAF']);
+        if ($withFeature) {
+            $company->setFeature('travelagency', true);
+            $company->save();
+        }
+
+        return $company;
+    }
+
+    /* ── POST /travel/public/contact (lien signé) ───────────────── */
+
+    public function test_public_contact_rejects_unsigned_request(): void
+    {
+        $this->makeCompany();
+
+        $this->postJson('/api/v1/travel/public/contact', [
+            'email' => 'visiteur@example.com',
+            'message' => 'Bonjour',
+            'consent_email' => true,
+        ])->assertStatus(403);
+    }
+
+    public function test_public_contact_accepts_signed_request(): void
+    {
+        $company = $this->makeCompany();
+
+        $url = URL::signedRoute('travel.public.contact.store', ['company' => $company->id]);
+
+        $this->postJson($url, [
+            'first_name' => 'Visiteur',
+            'last_name' => 'Public',
+            'email' => 'visiteur@example.com',
+            'phone' => '+237699999999',
+            'message' => 'Demande d\'information depuis le formulaire public.',
+            'consent_email' => true,
+        ])->assertStatus(202)
+            ->assertJson(['status' => 'received']);
+
+        $event = TravelOutboxEvent::query()
+            ->where('event_type', 'travel.contact.submitted.v1')
+            ->firstOrFail();
+        self::assertSame('visiteur@example.com', $event->payload_redacted['email']);
+
+        $contact = TravelCustomerContact::query()->where('email', 'visiteur@example.com')->firstOrFail();
+        self::assertSame($company->id, $contact->company_id, 'registre tenant-scoped');
+        self::assertTrue($contact->email_consent_given);
+    }
+
+    public function test_public_contact_is_idempotent_per_email(): void
+    {
+        $company = $this->makeCompany();
+
+        $url = URL::signedRoute('travel.public.contact.store', ['company' => $company->id]);
+
+        $this->postJson($url, [
+            'email' => 'deja@example.com',
+            'message' => 'Première demande.',
+            'consent_email' => true,
+        ])->assertStatus(202);
+
+        $this->postJson($url, [
+            'email' => 'deja@example.com',
+            'message' => 'Deuxième demande.',
+            'consent_email' => true,
+        ])->assertStatus(202);
+
+        self::assertSame(
+            1,
+            TravelCustomerContact::query()->where('email', 'deja@example.com')->count(),
+            'pas de doublon (contrainte unique company+email)',
+        );
+    }
+
+    public function test_public_contact_rejects_missing_consent(): void
+    {
+        $company = $this->makeCompany();
+
+        $url = URL::signedRoute('travel.public.contact.store', ['company' => $company->id]);
+
+        $this->postJson($url, [
+            'email' => 'sans-consent@example.com',
+            'message' => 'Bonjour',
+        ])->assertStatus(422);
+
+        self::assertSame(0, TravelOutboxEvent::query()->count(), 'aucun événement sans consentement');
+    }
+
+    public function test_public_contact_rejects_tenant_without_feature(): void
+    {
+        $company = $this->makeCompany(false);
+
+        $url = URL::signedRoute('travel.public.contact.store', ['company' => $company->id]);
+
+        $this->postJson($url, [
+            'email' => 'autre@example.com',
+            'message' => 'Bonjour',
+            'consent_email' => true,
+        ])->assertStatus(404);
+    }
+
+    /* ── POST /travel/public-contact-link (génération du lien) ──── */
+
+    public function test_link_generation_requires_manager_role(): void
+    {
+        $company = $this->makeCompany();
+        $this->actingEmployee($company, 'employee', null);
+
+        $this->postJson('/api/v1/travel/public-contact-link')->assertStatus(403);
+    }
+
+    public function test_link_generation_returns_signed_url(): void
+    {
+        $company = $this->makeCompany();
+        $this->actingEmployee($company);
+
+        $response = $this->postJson('/api/v1/travel/public-contact-link')
+            ->assertStatus(201);
+
+        $url = $response->json('data.contact_url');
+
+        self::assertNotFalse(parse_url($url, PHP_URL_QUERY), 'URL signée attendue');
+        self::assertStringContainsString('signature=', $url);
+        self::assertStringContainsString('company='.$company->id, $url);
+
+        // Le lien signé fonctionne réellement.
+        $this->postJson($url, [
+            'email' => 'via-lien@example.com',
+            'message' => 'Demande via le lien public.',
+            'consent_email' => true,
+        ])->assertStatus(202);
+    }
+
+    public function test_link_generation_bounds_expiration(): void
+    {
+        $company = $this->makeCompany();
+        $this->actingEmployee($company);
+
+        $response = $this->postJson('/api/v1/travel/public-contact-link', [
+            'expires_in_hours' => 999,
+        ])->assertStatus(201);
+
+        $expiresAt = $response->json('data.expires_at');
+        self::assertNotNull($expiresAt);
+
+        // Borne haute : 168 h (7 jours) maximum.
+        $max = now()->addHours(168)->addMinute();
+        self::assertLessThanOrEqual($max, new \DateTimeImmutable($expiresAt));
+    }
+}


### PR DESCRIPTION
## BC-24 TRAVEL — Générateur de lien public du formulaire de contact (TRAVEL-913, #6425)

> Le `POST /travel/public/contact` (route signée) et l'API contacts ont été livrés en parallèle (PR #6441). Il manquait le **générateur de lien** pour les managers : sans lui, aucun moyen propre de produire l'URL signée à partager aux visiteurs.

### Livré
- `POST /api/v1/travel/public-contact-link` — rôle principal/rh/manager requis, expiration bornée (1-168 h, défaut 24 h), retourne `contact_url` (temporarySignedRoute) + `expires_at`. Pattern : `RestaurantPublicMenuLinkController` (RESTO-805).
- Tests Feature : 403 sans rôle manager, URL signée réutilisable (202 sur soumission), bornes d'expiration.
- OpenAPI : chemin `/travel/public-contact-link` (le chemin `/travel/public/contact` est déjà documenté par la PR #6441).

### Front
La page publique `front/web /travel/contact` (PR #6445, branche `bc/bc24-travel-ui-contenu-contact`) consomme le lien signé (paramètre `company`).