### PR TITLE
fix(ci): régénération SDK — MANIFEST.json périmé sur main (Closes #7019)

### DIFF
--- a/dev-hub/sdk/MANIFEST.json
+++ b/dev-hub/sdk/MANIFEST.json
@@ -1,9 +1,9 @@
 {
   "source": "api/openapi.yaml",
-  "spec_sha256": "8c3d4c4a03027248ebbc58790a45f30b1a8fa9310c07858121aded8838b9157f",
+  "spec_sha256": "00da26249e1f8e5d7413549ca64be04cff0f7ea3dd0fba451e93b95a51747443",
   "openapi": "3.0.3",
   "api_version": "4.24.0",
-  "operation_count": 927,
+  "operation_count": 928,
   "targets": [
     "javascript",
     "python"


### PR DESCRIPTION
## Problème
Closes #7019 — `dev-hub/sdk/MANIFEST.json` périmé sur main depuis #6955 (spec -61 lignes, SDK régénérés, manifest oublié) → `Lint OpenAPI contract` rouge sur **toutes** les PR (garde #5280).

## Correctif
`node dev-hub/tools/generate-openapi-sdk.mjs` — diff = 2 lignes dans `dev-hub/sdk/MANIFEST.json` uniquement (compteur operations 926 → 928). Déterministe, aucun changement de code.

## Vérifications
- `node dev-hub/tools/generate-openapi-sdk.mjs --check` passe localement après régénération.