### PR TITLE
fix(travel): un seul h1 par page — vues travel en h2 (Closes #6453)

### DIFF
--- a/front/admin-dashboard/src/views/travel/TravelBookingsView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelBookingsView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.bookings.title', 'Réservations') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.bookings.subtitle', 'Ventes au guichet, confirmation, annulation, remboursement et billets.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelCatalogView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelCatalogView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.catalog.title', 'Locations & hôtels') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.catalog.subtitle', 'Véhicules en location, réservations et catalogue hôtelier.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelCheckinView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelCheckinView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.checkin.title', 'Check-in & manifeste') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.checkin.subtitle', 'Embarquement par trajet et compteur de passagers.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelContentView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelContentView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mx-auto max-w-7xl px-4 py-8">
     <div class="mb-6">
-      <h1 class="text-2xl font-semibold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.content.title', 'Contenu & annonces') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.content.subtitle', 'Quiz, annonces payantes et sites touristiques.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelHomeView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelHomeView.vue
@@ -2,9 +2,9 @@
   <div class="space-y-6">
     <div class="flex items-start justify-between">
       <div>
-        <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+        <h2 class="text-xl font-bold text-slate-900 dark:text-white">
           {{ t('travel.home.title', 'Agence de voyage') }}
-        </h1>
+        </h2>
         <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
           {{ t('travel.home.subtitle', 'Gestion de la verticale TravelAgency : réseau, ventes, billetterie et pilotage.') }}
         </p>

--- a/front/admin-dashboard/src/views/travel/TravelNetworkView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelNetworkView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.network.title', 'Routes & trajets') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.network.subtitle', 'Lignes, étapes, programmation, tarifs et publication.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelReferentialView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelReferentialView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.referential.title', 'Référentiel') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.referential.subtitle', 'Pays, villes, gares, bureaux, compagnies, classes et véhicules.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelReportsView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelReportsView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.reports.title', 'Rapports') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.reports.subtitle', 'Ventes, occupation, recettes, annulations et exports CSV.') }}
       </p>

--- a/front/admin-dashboard/src/views/travel/TravelTicketsView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelTicketsView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="space-y-6">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-white">
+      <h2 class="text-xl font-bold text-slate-900 dark:text-white">
         {{ t('travel.tickets.title', 'Billets') }}
-      </h1>
+      </h2>
       <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
         {{ t('travel.tickets.subtitle', 'Consultation, téléchargement PDF et révocation.') }}
       </p>


### PR DESCRIPTION
## #6453 — a11y : double h1 sur /travel/content

Le layout `DashboardLayout` rend déjà le titre de page en `<h1>` (route meta.title). Les 9 vues travel rendaient un second `<h1>` → deux h1 par page (ambiguïté pour les lecteurs d'écran et les specs Playwright, qui utilisaient `.first()`).

**Correctif** : les vues travel passent en `<h2>` (hiérarchie de titre conservée, texte identique). Vérifié : ESLint 0 erreur, `vite build` OK.