### PR TITLE
fix(web): login — middleware accepte le token Sanctum id|secret (P0, Closes #6679)

### DIFF
--- a/front/web/src/lib/__tests__/session-token-format.test.ts
+++ b/front/web/src/lib/__tests__/session-token-format.test.ts
@@ -36,7 +36,7 @@ describe('session token format vs middleware guard (#6679)', () => {
     );
     // Le cookie reçoit directement la valeur `token` de la réponse backend
     // (pas un hash dérivé) — c'est ce qui impose l'acceptation du `|`.
-    const cookieSet = loginSrc.match(/cookies\.set\([^)]*token[^)]*\)/s);
+    const cookieSet = loginSrc.match(/cookies\.set\([^)]*token[^)]*\)/);
     expect(cookieSet).not.toBeNull();
   });
 });

--- a/front/web/src/lib/__tests__/session-token-format.test.ts
+++ b/front/web/src/lib/__tests__/session-token-format.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Issue #6679 (P0) — le middleware de garde du dashboard doit accepter le
+ * format de token Sanctum posé dans le cookie de session :
+ * `id|secret` (ex. `1001|HVs0OH…`) et sa forme URL-encodée `%7C`.
+ *
+ * La garde est cosmétique (#3522 — la vraie auth est serveur), mais un
+ * faux négatif ici boucle l'utilisateur vers /auth/login après un login
+ * réussi.
+ */
+describe('session token format vs middleware guard (#6679)', () => {
+  const middlewareSrc = readFileSync(join(__dirname, '../../middleware.ts'), 'utf8');
+
+  it('le regex du middleware accepte le pipe (format Sanctum id|secret) et sa forme encodée', () => {
+    const regexMatch = middlewareSrc.match(
+      /isValidToken\s*=\s*[\s\S]*?\/\^(\[A-Za-z0-9._|%-\]+)\\\/\.test/
+    );
+    expect(regexMatch).not.toBeNull();
+    const pattern = regexMatch?.[1] ?? '';
+    const regex = new RegExp(`^${pattern}+$`);
+
+    // Format réel posé par login/route.ts (token Sanctum brut).
+    expect(regex.test('1001|HVs0OHabcdefghijklmnopqrstuvwxyz')).toBe(true);
+    // Forme URL-encodée (cookie encodé par le navigateur) : `%7C`.
+    expect(regex.test('1001%7CHVs0OHabcdefghijklmnopqrstuvwxyz')).toBe(true);
+    // Les tokens ordinaires restent acceptés.
+    expect(regex.test('abcdefghijklmnopqrstuvwxyz0123456789.-_')).toBe(true);
+  });
+
+  it('le login pose le token BACKEND BRUT (id|secret) dans le cookie, sans transformation', () => {
+    const loginSrc = readFileSync(
+      join(__dirname, '../../app/api/v1/auth/login/route.ts'),
+      'utf8'
+    );
+    // Le cookie reçoit directement la valeur `token` de la réponse backend
+    // (pas un hash dérivé) — c'est ce qui impose l'acceptation du `|`.
+    const cookieSet = loginSrc.match(/cookies\.set\([^)]*token[^)]*\)/s);
+    expect(cookieSet).not.toBeNull();
+  });
+});

--- a/front/web/src/middleware.ts
+++ b/front/web/src/middleware.ts
@@ -46,8 +46,13 @@ export function middleware(request: NextRequest) {
     // the client-side app mounts. It is NOT a security boundary: a valid
     // shape here does not mean a valid session. Real authentication and
     // authorization are enforced server-side by the API on every request.
+    // Issue #6679 (P0) : le cookie porte le token Sanctum BRUT au format
+    // `id|secret` (ex. `1001|HVs0OH…`), URL-encodé en `%7C` par le navigateur.
+    // Le regex précédent (`[A-Za-z0-9._-]`) rejetait le pipe → boucle de
+    // redirection /auth/login après un login pourtant réussi. Le `|` (et sa
+    // forme encodée `%`) est donc accepté — la garde reste cosmétique (#3522).
     const isValidToken =
-      !!token && token.length >= 20 && /^[A-Za-z0-9._-]+$/.test(token);
+      !!token && token.length >= 20 && /^[A-Za-z0-9._|%-]+$/.test(token);
 
     if (!isValidToken) {
       const loginUrl = new URL('/auth/login', request.url);


### PR DESCRIPTION
## Closes #6679 (P0) — login web : boucle de redirection /auth/login

### Constat
Login réussi (cookie `leopardo_token` posé, `/auth/me` 200) mais toute navigation vers `/dashboard` → 307 vers `/auth/login`.

### Cause racine
`front/web/src/middleware.ts` : `isValidToken = /^[A-Za-z0-9._-]+$/` rejette le token Sanctum BRUT posé dans le cookie (`1001|HVs0OH…` — format `id|secret`, encodé `%7C` par le navigateur) → le `|` ne matche pas → redirection systématique.

### Fix
- Regex élargi à `/^[A-Za-z0-9._|%-]+$/` (accepte le pipe et sa forme encodée). La garde reste cosmétique (#3522 — la vraie auth est serveur).
- Test unitaire `session-token-format.test.ts` : le regex accepte le format réel `id|secret` (brut + URL-encodé) et les tokens ordinaires ; le login pose bien le token brut (pas un hash).

### Impact
Le dashboard web redevient accessible après connexion (flux mobile non affecté — Bearer direct).