### PR TITLE
fix(admin): dashboard — settings 401 #6714, middleware Sanctum #6726, fuel référentiel #6712, gate travel #6713

### DIFF
--- a/api/app/Modules/FuelStation/Interfaces/Api/V1/Controllers/FuelStationReferentialController.php
+++ b/api/app/Modules/FuelStation/Interfaces/Api/V1/Controllers/FuelStationReferentialController.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\FuelStation\Interfaces\Api\V1\Controllers;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * #6712 — Référentiel FuelStation consommé par le dashboard admin
+ * (`FuelManagerView.vue`) : stations, incidents (équipements non actifs) et
+ * rapprochements de caisse.
+ *
+ * Read-only, tenant-scoped (auth:sanctum + api.manager), pagination bornée.
+ * NB : l'API « référentiel » complète est planifiée (#6391/#6373) — ici on
+ * sert les VRAIES tables existantes (fuel_stations, fuel_cash_sessions,
+ * fuel_pumps/fuel_tanks) pour débloquer l'UI sans contrat fantôme.
+ */
+final class FuelStationReferentialController extends Controller
+{
+    public function stations(Request $request): JsonResponse
+    {
+        $this->assertManager($request);
+
+        $query = DB::table('fuel_stations')
+            ->where('company_id', currentCompany()->id);
+
+        $status = (string) $request->query('status', '');
+        if ($status !== '') {
+            $query->where('status', $status);
+        }
+
+        $stations = $query
+            ->orderBy('name')
+            ->paginate(min(max($request->integer('per_page', 100), 1), 200))
+            ->through(fn (object $station): array => [
+                'id' => $station->id,
+                'code' => $station->code,
+                'name' => $station->name,
+                'address' => $station->address,
+                'phone' => $station->phone,
+                'timezone' => $station->timezone,
+                'currency' => $station->currency,
+                'status' => $station->status,
+                'created_at' => $station->created_at,
+            ]);
+
+        return new JsonResponse(['data' => $stations->items()]);
+    }
+
+    public function incidents(Request $request): JsonResponse
+    {
+        $this->assertManager($request);
+
+        $companyId = currentCompany()->id;
+
+        // Incidents dérivés : équipements (pompes/cuves) non actifs.
+        // Pas de table d'incidents dédiée à ce stade (#6712) — l'UI affiche
+        // le titre/type/priorité dérivés de l'état de l'équipement.
+        $pumps = DB::table('fuel_pumps')
+            ->where('company_id', $companyId)
+            ->whereIn('status', ['inactive', 'retired'])
+            ->get(['id', 'station_id', 'code', 'status', 'updated_at']);
+
+        $tanks = DB::table('fuel_tanks')
+            ->where('company_id', $companyId)
+            ->whereIn('status', ['inactive', 'retired'])
+            ->get(['id', 'station_id', 'code', 'status', 'updated_at']);
+
+        $stations = DB::table('fuel_stations')
+            ->where('company_id', $companyId)
+            ->pluck('name', 'id');
+
+        $incidents = [];
+
+        foreach ($pumps as $pump) {
+            $incidents[] = $this->incidentRow('pump', $pump, $stations, 'Pompe');
+        }
+        foreach ($tanks as $tank) {
+            $incidents[] = $this->incidentRow('tank', $tank, $stations, 'Cuve');
+        }
+
+        // Tri par date décroissante (plus récent d'abord).
+        usort($incidents, static fn (array $a, array $b): int => strcmp((string) $b['created_at'], (string) $a['created_at']));
+
+        return new JsonResponse(['data' => $incidents]);
+    }
+
+    public function reconciliations(Request $request): JsonResponse
+    {
+        $this->assertManager($request);
+
+        $query = DB::table('fuel_cash_sessions')
+            ->where('company_id', currentCompany()->id);
+
+        // L'UI demande status=pending_review (rapprochements à valider) :
+        // sessions closes non approuvées (+ approuvées pour l'historique).
+        $status = (string) $request->query('status', '');
+        if ($status === 'pending_review') {
+            $query->whereIn('status', ['closed', 'approved']);
+        } elseif ($status !== '') {
+            $query->where('status', $status);
+        }
+
+        $reconciliations = $query
+            ->orderByDesc('closed_at')
+            ->paginate(min(max($request->integer('per_page', 100), 1), 200))
+            ->through(fn (object $session): array => [
+                'id' => $session->id,
+                'station_id' => $session->station_id,
+                'status' => $session->status,
+                'opened_at' => $session->opened_at,
+                'closed_at' => $session->closed_at,
+                'opening_balance' => $session->opening_balance,
+                'closing_balance' => $session->closing_balance,
+                'expected_balance' => $session->expected_balance,
+                'variance' => $session->variance,
+                'report_date' => $session->closed_at ?? $session->opened_at,
+                'approved_by' => $session->approved_by,
+            ]);
+
+        return new JsonResponse(['data' => $reconciliations->items()]);
+    }
+
+    private function assertManager(Request $request): void
+    {
+        /** @var Employee|null $actor */
+        $actor = $request->user();
+        abort_unless($actor?->isManager(), 403, 'FORBIDDEN');
+    }
+
+    /**
+     * @param  Collection<int, string>  $stations
+     * @return array<string, mixed>
+     */
+    private function incidentRow(string $equipmentType, object $equipment, $stations, string $label): array
+    {
+        $statusLabel = $equipment->status === 'retired' ? 'retiré' : 'inactif';
+
+        return [
+            'id' => $equipmentType.'-'.$equipment->id,
+            'title' => "{$label} {$equipment->code} — {$statusLabel}",
+            'description' => "Équipement {$equipment->code} (station ".($stations[$equipment->station_id] ?? '#'.$equipment->station_id).') '.$statusLabel.'.',
+            'equipment_type' => $equipmentType,
+            'equipment_code' => $equipment->code,
+            'station_id' => $equipment->station_id,
+            'priority' => $equipment->status === 'retired' ? 'high' : 'medium',
+            'status' => $equipment->status,
+            'created_at' => $equipment->updated_at,
+        ];
+    }
+}

--- a/api/routes/modules/fuel_station.php
+++ b/api/routes/modules/fuel_station.php
@@ -21,9 +21,19 @@ use App\Modules\FuelStation\Interfaces\Api\V1\Controllers\FuelMeterReadingContro
 use App\Modules\FuelStation\Interfaces\Api\V1\Controllers\FuelPresenceController;
 use App\Modules\FuelStation\Interfaces\Api\V1\Controllers\FuelSaleController;
 use App\Modules\FuelStation\Interfaces\Api\V1\Controllers\FuelShiftController;
+use App\Modules\FuelStation\Interfaces\Api\V1\Controllers\FuelStationReferentialController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['throttle:api', 'auth:sanctum', 'token.refresh', 'tenant', 'throttle:api-plan'])->group(function (): void {
+    // #6712 — référentiel read-only consommé par le dashboard admin
+    // (FuelManagerView) : stations, incidents (équipements non actifs),
+    // rapprochements de caisse. RBAC manager.
+    Route::middleware('api.manager')->group(function (): void {
+        Route::get('/fuel-station/stations', [FuelStationReferentialController::class, 'stations']);
+        Route::get('/fuel-station/incidents', [FuelStationReferentialController::class, 'incidents']);
+        Route::get('/fuel-station/reconciliations', [FuelStationReferentialController::class, 'reconciliations']);
+    });
+
     // FUEL-004 — relevés de compteur par pompe (spec §13.4).
     Route::post('/fuel-station/stations/{station}/pumps/{pump}/meters/{meter}/readings', [FuelMeterReadingController::class, 'record'])
         ->whereNumber('station')

--- a/api/tests/Feature/FuelStation/FuelStationReferentialTest.php
+++ b/api/tests/Feature/FuelStation/FuelStationReferentialTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\FuelStation;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Support\Facades\DB;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #6712 — le dashboard admin « Fuel stations » appelle 3 endpoints
+ * (stations, incidents, reconciliations) qui n'existaient pas → 3 toasts
+ * d'erreur permanents. Le référentiel read-only est désormais servi sur les
+ * VRAIES tables fuel.
+ */
+class FuelStationReferentialTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private Company $company;
+
+    private Employee $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Company $company */
+        $company = Company::factory()->create([
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'country' => 'DZ',
+            'currency' => 'DZD',
+            'timezone' => 'Africa/Algiers',
+        ]);
+        $this->company = $company;
+
+        /** @var Employee $manager */
+        $manager = Employee::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'manager',
+            'manager_role' => 'principal',
+        ]);
+        $this->manager = $manager;
+
+        DB::statement('SET search_path TO shared_tenants,public');
+    }
+
+    public function test_stations_endpoint_lists_fuel_stations(): void
+    {
+        DB::table('fuel_stations')->insert([
+            'company_id' => $this->company->id,
+            'code' => 'ST-001',
+            'name' => 'Station Alger Centre',
+            'timezone' => 'Africa/Algiers',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->actingAs($this->manager)
+            ->getJson('/api/v1/fuel-station/stations?per_page=100')
+            ->assertOk()
+            ->assertJsonPath('data.0.code', 'ST-001')
+            ->assertJsonPath('data.0.name', 'Station Alger Centre')
+            ->assertJsonPath('data.0.status', 'active');
+    }
+
+    public function test_incidents_endpoint_derives_from_inactive_equipment(): void
+    {
+        $stationId = DB::table('fuel_stations')->insertGetId([
+            'company_id' => $this->company->id,
+            'code' => 'ST-002',
+            'name' => 'Station Oran',
+            'timezone' => 'Africa/Algiers',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('fuel_pumps')->insert([
+            'company_id' => $this->company->id,
+            'station_id' => $stationId,
+            'code' => 'P-01',
+            'status' => 'retired',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->actingAs($this->manager)
+            ->getJson('/api/v1/fuel-station/incidents?per_page=100')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.equipment_type', 'pump')
+            ->assertJsonPath('data.0.priority', 'high');
+    }
+
+    public function test_reconciliations_endpoint_maps_pending_review(): void
+    {
+        $stationId = DB::table('fuel_stations')->insertGetId([
+            'company_id' => $this->company->id,
+            'code' => 'ST-003',
+            'name' => 'Station Blida',
+            'timezone' => 'Africa/Algiers',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('fuel_cash_sessions')->insert([
+            'company_id' => $this->company->id,
+            'station_id' => $stationId,
+            'opened_by' => $this->manager->id,
+            'opened_at' => now()->subDay(),
+            'closed_at' => now(),
+            'opening_balance' => 1000,
+            'closing_balance' => 1500,
+            'expected_balance' => 1490,
+            'variance' => 10,
+            'status' => 'closed',
+            'created_at' => now()->subDay(),
+            'updated_at' => now(),
+        ]);
+
+        $this->actingAs($this->manager)
+            ->getJson('/api/v1/fuel-station/reconciliations?status=pending_review&per_page=100')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.status', 'closed')
+            ->assertJsonPath('data.0.variance', '10.00');
+    }
+
+    public function test_referential_requires_manager_role(): void
+    {
+        /** @var Employee $employee */
+        $employee = Employee::factory()->create([
+            'company_id' => $this->company->id,
+            'role' => 'employee',
+        ]);
+
+        $this->actingAs($employee)
+            ->getJson('/api/v1/fuel-station/stations')
+            ->assertForbidden();
+    }
+}

--- a/front/admin-dashboard/src/views/settings/SettingsView.vue
+++ b/front/admin-dashboard/src/views/settings/SettingsView.vue
@@ -319,7 +319,12 @@ const bankingForm = reactive({ company_iban: '', company_bic: '' })
 async function loadBanking() {
   isBankingLoading.value = true
   try {
-    const res = await api.get('/company/banking')
+    // #6714 : /company/banking est une route TENANT — le super admin reçoit
+    // 401 attendu. Sans _skipAuthRedirect, l'intercepteur détruisait la
+    // session admin (removeAuthToken + redirect /login) au simple clic sur
+    // « Paramètres ». Le code gère déjà l'échec proprement (console.warn +
+    // section désactivée).
+    const res = await api.get('/company/banking', { _skipAuthRedirect: true })
     const data = res.data?.data || {}
     bankingData.company_iban = data.company_iban ?? null
     bankingData.company_bic = data.company_bic ?? null

--- a/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
+++ b/front/admin-dashboard/src/views/travel/TravelAgencyView.vue
@@ -130,6 +130,11 @@ function selectTab(tab) {
  * signifie que le flag « travelagency » est désactivé pour le tenant connecté.
  * _skipAuthRedirect (#4170) : un 401 (super-admin hors contexte tenant) ne
  * doit pas détruire la session admin.
+ *
+ * #6713 : le backend BC-24 n'est pas encore livré (#6127) — /travel/ping
+ * répond 404. On traite 404 comme « module non activé » (état propre,
+ * pas une fausse panne avec Retry permanent). Le 403 du middleware
+ * module.travelagency prendra le relais quand #6127 sera livré.
  */
 async function checkGate() {
   gateStatus.value = 'checking'
@@ -139,7 +144,9 @@ async function checkGate() {
     gateStatus.value = 'ready'
   } catch (err) {
     const status = err.response?.status
-    if (status === 403) {
+    if (status === 403 || status === 404) {
+      // 403 = flag désactivé ; 404 = backend pas encore livré (#6127) :
+      // dans les deux cas le module n'est pas disponible → état « disabled ».
       gateStatus.value = 'disabled'
     } else {
       gateStatus.value = 'error'

--- a/front/web/src/lib/__tests__/session-token.test.ts
+++ b/front/web/src/lib/__tests__/session-token.test.ts
@@ -1,0 +1,33 @@
+import { isValidSessionTokenShape } from '@/lib/session-token';
+
+/**
+ * Issue #6726 — la garde de forme du token de session (middleware Next.js)
+ * doit accepter les tokens Sanctum `{id}|{plaintext}` : le regex historique
+ * excluait le `|` → tout utilisateur authentifié était redirigé en boucle
+ * vers /auth/login (dashboard web mort en prod).
+ */
+describe('isValidSessionTokenShape (#6726)', () => {
+  it('accepte un vrai token Sanctum id|plain (format prod)', () => {
+    expect(isValidSessionTokenShape('990|1FVyYnVzSbMu8F1OCOtkXyZ1234567890ab')).toBe(true);
+  });
+
+  it('accepte la forme legacy simple (sans pipe)', () => {
+    expect(isValidSessionTokenShape('1FVyYnVzSbMu8F1OCOtkXyZ1234567890ab')).toBe(true);
+  });
+
+  it('rejette les tokens trop courts', () => {
+    expect(isValidSessionTokenShape('short')).toBe(false);
+    expect(isValidSessionTokenShape('12|short')).toBe(false);
+  });
+
+  it('rejette l’absence de token', () => {
+    expect(isValidSessionTokenShape(undefined)).toBe(false);
+    expect(isValidSessionTokenShape(null)).toBe(false);
+    expect(isValidSessionTokenShape('')).toBe(false);
+  });
+
+  it('rejette les valeurs manifestement invalides (gate cosmétique #3522)', () => {
+    expect(isValidSessionTokenShape('ééééééééééééééééééééééééé')).toBe(false);
+    expect(isValidSessionTokenShape('$$$$$$$$$$$$$$$$$$$$$$$')).toBe(false);
+  });
+});

--- a/front/web/src/lib/session-token.ts
+++ b/front/web/src/lib/session-token.ts
@@ -1,0 +1,24 @@
+/**
+ * Garde de forme « cosmétique » du cookie de session (gate UX du middleware
+ * Next.js, issue #3522). Ce n'est PAS une frontière de sécurité : la vraie
+ * auth est côté serveur (API). Elle évite seulement de servir le HTML/JS du
+ * dashboard à un visiteur manifestement non authentifié.
+ *
+ * #6726 : les tokens Sanctum ont le format `{id}|{plaintext}` (ex.
+ * "990|1FVyYnVzSbMu8F1OCOtk…"). Le regex historique excluait le séparateur
+ * `|` → tout utilisateur authentifié était redirigé en boucle vers
+ * /auth/login (dashboard web mort en prod).
+ */
+export function isValidSessionTokenShape(token: string | undefined | null): boolean {
+  if (!token || token.length < 20) {
+    return false;
+  }
+
+  // Forme legacy simple (token sans pipe).
+  if (/^[A-Za-z0-9._-]+$/.test(token)) {
+    return true;
+  }
+
+  // Forme Sanctum : `{id}|{plaintext}` (#6726).
+  return /^[0-9]+\|[A-Za-z0-9._-]{20,}$/.test(token);
+}

--- a/front/web/src/middleware.ts
+++ b/front/web/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { isSupportedLocale, resolveSsrVitrineLang } from '@/lib/i18n';
+import { isValidSessionTokenShape } from '@/lib/session-token';
 
 /**
  * Middleware de protection serveur de la zone dashboard (QA wave 2026-08-14,
@@ -46,8 +47,9 @@ export function middleware(request: NextRequest) {
     // the client-side app mounts. It is NOT a security boundary: a valid
     // shape here does not mean a valid session. Real authentication and
     // authorization are enforced server-side by the API on every request.
-    const isValidToken =
-      !!token && token.length >= 20 && /^[A-Za-z0-9._-]+$/.test(token);
+    // #6726 : la garde accepte désormais les tokens Sanctum `{id}|{plain}`
+    // (le `|` était exclu du regex → boucle de redirection en prod).
+    const isValidToken = isValidSessionTokenShape(token);
 
     if (!isValidToken) {
       const loginUrl = new URL('/auth/login', request.url);


### PR DESCRIPTION
## Lot 3 — bugs admin-dashboard / web dashboard (agent PM)

### Issues fermées (4)
- **Closes #6714** — Paramètres : `_skipAuthRedirect` sur `/company/banking` (route tenant → 401 attendu super-admin, l'intercepteur détruisait la session)
- **Closes #6726** — middleware Next.js : tokens Sanctum `{id}|{plain}` acceptés (le `|` était exclu → boucle /auth/login, dashboard web mort en prod) ; validation extraite en `lib/session-token.ts` + tests unitaires
- **Closes #6712** — Fuel stations : les 3 endpoints (stations/incidents/reconciliations) servis sur les VRAIES tables (`fuel_stations`, équipements non actifs → incidents, `fuel_cash_sessions` → rapprochements) + tests + RBAC manager
- **Closes #6713** — TravelAgency : le gate traite 404 comme « module non activé » (backend BC-24 #6127 pas encore livré) — plus de fausse panne + Retry permanent

### Validations
- Tests : FuelStationReferential 4/4 · session-token 5/5 (unitaires) · Pint OK