### PR TITLE
fix(auth): forgot-password — SMTP en échec = 200 anti-énumération (Closes #6751)

### DIFF
--- a/api/app/Core/Auth/Interfaces/Api/V1/PasswordResetController.php
+++ b/api/app/Core/Auth/Interfaces/Api/V1/PasswordResetController.php
@@ -11,11 +11,11 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules\Password;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
 
 /**
  * Issue #2626 — réinitialisation de mot de passe.
@@ -37,6 +37,7 @@ class PasswordResetController
 
     public function forgot(Request $request): JsonResponse
     {
+        /** @var array{email: string} $validated */
         $validated = $request->validate([
             'email' => ['required', 'email', 'max:255'],
         ]);
@@ -60,7 +61,20 @@ class PasswordResetController
                 'updated_at' => now(),
             ]);
 
-            Mail::to($email)->send(new PasswordResetMail($token, $email));
+            // Issue #6751 (P1) : un échec de transport SMTP ne doit NI faire
+            // 500 NI différencier la réponse publique (anti-énumération #2626 :
+            // 200 identique que l'email existe ou non). Le jeton est déjà en
+            // base ; l'email sera retenté par l'équipe ops (log) — le parcours
+            // « mot de passe oublié » reste fonctionnel côté utilisateur.
+            try {
+                Mail::to($email)->send(new PasswordResetMail($token, $email));
+            } catch (\Throwable $exception) {
+                Log::error('auth.forgot_password_mail_failed', [
+                    'email' => $email,
+                    'employee_id' => $employee->id,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
         }
 
         return new JsonResponse([
@@ -74,6 +88,7 @@ class PasswordResetController
     {
         // #5620 — Password::min(8)->numbers() : au moins un chiffre,
         // cohérent avec l'indicateur de force du frontend.
+        /** @var array{email: string, token: string, password: string, password_confirmation: string} $validated */
         $validated = $request->validate([
             'email' => ['required', 'email', 'max:255'],
             'token' => ['required', 'string', 'max:64'],
@@ -84,6 +99,7 @@ class PasswordResetController
         $email = strtolower(trim($validated['email']));
         $tokenHash = hash('sha256', $validated['token']);
 
+        /** @var object{used_at: string|null, expires_at: string}|null $row */
         $row = DB::table('public.password_reset_tokens')
             ->where('email', $email)
             ->where('token_hash', $tokenHash)
@@ -246,6 +262,7 @@ class PasswordResetController
             return Schema::hasTable('user_lookups');
         }
 
+        /** @var object{table_name: string|null}|null $table */
         $table = DB::selectOne("select to_regclass('public.user_lookups') as table_name");
 
         return $table?->table_name !== null;
@@ -253,6 +270,7 @@ class PasswordResetController
 
     private function tenantEmployeesTableExists(string $schema): bool
     {
+        /** @var object{table_name: string|null}|null $table */
         $table = DB::selectOne('select to_regclass(?) as table_name', [$schema.'.employees']);
 
         return $table?->table_name !== null;
@@ -265,9 +283,12 @@ class PasswordResetController
 
     private function currentSearchPath(): ?string
     {
+        /** @var array{search_path?: mixed} $result */
         $result = (array) DB::selectOne('SHOW search_path');
 
-        return isset($result['search_path']) ? (string) $result['search_path'] : null;
+        $path = $result['search_path'] ?? null;
+
+        return \is_string($path) ? $path : null;
     }
 
     private function setTenantSearchPath(string $schema): void

--- a/api/tests/Feature/PasswordResetTest.php
+++ b/api/tests/Feature/PasswordResetTest.php
@@ -7,9 +7,13 @@ namespace Tests\Feature;
 use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Auth\Infrastructure\Mail\PasswordResetMail;
 use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;
 
@@ -42,7 +46,7 @@ class PasswordResetTest extends TestCase
 
     private function issueToken(string $email, ?string $expiresAt = null): string
     {
-        $token = 'reset-token-'.str()->random(20);
+        $token = 'reset-token-'.Str::random(20);
         DB::table('public.password_reset_tokens')->insert([
             'email' => $email,
             'token_hash' => hash('sha256', $token),
@@ -61,7 +65,36 @@ class PasswordResetTest extends TestCase
         $this->postJson('/api/v1/auth/forgot-password', ['email' => 'reset-me@example.com'])
             ->assertOk();
 
-        Mail::assertSent(PasswordResetMail::class, fn ($mail) => $mail->hasTo('reset-me@example.com'));
+        Mail::assertSent(PasswordResetMail::class, fn (PasswordResetMail $mail) => $mail->hasTo('reset-me@example.com'));
+        $this->assertDatabaseHas('password_reset_tokens', ['email' => 'reset-me@example.com']);
+    }
+
+    public function test_forgot_password_returns_200_even_when_mail_transport_fails(): void
+    {
+        // Issue #6751 (P1) : un échec d'envoi (SMTP injoignable) ne doit ni
+        // faire 500 ni fuiter l'existence du compte — réponse 200 générique
+        // identique, jeton persisté, échec loggé.
+        Mail::extend('smtp-down', function () {
+            return new class extends AbstractTransport
+            {
+                protected function doSend(SentMessage $message): void
+                {
+                    throw new \RuntimeException('SMTP unreachable (test #6751)');
+                }
+
+                public function __toString(): string
+                {
+                    return 'smtp-down';
+                }
+            };
+        });
+        config(['mail.default' => 'smtp-down']);
+
+        $this->postJson('/api/v1/auth/forgot-password', ['email' => 'reset-me@example.com'])
+            ->assertOk()
+            ->assertJson(['success' => true, 'message' => 'PASSWORD_RESET_SENT']);
+
+        // Le jeton est bien créé (le parcours pourra être retenté).
         $this->assertDatabaseHas('password_reset_tokens', ['email' => 'reset-me@example.com']);
     }
 
@@ -107,7 +140,7 @@ class PasswordResetTest extends TestCase
         ]);
 
         $searchPathStatements = [];
-        DB::listen(static function ($query) use (&$searchPathStatements): void {
+        DB::listen(static function (QueryExecuted $query) use (&$searchPathStatements): void {
             if (str_starts_with(strtolower(trim((string) $query->sql)), 'set search_path')) {
                 $searchPathStatements[] = $query->sql;
             }
@@ -299,7 +332,7 @@ class PasswordResetTest extends TestCase
             ->assertOk();
 
         $rawToken = null;
-        Mail::assertSent(PasswordResetMail::class, function ($mail) use (&$rawToken) {
+        Mail::assertSent(PasswordResetMail::class, function (PasswordResetMail $mail) use (&$rawToken) {
             $rawToken = $mail->token;
 
             return $mail->hasTo('schema-tenant@example.com');
@@ -324,7 +357,7 @@ class PasswordResetTest extends TestCase
         $this->assertTrue(
             Hash::check(
                 'new-password-123',
-                (string) DB::table($schema.'.employees')->where('id', $employeeId)->value('password_hash')
+                \is_string(DB::table($schema.'.employees')->where('id', $employeeId)->value('password_hash')) ? (string) DB::table($schema.'.employees')->where('id', $employeeId)->value('password_hash') : ''
             ),
             'Le mot de passe doit être mis à jour dans le schéma tenant.'
         );


### PR DESCRIPTION
**Closes #6751 (P1 security)** — `POST /auth/forgot-password` renvoyait 500 dès que l'email existe (échec SMTP non attrapé) → parcours cassé + fuite d'énumération (200 inconnu / 500 existant).

- L'envoi `Mail::to()->send()` est enveloppé dans un try/catch : échec loggé (`auth.forgot_password_mail_failed`), réponse 200 générique `PASSWORD_RESET_SENT` inchangée (anti-énumération #2626). Le jeton reste persisté (retry possible).
- Test : transport SMTP qui lève une exception → 200 + jeton en base + réponse uniforme.
- Vérifié : PasswordResetTest + PasswordResetLocalizationTest 13 tests / 46 assertions ✓, PHPStan strict 0 erreur (fichiers nettoyés des erreurs préexistantes), Pint ✓.