### PR TITLE
fix(openapi): resynchronise dev-hub/sdk/MANIFEST.json — déblocage OpenAPI CI sur main

### DIFF
--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "2a88baad1213858f7b683c1341effd27f96a2d7b323171246482b724b26387de",
+  "spec_sha256": "dcbcab3198408e84644f0134549fc96a854e90f62bef1f10a4166d6e1b49aa7b",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
   "operation_count": 896,


### PR DESCRIPTION
## Déblocage file de merges — OpenAPI CI rouge sur main

### Constat
Le check `node dev-hub/tools/generate-openapi-sdk.mjs --check` échoue sur **main** (run OpenAPI CI du merge #6522, 2026-08-31 15:53) : `dev-hub/sdk/MANIFEST.json is not up to date`. Toute PR basée sur ce main hérite du rouge → toute la file de merges bloquée.

### Correctif
Régénération canonique (`generate-openapi-sdk.mjs`) : seul `dev-hub/sdk/MANIFEST.json` était périmé (2 lignes). Le miroir `dev-hub/openapi/v1.yaml` et les SDK JS/Python étaient déjà synchrones (896 opérations).

### Vérification
- `node dev-hub/tools/generate-openapi-sdk.mjs --check` → **vert**.
- Aucun autre fichier modifié.