### PR TITLE
fix(bc24): PHPStan strict 38 findings → 0 + Pint PASS (déblocage check requis #6127)

### DIFF
--- a/api/app/Modules/TravelAgency/Application/Actions/ParticipateQuizAction.php
+++ b/api/app/Modules/TravelAgency/Application/Actions/ParticipateQuizAction.php
@@ -22,6 +22,10 @@ use Illuminate\Support\Facades\DB;
  */
 final class ParticipateQuizAction
 {
+    /**
+     * @param  array<int, array<string, mixed>>  $answers
+     * @return array{participation: TravelQuizParticipation, score: int, bonus: int}
+     */
     public function execute(
         TravelQuiz $quiz,
         ?string $participantEmail,

--- a/api/app/Modules/TravelAgency/Application/Actions/SubmitTravelContactAction.php
+++ b/api/app/Modules/TravelAgency/Application/Actions/SubmitTravelContactAction.php
@@ -27,7 +27,7 @@ class SubmitTravelContactAction
     public function __construct(private readonly TravelOutboxPublisher $outbox) {}
 
     /**
-     * @param  array{first_name?: string|null, last_name?: string|null, email: string, phone?: string|null, message: string}  $data
+     * @param  array<string, mixed>  $data
      */
     public function execute(string $companyId, array $data): void
     {

--- a/api/app/Modules/TravelAgency/Application/Actions/TravelManualNotificationAction.php
+++ b/api/app/Modules/TravelAgency/Application/Actions/TravelManualNotificationAction.php
@@ -32,6 +32,10 @@ final class TravelManualNotificationAction
     /**
      * @return array{channels: list<string>}
      */
+    /**
+     * @param  list<string>  $channels
+     * @return array{channels: list<string>}
+     */
     public function execute(
         TravelCustomerContact $contact,
         Employee $actor,

--- a/api/app/Modules/TravelAgency/Console/Commands/TravelLegacyImportCommand.php
+++ b/api/app/Modules/TravelAgency/Console/Commands/TravelLegacyImportCommand.php
@@ -37,15 +37,18 @@ final class TravelLegacyImportCommand extends Command
         TenantManager $tenantManager,
         TravelLegacyImportService $service,
     ): int {
-        $company = $this->resolveCompany((string) $this->option('company'));
+        $companyValue = $this->option('company');
+        $companySlug = is_string($companyValue) ? $companyValue : '';
+        $company = $this->resolveCompany($companySlug);
 
         if ($company === null) {
-            $this->error("Company introuvable : {$this->option('company')}");
+            $this->error("Company introuvable : {$companySlug}");
 
             return self::FAILURE;
         }
 
-        $path = (string) $this->argument('dump');
+        $dumpValue = $this->argument('dump');
+        $path = is_string($dumpValue) ? $dumpValue : '';
 
         if (! is_file($path) || ! is_readable($path)) {
             $this->error("Fichier dump illisible : {$path}");

--- a/api/app/Modules/TravelAgency/Domain/Enums/TravelWebhookEvent.php
+++ b/api/app/Modules/TravelAgency/Domain/Enums/TravelWebhookEvent.php
@@ -20,6 +20,7 @@ enum TravelWebhookEvent: string
     case TRIP_PUBLISHED = 'travel.trip.published.v1';
     case TRIP_CANCELLED = 'travel.trip.cancelled.v1';
 
+    /** @return list<string> */
     public static function values(): array
     {
         return array_map(static fn (self $case): string => $case->value, self::cases());

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelArticle.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelArticle.php
@@ -6,6 +6,7 @@ namespace App\Modules\TravelAgency\Domain\Models;
 
 use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
 class TravelArticle extends Model
 {
     use BelongsToCompany;
+
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'travel_articles';

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelArticleCategory.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelArticleCategory.php
@@ -6,6 +6,7 @@ namespace App\Modules\TravelAgency\Domain\Models;
 
 use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
 class TravelArticleCategory extends Model
 {
     use BelongsToCompany;
+
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'travel_article_categories';

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelComment.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelComment.php
@@ -6,6 +6,7 @@ namespace App\Modules\TravelAgency\Domain\Models;
 
 use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
 class TravelComment extends Model
 {
     use BelongsToCompany;
+
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'travel_comments';

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelCustomerContact.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelCustomerContact.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $sms_consent_at
  * @property bool $whatsapp_consent_given
  * @property Carbon|null $whatsapp_consent_at
- * @property string|null $metadata_json
+ * @property array<string, mixed>|null $metadata_json
  *
  * @mixin Builder<static>
  */

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelLike.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelLike.php
@@ -6,6 +6,7 @@ namespace App\Modules\TravelAgency\Domain\Models;
 
 use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
 class TravelLike extends Model
 {
     use BelongsToCompany;
+
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'travel_likes';

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelRating.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelRating.php
@@ -6,6 +6,7 @@ namespace App\Modules\TravelAgency\Domain\Models;
 
 use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
 class TravelRating extends Model
 {
     use BelongsToCompany;
+
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'travel_ratings';

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelShare.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelShare.php
@@ -6,6 +6,7 @@ namespace App\Modules\TravelAgency\Domain\Models;
 
 use App\Shared\Traits\BelongsToCompany;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
 class TravelShare extends Model
 {
     use BelongsToCompany;
+
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'travel_shares';

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelWebhookDelivery.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelWebhookDelivery.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 
 /**
  * TRAVEL-806 (#6097) — Livraison de webhook (journal idempotent).
@@ -71,12 +72,15 @@ class TravelWebhookDelivery extends Model
     protected static function booted(): void
     {
         static::creating(function (self $delivery): void {
-            if ($delivery->id === null) {
-                $delivery->id = (string) \Illuminate\Support\Str::uuid();
+            /** @var string|null $id */
+            $id = $delivery->id;
+            if ($id === null) {
+                $delivery->id = (string) Str::uuid();
             }
         });
     }
 
+    /** @return BelongsTo<TravelWebhookSubscription, $this> */
     public function subscription(): BelongsTo
     {
         return $this->belongsTo(TravelWebhookSubscription::class, 'subscription_id');

--- a/api/app/Modules/TravelAgency/Domain/Models/TravelWebhookSubscription.php
+++ b/api/app/Modules/TravelAgency/Domain/Models/TravelWebhookSubscription.php
@@ -10,6 +10,7 @@ use App\Shared\Traits\BelongsToCompany;
 use Database\Factories\TravelWebhookSubscriptionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 /**
  * TRAVEL-806 (#6097) — Abonnement webhook d'un transporteur.
@@ -57,8 +58,10 @@ class TravelWebhookSubscription extends Model
     protected static function booted(): void
     {
         static::creating(function (self $subscription): void {
-            if ($subscription->id === null) {
-                $subscription->id = (string) \Illuminate\Support\Str::uuid();
+            /** @var string|null $id */
+            $id = $subscription->id;
+            if ($id === null) {
+                $subscription->id = (string) Str::uuid();
             }
         });
     }

--- a/api/app/Modules/TravelAgency/Infrastructure/Jobs/ExpirePendingBookingsJob.php
+++ b/api/app/Modules/TravelAgency/Infrastructure/Jobs/ExpirePendingBookingsJob.php
@@ -48,7 +48,7 @@ final class ExpirePendingBookingsJob implements ShouldQueue, TenantScopedJob
 
     public function __construct(public readonly string $companyId) {}
 
-    public function tenantCompanyId(): ?string
+    public function tenantCompanyId(): string
     {
         return $this->companyId;
     }

--- a/api/app/Modules/TravelAgency/Infrastructure/Services/TravelLegacyImportService.php
+++ b/api/app/Modules/TravelAgency/Infrastructure/Services/TravelLegacyImportService.php
@@ -89,6 +89,10 @@ final class TravelLegacyImportService
     /**
      * @param  list<array<string, mixed>>  $routes
      */
+    /**
+     * @param  list<mixed>  $routes
+     * @param  array<string, mixed>  $cityByKey
+     */
     private function countResolvableRoutes(array $routes, array $cityByKey): int
     {
         $count = 0;

--- a/api/app/Modules/TravelAgency/Infrastructure/Services/TravelWebhookDispatcher.php
+++ b/api/app/Modules/TravelAgency/Infrastructure/Services/TravelWebhookDispatcher.php
@@ -7,7 +7,6 @@ namespace App\Modules\TravelAgency\Infrastructure\Services;
 use App\Modules\TravelAgency\Domain\Enums\TravelWebhookDeliveryStatus;
 use App\Modules\TravelAgency\Domain\Models\TravelWebhookDelivery;
 use App\Modules\TravelAgency\Domain\Models\TravelWebhookSubscription;
-use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -80,7 +79,7 @@ final class TravelWebhookDispatcher
             $this->markFailed($delivery, (int) $response->status(), 'HTTP '.$response->status());
 
             return false;
-        } catch (ConnectionException|Throwable $exception) {
+        } catch (Throwable $exception) {
             $this->markFailed($delivery, null, $this->truncateError($exception->getMessage()));
 
             return false;
@@ -120,17 +119,22 @@ final class TravelWebhookDispatcher
             ->retry(0); // retries gérés par le journal de livraison (backoff)
     }
 
-    /** @param array<string, mixed> $payload */
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
     private function redactedPayload(array $payload): array
     {
         $redacted = [];
         foreach ($payload as $key => $value) {
             if (is_array($value)) {
                 $redacted[$key] = $this->redactedPayload($value);
+
                 continue;
             }
             if (in_array($key, ['secret', 'token', 'password', 'validation_code', 'document_number'], true)) {
                 $redacted[$key] = '[REDACTED]';
+
                 continue;
             }
             $redacted[$key] = $value;

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelAdvertPositionController.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelAdvertPositionController.php
@@ -19,8 +19,11 @@ class TravelAdvertPositionController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
         $positions = TravelAdvertPosition::query()
-            ->where('company_id', $request->user()->company_id)
+            ->where('company_id', $actor->company_id)
             ->orderBy('code')
             ->get()
             ->map(fn (TravelAdvertPosition $p) => ['id' => $p->id, 'code' => $p->code, 'label' => $p->label]);

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelAdvertPriceController.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelAdvertPriceController.php
@@ -19,8 +19,11 @@ class TravelAdvertPriceController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
         $prices = TravelAdvertPrice::query()
-            ->where('company_id', $request->user()->company_id)
+            ->where('company_id', $actor->company_id)
             ->with(['advertType:id,code,label', 'advertPosition:id,code,label'])
             ->orderBy('id')
             ->get()

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelAdvertTypeController.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelAdvertTypeController.php
@@ -19,8 +19,11 @@ class TravelAdvertTypeController extends Controller
 {
     public function index(Request $request): JsonResponse
     {
+        /** @var Employee $actor */
+        $actor = $request->user();
+
         $types = TravelAdvertType::query()
-            ->where('company_id', $request->user()->company_id)
+            ->where('company_id', $actor->company_id)
             ->orderBy('code')
             ->get()
             ->map(fn (TravelAdvertType $t) => ['id' => $t->id, 'code' => $t->code, 'label' => $t->label]);

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelReportController.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelReportController.php
@@ -72,6 +72,9 @@ class TravelReportController extends Controller
     /**
      * @param  callable(string, CarbonImmutable, CarbonImmutable, array<string, mixed>): array  $aggregate
      */
+    /**
+     * @param  callable(string, CarbonImmutable, CarbonImmutable, array<string, mixed>): array<string, mixed>  $aggregate
+     */
     private function report(TravelReportRequest $request, callable $aggregate): JsonResponse
     {
         /** @var Employee $actor */

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelWebhookSubscriptionController.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Controllers/TravelWebhookSubscriptionController.php
@@ -117,7 +117,7 @@ class TravelWebhookSubscriptionController extends Controller
             'carrier_id' => $subscription->carrier_id,
             'events' => $subscription->events ?? [],
             'active' => $subscription->active,
-            'has_secret' => $subscription->secret_encrypted !== null && $subscription->secret_encrypted !== '',
+            'has_secret' => $subscription->secret_encrypted !== '',
             'created_at' => $subscription->created_at?->toIso8601String(),
             'updated_at' => $subscription->updated_at?->toIso8601String(),
         ];

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Requests/StoreTravelAdvertPriceRequest.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Requests/StoreTravelAdvertPriceRequest.php
@@ -10,6 +10,7 @@ use App\Modules\TravelAgency\Domain\Models\TravelAdvertType;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 /**
  * TRAVEL-906 (#6109) — Création d'une grille tarifaire.
@@ -49,7 +50,7 @@ class StoreTravelAdvertPriceRequest extends FormRequest
         ];
     }
 
-    public function withValidator($validator): void
+    public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator): void {
             $user = $this->user();

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Requests/StoreTravelQuizQuestionRequest.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Requests/StoreTravelQuizQuestionRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\TravelAgency\Interfaces\Api\V1\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
 
 /**
  * TRAVEL-904 (#6107) — Ajout d'une question à un quiz.
@@ -32,7 +33,7 @@ class StoreTravelQuizQuestionRequest extends FormRequest
         ];
     }
 
-    public function withValidator($validator): void
+    public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator): void {
             $index = (int) $this->input('correct_option_index');

--- a/api/app/Modules/TravelAgency/Interfaces/Api/V1/Requests/UpdateTravelArticleRequest.php
+++ b/api/app/Modules/TravelAgency/Interfaces/Api/V1/Requests/UpdateTravelArticleRequest.php
@@ -27,8 +27,9 @@ class UpdateTravelArticleRequest extends FormRequest
     {
         $companyId = $this->user() instanceof Employee ? $this->user()->company_id : null;
 
-        /** @var int|null $articleId */
-        $articleId = $this->route('travelArticle')?->id;
+        /** @var TravelArticle|null $travelArticle */
+        $travelArticle = $this->route('travelArticle');
+        $articleId = $travelArticle instanceof TravelArticle ? $travelArticle->id : null;
 
         return [
             'category_id' => ['nullable', 'integer'],


### PR DESCRIPTION
## Correctifs CI BC-24 — lot 2 (checks requis de #6127)

Suite de #6518 (mergée). Nouveaux fixes vérifiés localement :

1. **PHPStan — Strict (Core/Modules/Shared, level 8)** : 38 findings du module TravelAgency corrigés → 0 erreur (`vendor/bin/phpstan analyse -c phpstan-strict.neon app/Modules/TravelAgency ...`).
   - Types itérables (array shapes) : ParticipateQuizAction, TravelManualNotificationAction, TravelLegacyImportService, TravelReportController (callable 4 params), TravelWebhookEvent::values(), redactedPayload.
   - Modèles : `@use HasFactory<Factory<static>>` (6 modèles), `metadata_json` typé `array|null`, hooks creating uuid typés, `@return BelongsTo<T,...>`.
   - Controllers/Requests : `@var Employee $actor`, `withValidator(Validator $validator)`, route param typé, casts option()/argument().
   - TravelWebhookDispatcher : catch Throwable seul (ConnectionException dead catch supprimé).
2. **Pint** : 25 fichiers du diff PASS.

Vérifié localement : phpstan-strict 0 erreur, Pint PASS, php -l OK, isolation ✅, i18n ✅, Redocly 0 erreur (lot 1).
