### PR TITLE
fix(openapi): corriger les tags Auth et Delivery

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40,8 +40,6 @@ tags:
 - name: Health
   description: Groupe d'opérations Health
 - name: Auth
-- name: Delivery
-  description: Groupe d'opérations Delivery (BC-26 DELIVERY)
   description: Groupe d'opérations Auth
 - name: Delivery
   description: Groupe d'opérations Delivery (BC-26 DELIVERY)

--- a/dev-hub/openapi/v1.yaml
+++ b/dev-hub/openapi/v1.yaml
@@ -51,8 +51,6 @@ tags:
 - name: Health
   description: Groupe d'opérations Health
 - name: Auth
-- name: Delivery
-  description: Groupe d'opérations Delivery (BC-26 DELIVERY)
   description: Groupe d'opérations Auth
 - name: Delivery
   description: Groupe d'opérations Delivery (BC-26 DELIVERY)

--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "eae09542a4e00110caa2defedfb7ee12022c0a4f38a00a6304ee703dcbae6587",
+  "spec_sha256": "49c54adfe1ed8de706d5cc18ca82827cbd5bda9410cc1328874781e1eb716f12",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
   "operation_count": 923,


### PR DESCRIPTION
Closes #6789\n\nLe lint OpenAPI échouait sur une clé YAML description dupliquée et deux entrées Delivery.\n\nCette PR restaure la structure canonique des tags et régénère le miroir OpenAPI ainsi que le manifest SDK.\n\nValidations locales : Redocly lint, génération/mirror SDK en mode check.