### PR TITLE
fix(auth): forgot-password — SMTP down ne casse plus le parcours ni l'anti-énumération (Closes #6751)

### DIFF
--- a/api/app/Core/Auth/Interfaces/Api/V1/PasswordResetController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/PasswordResetController.php
@@ -11,11 +11,11 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules\Password;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
 
 /**
  * Issue #2626 — réinitialisation de mot de passe.
@@ -60,7 +60,20 @@ class PasswordResetController
                 'updated_at' => now(),
             ]);
 
-            Mail::to($email)->send(new PasswordResetMail($token, $email));
+            // #6751 : un échec de TRANSPORT (SMTP injoignable, credentials
+            // invalides) ne doit NI casser le parcours (500) NI fuiter
+            // l'existence du compte (200 inconnu vs 500 existant = énumération).
+            // Le token est déjà en base : l'échec est tracé (report → Sentry/logs),
+            // et la réponse publique reste la réponse anti-énumération standard.
+            try {
+                Mail::to($email)->send(new PasswordResetMail($token, $email));
+            } catch (\Throwable $exception) {
+                report($exception);
+                Log::warning('auth.password_reset.mail_send_failed', [
+                    'email_domain' => substr((string) strrchr($email, '@'), 1),
+                    'exception' => $exception->getMessage(),
+                ]);
+            }
         }
 
         return new JsonResponse([

--- a/api/tests/Feature/Auth/ForgotPasswordNoEnumerationTest.php
+++ b/api/tests/Feature/Auth/ForgotPasswordNoEnumerationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use RuntimeException;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * Issue #6751 — POST /auth/forgot-password :
+ *  - un échec de transport email (SMTP down) ne doit NI produire un 500 NI
+ *    différencier la réponse (anti-énumération 200 inconnu vs 500 existant) ;
+ *  - le token est tout de même inséré en base (réessai possible côté ops).
+ */
+class ForgotPasswordNoEnumerationTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    private function existingEmployee(): Employee
+    {
+        /** @var Company $company */
+        $company = Company::factory()->create([
+            'schema_name' => 'shared_tenants',
+            'tenancy_type' => 'shared',
+            'country' => 'DZ',
+        ]);
+
+        /** @var Employee $employee */
+        $employee = new Employee(['email' => 'fatima.meziane@techcorp-algerie.dz']);
+        $employee->forceFill([
+            'password_hash' => Hash::make('password123'),
+            'first_name' => 'Fatima',
+            'last_name' => 'Meziane',
+        ])->save();
+        $employee->forceFill([
+            'company_id' => $company->id,
+            'role' => 'manager',
+            'manager_role' => 'rh',
+            'status' => 'active',
+        ])->save();
+
+        return $employee;
+    }
+
+    public function test_unknown_email_returns_200_anti_enumeration(): void
+    {
+        $this->postJson('/api/v1/auth/forgot-password', ['email' => 'inconnu-xyz@test.invalid'])
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('message', 'PASSWORD_RESET_SENT');
+    }
+
+    public function test_existing_email_with_mail_transport_failure_still_returns_200(): void
+    {
+        // #6751 : l'envoi SMTP échoue (transport down) → le parcours ne doit
+        // pas 500 : réponse anti-énumération identique à l'email inconnu.
+        $this->existingEmployee();
+
+        Mail::shouldReceive('to')->once()->andThrow(new RuntimeException('Failed to authenticate on SMTP server'));
+
+        $this->postJson('/api/v1/auth/forgot-password', ['email' => 'fatima.meziane@techcorp-algerie.dz'])
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('message', 'PASSWORD_RESET_SENT');
+
+        // Le token est quand même inséré en base (réessai possible).
+        $this->assertDatabaseHas('public.password_reset_tokens', [
+            'email' => 'fatima.meziane@techcorp-algerie.dz',
+        ]);
+    }
+
+    public function test_existing_email_with_mail_ok_returns_200_and_inserts_token(): void
+    {
+        Mail::fake();
+
+        $this->existingEmployee();
+
+        $this->postJson('/api/v1/auth/forgot-password', ['email' => 'fatima.meziane@techcorp-algerie.dz'])
+            ->assertOk()
+            ->assertJsonPath('message', 'PASSWORD_RESET_SENT');
+
+        $this->assertDatabaseHas('public.password_reset_tokens', [
+            'email' => 'fatima.meziane@techcorp-algerie.dz',
+        ]);
+    }
+}


### PR DESCRIPTION
## #6751 — POST /auth/forgot-password → 500 pour tout email existant

### Cause racine
`PasswordResetController::forgot()` : l'envoi `Mail::to()->send(PasswordResetMail)` n'était pas protégé — une exception de transport SMTP remontait en 500, révélant l'existence du compte (200 inconnu vs 500 existant).

### Correctif
- `try/catch (Throwable)` autour de l'envoi : `report()` (Sentry/logs) + réponse anti-énumération standard `200 PASSWORD_RESET_SENT` dans TOUS les cas ;
- le token reste inséré en base (réessai ops possible) ;
- log sans PII (domaine seulement).

### Tests (3 nouveaux + 12 existants verts)
- email inconnu → 200 ;
- email existant + transport SMTP en échec → **200** (avant : 500) + token en base ;
- email existant + mail OK → 200 + token en base.