### PR TITLE
fix(ci): golden-journeys — solution delivery marquée planned, GJ-DELIVERY-01 gardé (Closes #6470)

### DIFF
--- a/dev-hub/tools/golden-journeys.json
+++ b/dev-hub/tools/golden-journeys.json
@@ -19,7 +19,7 @@
     },
     "delivery": {
       "label": "DeliveryAgency (BC-26 DELIVERY)",
-      "status": "active"
+      "status": "planned"
     }
   },
   "journeys": [

--- a/dev-hub/tools/runbook-registry.json
+++ b/dev-hub/tools/runbook-registry.json
@@ -187,10 +187,9 @@
     {
       "code": "BC-26",
       "name": "DELIVERY",
-      "runbooks": [
-        "docs/ops/RUNBOOK_DELIVERY.md"
-      ],
-      "notes": "Module de livraison dernier-kilomètre : runbook dédié (activation, endpoints, invariants, incidents, DLQ/replay, runbook rollback données tenant couvert par RUNBOOK_BACKUP_RESTORE/RUNBOOK_ROLLBACK plateforme)."
+      "runbooks": [],
+      "notes": "Module de livraison dernier-kilomètre (conception #6281) : runbook dédié (activation, endpoints, invariants, incidents, DLQ/replay) à livrer avec le module ; rollback données tenant couvert par RUNBOOK_BACKUP_RESTORE/RUNBOOK_ROLLBACK plateforme.",
+      "status": "planned"
     }
   ]
 }


### PR DESCRIPTION
## Problème

Garde **Hygiene Guards** (MAT-013/015) rouge sur toute PR basée sur main — 2 défauts introduits par #6352 (mergée 18:39) :

1. **golden-journeys (MAT-013)** : `solutions.delivery.status = "active"` + GJ-DELIVERY-01 (7 étapes /api/v1/delivery/*) alors que le module BC-26 DELIVERY est planned → routes introuvables.
2. **runbook-registry (MAT-015)** : entrée BC-26 référençant `docs/ops/RUNBOOK_DELIVERY.md` inexistant.

## Correctif (les 2 registres du garde)

- `dev-hub/tools/golden-journeys.json` : `solutions.delivery.status = "planned"` (pattern GJ-TRAVEL-01) ; GJ-DELIVERY-01 reste documenté pour le merge du module.
- `dev-hub/tools/runbook-registry.json` : BC-26 `status: planned`, `runbooks: []` (format BC-15).

## Validation

- `bash dev-hub/tools/check-golden-journeys.sh api dev-hub/tools/golden-journeys.json` → ✅ « 8 parcours, 883 routes résolues ».
- `check-runbooks.sh` → l erreur BC-26 disparaît (seules restent les absences docs/ locales dues au sparse checkout).

Closes #6470. Complète/complémentaire de #6468 (mêmes correctifs, côté process parallèle).