### PR TITLE
fix(web): clé nav unique restaurant_kitchen — warning duplicate key (Closes #6450)

### DIFF
--- a/front/web/e2e/restaurant-reservations.spec.ts
+++ b/front/web/e2e/restaurant-reservations.spec.ts
@@ -42,9 +42,21 @@ const baseUser = {
   },
 };
 
+type MockReservation = {
+  id: number;
+  reference: string;
+  contact_name: string;
+  contact_phone: string;
+  reserved_at: string | null;
+  covers: number;
+  table_id: number | null;
+  status: string;
+  deposit_minor: number | null;
+};
+
 /** Mock d'état : la liste évolue avec les transitions, comme le backend réel. */
 function reservationStateFactory() {
-  const rows = [
+  const rows: MockReservation[] = [
     {
       id: 1,
       reference: 'RES-0001',

--- a/front/web/src/lib/client-features.ts
+++ b/front/web/src/lib/client-features.ts
@@ -16,7 +16,8 @@ export type ClientModuleKey =
   | 'marketing'
   | 'accounting'
   | 'crm'
-  | 'restaurant';
+  | 'restaurant'
+  | 'restaurant_kitchen';
 
 export type FeatureState = 'available' | 'trial' | 'locked';
 
@@ -204,7 +205,7 @@ export const CLIENT_MODULES: ClientModule[] = [
     upgradeLabel: 'CRM Client',
   },
   {
-    key: 'restaurant',
+    key: 'restaurant_kitchen',
     href: '/restaurant/kitchen',
     label: 'Restaurant',
     group: 'general',
@@ -236,7 +237,7 @@ const ROUTE_TO_MODULE: Record<string, ClientModuleKey> = {
   '/crm/leads': 'crm',
   '/crm/pipeline': 'crm',
   '/restaurant': 'restaurant',
-  '/restaurant/kitchen': 'restaurant',
+  '/restaurant/kitchen': 'restaurant_kitchen',
 };
 
 function normalizedRole(user?: StoredAuthUser | null): string {


### PR DESCRIPTION
## BC-25 RESTAURANT — Fix warning React « duplicate key `restaurant` » (navigation portail web)

Closes #6450

### Cause
`front/web/src/lib/client-features.ts` (branche admin-ui) déclarait **deux** modules avec `key: 'restaurant'` dans le groupe `general` :
1. le hub `/restaurant` (module principal),
2. l'écran cuisine `/restaurant/kitchen`.

→ `navGroups.general.map()` rendait deux `SidebarLink` avec la même clé → warning React (identité des enfants ambiguë).

### Correctif
- Clé unique `restaurant_kitchen` pour l'entrée cuisine + ajout au type `ClientModuleKey`.
- `ROUTE_TO_MODULE['/restaurant/kitchen'] = 'restaurant_kitchen'` (état actif conservé).
- Typage strict du mock e2e `restaurant-reservations.spec.ts` (table_id `number | null`).

### Vérifications
- Console navigateur : plus aucun warning « same key » sur /restaurant et /restaurant/kitchen (capture Playwright).
- tsc --noEmit : 0 erreur · ESLint OK.