### PR TITLE
fix(ci): PHPStan strict — Employee : doublon @property email supprimé (Part of #6818)

### DIFF
--- a/api/app/Core/Auth/Domain/Models/Employee.php
+++ b/api/app/Core/Auth/Domain/Models/Employee.php
@@ -113,7 +113,6 @@ use Laravel\Sanctum\HasApiTokens;
  * @property int $failed_login_attempts
  * @property Carbon|null $locked_until
  * @property Carbon|null $email_bounced_at
- * @property string|null $email
  * @property string|null $google_id_bounce_reason
  * @property string|null $two_fa_secret
  * @property Carbon|null $two_fa_enabled_at


### PR DESCRIPTION
## PHPStan strict — Employee : doublon `@property email` supprimé (résidu de merge)

Suite du verdissement #6818. Les corrections Console/Core que cette PR portait initialement (WriteActionRunner, FuelAlertsScanCommand, GdprAnonymizeEmployeeCommand, GenerateMonthlyInvoices, ImportLegacy*, PilotSeedCommand) ont été **absorbées par les rounds 24→26 de #6817** (squash 99d984a25) — la PR a été réduite à sa **valeur ajoutée résiduelle**.

**Correctif (1 fichier, −1) :**
- `Employee` : doublon résiduel de merge `@property string|null $email` (ligne 116) supprimé. La colonne `email` est **NOT NULL** en migration (`string('email', 150)` sans nullable) ; le `@property string $email` canonique (ligne 69) est conservé. Le doublon nullable polluait le typage et causait en cascade les erreurs « `string|null` given » chez `OnboardingReminderMail`, `TrialDayOneMail`, `UserInvitationService`, `TwoFactorAuthService`, `NotifyTaxRateValidation` et `SendOnboardingRemindersCommand`.

**Vérification locale** (PHP 8.4.25, `phpstan-strict.neon`) : 0 erreur sur Employee + sous-ensemble HR/Core-Auth/Mail/Listeners/Jobs/Http/Console. Aucune régression (les null-checks `->email === null` sur Employee n'existent pas dans api/app).

Stackée sur `fix/ci-main-green-2026-09-04` (à retargeter sur main après #6817). Part of #6818.
