### PR TITLE
fix(ci): PHPStan strict level 8 — module Delivery assaini (déblocage main vert, Part of #6749)

### DIFF
--- a/api/app/Jobs/GenerateDeliveryExportJob.php
+++ b/api/app/Jobs/GenerateDeliveryExportJob.php
@@ -84,6 +84,9 @@ class GenerateDeliveryExportJob implements ShouldQueue, TenantScopedJob
                 ->get();
 
             $handle = fopen('php://temp', 'w+');
+            if ($handle === false) {
+                throw new \RuntimeException("Impossible d'ouvrir le flux CSV de sortie.");
+            }
             fputcsv($handle, [
                 'reference', 'source', 'type', 'status', 'cod_amount_minor',
                 'dropoff_address', 'created_at', 'delivered_at',

--- a/api/app/Modules/Delivery/Application/Services/DeliveryCodSettlementService.php
+++ b/api/app/Modules/Delivery/Application/Services/DeliveryCodSettlementService.php
@@ -100,7 +100,7 @@ final class DeliveryCodSettlementService
                 'collected_at' => now(),
             ])->save();
 
-            return $settlement->fresh();
+            return $this->freshSettlement($settlement);
         });
     }
 
@@ -133,7 +133,7 @@ final class DeliveryCodSettlementService
                 'settled_at' => now(),
             ])->save();
 
-            return $settlement->fresh();
+            return $this->freshSettlement($settlement);
         });
     }
 
@@ -155,8 +155,19 @@ final class DeliveryCodSettlementService
 
             $settlement->forceFill(['status' => 'reconciled'])->save();
 
-            return $settlement->fresh();
+            return $this->freshSettlement($settlement);
         });
+    }
+
+    private function freshSettlement(DeliveryCodSettlement $settlement): DeliveryCodSettlement
+    {
+        $fresh = $settlement->fresh();
+
+        if ($fresh === null) {
+            abort(500, 'SETTLEMENT_RELOAD_FAILED');
+        }
+
+        return $fresh;
     }
 
     private function lockSettlement(int $settlementId, string $companyId): DeliveryCodSettlement

--- a/api/app/Modules/Delivery/Application/Services/DeliveryReportService.php
+++ b/api/app/Modules/Delivery/Application/Services/DeliveryReportService.php
@@ -78,13 +78,13 @@ final class DeliveryReportService
             ->first();
 
         return [
-            'deliveries' => (int) ($row->getAttribute('deliveries') ?? 0),
-            'delivered' => (int) ($row->getAttribute('delivered') ?? 0),
-            'failed' => (int) ($row->getAttribute('failed') ?? 0),
-            'cancelled' => (int) ($row->getAttribute('cancelled') ?? 0),
-            'returned' => (int) ($row->getAttribute('returned') ?? 0),
-            'avg_delay_minutes' => (int) round((float) ($row->getAttribute('avg_delay_minutes') ?? 0)),
-            'cod_expected_minor' => (int) ($row->getAttribute('cod_expected_minor') ?? 0),
+            'deliveries' => (int) ($row->deliveries ?? 0),
+            'delivered' => (int) ($row->delivered ?? 0),
+            'failed' => (int) ($row->failed ?? 0),
+            'cancelled' => (int) ($row->cancelled ?? 0),
+            'returned' => (int) ($row->returned ?? 0),
+            'avg_delay_minutes' => (int) round((float) ($row->avg_delay_minutes ?? 0)),
+            'cod_expected_minor' => (int) ($row->cod_expected_minor ?? 0),
         ];
     }
 
@@ -169,7 +169,7 @@ final class DeliveryReportService
             ->orderByDesc('deliveries')
             ->get()
             ->map(fn ($row): array => [
-                'driver_id' => $row->driver_id !== null ? (int) $row->driver_id : null,
+                'driver_id' => $row->getAttribute('driver_id') !== null ? (int) $row->getAttribute('driver_id') : null,
                 'deliveries' => (int) $row->getAttribute('deliveries'),
                 'delivered' => (int) $row->getAttribute('delivered'),
             ])

--- a/api/app/Modules/Delivery/Application/Services/DeliveryReportService.php
+++ b/api/app/Modules/Delivery/Application/Services/DeliveryReportService.php
@@ -78,13 +78,13 @@ final class DeliveryReportService
             ->first();
 
         return [
-            'deliveries' => (int) ($row->deliveries ?? 0),
-            'delivered' => (int) ($row->delivered ?? 0),
-            'failed' => (int) ($row->failed ?? 0),
-            'cancelled' => (int) ($row->cancelled ?? 0),
-            'returned' => (int) ($row->returned ?? 0),
-            'avg_delay_minutes' => (int) round((float) ($row->avg_delay_minutes ?? 0)),
-            'cod_expected_minor' => (int) ($row->cod_expected_minor ?? 0),
+            'deliveries' => (int) ($row->getAttribute('deliveries') ?? 0),
+            'delivered' => (int) ($row->getAttribute('delivered') ?? 0),
+            'failed' => (int) ($row->getAttribute('failed') ?? 0),
+            'cancelled' => (int) ($row->getAttribute('cancelled') ?? 0),
+            'returned' => (int) ($row->getAttribute('returned') ?? 0),
+            'avg_delay_minutes' => (int) round((float) ($row->getAttribute('avg_delay_minutes') ?? 0)),
+            'cod_expected_minor' => (int) ($row->getAttribute('cod_expected_minor') ?? 0),
         ];
     }
 
@@ -93,7 +93,7 @@ final class DeliveryReportService
      */
     private function bySource(string $companyId, Carbon $from, Carbon $to): array
     {
-        return Delivery::query()
+        $rows = Delivery::query()
             ->where('company_id', $companyId)
             ->whereBetween('created_at', [$from, $to])
             ->selectRaw(
@@ -107,11 +107,15 @@ final class DeliveryReportService
             ->get()
             ->map(fn ($row): array => [
                 'source' => (string) $row->source,
-                'deliveries' => (int) $row->deliveries,
-                'delivered' => (int) $row->delivered,
-                'success_rate_pct' => $row->deliveries > 0 ? round(((int) $row->delivered / (int) $row->deliveries) * 100, 1) : 0.0,
+                'deliveries' => (int) $row->getAttribute('deliveries'),
+                'delivered' => (int) $row->getAttribute('delivered'),
+                'success_rate_pct' => (int) $row->getAttribute('deliveries') > 0
+                    ? round(((int) $row->getAttribute('delivered') / (int) $row->getAttribute('deliveries')) * 100, 1)
+                    : 0.0,
             ])
             ->all();
+
+        return array_values($rows);
     }
 
     /**
@@ -119,7 +123,7 @@ final class DeliveryReportService
      */
     private function byDay(string $companyId, Carbon $from, Carbon $to): array
     {
-        return Delivery::query()
+        $rows = Delivery::query()
             ->where('company_id', $companyId)
             ->whereBetween('created_at', [$from, $to])
             ->selectRaw(
@@ -132,11 +136,13 @@ final class DeliveryReportService
             ->orderBy('day')
             ->get()
             ->map(fn ($row): array => [
-                'date' => (string) $row->day,
-                'deliveries' => (int) $row->deliveries,
-                'delivered' => (int) $row->delivered,
+                'date' => (string) $row->getAttribute('day'),
+                'deliveries' => (int) $row->getAttribute('deliveries'),
+                'delivered' => (int) $row->getAttribute('delivered'),
             ])
             ->all();
+
+        return array_values($rows);
     }
 
     /**
@@ -144,7 +150,7 @@ final class DeliveryReportService
      */
     private function byDriver(string $companyId, Carbon $from, Carbon $to): array
     {
-        return Delivery::query()
+        $rows = Delivery::query()
             // #675x : qualification explicite — delivery_stops/delivery_routes
             // portent AUSSI company_id/created_at (tables tenant-scopées) →
             // sans préfixe, PostgreSQL lève 42702 « ambiguous column » après
@@ -164,10 +170,12 @@ final class DeliveryReportService
             ->get()
             ->map(fn ($row): array => [
                 'driver_id' => $row->driver_id !== null ? (int) $row->driver_id : null,
-                'deliveries' => (int) $row->deliveries,
-                'delivered' => (int) $row->delivered,
+                'deliveries' => (int) $row->getAttribute('deliveries'),
+                'delivered' => (int) $row->getAttribute('delivered'),
             ])
             ->all();
+
+        return array_values($rows);
     }
 
     private function codCollected(string $companyId, Carbon $from, Carbon $to): int

--- a/api/app/Modules/Delivery/Domain/Models/DeliveryCodSettlement.php
+++ b/api/app/Modules/Delivery/Domain/Models/DeliveryCodSettlement.php
@@ -55,7 +55,6 @@ class DeliveryCodSettlement extends Model
     protected $casts = [
         'collected_at' => 'datetime',
         'settled_at' => 'datetime',
-        'settled_at' => 'datetime',
         'expected_minor' => 'int',
         'collected_minor' => 'int',
         'commission_minor' => 'int',

--- a/api/app/Modules/Delivery/Domain/Support/DeliveryStateMachine.php
+++ b/api/app/Modules/Delivery/Domain/Support/DeliveryStateMachine.php
@@ -56,7 +56,7 @@ final class DeliveryStateMachine
         DeliveryStatus $to,
         bool $hasProof = false,
     ): void {
-        $allowed = self::ALLOWED_TRANSITIONS[$from->value] ?? [];
+        $allowed = self::ALLOWED_TRANSITIONS[$from->value];
 
         if (! in_array($to->value, $allowed, true)) {
             throw InvalidDeliveryTransitionException::notAllowed($from, $to);

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryCodSettlementController.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryCodSettlementController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Modules\Delivery\Interfaces\Api\V1\Controllers;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Delivery\Application\Services\DeliveryCodSettlementService;
 use App\Modules\Delivery\Domain\Models\DeliveryCodSettlement;
 use App\Modules\Delivery\Interfaces\Api\V1\Requests\DeliverySettlementCollectRequest;
@@ -111,7 +112,7 @@ final class DeliveryCodSettlementController
                 ],
                 'by_status' => $rows->map(fn ($row): array => [
                     'status' => (string) $row->status,
-                    'settlements' => (int) $row->settlements,
+                    'settlements' => (int) $row->getAttribute('settlements'),
                     'expected_minor' => (int) $row->expected_minor,
                     'collected_minor' => (int) $row->collected_minor,
                     'commission_minor' => (int) $row->commission_minor,
@@ -128,7 +129,7 @@ final class DeliveryCodSettlementController
     {
         $employee = $request->user();
 
-        if (! $employee->isManager() || ! $employee->hasManagerRole('principal')) {
+        if (! $employee instanceof Employee || ! $employee->isManager() || ! $employee->hasManagerRole('principal')) {
             abort(403, 'DELIVERY_ROLE_REQUIRED');
         }
     }

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryNotificationController.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryNotificationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Modules\Delivery\Interfaces\Api\V1\Controllers;
 
+use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\Delivery\Application\Services\DeliveryNotificationService;
 use App\Modules\Delivery\Domain\Models\DeliveryNotification;
 use App\Modules\Delivery\Domain\Support\DeliveryRoleResolver;
@@ -50,7 +51,8 @@ final class DeliveryNotificationController
         // (matrice fine BC-26-D05/#6312 — DeliveryRoleResolver).
         // #675x (consolidation BC-26) : doublon de calcul supprimé — la
         // deuxième affectation écrasait la première.
-        $maskPhone = ! (new DeliveryRoleResolver)->hasAnyRole($request->user(), ['admin']);
+        $actor = $request->user();
+        $maskPhone = ! ($actor instanceof Employee && (new DeliveryRoleResolver)->hasAnyRole($actor, ['admin']));
 
         $notifications = $query->paginate(min((int) $request->integer('per_page', 15), 100));
 
@@ -60,9 +62,9 @@ final class DeliveryNotificationController
         // #675x : ->each() retourne la Collection sous-jacente — appelé en
         // dernière expression, il cassait le type de retour déclaré
         // (AnonymousResourceCollection) → TypeError 500 sur GET /notifications.
-        $resources->each(function (DeliveryNotificationResource $resource) use ($maskPhone): void {
+        foreach ($resources as $resource) {
             $resource->withMask($maskPhone);
-        });
+        }
 
         return $resources;
     }

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryReportController.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryReportController.php
@@ -48,6 +48,9 @@ final class DeliveryReportController
 
         $stream = function () use ($deliveries): void {
             $handle = fopen('php://output', 'wb');
+            if ($handle === false) {
+                throw new \RuntimeException("Impossible d'ouvrir le flux CSV de sortie.");
+            }
             fputcsv($handle, [
                 'reference', 'source', 'type', 'status', 'cod_amount_minor',
                 'dropoff_address', 'created_at', 'delivered_at',

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryRiderController.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryRiderController.php
@@ -38,6 +38,10 @@ final class DeliveryRiderController
     public function today(Request $request): JsonResponse
     {
         $employee = $request->user();
+        if (! $employee instanceof Employee) {
+            abort(401, 'AUTH_EMPLOYEE_REQUIRED');
+        }
+
         $companyId = $this->companyId($request);
         $today = now()->toDateString();
 
@@ -61,6 +65,10 @@ final class DeliveryRiderController
     {
         $validated = $request->validated();
         $employee = $request->user();
+        if (! $employee instanceof Employee) {
+            abort(401, 'AUTH_EMPLOYEE_REQUIRED');
+        }
+
         $companyId = $this->companyId($request);
 
         $updated = DB::transaction(function () use ($stop, $companyId, $validated, $employee): DeliveryStop {
@@ -121,7 +129,12 @@ final class DeliveryRiderController
                 'proof_id' => $status === 'delivered' ? $proofId : $found->proof_id,
             ])->save();
 
-            return $found->fresh();
+            $fresh = $found->fresh();
+            if ($fresh === null) {
+                abort(500, 'DELIVERY_STOP_RELOAD_FAILED');
+            }
+
+            return $fresh;
         });
 
         return (new DeliveryRouteStopResource($updated))->response();

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryRouteController.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/DeliveryRouteController.php
@@ -36,7 +36,7 @@ final class DeliveryRouteController
             companyId: $this->companyId($request),
             routeDate: $routeDate,
             zone: $validated['zone'] ?? null,
-            deliveryIds: array_map('intval', $validated['delivery_ids']),
+            deliveryIds: array_values(array_map('intval', $validated['delivery_ids'])),
         );
 
         return (new DeliveryRouteResource($route))

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/PublicDeliveryTrackingController.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Controllers/PublicDeliveryTrackingController.php
@@ -50,7 +50,7 @@ final class PublicDeliveryTrackingController
                     ->sortByDesc('event_at')
                     ->map(fn ($event): array => [
                         'type' => $event->type,
-                        'event_at' => $event->event_at?->toIso8601String(),
+                        'event_at' => $event->event_at->toIso8601String(),
                     ])
                     ->values()
                     ->all(),

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Resources/DeliveryEventResource.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Resources/DeliveryEventResource.php
@@ -25,7 +25,7 @@ final class DeliveryEventResource extends JsonResource
             'id' => $this->id,
             'delivery_id' => $this->delivery_id,
             'type' => $this->type,
-            'event_at' => $this->event_at?->toIso8601String(),
+            'event_at' => $this->event_at->toIso8601String(),
             'latitude' => $this->latitude !== null ? (float) $this->latitude : null,
             'longitude' => $this->longitude !== null ? (float) $this->longitude : null,
             'origin' => $this->origin,

--- a/api/app/Modules/Delivery/Interfaces/Api/V1/Resources/DeliveryRouteResource.php
+++ b/api/app/Modules/Delivery/Interfaces/Api/V1/Resources/DeliveryRouteResource.php
@@ -22,7 +22,7 @@ final class DeliveryRouteResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'route_date' => $this->route_date?->toDateString(),
+            'route_date' => $this->route_date->toDateString(),
             'zone' => $this->zone,
             'status' => $this->status,
             'driver_id' => $this->driver_id,

--- a/api/tests/Feature/Delivery/DeliveryGoldenJourneyTest.php
+++ b/api/tests/Feature/Delivery/DeliveryGoldenJourneyTest.php
@@ -110,7 +110,7 @@ class DeliveryGoldenJourneyTest extends TestCase
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.driver_id', 91);
-        $stops = collect($today->json('data.0.stops'));
+        $stops = collect((array) $today->json('data.0.stops'));
 
         // ── 4. Exécution : picked_up (manager — gate api.manager tant que la
         //    matrice delivery.role n'est pas mergée, BC-26-D05/#6312) puis

--- a/api/tests/Feature/Delivery/DeliveryIsolationTest.php
+++ b/api/tests/Feature/Delivery/DeliveryIsolationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Delivery;
 
 use App\Core\Tenant\Domain\Models\Company;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Tests\RefreshTenantDatabase;
 use Tests\TestCase;

--- a/api/tests/Feature/Delivery/DeliveryIsolationTest.php
+++ b/api/tests/Feature/Delivery/DeliveryIsolationTest.php
@@ -59,8 +59,8 @@ class DeliveryIsolationTest extends TestCase
                 $this->insertDelivery($companyA, 'DLV-2026-000003', 'restaurant', 'RST-2026-0001');
             });
             self::fail('Unique (company_id, source, source_reference) attendu.');
-        } catch (\Throwable) {
-            self::assertTrue(true);
+        } catch (QueryException $e) {
+            self::assertInstanceOf(QueryException::class, $e);
         }
 
         // Le doublon intra-tenant a été rejeté : companyA garde 1 livraison

--- a/api/tests/Feature/Delivery/DeliveryReportApiTest.php
+++ b/api/tests/Feature/Delivery/DeliveryReportApiTest.php
@@ -182,18 +182,18 @@ class DeliveryReportApiTest extends TestCase
         self::assertSame(100, $totals['avg_delivery_delay_minutes']); // (2h, 2h, 1h) → 100 min
 
         // Ventilation par source : manual 3 (2 livrées), restaurant 1.
-        $bySource = collect($first->json('data.by_source'))->keyBy('source');
+        $bySource = collect((array) $first->json('data.by_source'))->keyBy('source');
         self::assertSame(3, $bySource['manual']['deliveries']);
         self::assertSame(2, $bySource['manual']['delivered']);
         self::assertSame(1, $bySource['restaurant']['deliveries']);
         self::assertSame(100, $bySource['restaurant']['success_rate_pct']); // contrat API : entier
 
         // Par jour : 2026-08-01 concentre les 4 livraisons.
-        $byDay = collect($first->json('data.by_day'))->keyBy('date');
+        $byDay = collect((array) $first->json('data.by_day'))->keyBy('date');
         self::assertSame(4, $byDay['2026-08-01']['deliveries']);
 
         // Par livreur : driver 5 → 3 livraisons.
-        $byDriver = collect($first->json('data.by_driver'))->keyBy('driver_id');
+        $byDriver = collect((array) $first->json('data.by_driver'))->keyBy('driver_id');
         self::assertSame(3, $byDriver[5]['deliveries']);
     }
 

--- a/api/tests/Feature/Delivery/DeliveryRiderApiTest.php
+++ b/api/tests/Feature/Delivery/DeliveryRiderApiTest.php
@@ -126,7 +126,10 @@ class DeliveryRiderApiTest extends TestCase
         // Colis déjà picked_up (la machine à états interdit assigned →
         // out_for_delivery ; le picked_up est enregistré côté dispatcher/manager).
         $route = $this->createRouteFor(11, deliveryStatus: 'picked_up');
-        $stopId = (int) $route->stops()->first()->id;
+        $stop = $route->stops()->first();
+        self::assertNotNull($stop, 'Stop attendu pour la tournée.');
+        /** @var DeliveryStop $stop */
+        $stopId = (int) $stop->id;
 
         Sanctum::actingAs($this->rider(11));
 
@@ -152,9 +155,15 @@ class DeliveryRiderApiTest extends TestCase
             ->assertJsonPath('data.proof_id', 555);
 
         // La livraison est passée delivered via la machine à états.
-        $deliveryId = (int) $route->stops()->find($stopId)->delivery_id;
-        self::assertSame('delivered', Delivery::query()->find($deliveryId)->status);
-        self::assertNotNull(Delivery::query()->find($deliveryId)->delivered_at);
+        $stop2 = $route->stops()->find($stopId);
+        self::assertNotNull($stop2, 'Stop re-trouvé après transition.');
+        /** @var DeliveryStop $stop2 */
+        $deliveryId = (int) $stop2->delivery_id;
+        $delivery = Delivery::query()->find($deliveryId);
+        self::assertNotNull($delivery, 'Livraison attendue en base.');
+        /** @var Delivery $delivery */
+        self::assertSame('delivered', $delivery->status);
+        self::assertNotNull($delivery->delivered_at);
     }
 
     public function test_stop_status_replay_is_idempotent(): void
@@ -163,7 +172,10 @@ class DeliveryRiderApiTest extends TestCase
         // arrived) : on démarre à out_for_delivery pour que 'arrived' soit
         // une transition légale, puis on rejoue le même statut (idempotent).
         $route = $this->createRouteFor(11, deliveryStatus: 'out_for_delivery');
-        $stopId = (int) $route->stops()->first()->id;
+        $stop = $route->stops()->first();
+        self::assertNotNull($stop, 'Stop attendu pour la tournée.');
+        /** @var DeliveryStop $stop */
+        $stopId = (int) $stop->id;
 
         Sanctum::actingAs($this->rider(11));
 
@@ -181,7 +193,10 @@ class DeliveryRiderApiTest extends TestCase
     public function test_rider_cannot_update_other_drivers_stop(): void
     {
         $route = $this->createRouteFor(12);
-        $stopId = (int) $route->stops()->first()->id;
+        $stop = $route->stops()->first();
+        self::assertNotNull($stop, 'Stop attendu pour la tournée.');
+        /** @var DeliveryStop $stop */
+        $stopId = (int) $stop->id;
 
         Sanctum::actingAs($this->rider(11));
 
@@ -193,7 +208,10 @@ class DeliveryRiderApiTest extends TestCase
     public function test_stop_status_is_tenant_scoped(): void
     {
         $route = $this->createRouteFor(11);
-        $stopId = (int) $route->stops()->first()->id;
+        $stop = $route->stops()->first();
+        self::assertNotNull($stop, 'Stop attendu pour la tournée.');
+        /** @var DeliveryStop $stop */
+        $stopId = (int) $stop->id;
 
         /** @var Company $other */
         $other = Company::factory()->create(['country' => 'MA', 'currency' => 'MAD']);

--- a/api/tests/Feature/Delivery/DeliveryRouteApiTest.php
+++ b/api/tests/Feature/Delivery/DeliveryRouteApiTest.php
@@ -8,6 +8,7 @@ use App\Core\Auth\Domain\Models\Employee;
 use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\Delivery\Domain\Models\Delivery;
 use App\Modules\Delivery\Domain\Models\DeliveryRoute;
+use App\Modules\Delivery\Domain\Models\DeliveryStop;
 use Illuminate\Support\Carbon;
 use Laravel\Sanctum\Sanctum;
 use Tests\RefreshTenantDatabase;
@@ -142,7 +143,7 @@ class DeliveryRouteApiTest extends TestCase
         $response->assertJsonPath('data.status', 'draft');
         $response->assertJsonCount(3, 'data.stops');
 
-        $orders = collect($response->json('data.stops'))->pluck('sort_order')->all();
+        $orders = collect((array) $response->json('data.stops'))->pluck('sort_order')->all();
         self::assertSame([1, 2, 3], $orders);
     }
 
@@ -241,9 +242,18 @@ class DeliveryRouteApiTest extends TestCase
 
         // 2 stops livrés (COD 5000 chacun) + 1 stop en échec.
         $stops = $route->stops()->get();
-        $stops->get(0)->forceFill(['status' => 'delivered', 'delivered_at' => Carbon::parse('2026-09-01 18:00:00')])->save();
-        $stops->get(1)->forceFill(['status' => 'delivered', 'delivered_at' => Carbon::parse('2026-09-01 18:05:00')])->save();
-        $stops->get(2)->forceFill(['status' => 'failed'])->save();
+        $delivered0 = $stops->get(0);
+        $delivered1 = $stops->get(1);
+        $failed2 = $stops->get(2);
+        self::assertNotNull($delivered0);
+        self::assertNotNull($delivered1);
+        self::assertNotNull($failed2);
+        /** @var DeliveryStop $delivered0 */
+        /** @var DeliveryStop $delivered1 */
+        /** @var DeliveryStop $failed2 */
+        $delivered0->forceFill(['status' => 'delivered', 'delivered_at' => Carbon::parse('2026-09-01 18:00:00')])->save();
+        $delivered1->forceFill(['status' => 'delivered', 'delivered_at' => Carbon::parse('2026-09-01 18:05:00')])->save();
+        $failed2->forceFill(['status' => 'failed'])->save();
 
         $first = $this->postJson(sprintf('/api/v1/delivery/deliveries/routes/%d/close', $route->id))->assertOk();
 

--- a/api/tests/Feature/Delivery/DeliverySchemaTest.php
+++ b/api/tests/Feature/Delivery/DeliverySchemaTest.php
@@ -21,7 +21,7 @@ class DeliverySchemaTest extends TestCase
     use RefreshTenantDatabase;
 
     /**
-     * @return array<int, string>
+     * @return array<int, list<string>>
      */
     public static function deliveryTables(): array
     {

--- a/api/tests/Feature/Delivery/DeliveryTenantIsolationMatrixTest.php
+++ b/api/tests/Feature/Delivery/DeliveryTenantIsolationMatrixTest.php
@@ -29,8 +29,6 @@ class DeliveryTenantIsolationMatrixTest extends TestCase
 
     private Company $companyA;
 
-    private Company $companyB;
-
     private Employee $managerA;
 
     private Employee $managerB;
@@ -52,7 +50,6 @@ class DeliveryTenantIsolationMatrixTest extends TestCase
         $b = Company::factory()->create(['country' => 'MA', 'currency' => 'MAD']);
         $b->setFeature('delivery', true);
         $b->save();
-        $this->companyB = $b;
 
         /** @var Employee $managerA */
         $managerA = Employee::factory()->create([

--- a/api/tests/Feature/Delivery/DeliveryTrackingApiTest.php
+++ b/api/tests/Feature/Delivery/DeliveryTrackingApiTest.php
@@ -152,7 +152,10 @@ class DeliveryTrackingApiTest extends TestCase
         $second = $this->postJson('/api/v1/delivery/deliveries/events', $payload)->assertStatus(201);
 
         self::assertSame($first->json('data.id'), $second->json('data.id'));
-        self::assertSame(1, Delivery::query()->find($delivery->id)->events()->count());
+        $tracked = Delivery::query()->find($delivery->id);
+        self::assertNotNull($tracked, 'Livraison attendue en base.');
+        /** @var Delivery $tracked */
+        self::assertSame(1, $tracked->events()->count());
     }
 
     public function test_event_duplicate_type_and_event_at_is_deduped(): void

--- a/api/tests/Unit/Delivery/DeliveryReferenceTest.php
+++ b/api/tests/Unit/Delivery/DeliveryReferenceTest.php
@@ -34,7 +34,7 @@ final class DeliveryReferenceTest extends TestCase
                 DeliveryReference::fromString($invalid);
                 self::fail(sprintf('Expected InvalidArgumentException for "%s".', $invalid));
             } catch (InvalidArgumentException) {
-                self::assertTrue(true);
+                self::addToAssertionCount(1);
             }
         }
     }


### PR DESCRIPTION
## Contexte
`PHPStan — Strict (Core/Modules/Shared, level 8)` est **rouge sur main** depuis le merge de la consolidation BC-26 DELIVERY (2026-09-02 03:19, PR #6757) : le module est arrivé avec ~64 erreurs niveau 8 (code + tests) jamais assainies. Conséquence : **toute PR touchant `api/` est bloquée** sur un check requis → main ne peut plus recevoir de code backend.

## Correctifs (22 fichiers, zéro baseline ajouté)
- Resources : nullsafe superflus sur colonnes NOT NULL
- DeliveryCodSettlement : doublon de cast `settled_at` supprimé
- DeliveryStateMachine : `?? []` sur offset toujours présent
- DeliveryReportService : alias d'agrégats via `getAttribute()` + retours `list<>` garantis (`array_values`)
- DeliveryCodSettlementService : `fresh()` nullable → helper avec garde explicite
- Contrôleurs : acteurs typés (`instanceof Employee`), agrégats `getAttribute()`, flux CSV guardés (`fopen` false), `list<int>`
- Tests Delivery : `collect()` typé, accès nullable sécurisés (assertNotNull), exception typée, provider `list<string>`, propriété morte retirée

## Validation
- `phpstan analyse -c phpstan-strict.neon` sur app/Modules/Delivery + tests : **0 erreur**
- `php -l` OK sur les 22 fichiers

Part of #6749 (main green) — débloque aussi #6665 #6666 #6699 #6704 #6707 #6732 #6733 #6735 #6736 #6742 #6744 #6756 (PRs api en attente de ce check).