### PR TITLE
fix: hygiene guards verts (#6463 pilot dedupe + #6467 BC-26 DELIVERY planned)

### DIFF
--- a/dev-hub/tools/pilot-gates.json
+++ b/dev-hub/tools/pilot-gates.json
@@ -6,15 +6,51 @@
       "label": "FuelStation",
       "go_decision": "pending",
       "gates": [
-        { "id": "manifest", "label": "Manifest + activation tenant (FUEL-001)", "status": "pending" },
-        { "id": "core_flow", "label": "Parcours station → pompe → compteur → vente → écart (FUEL-002..009)", "status": "pending" },
-        { "id": "api_security", "label": "API, Policies, tests cross-tenant (FUEL-011)", "status": "pending" },
-        { "id": "runbook", "label": "Pilote, runbook et rollback (FUEL-021)", "status": "pending" },
-        { "id": "security_review", "label": "Revue sécurité uploads/OCR/WhatsApp/POS/devices (MAT-017)", "status": "pending" },
-        { "id": "performance", "label": "Budgets performance (MAT-014)", "status": "pending" },
-        { "id": "observability", "label": "Observabilité et corrélation (MAT-009)", "status": "pending" },
-        { "id": "golden_journey", "label": "Golden journey pilote (GJ-06)", "status": "pending" },
-        { "id": "recette", "label": "Recette métier signée (FUEL-022)", "status": "pending" }
+        {
+          "id": "manifest",
+          "label": "Manifest + activation tenant (FUEL-001)",
+          "status": "pending"
+        },
+        {
+          "id": "core_flow",
+          "label": "Parcours station → pompe → compteur → vente → écart (FUEL-002..009)",
+          "status": "pending"
+        },
+        {
+          "id": "api_security",
+          "label": "API, Policies, tests cross-tenant (FUEL-011)",
+          "status": "pending"
+        },
+        {
+          "id": "runbook",
+          "label": "Pilote, runbook et rollback (FUEL-021)",
+          "status": "pending"
+        },
+        {
+          "id": "security_review",
+          "label": "Revue sécurité uploads/OCR/WhatsApp/POS/devices (MAT-017)",
+          "status": "pending"
+        },
+        {
+          "id": "performance",
+          "label": "Budgets performance (MAT-014)",
+          "status": "pending"
+        },
+        {
+          "id": "observability",
+          "label": "Observabilité et corrélation (MAT-009)",
+          "status": "pending"
+        },
+        {
+          "id": "golden_journey",
+          "label": "Golden journey pilote (GJ-06)",
+          "status": "pending"
+        },
+        {
+          "id": "recette",
+          "label": "Recette métier signée (FUEL-022)",
+          "status": "pending"
+        }
       ]
     },
     {
@@ -22,52 +58,157 @@
       "label": "EduManager",
       "go_decision": "pending",
       "gates": [
-        { "id": "manifest", "label": "Manifest + activation tenant (EDU-001)", "status": "pending" },
-        { "id": "core_flow", "label": "Parcours campus → classe → élève → présence → notes (EDU-002..008)", "status": "pending" },
-        { "id": "api_security", "label": "API, Policies, RBAC scolaire (EDU-009..010)", "status": "pending" },
-        { "id": "runbook", "label": "Pilote établissement et runbook (EDU-021)", "status": "pending" },
-        { "id": "security_review", "label": "Revue sécurité (MAT-017)", "status": "pending" },
-        { "id": "performance", "label": "Budgets performance (MAT-014)", "status": "pending" },
-        { "id": "observability", "label": "Observabilité (MAT-009)", "status": "pending" },
-        { "id": "golden_journey", "label": "Golden journey pilote (GJ-07)", "status": "pending" },
-        { "id": "recette", "label": "Recette métier signée (EDU-022)", "status": "pending" }
+        {
+          "id": "manifest",
+          "label": "Manifest + activation tenant (EDU-001)",
+          "status": "pending"
+        },
+        {
+          "id": "core_flow",
+          "label": "Parcours campus → classe → élève → présence → notes (EDU-002..008)",
+          "status": "pending"
+        },
+        {
+          "id": "api_security",
+          "label": "API, Policies, RBAC scolaire (EDU-009..010)",
+          "status": "pending"
+        },
+        {
+          "id": "runbook",
+          "label": "Pilote établissement et runbook (EDU-021)",
+          "status": "pending"
+        },
+        {
+          "id": "security_review",
+          "label": "Revue sécurité (MAT-017)",
+          "status": "pending"
+        },
+        {
+          "id": "performance",
+          "label": "Budgets performance (MAT-014)",
+          "status": "pending"
+        },
+        {
+          "id": "observability",
+          "label": "Observabilité (MAT-009)",
+          "status": "pending"
+        },
+        {
+          "id": "golden_journey",
+          "label": "Golden journey pilote (GJ-07)",
+          "status": "pending"
+        },
+        {
+          "id": "recette",
+          "label": "Recette métier signée (EDU-022)",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "id": "restaurantmanager",
+      "label": "RestaurantManager (verticale restauration, BC-25)",
+      "go_decision": "pending",
+      "gates": [
+        {
+          "id": "manifest",
+          "label": "Manifest + activation tenant (RESTO-105/106)",
+          "status": "validated"
+        },
+        {
+          "id": "core_flow",
+          "label": "Flux roi service en salle (GJ-RESTO-01) — dépend de la série POS 4xx",
+          "status": "pending"
+        },
+        {
+          "id": "api_security",
+          "label": "Matrice permissions restaurant.* + Policies RBAC (RESTO-306)",
+          "status": "validated"
+        },
+        {
+          "id": "runbook",
+          "label": "Runbook pilote + recette UAT (RESTO-903)",
+          "status": "validated"
+        },
+        {
+          "id": "security_review",
+          "label": "Audit sécurité & RGPD avant pilote (RESTO-904)",
+          "status": "validated"
+        },
+        {
+          "id": "performance",
+          "label": "Benchmarks POS/réservations (volumes attendus)",
+          "status": "pending"
+        },
+        {
+          "id": "observability",
+          "label": "Outbox + jobs surveillés (logs, dead-letter)",
+          "status": "pending"
+        },
+        {
+          "id": "golden_journey",
+          "label": "GJ-RESTO-01 passe en CI (MAT-013) — dépend de la série POS 4xx",
+          "status": "pending"
+        },
+        {
+          "id": "recette",
+          "label": "Recette UAT signée par le chef de projet",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "id": "travelagency",
+      "label": "TravelAgency (verticale voyage, BC-24)",
+      "go_decision": "pending",
+      "gates": [
+        {
+          "id": "manifest",
+          "label": "Manifest + activation tenant (TRAVEL-105/106)",
+          "status": "validated"
+        },
+        {
+          "id": "core_flow",
+          "label": "Flux roi recherche → réservation → paiement → billet (GJ-TRAVEL-01) — dépend du merge du module sur main",
+          "status": "pending"
+        },
+        {
+          "id": "api_security",
+          "label": "Matrice permissions travel.* + Policies RBAC (TRAVEL-3xx)",
+          "status": "validated"
+        },
+        {
+          "id": "runbook",
+          "label": "Runbook pilote + recette UAT (TRAVEL-1010)",
+          "status": "validated"
+        },
+        {
+          "id": "security_review",
+          "label": "Audit sécurité & RGPD avant pilote (TRAVEL-1013)",
+          "status": "validated"
+        },
+        {
+          "id": "performance",
+          "label": "Benchmarks recherche/réservation/PDF (volumes attendus)",
+          "status": "pending"
+        },
+        {
+          "id": "observability",
+          "label": "Outbox + jobs surveillés (logs, dead-letter)",
+          "status": "pending"
+        },
+        {
+          "id": "golden_journey",
+          "label": "GJ-TRAVEL-01 passe en CI (MAT-013) — dépend du merge du module",
+          "status": "pending"
+        },
+        {
+          "id": "recette",
+          "label": "Recette UAT signée par le chef de projet",
+          "status": "pending"
+        }
       ]
     }
-  ,
-  { "id": "restaurantmanager", "label": "RestaurantManager (verticale restauration, BC-25)", "go_decision": "pending", "gates": [
-    { "id": "manifest", "label": "Manifest + activation tenant (RESTO-105/106)", "status": "validated" },
-    { "id": "core_flow", "label": "Flux roi service en salle (GJ-RESTO-01) — dépend de la série POS 4xx", "status": "pending" },
-    { "id": "api_security", "label": "Matrice permissions restaurant.* + Policies RBAC (RESTO-306)", "status": "validated" },
-    { "id": "runbook", "label": "Runbook pilote + recette UAT (RESTO-903)", "status": "validated" },
-    { "id": "security_review", "label": "Audit sécurité & RGPD avant pilote (RESTO-904)", "status": "validated" },
-    { "id": "performance", "label": "Benchmarks POS/réservations (volumes attendus)", "status": "pending" },
-    { "id": "observability", "label": "Outbox + jobs surveillés (logs, dead-letter)", "status": "pending" },
-    { "id": "golden_journey", "label": "GJ-RESTO-01 passe en CI (MAT-013) — dépend de la série POS 4xx", "status": "pending" },
-    { "id": "recette", "label": "Recette UAT signée par le chef de projet", "status": "pending" }
-  ] },
-  { "id": "travelagency", "label": "TravelAgency (verticale agence de voyage, BC-24)", "go_decision": "pending", "gates": [
-    { "id": "manifest", "label": "Manifest + activation tenant (TRAVEL-105/106)", "status": "pending" },
-    { "id": "core_flow", "label": "Parcours réseau → trajet → réservation → passagers → billet → check-in (TRAVEL-2xx/3xx)", "status": "pending" },
-    { "id": "api_security", "label": "API, Policies, matrice RBAC travel.* (TRAVEL-322)", "status": "pending" },
-    { "id": "runbook", "label": "Runbook pilote + recette UAT (TRAVEL-050)", "status": "pending" },
-    { "id": "security_review", "label": "Audit sécurité & RGPD avant pilote (TRAVEL-1013)", "status": "pending" },
-    { "id": "performance", "label": "Budgets performance (MAT-014)", "status": "pending" },
-    { "id": "observability", "label": "Outbox + jobs surveillés (logs, dead-letter)", "status": "pending" },
-    { "id": "golden_journey", "label": "GJ-TRAVEL-01 passe en CI (MAT-013, TRAVEL-1007)", "status": "pending" },
-    { "id": "recette", "label": "Recette UAT signée par le chef de projet (TRAVEL-051)", "status": "pending" }
-  ] }
-  ,
-  { "id": "travelagency", "label": "TravelAgency (verticale voyage, BC-24)", "go_decision": "pending", "gates": [
-    { "id": "manifest", "label": "Manifest + activation tenant (TRAVEL-105/106)", "status": "validated" },
-    { "id": "core_flow", "label": "Flux roi recherche → réservation → paiement → billet (GJ-TRAVEL-01) — dépend du merge du module sur main", "status": "pending" },
-    { "id": "api_security", "label": "Matrice permissions travel.* + Policies RBAC (TRAVEL-3xx)", "status": "validated" },
-    { "id": "runbook", "label": "Runbook pilote + recette UAT (TRAVEL-1010)", "status": "validated" },
-    { "id": "security_review", "label": "Audit sécurité & RGPD avant pilote (TRAVEL-1013)", "status": "validated" },
-    { "id": "performance", "label": "Benchmarks recherche/réservation/PDF (volumes attendus)", "status": "pending" },
-    { "id": "observability", "label": "Outbox + jobs surveillés (logs, dead-letter)", "status": "pending" },
-    { "id": "golden_journey", "label": "GJ-TRAVEL-01 passe en CI (MAT-013) — dépend du merge du module", "status": "pending" },
-    { "id": "recette", "label": "Recette UAT signée par le chef de projet", "status": "pending" }
-  ] }
   ],
   "decision_rules": {
     "go": "Tous les gates validés + recette métier signée + fenêtre de pilote planifiée.",

--- a/dev-hub/tools/runbook-registry.json
+++ b/dev-hub/tools/runbook-registry.json
@@ -187,10 +187,9 @@
     {
       "code": "BC-26",
       "name": "DELIVERY",
-      "runbooks": [
-        "docs/ops/RUNBOOK_DELIVERY.md"
-      ],
-      "notes": "Module de livraison dernier-kilomètre : runbook dédié (activation, endpoints, invariants, incidents, DLQ/replay, runbook rollback données tenant couvert par RUNBOOK_BACKUP_RESTORE/RUNBOOK_ROLLBACK plateforme)."
+      "runbooks": [],
+      "notes": "Module de livraison dernier-kilometre (planned): runbook dedie RUNBOOK_DELIVERY.md arrive avec la consolidation du socle DELIVERY (PR #6338). Couverture rollback/backup tenant assuree par RUNBOOK_BACKUP_RESTORE / RUNBOOK_ROLLBACK plateforme a l'activation.",
+      "status": "planned"
     }
   ]
 }


### PR DESCRIPTION
Corrige les deux gardes Hygiene Guards rouges sur main et sur toutes les PRs.\n\n- #6463 (MAT-018): suppression de l entree travelagency dupliquee dans pilot-gates.json (on conserve l entree la plus complete: manifest/api_security/runbook/security_review validated). check-pilot-gates.sh vert, tests 5/5.\n- #6467 (MAT-015): BC-26 DELIVERY marque status=planned, runbooks=[] dans runbook-registry.json (RUNBOOK_DELIVERY.md arrive avec PR #6338). check-runbooks.sh vert, tests 5/5.\n\nFixes #6463\nFixes #6467