### PR TITLE
fix(ci): dédupliquer le registre de budgets MAT-014

### DIFF
--- a/dev-hub/tools/performance-budgets.json
+++ b/dev-hub/tools/performance-budgets.json
@@ -102,14 +102,6 @@
    "p95_ms": 200,
    "pagination": false,
    "notes": "Tournée du jour rider (DELIVERY-203) - scope propriété."
-  },
-  {
-   "method": "GET",
-   "route": "/api/v1/delivery/deliveries/reports/summary",
-   "max_queries": 8,
-   "p95_ms": 300,
-   "pagination": false,
-   "notes": "Read model KPIs (DELIVERY-207) - 5 agrégations scopées."
   }
  ],
  "required_indexes": [


### PR DESCRIPTION
Closes #5872

Le guard MAT-014 échouait car GET /api/v1/delivery/deliveries/reports/summary était déclaré deux fois dans dev-hub/tools/performance-budgets.json.

Cette PR supprime uniquement le doublon. Les seuils de requêtes, p95, pagination et index restent inchangés.

Validation locale : check-performance-budgets.sh api passe.