### PR TITLE
fix(governance): BC-26 DELIVERY marqué planifié dans runbook-registry (débloque main)

### DIFF
--- a/dev-hub/tools/runbook-registry.json
+++ b/dev-hub/tools/runbook-registry.json
@@ -187,10 +187,9 @@
     {
       "code": "BC-26",
       "name": "DELIVERY",
-      "runbooks": [
-        "docs/ops/RUNBOOK_DELIVERY.md"
-      ],
-      "notes": "Module de livraison dernier-kilomètre : runbook dédié (activation, endpoints, invariants, incidents, DLQ/replay, runbook rollback données tenant couvert par RUNBOOK_BACKUP_RESTORE/RUNBOOK_ROLLBACK plateforme)."
+      "runbooks": [],
+      "notes": "Module DELIVERY planifié (cf. bounded-context-registry BC-26 planned) : couverture runbook à l'activation — docs/ops/RUNBOOK_DELIVERY.md arrive avec la consolidation #6338 (pm/merge-delivery-socle).",
+      "status": "planned"
     }
   ]
 }


### PR DESCRIPTION
## Blocage — main rouge (MAT-015/#5873)
`dev-hub/tools/runbook-registry.json` référençait `docs/ops/RUNBOOK_DELIVERY.md` pour BC-26, fichier qui n'existe **que sur la branche de consolidation #6338** (`pm/merge-delivery-socle`), pas sur main → `check-runbooks.sh` échoue (« runbook référencé introuvable ») sur main ET sur chaque PR (Hygiene Guards), bloquant la file de merge (#6461, #6127, #6338, #5973, #5975, #6270…).

## Correctif
BC-26 est `planned` dans `bounded-context-registry.json` → l'entrée runbook est marquée `status: planned` (runbooks `[]`), la couverture arrivant à l'activation avec #6338.

## Vérifications
- `bash dev-hub/tools/check-runbooks.sh` ✅ (21 BC actifs couverts)
- tests garde 5/5 ✅

Closes #6467
