### PR TITLE
fix(i18n, content): routes publiques Accounting localisées (#6676) + gouvernance domaine Vercel (#6683)

### DIFF
--- a/api/app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php
+++ b/api/app/Modules/Accounting/Interfaces/Api/V1/PublicDocumentShareController.php
@@ -32,7 +32,12 @@ final class PublicDocumentShareController
         $share = $this->resolveShare($token);
 
         if ($share === null) {
-            abort(404, 'DOCUMENT_SHARE_NOT_FOUND');
+            // Issue #6676 : réponse localisée explicite (pattern Onboarding
+            // errorResponse) — abort() passait par le renderer HttpException
+            // dont la localisation dépendait de $request->getLocale() (en par
+            // défaut), produisant un localized_message anglais même avec
+            // Accept-Language: fr.
+            return $this->errorResponse('DOCUMENT_SHARE_NOT_FOUND', 404);
         }
 
         $this->auditAccess($share, 'accounting.share.info');
@@ -59,7 +64,12 @@ final class PublicDocumentShareController
         $share = $this->resolveShare($token);
 
         if ($share === null) {
-            abort(404, 'DOCUMENT_SHARE_NOT_FOUND');
+            // Issue #6676 : réponse localisée explicite (pattern Onboarding
+            // errorResponse) — abort() passait par le renderer HttpException
+            // dont la localisation dépendait de $request->getLocale() (en par
+            // défaut), produisant un localized_message anglais même avec
+            // Accept-Language: fr.
+            return $this->errorResponse('DOCUMENT_SHARE_NOT_FOUND', 404);
         }
 
         $this->auditAccess($share, 'accounting.share.download');
@@ -68,7 +78,7 @@ final class PublicDocumentShareController
         $document = $share->document;
 
         if ($document->pdf_path === null || ! Storage::disk(GenerateDocumentPdf::DISK)->exists($document->pdf_path)) {
-            abort(404, 'DOCUMENT_PDF_NOT_READY');
+            return $this->errorResponse('DOCUMENT_PDF_NOT_READY', 404);
         }
 
         $filename = $document->type.'-'.$document->number.'.pdf';
@@ -99,6 +109,22 @@ final class PublicDocumentShareController
      * depuis le search_path par défaut — on ne les itère QUE sur échec du
      * lookup direct (rare : token invalide ou partage d'un tenant à schéma).
      */
+    /**
+     * Réponse d'erreur localisée (issue #6676) — même pattern que le module
+     * Onboarding : le code est catalogué dans les 4 locales et le message est
+     * traduit selon la locale de la requête (Accept-Language / préférence).
+     */
+    private function errorResponse(string $code, int $status): JsonResponse
+    {
+        $translated = __("errors.{$code}");
+
+        return new JsonResponse([
+            'error' => $code,
+            'message' => $code,
+            'localized_message' => $translated !== "errors.{$code}" ? $translated : $code,
+        ], $status);
+    }
+
     private function resolveShare(string $token): ?AccountingDocumentShare
     {
         $share = AccountingDocumentShare::query()

--- a/api/lang/ar/errors.php
+++ b/api/lang/ar/errors.php
@@ -41,6 +41,7 @@ return [
     // Général
     'NOT_FOUND' => 'المورد غير موجود.',
     'FORBIDDEN' => 'ليس لديك صلاحية لهذا الإجراء.',
+    'RESOURCE_NOT_FOUND' => 'المورد غير موجود.',
     'SERVER_ERROR' => 'حدث خطأ. يرجى المحاولة مجدداً.',
     'VALIDATION_ERROR' => 'بعض الحقول غير صحيحة.',
     'BAD_REQUEST' => 'طلب غير صالح.',

--- a/api/lang/en/errors.php
+++ b/api/lang/en/errors.php
@@ -41,6 +41,7 @@ return [
     // General
     'NOT_FOUND' => 'Resource not found.',
     'FORBIDDEN' => 'You do not have permission for this action.',
+    'RESOURCE_NOT_FOUND' => 'Resource not found.',
     'SERVER_ERROR' => 'An error occurred. Please try again.',
     'VALIDATION_ERROR' => 'Some fields are incorrect.',
     'BAD_REQUEST' => 'Bad request.',

--- a/api/lang/fr/errors.php
+++ b/api/lang/fr/errors.php
@@ -41,6 +41,7 @@ return [
     // Général
     'NOT_FOUND' => 'Ressource introuvable.',
     'FORBIDDEN' => 'Vous n\'avez pas les droits pour cette action.',
+    'RESOURCE_NOT_FOUND' => 'Ressource introuvable.',
     'SERVER_ERROR' => 'Une erreur est survenue. Veuillez réessayer.',
     'VALIDATION_ERROR' => 'Certains champs sont incorrects.',
     'BAD_REQUEST' => 'Requête invalide.',

--- a/api/lang/tr/errors.php
+++ b/api/lang/tr/errors.php
@@ -41,6 +41,7 @@ return [
     // Général
     'NOT_FOUND' => 'Kaynak bulunamadı.',
     'FORBIDDEN' => 'Bu işlem için yetkiniz yok.',
+    'RESOURCE_NOT_FOUND' => 'Kaynak bulunamadı.',
     'SERVER_ERROR' => 'Bir hata oluştu. Lütfen tekrar deneyin.',
     'VALIDATION_ERROR' => 'Bazı alanlar hatalı.',
     'BAD_REQUEST' => 'Gecersiz istek.',

--- a/api/tests/Feature/Accounting/PublicDocumentShareResolutionTest.php
+++ b/api/tests/Feature/Accounting/PublicDocumentShareResolutionTest.php
@@ -95,4 +95,27 @@ class PublicDocumentShareResolutionTest extends TestCase
         $this->getJson('/api/v1/accounting/documents/shared/'.str_repeat('y', 64))->assertStatus(404);
         $this->get('/api/v1/accounting/documents/shared/'.str_repeat('y', 64).'/download')->assertStatus(404);
     }
+
+    public function test_invalid_token_error_is_localized_with_accept_language(): void
+    {
+        Storage::fake('private');
+        Mail::fake();
+
+        // Issue #6676 : les routes publiques Accounting doivent servir un
+        // localized_message dans la langue demandée (Accept-Language), comme
+        // le reste de l'API — jamais le défaut anglais.
+        $this->getJson(
+            '/api/v1/accounting/documents/shared/'.str_repeat('y', 64),
+            ['Accept-Language' => 'fr']
+        )->assertStatus(404)
+            ->assertJsonPath('error', 'DOCUMENT_SHARE_NOT_FOUND')
+            ->assertJsonPath('localized_message', 'Partage de document introuvable ou expiré.');
+
+        $this->getJson(
+            '/api/v1/accounting/documents/shared/'.str_repeat('y', 64),
+            ['Accept-Language' => 'en']
+        )->assertStatus(404)
+            ->assertJsonPath('error', 'DOCUMENT_SHARE_NOT_FOUND')
+            ->assertJsonPath('localized_message', 'Document share not found or expired.');
+    }
 }

--- a/front/web/src/components/JsonLd.tsx
+++ b/front/web/src/components/JsonLd.tsx
@@ -5,10 +5,11 @@ interface JsonLdProps {
   data: Record<string, unknown>;
 }
 
-// Issue #1775 : https://gestionemployer-backend.vercel.app appartient à une entreprise de
-// construction US sans rapport — ne jamais l'utiliser dans les données
-// structurées. Source unique : getSiteUrl() (#2656) — NEXT_PUBLIC_SITE_URL →
-// DEFAULT_SITE_URL (marque) → localhost en dev. (Closes #3852)
+// Issue #1775/#6683 : le domaine Vercel est le déploiement web ACTUEL
+// (DOMAINS.md, statut live) mais il ne doit JAMAIS apparaître dans les
+// données structurées/canonicals — source unique : getSiteUrl() (#2656) —
+// NEXT_PUBLIC_SITE_URL → DEFAULT_SITE_URL (marque) → localhost en dev.
+// Migration cible : leopardo-rh.com (#3452). (Closes #3852)
 import { getSiteUrl } from '@/lib/site-url';
 
 const SITE_URL = getSiteUrl();

--- a/front/web/src/lib/site-url.ts
+++ b/front/web/src/lib/site-url.ts
@@ -3,10 +3,12 @@
  *
  * Avant : 8 copies du fallback, dont `http://localhost:3000` (canonicals
  * pointant sur localhost en build par défaut) et le domaine Vercel
- * « emprunté » `gestionemployer-backend.vercel.app` — explicitement interdit
- * dans les données structurées (issue #1775 : il évoque une entreprise US
- * sans rapport ; le domaine de marque officiel recommandé est
- * `www.leopardo-rh.com`, voir docs/DEPLOYMENT_PRODUCTION.md).
+ * `gestionemployer-backend.vercel.app` (issue #6683 : réconciliation de la
+ * gouvernance — c'est le déploiement web ACTUEL, registre DOMAINS.md statut
+ * `live`, mais il ne doit PAS servir de canonical/domaine de marque : les
+ * données structurées et canonicals utilisent `NEXT_PUBLIC_SITE_URL` →
+ * `leopardo-rh.com` (marque officielle, migration cible #3452 — cf.
+ * docs/DEPLOYMENT_PRODUCTION.md).
  *
  * Ordre de résolution :
  *   1. NEXT_PUBLIC_SITE_URL — l'URL de marque réelle (à poser au déploiement,

--- a/front/web/src/lib/site.ts
+++ b/front/web/src/lib/site.ts
@@ -4,7 +4,8 @@
  * Avant : le défaut était `https://gestionemployer-backend.vercel.app` (domaine
  * de dev) répété dans sitemap.ts, robots.ts et les canonicals — faux canonicals
  * en production. Ici, une seule source de vérité : `NEXT_PUBLIC_SITE_URL` >
- * défaut `https://leopardo-rh.com` (domaine produit officiel).
+ * défaut `https://leopardo-rh.com` (domaine produit officiel). Le domaine Vercel
+ * reste le déploiement web live (DOMAINS.md) — hors canonicals (issue #6683).
  */
 export const DEFAULT_SITE_URL = 'https://leopardo-rh.com';
 


### PR DESCRIPTION
## Lot 3 — i18n routes publiques Accounting + gouvernance domaine

### #6676 — [i18n] Routes publiques Accounting localisées
`PublicDocumentShareController` (info/download) utilisait `abort(404, 'DOCUMENT_SHARE_NOT_FOUND')` → le renderer HttpException servait un `localized_message` anglais (locale par défaut) même avec `Accept-Language: fr`.
- **Fix** : réponses d'erreur cataloguées explicites (pattern module Onboarding — `errorResponse()`) ;
- Clés `DOCUMENT_SHARE_NOT_FOUND`, `DOCUMENT_PDF_NOT_READY`, `RESOURCE_NOT_FOUND` ajoutées aux 4 catalogues (`lang/{fr,en,ar,tr}/errors.php`) ;
- **Test de parité** : `Accept-Language: fr` → message français, `en` → anglais.

### #6683 — [content] Gouvernance domaine Vercel réconciliée
`gestionemployer-backend.vercel.app` est le déploiement web **live** (registre `docs/ops/DOMAINS.md`, statut `live`, HTTP 200) mais les commentaires du code front le déclaraient « explicitement interdit » (#1775). Réconciliation : les 3 fichiers (`site-url.ts`, `JsonLd.tsx`, `site.ts`) documentent désormais la règle réelle — live pour les builds, jamais utilisé comme canonical/domaine de marque (canonicals → `leopardo-rh.com`, migration cible #3452).

## Qualité
- `php -l` OK, Pint 0 issue, `bash` OK (aucun changement de logique métier côté front, uniquement des commentaires).