### PR TITLE
fix(web): clé de module restaurant dupliquée dans CLIENT_MODULES (Closes #6450)

### DIFF
--- a/front/web/src/lib/client-features.ts
+++ b/front/web/src/lib/client-features.ts
@@ -43,7 +43,7 @@ export const CLIENT_MODULES: ClientModule[] = [
     href: '/restaurant',
     label: 'Restaurant',
     group: 'general',
-    capabilityKeys: ['restaurant', 'restaurantmanager', 'can_view_restaurant'],
+    capabilityKeys: ['restaurant', 'restaurant.kitchen', 'restaurantmanager', 'can_view_restaurant'],
     featureKeys: ['restaurantmanager', 'restaurant'],
     allowedRoles: ['super_admin', 'admin', 'manager'],
     upgradeLabel: 'Restaurant Manager',
@@ -202,16 +202,6 @@ export const CLIENT_MODULES: ClientModule[] = [
     featureKeys: ['crm'],
     allowedRoles: ['manager'],
     upgradeLabel: 'CRM Client',
-  },
-  {
-    key: 'restaurant',
-    href: '/restaurant/kitchen',
-    label: 'Restaurant',
-    group: 'general',
-    capabilityKeys: ['restaurant', 'restaurant.kitchen'],
-    featureKeys: ['restaurantmanager'],
-    allowedRoles: ['super_admin', 'admin', 'manager'],
-    upgradeLabel: 'Restaurant',
   },
 ];
 


### PR DESCRIPTION
## #6450 — « Encountered two children with the same key, restaurant »

`CLIENT_MODULES` contenait deux entrées `key: 'restaurant'` (entrée admin `href: /restaurant` + entrée kitchen `href: /restaurant/kitchen`) → avertissement React sur la navigation du portail web.

**Correctif** : fusion en une entrée unique (navigation admin `/restaurant`, `capabilityKeys` = union incluant `restaurant.kitchen`).