### PR TITLE
fix(admin): pages Paramètres / Fuel / Travel — fin des toasts permanents et de la déconnexion (#6714 #6712 #6713)

### DIFF
--- a/front/admin-dashboard/src/i18n/locales/ar.json
+++ b/front/admin-dashboard/src/i18n/locales/ar.json
@@ -2621,7 +2621,8 @@
     "errReconciliations": "تعذر تحميل المطابقات.",
     "stationsCaption": "محطات الأسطول",
     "incidentsCaption": "الحوادث المبلغ عنها",
-    "reconciliationsCaption": "تقارير المطابقة"
+    "reconciliationsCaption": "تقارير المطابقة",
+    "apiUnavailable": "لم يتم تسليم واجهة FuelStation (مرجع المحطات، الحوادث، التسويات) بعد — ستعمل الصفحة مع دفعة BC-15 (#6373)."
   },
   "adminPalette": {
     "appLoading": "جارٍ تحميل لوحة الإدارة…",

--- a/front/admin-dashboard/src/i18n/locales/en.json
+++ b/front/admin-dashboard/src/i18n/locales/en.json
@@ -2621,7 +2621,8 @@
     "errReconciliations": "Unable to load reconciliations.",
     "stationsCaption": "Fleet stations",
     "incidentsCaption": "Reported incidents",
-    "reconciliationsCaption": "Reconciliation reports"
+    "reconciliationsCaption": "Reconciliation reports",
+    "apiUnavailable": "The FuelStation API (stations reference, incidents, reconciliations) is not delivered yet — the page will become operational with the BC-15 batch (#6373)."
   },
   "adminPalette": {
     "appLoading": "Loading the administration…",

--- a/front/admin-dashboard/src/i18n/locales/fr.json
+++ b/front/admin-dashboard/src/i18n/locales/fr.json
@@ -2621,7 +2621,8 @@
     "errReconciliations": "Impossible de charger les rapprochements.",
     "stationsCaption": "Stations de la flotte",
     "incidentsCaption": "Incidents signalés",
-    "reconciliationsCaption": "Rapports de rapprochement"
+    "reconciliationsCaption": "Rapports de rapprochement",
+    "apiUnavailable": "L'API FuelStation (référentiel stations, incidents, rapprochements) n'est pas encore livrée — la page sera opérationnelle avec le batch BC-15 (#6373)."
   },
   "adminPalette": {
     "appLoading": "Chargement de l'administration…",

--- a/front/admin-dashboard/src/i18n/locales/tr.json
+++ b/front/admin-dashboard/src/i18n/locales/tr.json
@@ -2621,7 +2621,8 @@
     "errReconciliations": "Mutabakatlar yüklenemedi.",
     "stationsCaption": "Filo istasyonları",
     "incidentsCaption": "Bildirilen olaylar",
-    "reconciliationsCaption": "Mutabakat raporları"
+    "reconciliationsCaption": "Mutabakat raporları",
+    "apiUnavailable": "FuelStation API'si (istasyon referansı, olaylar, mutabakatlar) henüz teslim edilmedi — sayfa BC-15 partisiyle (#6373) birlikte çalışır hale gelecek."
   },
   "adminPalette": {
     "appLoading": "Yönetim yükleniyor…",

--- a/front/admin-dashboard/src/views/fuel/FuelManagerView.vue
+++ b/front/admin-dashboard/src/views/fuel/FuelManagerView.vue
@@ -8,7 +8,10 @@
       <StatsCard :title="t('fuel.statVariance', 'Écarts à expliquer')" :value="stats.varianceMinor" icon="ArrowDownTrayIcon" color="green" />
     </div>
 
-    <div v-if="globalError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+    <div v-if="apiUnavailable" class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700" role="status">
+      {{ t('fuel.apiUnavailable', 'L\'API FuelStation (référentiel stations, incidents, rapprochements) n\'est pas encore livrée — la page sera opérationnelle avec le batch BC-15 (#6373).') }}
+    </div>
+    <div v-else-if="globalError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
       {{ globalError }}
     </div>
 
@@ -98,6 +101,7 @@ const t = (key, fallback = '') => translate(localeStore.current, key, fallback)
 
 const loading = ref(false)
 const globalError = ref('')
+const apiUnavailable = ref(false)
 const errors = ref({ stations: '', incidents: '', reconciliations: '' })
 const stations = ref([])
 const incidents = ref([])
@@ -173,25 +177,35 @@ async function fetchData() {
   loading.value = true
   globalError.value = ''
   errors.value = { stations: '', incidents: '', reconciliations: '' }
+  // #6712 : _skipToast — les 404 (API BC-15 non encore livrée) ne doivent pas
+  // produire 3 toasts d'erreur permanents ; un 404 est un état « module en
+  // préparation », pas une erreur.
+  const handleFailure = (err, key, fallback) => {
+    if (err?.response?.status === 404) {
+      apiUnavailable.value = true
+      return
+    }
+    errors.value[key] = fallback
+  }
   try {
     // Routes tenant (auth:sanctum + api.manager) : 401 attendu en super-admin
     // — _skipAuthRedirect (#4170) évite la déconnexion de session.
-    const sRes = await api.get('/fuel-station/stations?per_page=100', { _skipAuthRedirect: true })
+    const sRes = await api.get('/fuel-station/stations?per_page=100', { _skipAuthRedirect: true, _skipToast: true })
     stations.value = sRes.data.data || []
-  } catch {
-    errors.value.stations = t('fuel.errStations', 'Impossible de charger les stations.')
+  } catch (err) {
+    handleFailure(err, 'stations', t('fuel.errStations', 'Impossible de charger les stations.'))
   }
   try {
-    const iRes = await api.get('/fuel-station/incidents?per_page=100', { _skipAuthRedirect: true })
+    const iRes = await api.get('/fuel-station/incidents?per_page=100', { _skipAuthRedirect: true, _skipToast: true })
     incidents.value = iRes.data.data || []
-  } catch {
-    errors.value.incidents = t('fuel.errIncidents', 'Impossible de charger les incidents.')
+  } catch (err) {
+    handleFailure(err, 'incidents', t('fuel.errIncidents', 'Impossible de charger les incidents.'))
   }
   try {
-    const rRes = await api.get('/fuel-station/reconciliations?status=pending_review&per_page=100', { _skipAuthRedirect: true })
+    const rRes = await api.get('/fuel-station/reconciliations?status=pending_review&per_page=100', { _skipAuthRedirect: true, _skipToast: true })
     reconciliations.value = rRes.data.data || []
-  } catch {
-    errors.value.reconciliations = t('fuel.errReconciliations', 'Impossible de charger les rapprochements.')
+  } catch (err) {
+    handleFailure(err, 'reconciliations', t('fuel.errReconciliations', 'Impossible de charger les rapprochements.'))
   }
   stats.value = {
     stations: stations.value.length,

--- a/front/admin-dashboard/src/views/settings/SettingsView.vue
+++ b/front/admin-dashboard/src/views/settings/SettingsView.vue
@@ -319,7 +319,10 @@ const bankingForm = reactive({ company_iban: '', company_bic: '' })
 async function loadBanking() {
   isBankingLoading.value = true
   try {
-    const res = await api.get('/company/banking')
+    // #6714 : /company/banking est un endpoint TENANT — un super-admin
+    // reçoit 401 ; _skipAuthRedirect (#4170) évite que l'intercepteur
+    // détruise la session admin (repro : ouvrir Paramètres déconnectait).
+    const res = await api.get('/company/banking', { _skipAuthRedirect: true })
     const data = res.data?.data || {}
     bankingData.company_iban = data.company_iban ?? null
     bankingData.company_bic = data.company_bic ?? null
@@ -338,10 +341,11 @@ async function loadBanking() {
 async function submitBanking() {
   isSavingBanking.value = true
   try {
+    // #6714 : même opt-out que le GET — jamais de déconnexion de session.
     const res = await api.patch('/company/banking', {
       company_iban: bankingForm.company_iban.trim().toUpperCase().replace(/\s/g, '') || null,
       company_bic: bankingForm.company_bic.trim().toUpperCase() || null,
-    })
+    }, { _skipAuthRedirect: true })
     const data = res.data?.data || {}
     bankingData.company_iban = data.company_iban ?? null
     bankingData.company_bic = data.company_bic ?? null

--- a/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
@@ -135,11 +135,14 @@ async function checkGate() {
   gateStatus.value = 'checking'
   gateError.value = ''
   try {
-    await api.get('/travel/ping', { _skipAuthRedirect: true })
+    await api.get('/travel/ping', { _skipAuthRedirect: true, _skipToast: true })
     gateStatus.value = 'ready'
   } catch (err) {
     const status = err.response?.status
-    if (status === 403) {
+    // #6713 : le backend BC-24 n'est pas encore livré sur main (#6127) —
+    // /travel/ping répond 404 au lieu du 403 attendu. Les deux états sont
+    // « module non disponible » : jamais d'erreur rouge + Retry.
+    if (status === 403 || status === 404) {
       gateStatus.value = 'disabled'
     } else {
       gateStatus.value = 'error'


### PR DESCRIPTION
## Lot pages admin-dashboard (frontend)

### #6714 — Paramètres déconnecte le super admin
`SettingsView` appelait `/company/banking` (endpoint tenant) sans `_skipAuthRedirect` → 401 → l'intercepteur détruisait la session. Correctif : opt-out sur GET + PATCH (pattern #4170).

### #6712 — Page Fuel stations : 3 toasts permanents
`FuelManagerView` appelle 3 endpoints BC-15 non livrés (#6373) → 404. Correctif : `_skipToast` + état honnête « API FuelStation en préparation » (bannière ambre) au lieu de 3 toasts d'erreur + tableaux vides. i18n ×4 (fr/en/tr/ar).

### #6713 — Page Travel agency : fausse panne permanente
`/travel/ping` n'existe pas (backend BC-24 #6127 non livré) → 404 non géré par le gate (403 attendu). Correctif : 404 traité comme « module non activé » (état ambre, pas d'erreur rouge + Retry) + `_skipToast`.

Vérifié : ESLint 0 erreur, vite build OK (VITE_API_URL fourni).

Closes #6714
Closes #6712
Closes #6713