### PR TITLE
fix(frontend): bugs prod lot web/admin — middleware Sanctum, settings session, travel/fuel gates

### DIFF
--- a/front/admin-dashboard/e2e/prod-bugs-6712-6714.spec.js
+++ b/front/admin-dashboard/e2e/prod-bugs-6712-6714.spec.js
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * E2E bugs prod lot frontend admin-dashboard (2026-09-01/02) :
+ *  - #6714 : /settings en super-admin ne doit plus déconnecter (401 sur
+ *    /company/banking sans _skipAuthRedirect → l'intercepteur détruisait la
+ *    session).
+ *  - #6713 : /travel avec /travel/ping en 404 (backend BC-24 non livré,
+ *    #6127) → état « module non activé » et non une fausse panne.
+ *  - #6712 : /fuel-station avec l'API référentiel absente (3×404, #6391/#6373)
+ *    → panneau « module en préparation » et non 3 toasts d'erreur permanents.
+ *
+ * Stratégie (même pattern que travel-admin.spec.js) : mocks API (page.route)
+ * + login via token — déterministe en CI sans backend ; utilisable contre
+ * staging avec PLAYWRIGHT_AUTH_TOKEN (BACKEND_LIVE=1 → mocks désactivés).
+ */
+
+const AUTHENTICATED = Boolean(process.env.PLAYWRIGHT_AUTH_TOKEN)
+const LIVE = process.env.BACKEND_LIVE === '1'
+
+test.describe.configure({ timeout: 120_000 })
+
+const ADMIN_USER = {
+  id: 1,
+  name: 'Agent E2E',
+  email: 'agent.e2e@leopardo.test',
+  role: 'superadmin',
+  language: 'fr',
+}
+
+/** Login via sessionStorage + mocks API génériques (auth + données). */
+async function mockBaseApi(page) {
+  // Catch-all API : les endpoints non mockés renvoient 200 vide pour ne pas
+  // déclencher l'intercepteur 401 (qui détruirait la session de test).
+  await page.route('**/api/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) }),
+  )
+  await page.route(/^https?:\/\/[^/]+\/api\/v1\/platform\/auth\/me(\?.*)?$/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: ADMIN_USER }) }),
+  )
+}
+
+async function loginViaToken(page) {
+  await page.addInitScript((token) => {
+    sessionStorage.setItem('admin_token', token)
+  }, process.env.PLAYWRIGHT_AUTH_TOKEN)
+}
+
+test.describe('Settings — session super-admin préservée (#6714)', () => {
+  test.skip(!AUTHENTICATED, 'Skipped: requiert PLAYWRIGHT_AUTH_TOKEN (tests authentifiés)')
+  test.skip(LIVE, 'Skipped: BACKEND_LIVE=1 — tests mock désactivés')
+
+  test('visiter /settings avec /company/banking en 401 ne déconnecte pas', async ({ page }) => {
+    const toasts = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') toasts.push(msg.text())
+    })
+    await loginViaToken(page)
+    await mockBaseApi(page)
+    // Route tenant : 401 attendu pour le super-admin — doit être ignoré grâce
+    // à _skipAuthRedirect (#4170/#6714), la session doit survivre.
+    await page.route(/^https?:\/\/[^/]+\/api\/v1\/company\/banking(\?.*)?$/, (route) =>
+      route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ message: 'Unauthenticated.' }) }),
+    )
+
+    await page.goto('/settings')
+    await expect(page.getByRole('heading', { name: /Paramètres/i }).first()).toBeVisible({ timeout: 15_000 })
+    // Pas de redirection vers /login (session non détruite)
+    await page.waitForTimeout(1500)
+    expect(page.url()).not.toContain('/login')
+    // Pas de toast « Authentication required »
+    await expect(page.locator('.toast, [role="alert"]').filter({ hasText: /Authentication required/i })).toHaveCount(0)
+  })
+})
+
+test.describe('TravelAgency — gate 404 = module non livré (#6713)', () => {
+  test.skip(!AUTHENTICATED, 'Skipped: requiert PLAYWRIGHT_AUTH_TOKEN (tests authentifiés)')
+  test.skip(LIVE, 'Skipped: BACKEND_LIVE=1 — tests mock désactivés')
+
+  test('404 sur /travel/ping → « module non activé », pas de fausse panne', async ({ page }) => {
+    await loginViaToken(page)
+    await mockBaseApi(page)
+    await page.route(/^https?:\/\/[^/]+\/api\/v1\/travel\/ping(\?.*)?$/, (route) =>
+      route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'RESOURCE_NOT_FOUND' }) }),
+    )
+
+    await page.goto('/travel')
+    await expect(
+      page.getByRole('heading', { name: /Module Agence de voyage non activé/i }),
+    ).toBeVisible({ timeout: 15_000 })
+    // Pas l'état d'erreur « temporairement indisponible »
+    await expect(
+      page.getByRole('heading', { name: /Module temporairement indisponible/i }),
+    ).toHaveCount(0)
+  })
+})
+
+test.describe('Fuel stations — API référentiel absente (#6712)', () => {
+  test.skip(!AUTHENTICATED, 'Skipped: requiert PLAYWRIGHT_AUTH_TOKEN (tests authentifiés)')
+  test.skip(LIVE, 'Skipped: BACKEND_LIVE=1 — tests mock désactivés')
+
+  test('3×404 → panneau « Module Fuel en préparation », pas de toasts', async ({ page }) => {
+    const toasts = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') toasts.push(msg.text())
+    })
+    await loginViaToken(page)
+    await mockBaseApi(page)
+    // Les 3 endpoints référentiel n'existent pas encore (#6391/#6373) → 404.
+    for (const path of ['/fuel-station/stations', '/fuel-station/incidents', '/fuel-station/reconciliations']) {
+      await page.route(new RegExp(`^https?:\\/\\/[^/]+/api/v1${path}(\\?.*)?$`), (route) =>
+        route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'RESOURCE_NOT_FOUND' }) }),
+      )
+    }
+
+    await page.goto('/fuel-station')
+    await expect(
+      page.getByRole('heading', { name: /Module Fuel en préparation/i }),
+    ).toBeVisible({ timeout: 15_000 })
+    // Pas de toast « Resource not found » permanent
+    await expect(page.locator('.toast, [role="alert"]').filter({ hasText: /Resource not found/i })).toHaveCount(0)
+  })
+
+  test('API livrée (200) → KPIs et onglets rendus', async ({ page }) => {
+    await loginViaToken(page)
+    await mockBaseApi(page)
+    await page.route(/^https?:\/\/[^/]+\/api\/v1\/fuel-station\/stations(\?.*)?$/, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [{ id: 1, code: 'DZ-01', name: 'Alger Centre', timezone: 'Africa/Algiers', status: 'active' }] }) }),
+    )
+    await page.route(/^https?:\/\/[^/]+\/api\/v1\/fuel-station\/incidents(\?.*)?$/, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) }),
+    )
+    await page.route(/^https?:\/\/[^/]+\/api\/v1\/fuel-station\/reconciliations(\?.*)?$/, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) }),
+    )
+
+    await page.goto('/fuel-station')
+    await expect(page.getByRole('tab', { name: /Stations/i }).first()).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Alger Centre')).toBeVisible()
+  })
+})

--- a/front/admin-dashboard/src/views/fuel/FuelManagerView.vue
+++ b/front/admin-dashboard/src/views/fuel/FuelManagerView.vue
@@ -1,12 +1,32 @@
 <template>
   <div class="space-y-6">
-    <!-- FUEL-012 (#5806) : interface manager multi-stations — KPIs tenant -->
-    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
-      <StatsCard :title="t('fuel.statStations', 'Stations')" :value="stats.stations" icon="BoltIcon" color="blue" />
-      <StatsCard :title="t('fuel.statOpenIncidents', 'Incidents ouverts')" :value="stats.openIncidents" icon="ExclamationTriangleIcon" color="red" />
-      <StatsCard :title="t('fuel.statPendingReconciliations', 'Rapprochements à revoir')" :value="stats.pendingReconciliations" icon="ClipboardDocumentListIcon" color="yellow" />
-      <StatsCard :title="t('fuel.statVariance', 'Écarts à expliquer')" :value="stats.varianceMinor" icon="ArrowDownTrayIcon" color="green" />
+    <!-- Issue #6712 : API référentiel BC-15 non livrée (#6391/#6373) — état
+         explicite « module en préparation » au lieu de 3 toasts d'erreur. -->
+    <div
+      v-if="moduleState === 'unavailable'"
+      class="mx-auto max-w-xl rounded-2xl border border-amber-200 bg-amber-50 px-8 py-10 text-center dark:border-amber-800 dark:bg-amber-900/20"
+      role="alert"
+    >
+      <ExclamationTriangleIcon class="mx-auto h-12 w-12 text-amber-500" />
+      <h2 class="mt-4 text-xl font-bold text-slate-900 dark:text-white">
+        {{ t('fuel.modulePreparingTitle', 'Module Fuel en préparation') }}
+      </h2>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+        {{ t('fuel.modulePreparingBody', "Le référentiel multi-stations (stations, incidents, rapprochements) n'est pas encore disponible. L'API correspondante est en cours de livraison — revenez plus tard.") }}
+      </p>
+      <button class="btn-secondary mt-6" type="button" @click="fetchData">
+        {{ t('fuel.retry', 'Réessayer') }}
+      </button>
     </div>
+
+    <template v-else>
+      <!-- FUEL-012 (#5806) : interface manager multi-stations — KPIs tenant -->
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        <StatsCard :title="t('fuel.statStations', 'Stations')" :value="stats.stations" icon="BoltIcon" color="blue" />
+        <StatsCard :title="t('fuel.statOpenIncidents', 'Incidents ouverts')" :value="stats.openIncidents" icon="ExclamationTriangleIcon" color="red" />
+        <StatsCard :title="t('fuel.statPendingReconciliations', 'Rapprochements à revoir')" :value="stats.pendingReconciliations" icon="ClipboardDocumentListIcon" color="yellow" />
+        <StatsCard :title="t('fuel.statVariance', 'Écarts à expliquer')" :value="stats.varianceMinor" icon="ArrowDownTrayIcon" color="green" />
+      </div>
 
     <div v-if="globalError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
       {{ globalError }}
@@ -80,7 +100,8 @@
       <template #cell-status="{ value }">
         <StatusBadge :status="value" :map="reconciliationStatusMap" />
       </template>
-    </DataTable>
+      </DataTable>
+    </template>
   </div>
 </template>
 
@@ -90,6 +111,7 @@ import api from '@/services/api'
 import StatsCard from '@/components/dashboard/StatsCard.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
 import { translate } from '@/i18n/index.js'
 import { useLocaleStore } from '@/stores/locale'
 
@@ -103,6 +125,10 @@ const stations = ref([])
 const incidents = ref([])
 const reconciliations = ref([])
 const activeTab = ref('stations')
+
+// Issue #6712 : « unavailable » = API référentiel BC-15 pas encore livrée
+// (3×404) → panneau « module en préparation » au lieu de toasts d'erreur.
+const moduleState = ref('loading')
 
 const stats = ref({ stations: 0, openIncidents: 0, pendingReconciliations: 0, varianceMinor: 0 })
 
@@ -173,25 +199,44 @@ async function fetchData() {
   loading.value = true
   globalError.value = ''
   errors.value = { stations: '', incidents: '', reconciliations: '' }
+  const outcomes = []
   try {
     // Routes tenant (auth:sanctum + api.manager) : 401 attendu en super-admin
-    // — _skipAuthRedirect (#4170) évite la déconnexion de session.
-    const sRes = await api.get('/fuel-station/stations?per_page=100', { _skipAuthRedirect: true })
+    // — _skipAuthRedirect (#4170) évite la déconnexion de session ;
+    // _skipToast (#4713) : les erreurs sont gérées localement ci-dessous.
+    const sRes = await api.get('/fuel-station/stations?per_page=100', { _skipAuthRedirect: true, _skipToast: true })
     stations.value = sRes.data.data || []
-  } catch {
+    outcomes.push('ok')
+  } catch (e) {
     errors.value.stations = t('fuel.errStations', 'Impossible de charger les stations.')
+    outcomes.push(e.response?.status ?? 'error')
   }
   try {
-    const iRes = await api.get('/fuel-station/incidents?per_page=100', { _skipAuthRedirect: true })
+    const iRes = await api.get('/fuel-station/incidents?per_page=100', { _skipAuthRedirect: true, _skipToast: true })
     incidents.value = iRes.data.data || []
-  } catch {
+    outcomes.push('ok')
+  } catch (e) {
     errors.value.incidents = t('fuel.errIncidents', 'Impossible de charger les incidents.')
+    outcomes.push(e.response?.status ?? 'error')
   }
   try {
-    const rRes = await api.get('/fuel-station/reconciliations?status=pending_review&per_page=100', { _skipAuthRedirect: true })
+    const rRes = await api.get('/fuel-station/reconciliations?status=pending_review&per_page=100', { _skipAuthRedirect: true, _skipToast: true })
     reconciliations.value = rRes.data.data || []
-  } catch {
+    outcomes.push('ok')
+  } catch (e) {
     errors.value.reconciliations = t('fuel.errReconciliations', 'Impossible de charger les rapprochements.')
+    outcomes.push(e.response?.status ?? 'error')
+  }
+  // Issue #6712 : l'API référentiel (stations / incidents / rapprochements)
+  // est planifiée (#6391/#6373) mais pas encore livrée — les 3 endpoints
+  // répondent 404 pour tout le monde. On affiche alors un état explicite
+  // « module en préparation » au lieu de 3 toasts d'erreur permanents et de
+  // tableaux vides. Dès que l'API sera livrée, la page repassera en mode
+  // normal sans autre changement.
+  if (outcomes.every((o) => o === 404)) {
+    moduleState.value = 'unavailable'
+  } else {
+    moduleState.value = 'ready'
   }
   stats.value = {
     stations: stations.value.length,

--- a/front/admin-dashboard/src/views/settings/SettingsView.vue
+++ b/front/admin-dashboard/src/views/settings/SettingsView.vue
@@ -319,7 +319,7 @@ const bankingForm = reactive({ company_iban: '', company_bic: '' })
 async function loadBanking() {
   isBankingLoading.value = true
   try {
-    const res = await api.get('/company/banking')
+    const res = await api.get('/company/banking', { _skipAuthRedirect: true })
     const data = res.data?.data || {}
     bankingData.company_iban = data.company_iban ?? null
     bankingData.company_bic = data.company_bic ?? null
@@ -341,7 +341,7 @@ async function submitBanking() {
     const res = await api.patch('/company/banking', {
       company_iban: bankingForm.company_iban.trim().toUpperCase().replace(/\s/g, '') || null,
       company_bic: bankingForm.company_bic.trim().toUpperCase() || null,
-    })
+    }, { _skipAuthRedirect: true })
     const data = res.data?.data || {}
     bankingData.company_iban = data.company_iban ?? null
     bankingData.company_bic = data.company_bic ?? null

--- a/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
@@ -19,7 +19,7 @@
         {{ $t('travel.gate.disabledTitle', 'Module Agence de voyage non activé') }}
       </h2>
       <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
-        {{ $t('travel.gate.disabledBody', "La verticale TravelAgency n'est pas activée pour le tenant connecté. Activez la fonctionnalité « travelagency » pour accéder à ce module.") }}
+        {{ gateMessage || $t('travel.gate.disabledBody', "La verticale TravelAgency n'est pas activée pour le tenant connecté. Activez la fonctionnalité « travelagency » pour accéder à ce module.") }}
       </p>
       <button class="btn-secondary mt-6" type="button" @click="checkGate">
         {{ $t('travel.gate.retry', 'Réessayer') }}
@@ -101,6 +101,7 @@ const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 /** checking | ready | disabled (403 flag) | error (autre) */
 const gateStatus = ref('checking')
 const gateError = ref('')
+const gateMessage = ref('')
 
 const activeTab = ref('referentiel')
 
@@ -134,13 +135,20 @@ function selectTab(tab) {
 async function checkGate() {
   gateStatus.value = 'checking'
   gateError.value = ''
+  gateMessage.value = ''
   try {
     await api.get('/travel/ping', { _skipAuthRedirect: true })
     gateStatus.value = 'ready'
   } catch (err) {
     const status = err.response?.status
-    if (status === 403) {
+    // 403 : flag « travelagency » désactivé pour le tenant connecté.
+    // 404 : backend BC-24 pas encore livré (#6127) — même rendu « non
+    // activé » au lieu d'une fausse panne (issue #6713).
+    if (status === 403 || status === 404) {
       gateStatus.value = 'disabled'
+      if (status === 404) {
+        gateMessage.value = t('travel.gate.notDeliveredBody', "Le module TravelAgency n'est pas encore disponible sur ce compte (service en cours de livraison). Revenez plus tard.")
+      }
     } else {
       gateStatus.value = 'error'
       gateError.value = err.response?.data?.message

--- a/front/web/e2e/middleware-sanctum-token.spec.ts
+++ b/front/web/e2e/middleware-sanctum-token.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Issue #6726 — le middleware Next.js (`src/middleware.ts`) rejetait les
+ * tokens Sanctum `{id}|{plaintext}` : la regex de format excluait le
+ * séparateur `|`, donc toute navigation vers la zone dashboard était
+ * redirigée en boucle vers /auth/login en production (cookie posé par le
+ * proxy `src/app/api/v1/auth/login/route.ts` au format réel « 990|1FVy… »).
+ *
+ * Les e2e mockés existants utilisaient un token opaque
+ * (« e2e-mocked-session-token », session-helpers.ts) qui passait l'ancienne
+ * regex — d'où l'absence de détection. Ce spec utilise un token au format
+ * Sanctum réel.
+ */
+const SESSION_COOKIE_NAME = 'leopardo_token';
+const SANCTUM_TOKEN = '990|1FVyYnVzSbMu8F1OCOtk';
+
+async function setSanctumCookie(page: import('@playwright/test').Page): Promise<void> {
+  const base = process.env.BASE_URL || 'http://localhost:3000';
+  await page.context().addCookies([
+    {
+      name: SESSION_COOKIE_NAME,
+      value: SANCTUM_TOKEN,
+      url: base,
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+test.describe('middleware — token Sanctum id|secret (#6726)', () => {
+  test('cookie Sanctum → /dashboard servi (pas de redirection /auth/login)', async ({ page }) => {
+    await setSanctumCookie(page);
+    // Catch-all API d'abord (la dernière route enregistrée est prioritaire) :
+    // évite qu'un appel non mocké redirige côté client.
+    await page.route('**/api/v1/**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) });
+    });
+    // Le reste de l'app peut appeler /auth/me : mocké pour rester déterministe.
+    await page.route('**/api/v1/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            id: 101,
+            first_name: 'Fatima',
+            last_name: 'Meziane',
+            email: 'fatima.meziane@techcorp-algerie.dz',
+            role: 'manager',
+            manager_role: 'rh',
+            language: 'fr',
+            is_rtl: false,
+          },
+        }),
+      });
+    });
+
+    const response = await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    // Le middleware ne redirige pas : statut 200 et URL restée sur /dashboard.
+    expect(response?.status()).toBe(200);
+    expect(page.url()).toContain('/dashboard');
+    expect(page.url()).not.toContain('/auth/login');
+  });
+
+  test('cookie opaque historique → toujours accepté (non-régression)', async ({ page }) => {
+    const base = process.env.BASE_URL || 'http://localhost:3000';
+    await page.context().addCookies([
+      {
+        name: SESSION_COOKIE_NAME,
+        value: 'e2e-mocked-session-token-abcdefghijklmnop',
+        url: base,
+        httpOnly: true,
+        sameSite: 'Lax',
+      },
+    ]);
+    await page.route('**/api/v1/**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) });
+    });
+    const response = await page.goto('/absences', { waitUntil: 'domcontentloaded' });
+    expect(response?.status()).toBe(200);
+    expect(page.url()).not.toContain('/auth/login');
+  });
+
+  test('sans cookie → redirigé vers /auth/login (garde intacte)', async ({ page }) => {
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    expect(page.url()).toContain('/auth/login');
+  });
+});

--- a/front/web/src/lib/__tests__/middleware-session-token.test.ts
+++ b/front/web/src/lib/__tests__/middleware-session-token.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+import { middleware } from '@/middleware';
+
+/**
+ * Issue #6726 — le gate cosmétique du middleware doit accepter le cookie de
+ * session Sanctum `{id}|{plaintext}` posé par `app/api/v1/auth/login/route.ts`.
+ * Avant le fix, le regex excluait le séparateur `|` → toute la zone dashboard
+ * redirigeait en boucle vers /auth/login en production.
+ */
+describe('middleware — gate de session zone dashboard (#6726)', () => {
+  const base = 'https://app.example.com';
+
+  function request(path: string, token?: string) {
+    const req = new NextRequest(`${base}${path}`);
+    if (token) req.cookies.set('leopardo_token', token);
+    return req;
+  }
+
+  function isRedirectedToLogin(response: Response): boolean {
+    return response.status === 307 && response.headers.get('location') === `${base}/auth/login`;
+  }
+
+  it('laisse passer un token Sanctum id|secret sur /dashboard', () => {
+    const res = middleware(request('/dashboard', '990|1FVyYnVzSbMu8F1OCOtk'));
+    expect(res.status).toBe(200);
+    expect(isRedirectedToLogin(res)).toBe(false);
+  });
+
+  it('laisse passer un token Sanctum sur chaque préfixe protégé', () => {
+    const token = '1234|abcdefghijklmnopqrstuvwxyz';
+    for (const prefix of ['/dashboard', '/absences', '/payroll', '/settings', '/social-marketing']) {
+      const res = middleware(request(`${prefix}/some/page`, token));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('laisse passer un token opaque historique (sans pipe)', () => {
+    const res = middleware(request('/dashboard', 'opaque-token-abcdefghijklmnopqrstuvwxyz'));
+    expect(res.status).toBe(200);
+  });
+
+  it('redirige vers /auth/login sans cookie', () => {
+    const res = middleware(request('/dashboard'));
+    expect(isRedirectedToLogin(res)).toBe(true);
+  });
+
+  it('redirige vers /auth/login pour un token au format invalide', () => {
+    for (const bad of ['1234|bad token!', 'hello world 12345678901234567890', 'short', 'a|b', '']) {
+      const res = middleware(request('/dashboard', bad));
+      expect(isRedirectedToLogin(res)).toBe(true);
+    }
+  });
+
+  it('ne bloque pas la vitrine (hors zone dashboard)', () => {
+    const res = middleware(request('/', '990|1FVyYnVzSbMu8F1OCOtk'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-vitrine-lang')).toBeTruthy();
+  });
+});

--- a/front/web/src/middleware.ts
+++ b/front/web/src/middleware.ts
@@ -46,8 +46,16 @@ export function middleware(request: NextRequest) {
     // the client-side app mounts. It is NOT a security boundary: a valid
     // shape here does not mean a valid session. Real authentication and
     // authorization are enforced server-side by the API on every request.
+    //
+    // Deux formats de cookie sont acceptés (issue #6726) :
+    //  - token opaque historique (>= 20 caractères alnum/._-) ;
+    //  - token Sanctum `{id}|{plaintext}` (ex. « 990|1FVyYnVzSbMu8F1OCOtk… »),
+    //    posé par le route handler `app/api/v1/auth/login/route.ts` — le `|`
+    //    était exclu du regex d'origine, rendant le dashboard inaccessible.
     const isValidToken =
-      !!token && token.length >= 20 && /^[A-Za-z0-9._-]+$/.test(token);
+      !!token &&
+      token.length >= 20 &&
+      (/^[A-Za-z0-9._-]+$/.test(token) || /^\d+\|[A-Za-z0-9._-]+$/.test(token));
 
     if (!isValidToken) {
       const loginUrl = new URL('/auth/login', request.url);


### PR DESCRIPTION
## Résumé
Lot **frontend** des bugs prod du 2026-09-01 (backend traité par l'autre agent sur `fix/batch1-backend-bugs`).

## Issues fermées
- **Closes #6726** — middleware Next.js : accepte le token Sanctum `{id}|{plaintext}` (regex sans `|` → boucle /auth/login sur toute la zone dashboard). + test unitaire du middleware (6 cas) + e2e Playwright avec vrai token Sanctum.
- **Closes #6714** — SettingsView : `_skipAuthRedirect` sur GET **et** PATCH `/company/banking` → la page Paramètres ne déconnecte plus le super admin.
- **Closes #6713** — TravelAgencyView : le 404 sur `/travel/ping` (backend BC-24 non livré, #6127) est traité comme « module non activé » au lieu d'une fausse panne + bouton Retry inutile.
- **Closes #6712** — FuelManagerView : les 3 endpoints référentiel absents (#6391/#6373) → état explicite « Module Fuel en préparation » (3×404 détectés), plus de 3 toasts d'erreur permanents. Repasse automatiquement en mode normal quand l'API sera livrée.

## Tests
- `front/web`: 6 tests middleware (Sanctum/opaque/invalides) ✓, suite jest 664 ✓ (2 échecs préexistants sur main : absences-page, lettering-page — vérifiés hors de ce lot), eslint + tsc ✓.
- `front/admin-dashboard`: eslint ✓, build Vite ✓, spec e2e `prod-bugs-6712-6714.spec.js` (mocks API, skip sans `PLAYWRIGHT_AUTH_TOKEN` comme travel-admin.spec.js), spec e2e web `middleware-sanctum-token.spec.ts`.

## Vérifications
- Migration : aucune ajoutée.
- Rebase sur `origin/main` à jour.