### PR TITLE
docs(protocoles): suite de protocoles v1.0 — validation marché, onboarding, vitrine, capitalisation, design, desktop, architecture 2 volets

### DIFF
--- a/.github/ISSUE_TEMPLATE/recette_version.yml
+++ b/.github/ISSUE_TEMPLATE/recette_version.yml
@@ -1,0 +1,60 @@
+name: "🧪 Recette de version (Porte Marché)"
+description: Ouvrir une recette de version avant toute mise sur le marché — PROTOCOLE 01, §5. Une issue par version.
+title: "Recette vX.Y.Z — <pays/périmètre>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **PROTOCOLE 01 — Validation & mise sur le marché (§5).** Cette issue est la recette
+        officielle de la version. Elle ne peut être close que par un verdict de Porte Marché
+        (cases §4 du protocole) et un sign-off du fondateur (@kitokoh).
+  - type: input
+    id: version
+    attributes:
+      label: Version / SHA du tag
+      description: Tag exact et SHA du commit (celui du rapport de porte).
+      placeholder: "vX.Y.Z @ <sha>"
+    validations:
+      required: true
+  - type: input
+    id: perimetre
+    attributes:
+      label: Périmètre & pays couverts
+      placeholder: "Cœur RH-pointage-paie + verticale X — DZ"
+    validations:
+      required: true
+  - type: input
+    id: testeur
+    attributes:
+      label: Testeur pilote / relecteur métier
+      placeholder: "Pilote 2 — SARL Y (paie : expert-comptable pays)"
+    validations:
+      required: false
+  - type: textarea
+    id: parcours
+    attributes:
+      label: Journal des parcours (G1-G8)
+      description: "Reprendre le tableau §5 du protocole — G1 prospect trial guidé, G2 trial self-service/OTP, G3 checkout, G4 création employé, G5 pointage mobile/kiosk, G6 paie pays → bulletin → export, G7 i18n fr+ar (RTL), G8 isolation cross-tenant. Une ligne par session (date, parcours, résultat chiffré, écart #issue, exécuté par)."
+      placeholder: |
+        | Date | Parcours | Résultat | Écart | Exécuté par |
+        |---|---|---|---|---|
+    validations:
+      required: true
+  - type: dropdown
+    id: verdict
+    attributes:
+      label: Verdict de la recette
+      options:
+        - "Zéro anomalie bloquante — recette signée"
+        - "Anomalies non bloquantes tracées en issues — Go conditionnel"
+        - "Anomalie bloquante — No-Go (re-certification requise, R7)"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        **Clôture** : rapport daté déposé dans `docs/validation/` (ou `docs/PROTOCOLS/rapports/`),
+        re-certification si corrections (R7), puis sign-off fondateur : *Go / Go conditionnel /
+        No-Go* — date et motif. Références : `docs/PROTOCOLS/01_VALIDATION_MARCHE.md`,
+        `docs/validation/RELEASE_READINESS_GATE.md`.

--- a/.github/ISSUE_TEMPLATE/retour_experience.yml
+++ b/.github/ISSUE_TEMPLATE/retour_experience.yml
@@ -1,0 +1,78 @@
+name: "🔁 Retour d'expérience (REX)"
+description: Capitaliser une leçon terrain (temps perdu, optimisation tentée, dette découverte, erreur évitable) en issue exploitable — PROTOCOLE 04.
+title: "[REX]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **PROTOCOLE 04 — Capitalisation de l'expérience.** Toute leçon vécue (succès, échec,
+        temps perdu, optimisation tentée) peut devenir une issue. Si la correction est petite
+        (≤ 1 fichier, ≤ 1 h, BC confié, hors freeze), tu peux l'implémenter directement :
+        voir le tableau d'arbitrage §4 de `docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md`.
+        Sinon, cette issue est transmise telle quelle — elle doit être « agent-ready » (§5).
+  - type: textarea
+    id: constat
+    attributes:
+      label: Constat / leçon
+      description: Ce qui s'est passé, factuellement (session, date, contexte).
+      placeholder: "Lors de la session QA du 2026-09-XX, 2 h ont été perdues car..."
+    validations:
+      required: true
+  - type: textarea
+    id: cause
+    attributes:
+      label: Cause racine
+      description: Pourquoi c'est arrivé (outil, doc manquante, règle ambiguë, dette...).
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact si non corrigé
+      description: Qui va revivre le problème, à quelle fréquence, à quel coût.
+      placeholder: "Tout nouvel agent retombera sur ce piège (cf. PROTOCOLE 02)."
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Correction proposée
+      description: Ce qu'il faudrait changer (code, doc, garde CI, processus) — même une piste incomplète est utile.
+    validations:
+      required: true
+  - type: input
+    id: surface
+    attributes:
+      label: Surface / BC
+      description: Partie du dépôt concernée (api, front/mobile_apps/leopardo_X, docs, .github/workflows...) et label BC si connu (registre dev-hub/governance/bounded-context-registry.json).
+      placeholder: "docs (BC-XX si applicable)"
+    validations:
+      required: true
+  - type: dropdown
+    id: decision
+    attributes:
+      label: Décision proposée
+      description: À qui revient la correction ?
+      options:
+        - "Implémentation directe par l'auteur (petite portée)"
+        - "À déléguer à un autre agent (issue agent-ready)"
+        - "À arbitrer par le PM (cas limite / freeze / BC non confié)"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Critères d'acceptation
+      description: Conditions vérifiables pour considérer la correction faite (obligatoire si déléguée — format agent-ready §5).
+      placeholder: |
+        1. ...
+        2. Tests verts sur le parcours concerné
+        3. Doc mise à jour si comportement modifié
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        **Après correction** : documenter la leçon consolidée dans `AGENTS.md` (si règle
+        opérationnelle), `CHANGELOG.md`, et clore avec `Closes #N` dans le body de la PR.

--- a/.github/ISSUE_TEMPLATE/retour_experience.yml
+++ b/.github/ISSUE_TEMPLATE/retour_experience.yml
@@ -1,7 +1,7 @@
 name: "🔁 Retour d'expérience (REX)"
 description: Capitaliser une leçon terrain (temps perdu, optimisation tentée, dette découverte, erreur évitable) en issue exploitable — PROTOCOLE 04.
 title: "[REX]: "
-labels: []
+labels: ["tech-debt"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/revue_mensuelle.md
+++ b/.github/ISSUE_TEMPLATE/revue_mensuelle.md
@@ -1,0 +1,41 @@
+---
+name: "🗓️ Revue mensuelle des protocoles"
+about: Rituel de fin de mois — exécuter, auditer et amender la suite de protocoles (docs/PROTOCOLS/00_INDEX.md §5).
+title: "Revue mensuelle des protocoles — YYYY-MM"
+labels: []
+assignees: ''
+---
+
+## Contexte
+
+Rituel du dernier jour ouvré du mois, défini dans `docs/PROTOCOLS/00_INDEX.md` §5.
+Le fondateur/PM exécute cette checklist ; le rapport consolidé est déposé dans
+`docs/PROTOCOLS/rapports/YYYY-MM.md`.
+
+## 1. Exécuter les rituels mensuels des protocoles
+
+- [ ] **01 — Validation & marché** (§7) : portes marché du mois rejouées, verdicts vs incidents réels
+- [ ] **02 — Onboarding** (§6) : retours des nouveaux entrants, pièges rencontrés
+- [ ] **03 — Vitrine** (§7) : chiffres régénérés et datés, surfaces comparées, issues d'écart ouvertes
+- [ ] **04 — Capitalisation** (§7) : moisson des leçons du mois (rapports figés, rétros, journal) → issues
+- [ ] **05 — Design** (§5) : audit visuel des surfaces, dérives détectées → issues
+- [ ] **06 — Desktop** (§7) : portefeuille des tranches verticales (actives, canaux, retours pilotes)
+- [ ] **07 — Architecture** (§5) : contrôle d'écart doc ↔ réalité des deux volets (health, versions, workers)
+
+## 2. Consolider
+
+- [ ] Rédiger `docs/PROTOCOLS/rapports/YYYY-MM.md` (synthèse par protocole, écarts, issues, métriques §6)
+- [ ] Premier rapport du mois suivant la création de la suite attendu (sinon noter l'écart)
+
+## 3. Auditer & amender
+
+- [ ] Règles de la suite réellement suivies ? Écart répété → amendement de protocole (issue + PR)
+- [ ] Décisions ouvertes de l'index (§8) rejouées, tranchées ou re-portées
+- [ ] États des lieux (§8) de chaque protocole mis à jour
+- [ ] Versions des protocoles amendés incrémentées + historique de l'index (§7) complété
+
+## 4. Sortie
+
+- [ ] Rapport mensuel déposé
+- [ ] Issues créées pour tout écart non soldé (`[REX]` / `[ECART]`, cf. PROTOCOLE 04)
+- [ ] Index `docs/PROTOCOLS/00_INDEX.md` à jour (statuts, historique, décisions ouvertes)

--- a/docs/PROTOCOLS/00_INDEX.md
+++ b/docs/PROTOCOLS/00_INDEX.md
@@ -1,0 +1,125 @@
+# PROTOCOLES LEOPARDO — INDEX & MÉTA-PROTOCOLE
+
+**Statut :** Actif v1.0 — 2026-09-09
+**Porteur :** fondateur (@kitokoh) / PM
+**Revue :** mensuelle, dernier jour ouvré du mois (rituel §5)
+
+> **Pourquoi.** Le projet a accumulé des dizaines de documents de gouvernance de grande
+> qualité, mais dispersés (AGENTS.md, CONVENTIONS.md, docs/GOUVERNANCE/, docs/validation/,
+> docs/GESTION_PROJET/, docs/GOTO_MARKET/…). Résultat : une même question (« quand est-on
+> prêt pour le marché ? », « que fait un nouvel agent le jour 1 ? », « comment présenter le
+> projet ? », « que faire de ce que je viens d'apprendre ? ») n'a pas de réponse unique, et
+> rien n'impose de re-questionner les règles à date fixe. Cette suite de protocoles répond à
+> chaque question par **un document unique, actionnable, relié à l'existant** — et le présent
+> index en est le point d'entrée et le mécanisme de révision mensuelle.
+
+## 1. Rôle de ce document
+
+1. **Point d'entrée unique** de la suite : le lecteur (fondateur, PM, agent, nouveau venu)
+   part d'ici pour trouver le protocole qui répond à son besoin.
+2. **Méta-protocole** : il définit comment un protocole se crée, se modifie, se versionne et
+   s'archivera — les règles du jeu s'appliquent aussi aux protocoles eux-mêmes.
+3. **Mécanisme de révision** : le rituel mensuel de fin de mois (§5) exige de rejouer chaque
+   protocole, de corriger les dérives et d'amender la suite — c'est le « définir les
+   protocoles chaque fin du mois » demandé par le fondateur.
+
+## 2. La suite de protocoles
+
+| # | Protocole | Répond au besoin | Porteur | État (2026-09-09) |
+|---|---|---|---|---|
+| 01 | [Validation & mise sur le marché](01_VALIDATION_MARCHE.md) | « Quels tests et quelles portes pour déclarer une version OK pour le marché ? » | fondateur/PM | Actif v1.0 |
+| 02 | [Intégration d'un nouvel agent](02_ONBOARDING_AGENTS.md) | « Un agent qui arrive ne doit pas se perdre ni revivre le temps perdu des autres » | fondateur/PM | Actif v1.0 |
+| 03 | [Présentation & vitrine](03_VITRINE_PRESENTATION.md) | « Présenter le projet à tout moment avec les bons termes, partout » | fondateur/PM + commercial | Actif v1.0 |
+| 04 | [Capitalisation de l'expérience](04_CAPITALISATION_EXPERIENCE.md) | « Chaque agent transforme ce qu'il a appris en issue/tâche, l'implémente ou la délègue » | chaque agent + agent PM | Actif v1.0 |
+| 05 | [Harmonisation du design](05_HARMONISATION_DESIGN.md) | « Une même valeur visuelle = une source unique, aucune surface ne diverge » | fondateur/PM + devs | Actif v1.0 |
+| 06 | [Distribution & tests desktop](06_DISTRIBUTION_DESKTOP.md) | « Extraire un .exe / .app par tranche verticale, le tester et le distribuer » | fondateur/PM + devs mobile | Actif v1.0 |
+| 07 | [Architecture à deux volets](07_ARCHITECTURE_ENVIRONNEMENTS.md) | « L'architecture dev/prod reste saine, documentée et sans dérive » | fondateur/PM + ops | Actif v1.0 |
+
+Chaque protocole suit le même format : en-tête (statut, porteur, revue) → « Pourquoi »
+(douleurs datées et sourcées) → objectif & périmètre → références existantes → règles
+numérotées → checklist exécutable → rituel mensuel → état des lieux daté.
+
+## 3. Cycle de vie d'un protocole
+
+1. **Création.** Tout nouveau protocole naît d'une **issue** (titre `[PROTOCOLE] <nom>`,
+   contexte + besoin + porteur pressenti), est rédigé en PR (`Closes #issue`), et n'est
+   « Actif » qu'après revue du fondateur. Il reçoit le numéro suivant dans la série.
+2. **Modification.** Tout amendement passe par une PR qui référence le protocole et
+   incrémente sa version (`v1.1`, `v2.0`…) dans l'en-tête + la ligne d'historique de
+   l'index (§7). Pas d'édition directe sur `main`.
+3. **Statuts.** `Actif` (en vigueur) → `En consolidation` (des règles existent ailleurs et
+   doivent le rejoindre) → `Archivé` (obsolète : déplacé dans `docs/archive/` avec un
+   renvoi, comme PILOTAGE.md #6698).
+4. **Conflit entre documents.** La règle de précédence : code exécutable > workflow/garde
+   CI > protocole > document historique. Tout conflit constaté devient une **issue**
+   (protocole 04), jamais une note marginale.
+
+## 4. Documents de référence (hors série)
+
+La suite ne réécrit pas l'existant ; elle le consolide. Références majeures à connaître :
+
+- `AGENTS.md` (racine) — guide opérationnel agent (règles, gardes, leçons).
+- `.specify/constitution.md` — spec-first, « loi fondamentale » du projet.
+- `BRANCH_PROTECTION_REQUIRED.md` — checks requis au merge sur `main`.
+- `CONVENTIONS.md` — standards de code, git, tests.
+- `docs/validation/` — gates de validation vivants + rapports datés figés.
+- `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md` — topologie réelle des deux volets.
+- `docs/GOTO_MARKET/` — source de vérité business / positionnement.
+- `.github/workflows/README.md` — cartographie des workflows CI/CD.
+
+## 5. Rituel mensuel de fin de mois (LA révision des protocoles)
+
+**Quand :** dernier jour ouvré du mois. **Qui :** fondateur/PM (1 h) + porteurs sollicités
+par protocole. **Où :** ouvrir l'issue gabarit
+[`revue_mensuelle.md`](../../.github/ISSUE_TEMPLATE/revue_mensuelle.md) et la cocher en direct.
+
+1. **Exécuter les rituels mensuels de chaque protocole** (dans l'ordre) :
+   01 §7 (portes marché du mois), 02 §6 (retours d'onboarding), 03 §7 (vitrine & chiffres),
+   04 §7 (moisson des leçons), 05 §5 (audit visuel), 06 §7 (portefeuille desktop),
+   07 §5 (contrôle d'écart architecture).
+2. **Consolider le rapport mensuel** : `docs/PROTOCOLS/rapports/YYYY-MM.md` — synthèse de
+   chaque rituel, écarts constatés, issues ouvertes, métriques de santé (§6). Premier
+   rapport attendu : fin septembre 2026.
+3. **Auditer la conformité** : les règles de la suite sont-elles suivies ? Tout écart
+   répété devient un amendement de protocole (issue + PR, §3), pas une tolérance.
+4. **Amender** : rejouer les décisions ouvertes (§8), mettre à jour les états des lieux de
+   chaque protocole, incrémenter les versions concernées.
+5. **Tracer** : mettre à jour l'historique de l'index (§7) et le statut de chaque protocole.
+
+**Sortie du rituel :** rapport mensuel déposé, protocoles amendés si besoin, index à jour,
+issues créées pour tout écart non soldé.
+
+## 6. Indicateurs de santé de la gouvernance
+
+| Indicateur | Cible | Mesure |
+|---|---|---|
+| Protocoles exécutés au rituel mensuel | 7/7 | Cases cochées dans le rapport `rapports/YYYY-MM.md` |
+| Écarts doc ↔ réalité non tracés en issue | 0 | Issues `[ECART]` ouvertes vs écarts constatés (§5.2) |
+| Âge du dernier rapport mensuel | ≤ 45 jours | Date du rapport vs date du jour |
+| Versions de protocoles sans historique | 0 | En-tête + historique index (§7) |
+| Décisions ouvertes (§8) sans porteur | 0 | Tableau §8 de l'index |
+
+## 7. Historique
+
+| Version | Date | Changement |
+|---|---|---|
+| v1.0 | 2026-09-09 | Création de la suite (protocoles 01-07) + index & rituel mensuel |
+
+## 8. État des lieux & décisions ouvertes au 2026-09-09
+
+La suite est livrée en **v1.0** ; elle documente l'existant et comble les trous constatés
+(état détaillé dans le §8 de chaque protocole). Décisions ouvertes transverses, à trancher
+par le fondateur lors des prochains rituels :
+
+- **DO-A (protocole 03 §8)** — positionnement EN de référence et nom de marque
+  (« Leopardo » vs « Leopardo RH ») ; sort de `site/gh-pages/` ; environnement de démo
+  publique (NXDOMAIN #3452).
+- **DO-B (protocole 06 §8 / annexe A)** — activation des runners Windows/macOS (coût CI) et
+  choix de la première tranche verticale desktop pilote.
+- **DO-C (protocole 07 §8)** — arbitrage budgétaire Render/Neon payants (workers prod,
+  scheduler, staging #1485) ; solde des dettes de nommage (APP_ENV sur le volet dev).
+- **DO-D (transverse)** — création des labels `tech-debt`/`lecon` (protocole 04 §6) ;
+  re-certification produit post-corrections (protocole 01) ; alignment des apps
+  accounting/travel_agent sur le core (protocole 05).
+
+Chaque décision tranchée met à jour le protocole concerné (PR) et archive la ligne ici.

--- a/docs/PROTOCOLS/00_INDEX.md
+++ b/docs/PROTOCOLS/00_INDEX.md
@@ -118,8 +118,6 @@ par le fondateur lors des prochains rituels :
   choix de la première tranche verticale desktop pilote.
 - **DO-C (protocole 07 §8)** — arbitrage budgétaire Render/Neon payants (workers prod,
   scheduler, staging #1485) ; solde des dettes de nommage (APP_ENV sur le volet dev).
-- **DO-D (transverse)** — création des labels `tech-debt`/`lecon` (protocole 04 §6) ;
-  re-certification produit post-corrections (protocole 01) ; alignment des apps
-  accounting/travel_agent sur le core (protocole 05).
+- **DO-D (transverse)** — adoption du label `tech-debt` (déjà présent sur le dépôt, vérifié 2026-09-09) pour les issues REX + ajustement de sa description si besoin (protocole 04 §6) ; re-certification produit post-corrections (protocole 01) ; alignement des apps accounting/travel_agent sur le core (protocole 05).
 
 Chaque décision tranchée met à jour le protocole concerné (PR) et archive la ligne ici.

--- a/docs/PROTOCOLS/01_VALIDATION_MARCHE.md
+++ b/docs/PROTOCOLS/01_VALIDATION_MARCHE.md
@@ -1,0 +1,239 @@
+# PROTOCOLE 01 — Validation & mise sur le marché
+
+**Statut :** Actif v1.0 — 2026-09-09
+**Porteur :** fondateur (@kitokoh) / PM
+**Revue :** mensuelle fin de mois (rituel §7) — index des protocoles : docs/PROTOCOLS/00_INDEX.md
+
+> **Pourquoi.** Des versions ont été livrées ou déclarées sans porte unique datée : le
+> 2026-08-19, le funnel prospect était cassé en prod alors que la santé API était OK (#5161 P0,
+> #5162 P1 — docs/qa/QA_PROD_2026-08-19.md) ; le 2026-08-27, verdict QA « PAS PRÊT mais très
+> proche » (Redis down prod, kiosk/PWA cassés — docs/qa/QA_RAPPORT_2026-08-27.md), suivi de
+> corrections sans re-certification produit depuis ; et la chaîne tag → release.yml →
+> deploy-prod.yml ne vérifie aucun critère produit (docs/RELEASE_PROCESS.md). Ce protocole
+> consolide l'existant en UNE porte datée, sans rien dupliquer.
+
+## 1. Objectif & périmètre
+
+**Objectif.** Définir « La Porte Marché » : la validation unique, datée et consolidée qu'une
+version doit franchir pour être déclarée « OK pour la mise sur le marché ». Elle chaîne :
+tag SemVer → CI verte → readiness → smoke funnel prospect en prod → recette de version →
+sign-off explicite → déploiement prod. Elle référence les gates existants (§2) au lieu de les
+recopier : toute évolution d'un gate référencé s'applique sans rééditer ce protocole (R11).
+
+**Périmètre.** Toute version destinée au marché : release commerciale prod multi-pays, cœur
+transverse RH-pointage-paie et solutions verticales pilotes. Hors périmètre : les
+déploiements continus de dev (deploy-main.yml), qui ne relèvent pas de la mise sur le marché.
+
+**Règle d'or.** Déclarer une version « OK pour la mise sur le marché » sans une Porte Marché
+exécutée et datée est interdit (R1). Les décisions Go/No-Go existantes (RELEASE_READINESS_GATE.md)
+restent la référence ; ce protocole ajoute les cases manquantes : recette de version générique,
+re-certification, critères produit, sign-off formalisé.
+
+## 2. Références existantes
+
+| Document / outil | Rôle dans la porte |
+|---|---|
+| docs/validation/RELEASE_READINESS_GATE.md (vivant) | Table de décision Go / Go conditionnel / No-Go / No-Go produit, surfaces contrôlées, commandes de validation |
+| dev-hub/tools/release-readiness.ps1 | 28 checks locaux de readiness ; rapport daté exigé (dernier : RELEASE_READINESS_REPORT_2026_08_14.md, 28/28 PASS) |
+| docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md | Matrice canonique domaine → scénarios → workflow → artefacts → gate ; définition « tests concluants » en 5 conditions = définition de la CI verte |
+| docs/plan/PLAN_100PCT.md | DoD « 100 % prod-ready » en 8 cases par module (dont « Recette ») : définition produit du prod-ready |
+| docs/RELEASE_PROCESS.md + .github/workflows/release.yml + deploy-prod.yml | Chaîne SemVer : tag vX.Y.Z → GitHub Release → déploiement prod (API Render, web Vercel, admin Cloudflare Pages). Vérifie les checks CI requis, aucun critère produit |
+| .github/workflows/e2e-staging.yml (renommé « E2E - Playwright Prod Smoke », cf. #3906) + front/web/playwright.staging-funnel.config.ts | Exécution E2E du funnel prospect contre la PROD (signup trial, provisioning, OTP) ; 59 specs Playwright au repo (31 front/web/e2e + 28 front/admin-dashboard/e2e) |
+| docs/validation/PILOT_RELEASE_GO_NOGO_CHECKLIST.md (figé, 2026-07-25) | Modèle de Go/No-Go daté par surface avec preuves (« Go conditionnel ») ; à rejouer à chaque porte |
+| docs/validation/RELEASE_READINESS_REPORT_2026_08_14.md, MARKET_LAUNCH_AUDIT_2026_06_05.md, rapports QA (figés) | Preuves historiques datées, jamais réécrites ; règle vivants/figés de docs/validation/README.md |
+| docs/qa/QA_RAPPORT_2026-08-27.md, docs/qa/QA_PROD_2026-08-19.md | Verdicts QA datés ; déclenchent l'obligation de re-certification (R7) |
+| docs/payroll/dz/RECETTE_PILOTE.md, docs/ops/RECETTE_UAT_TRAVEL.md (idem FUELSTATION / RESTAURANTMANAGER / EDUMANAGER) | Recettes verticales existantes ; source du gabarit générique §5 |
+| docs/GUIDES/GUIDE_TESTEURS_PILOTES.md | Comptes demo, liens testeurs, personas et parcours transverses pour exécuter la recette |
+
+## 3. Règles
+
+Chaque règle est écrite : condition → action → responsable → garde existante ou « à créer ».
+
+- **R1 — Porte Marché obligatoire.** Condition : une version est candidate à la mise sur le
+  marché. Action : exécuter intégralement la checklist §4 et produire le rapport daté §5 avant
+  tout Go. Responsable : préparation QA/agent, décision fondateur. Garde : le présent protocole
+  (à créer : issue de suivi + gabarit d'issue §5).
+- **R2 — CI verte selon le registre.** Condition : SHA candidat au tag. Action : vérifier que
+  les 5 conditions « tests concluants » du registre sont remplies (workflows verts + artefacts
+  minimums du domaine, aucun job critique failure/cancelled/timed_out). Responsable : agent/PM.
+  Garde : docs/GESTION_PROJET/REGISTRE_SCENARIOS_TESTS.md (existe).
+- **R3 — Readiness locale 28/28.** Condition : avant chaque porte. Action : exécuter
+  `dev-hub/tools/release-readiness.ps1 -Strict` (équivalent bash si pas de PowerShell) et
+  joindre un rapport daté au modèle RELEASE_READINESS_REPORT_*. Responsable : QA.
+  Garde : docs/validation/RELEASE_READINESS_GATE.md (existe).
+- **R4 — Décision par surface avec preuves.** Condition : candidat. Action : produire un
+  Go/No-Go daté par surface (API, admin, vitrine, mobile, kiosk, sécurité, ops) avec preuves CI
+  datées, au modèle PILOT_RELEASE_GO_NOGO_CHECKLIST.md. Responsable : QA (proposition), fondateur
+  (décision). Garde : modèle existant ; la case « porte » est à créer.
+- **R5 — Smoke funnel prospect en prod.** Condition : toute version market. Action : exécuter
+  la suite funnel (playwright.staging-funnel.config.ts via e2e-staging.yml) : trial guidé
+  signup → `ready` < 2 min avec login_url, trial self-service → OTP reçu → login, checkout,
+  puis création employé sur le tenant provisionné. Le verdict santé API seul ne suffit pas
+  (leçons #5161/#5162). Responsable : QA. Garde : specs et workflow existent ; l'intégration de
+  ce smoke comme condition bloquante de la porte est à créer.
+- **R6 — Recette de version générique.** Condition : version market multi-pays ou cœur
+  RH-pointage-paie. Action : un testeur pilote exécute la recette générique §5 (journal signé,
+  zéro anomalie bloquante) sur au moins un pays de production de la version et un parcours
+  vertical si le périmètre l'inclut. Responsable : PM + testeur pilote (supports :
+  GUIDE_TESTEURS_PILOTES.md). Garde : gabarit §5 à créer (les recettes verticales existantes ne
+  couvrent pas le cœur transverse).
+- **R7 — Re-certification après corrections.** Condition : verdict ≠ Go (No-Go, No-Go produit,
+  PAS PRÊT) puis corrections mergées. Action : re-exécuter la checklist §4 complète sur le SHA
+  final et déposer un nouveau rapport daté ; interdiction de déployer en prod sur un verdict
+  ancien + corrections sans re-certification (anti « PAS PRÊT → corrections → silence »,
+  cf. QA_RAPPORT_2026-08-27 → PR #5698 sans re-cert formelle depuis). Responsable : QA.
+  Garde : à créer (champ « re-certification » du rapport §5).
+- **R8 — Critères produit dans la porte.** Condition : candidat. Action : cocher les cases
+  produit C1-C7 (§4) — parcours prospect complet et parcours cœur recettés, pas seulement la
+  santé API — et les DoD 8 cases de docs/plan/PLAN_100PCT.md pour les modules de la version.
+  Responsable : préparation QA/agent. Garde : à créer (cases C1-C7).
+- **R9 — Sign-off fondateur unique.** Condition : cases §4 cochées et rapport déposé. Action :
+  @kitokoh prononce seul le Go final (ou Go conditionnel motivé), daté et référencé sur l'issue
+  de recette ; la préparation QA/agent ne décide jamais seule. Responsable : fondateur.
+  Garde : à créer (formalisation du sign-off dans le gabarit §5).
+- **R10 — Traçabilité et non-réécriture.** Condition : tout rapport produit par ce protocole.
+  Action : nommer avec date (`*_YYYY_MM_DD.md` ou `*_YYYY-MM-DD.md`), déposer dans docs/validation/
+  ou docs/qa/, ne jamais réécrire rétroactivement ; l'état courant se lit sur `main` et les
+  documents vivants. Responsable : auteur du rapport. Garde : docs/validation/README.md (existe).
+- **R11 — Pas de duplication.** Condition : évolution d'un gate référencé (§2). Action : mettre
+  à jour le gate source ; ce protocole s'y réfère sans le recopier. Toute nouvelle exigence
+  récurrente de validation s'ajoute ici par règle numérotée, pas en annexe d'un rapport.
+  Responsable : PM. Garde : présent protocole (actif).
+
+## 4. La Porte Marché — checklist exécutable
+
+Tout doit être coché avant le Go final (R9). Une case non cochée = No-Go, sauf Go conditionnel
+motivé par écrit (R4) et accepté par le fondateur.
+
+**A. CI et qualité (SHA exact du tag)**
+- [ ] A1 `Tests - Leopardo RH` success (≈ 4 010 tests backend, 60 min ; coverage gate ≥ 65 % ;
+      payroll-ci.yml ≥ 80 %) + artefacts du registre (R2)
+- [ ] A2 `Web CI - Leopardo Admin` success si le SHA touche front/admin-dashboard/**
+- [ ] A3 `Web Marketing CI - Leopardo Public` success si le SHA touche front/web/**
+- [ ] A4 Jest vitrine exécuté et vert (633 tests après correctifs du 2026-08-27 ; jamais en CI à
+      ce jour → exécution locale obligatoire par le préparateur tant que le job CI n'existe pas)
+- [ ] A5 Mobile : flutter analyze + flutter test verts (58 fichiers unit/widget ; aucun
+      integration_test → compensé par la recette manuelle mobile de la recette §5)
+- [ ] A6 Checks requis de protection de branche verts sur le SHA taggé (dont PHPStan strict,
+      Backend Coverage, Module Structure, Frontend ESLint+TS)
+
+**B. Readiness et décision**
+- [ ] B1 `release-readiness.ps1 -Strict` 28/28 + rapport daté (R3)
+- [ ] B2 Go/No-Go daté par surface avec preuves CI datées (R4)
+- [ ] B3 Aucun P0/P1 ouvert sur le périmètre de la version ; P2/P3 documentés avec mitigation
+      si Go conditionnel
+
+**C. Produit — parcours prospect et cœur (R5, R8)**
+- [ ] C1 Funnel prospect prod : trial guidé signup → `ready` < 2 min avec login_url fonctionnel
+      (anti #5161)
+- [ ] C2 Trial self-service : signup → OTP reçu → login complété (anti #5162)
+- [ ] C3 Checkout / activation du plan payant tel qu'exposé au marché
+- [ ] C4 Cœur RH-pointage-paie recetté sur un pays de production de la version : employé créé,
+      pointage, cycle paie → bulletin conforme, export (DoD 8 cases, PLAN_100PCT §1)
+- [ ] C5 Surfaces livrées avec la version fonctionnelles en prod : kiosk ZKTeco, PWA offline,
+      apps mobiles installables (anti régression du 2026-08-27)
+- [ ] C6 i18n ×4 (fr/ar/tr/en) vérifiée sur les parcours recettés, rendu RTL arabe
+- [ ] C7 Isolation tenant (404 sûr cross-tenant) et RBAC vérifiés sur les parcours recette
+
+**D. Recette et sign-off**
+- [ ] D1 Recette de version générique §5 exécutée sans assistance par un testeur pilote,
+      journal daté signé (R6)
+- [ ] D2 Rapport de porte daté déposé (gabarit §5) avec verdict et preuves
+- [ ] D3 Re-certification effectuée si corrections post-verdict : dernier rapport = SHA du tag (R7)
+- [ ] D4 Go final explicite de @kitokoh, daté, sur l'issue de recette (R9)
+
+**E. Mise sur le marché**
+- [ ] E1 CHANGELOG [Unreleased] consolidé + bump de version (docs/RELEASE_PROCESS.md)
+- [ ] E2 Tag vX.Y.Z (jamais de tag manuel) → release.yml → deploy-prod.yml verts (API/web/admin)
+- [ ] E3 Smokes post-déploiement prod verts : /api/v1/health, demo-auth, vitrine/admin 200
+- [ ] E4 Décision d'exposition multi-pays (feature flag vs tous tenants) actée par le fondateur
+      (cf. RELEASE_READINESS_REPORT_2026_08_14.md)
+
+## 5. Gabarit « recette de version »
+
+Bloc à copier dans une issue de recette (une issue par version ; titre : `Recette vX.Y.Z — <pays/périmètre>`).
+
+```
+# Recette de version vX.Y.Z (issue de la Porte Marché — PROTOCOLE 01)
+
+## 1. Contexte
+- Version / SHA exact du tag : vX.Y.Z @ <sha>   (SHA = celui du rapport de porte)
+- Date de la recette : YYYY-MM-DD · Environnement : prod · Pays couverts : <DZ/MA/...>
+- Périmètre : cœur RH-pointage-paie (obligatoire) + verticale(s) : <optionnel>
+- Testeur pilote : <nom> · Relecteur métier/expert : <nom> (si paie : expert-comptable pays)
+- Issue de suivi de la version : <#issue> · Lien rapport de porte : docs/validation/<fichier>
+
+## 2. Parcours obligatoires
+| # | Parcours | Résultat attendu | Réussi ? |
+|---|---|---|---|
+| G1 | Prospect : trial guidé → ready < 2 min → login_url | Compte provisionné, accès sans assistance | ☐ |
+| G2 | Prospect : trial self-service → OTP → login | OTP reçu, login complété | ☐ |
+| G3 | Checkout / activation plan (si exposé) | Paiement ou CTA conforme au marché | ☐ |
+| G4 | Employé : création complète → login employé | Fiche conforme, accès fonctionnel | ☐ |
+| G5 | Pointage : mobile/kiosk → journée validée | Pointages corrects, anomalies gérées | ☐ |
+| G6 | Paie : run pays → bulletin conforme → export | Net/taux exacts (écart ≤ 0,01), PDF valide | ☐ |
+| G7 | i18n : parcours G4-G6 en fr + ar (RTL) | 0 chaîne cassée, rendu correct | ☐ |
+| G8 | Isolation : accès cross-tenant | 404 sûr, aucune fuite | ☐ |
+
+## 3. Journal de validation (une ligne par session)
+| Date | Parcours | Résultat (chiffres clés) | Écart / anomalie (#issue) | Exécuté par |
+|---|---|---|---|---|
+|      |         |                          |                          |             |
+
+## 4. Verdict de la recette
+- [ ] Zéro anomalie bloquante ; anomalies non bloquantes tracées en issues
+- [ ] Recette signée par le testeur pilote (date) et le relecteur métier (date)
+
+## 5. Re-certification (R7 — ne remplir que si corrections post-verdict)
+- Corrections mergées : <PRs> · SHA final : <sha>
+- [ ] Checklist §4 du protocole re-exécutée sur le SHA final, nouveau rapport daté : <fichier>
+
+## 6. Sign-off Porte Marché
+- [ ] Cases §4 toutes cochées (rapport de porte joint)
+- [ ] Go final @kitokoh : <Go / Go conditionnel / No-Go> — date et motif :
+```
+
+Rapport de porte = ce gabarit complété, déposé daté (R10). Les verticales peuvent ajouter leurs
+scénarios UAT existants (RECETTE_UAT_*, RECETTE_PILOTE) en annexe, sans les recopier dans ce gabarit.
+
+## 6. Indicateurs de santé du protocole
+
+| Indicateur | Cible | Mesure |
+|---|---|---|
+| Versions market passées par une Porte Marché datée complète | 100 % | Rapports §5 déposés vs tags vX.Y.Z mis en prod |
+| Verdict ≠ Go → re-certification datée | 100 % sous 5 jours ouvrés | Dernier rapport §5 vs date du verdict QA |
+| Incident prod P0 sur un parcours couvert par la porte, découvert après Go | 0 | Issues P0 ouvertes post-release (ex. #5161 : découvert 2026-08-19 car la porte n'existait pas) |
+| Funnel prospect exécuté en prod à chaque porte | 100 % des portes | Case C1-C3 cochée + run e2e-staging.yml |
+| Corrections mergées sans re-certification | 0 | Suivi issues : « PAS PRÊT (date) → corrections → rapport (date) » |
+| Écart registre vs portes | 0 | §8 relu à chaque rituel mensuel |
+
+## 7. Rituel mensuel
+
+**Entrée.** Rapports de porte du mois, releases mises en prod, incidents prod et issues P0/P1
+ouvertes, changements des gates référencés (§2).
+
+**Actions (dernière semaine du mois, porteur + QA).**
+1. Re-vérifier l'état courant : A1-A6 et B1 sur main (les rapports figés ne font pas foi,
+   docs/validation/README.md).
+2. Comparer les verdicts de porte aux incidents réels : tout P0 prod non intercepté par la
+   porte enrichit la checklist §4 (une case ou une règle, pas une annexe).
+3. Mettre à jour §8 (état des lieux) avec les cases créées/restantes.
+4. Mettre à jour docs/PROTOCOLS/00_INDEX.md (statut de ce protocole, liens croisés).
+
+**Sortie.** §8 à jour, index 00 à jour, nouvelles issues si écart constaté, version de ce
+protocole incrémentée (v1.1, v2.0...) en tête de fichier si les règles changent.
+
+## 8. État des lieux au 2026-09-09
+
+| Élément de la porte | Existe déjà | Manque / à créer |
+|---|---|---|
+| CI verte + artefacts (A1-A3, A5-A6) | Oui — REGISTRE_SCENARIOS_TESTS.md + workflows (tests.yml, payroll-ci.yml ≥ 80 %, coverage ≥ 65 %) | Job jest vitrine en CI (A4 : exécution locale seulement) ; integration_test mobile (58 fichiers unit/widget, 0 integration_test) |
+| Readiness locale (B1) | Oui — RELEASE_READINESS_GATE.md + release-readiness.ps1 (rapport 2026-08-14 : 28/28) | Rapport à rejouer à chaque porte (dernier figé au 14/08) |
+| Go/No-Go par surface (B2) | Modèle — PILOT_RELEASE_GO_NOGO_CHECKLIST.md (2026-07-25, « Go conditionnel ») | Case « porte » datée rejouée systématiquement |
+| Smoke funnel prospect prod (C1-C3) | Specs E2E (front/web/e2e) + e2e-staging.yml « Prod Smoke » (#3906) | Condition bloquante de la porte (aucune porte ne l'exigeait : #5161/#5162 passés en prod) |
+| Recette de version générique (D1) | Recettes verticales seulement (RECETTE_UAT_TRAVEL/FUELSTATION/RESTAURANTMANAGER/EDUMANAGER, RECETTE_PILOTE paie DZ) | Gabarit générique cœur RH-pointage-paie multi-pays (§5) + issue de suivi du protocole |
+| Re-certification post-corrections (D3) | Rien de formalisé | Règle R7 (QA_RAPPORT 2026-08-27 « PAS PRÊT » → corrections PR #5698 → aucun rapport de re-cert depuis) |
+| Critères produit (C4-C7) | DoD 8 cases PLAN_100PCT.md ; deploy-prod.yml ne vérifie que les checks CI | Cases C1-C7 dans la porte |
+| Sign-off fondateur (D4) | De fait (décisions fondateur dans les issues) | Sign-off daté formalisé dans le gabarit §5 |
+| Traçabilité (R10) | Oui — règle vivants/figés docs/validation/README.md | Rien |
+| Index des protocoles | Oui — v1.0 (2026-09-09) | docs/PROTOCOLS/00_INDEX.md |

--- a/docs/PROTOCOLS/02_ONBOARDING_AGENTS.md
+++ b/docs/PROTOCOLS/02_ONBOARDING_AGENTS.md
@@ -1,0 +1,138 @@
+# PROTOCOLE 02 — Intégration d'un nouvel agent
+
+Statut : Actif v1.0 — 2026-09-09 | Porteur : fondateur/PM | Revue : mensuelle fin de mois, cf. docs/PROTOCOLS/00_INDEX.md
+
+> Pourquoi : chaque nouvel entrant (agent IA ou humain) se perd aujourd'hui entre 8 documents sans ordre
+> (AGENTS.md, quick card, prompt 14, AGENT-START-HERE, CONTEXT 01-04, constitution) et retombe dans des
+> pièges déjà payés par les devs précédents (doublons de PRs #2400, migrations en collision #1962, issues
+> jamais fermées #2512). Ce protocole capitalise ce temps perdu : un parcours unique, des réflexes d'entrée,
+> un critère de sortie mesurable.
+
+## 1. Objectif & périmètre
+
+Ce protocole s'applique à toute personne — développeur humain ou agent IA — qui démarre une session de
+travail sur le dépôt `leopardo-hr` (code, QA, ops, contenu). Il s'applique aussi, en rappel, à tout agent
+déjà actif qui revient après une interruption : la section 2 reste le chemin d'entrée obligatoire.
+
+Objectifs :
+
+- Rendre un nouvel entrant capable de livrer une première contribution sans casser une garde CI ni dupliquer
+  le travail d'un autre agent (douleurs sourcées : #2333 x3 PRs, #2329 x2 PRs — issue #2400 ; main rouge par
+  collision de migrations — issue #1962 ; issues restées ouvertes après merge — issue #2512).
+- Distinguer clairement ce qui relève de l'intégration d'un agent (ce protocole) de l'onboarding d'un client
+  pilote (`docs/pilotes/ONBOARDING_PILOTE.md`, parcours produit < 30 min) : deux chemins différents, ne pas
+  les confondre.
+
+Périmètre hors sujet : le contexte produit/vitrine pour les profils non techniques est traité par le
+protocole 03 (voir section 5).
+
+## 2. Parcours d'entrée unique — checklist J1
+
+Parcours chronométré, à suivre dans l'ordre. Ne lis que ce qui est listé : tout autre document (y compris
+`docs/README.md`) peut référencer des fichiers obsolètes (voir section 7). Durée totale cible : 75-90 min,
+environnement local déjà fonctionnel inclus.
+
+| # | Action | Durée | Validation de l'étape |
+|---|--------|-------|----------------------|
+| 1 | Cloner le dépôt et vérifier l'outillage : `gh auth status`, `git lfs install` (les assets sont en vrai Git LFS, #4124). Si l'environnement local n'est pas encore monté, suivre `docs/QUICKSTART.md` (setup Docker) — et uniquement lui, pas `docs/DEMARRAGE_RAPIDE.md` (obsolète). | 15 min | `git lfs ls-files` ne montre pas de pointeurs ~130 o pour `assets/**` ; `gh issue list --limit 1` répond. |
+| 2 | Lire `AGENTS.md` (racine, dernière MAJ 2026-09-05) : guide complet, règles actives et leçons récentes. C'est la référence de travail, pas un document de contexte. | 20 min | Tu peux citer la règle anti-doublon #2400, l'affectation par BC et le freeze scope #5147 sans les relire. |
+| 3 | Lire `dev-hub/prompts/00_AGENT_QUICK_CARD.md` : carte de référence rapide (interdits + obligatoires). Garde-la ouverte pendant les premiers commits. | 2 min | Tu connais les 4 interdits mobile et la règle `Closes #N`. |
+| 4 | Lire `dev-hub/prompts/14_ONBOARDING_AGENT.md` puis exécuter ses commandes de synchronisation : `git fetch origin main`, `git checkout main`, `git pull`, `git stash list`, `gh pr list --state open`, `gh run list --branch main --limit 3`. | 10 min | `main` local aligné sur `origin/main` ; tu sais si la CI de main est verte. |
+| 5 | Lire `docs/architecture/AGENT-START-HERE.md` (entrée par bounded context) puis ouvrir `dev-hub/governance/bounded-context-registry.json` : repérer ton BC (ex. BC-15 FUEL) et ses labels d'issues. | 10 min | Tu peux nommer ton BC et le préfixe de ses issues (DEP-BCxx, MAT-*, etc.). |
+| 6 | Lire, dans l'ordre indiqué par `docs/CONTEXT/README.md` : `docs/CONTEXT/01_PRODUCT_CONTEXT.md`, `docs/CONTEXT/02_TECHNICAL_CONTEXT.md`, `docs/CONTEXT/03_OPERATIONAL_CONTEXT.md`, `docs/CONTEXT/04_CURRENT_PRIORITIES.md`. | 15 min | Tu sais quelles surfaces tu touches (mobile/web/admin/api) et où est le backlog prioritaire. |
+| 7 | Lire `.specify/constitution.md` : la loi fondamentale du projet. Spec-first non négociable : toute feature/module significatif commence par une spec, pas par du code. | 10 min | Tu cites les sections I à III (spec-first, multi-tenant, conformité paie). |
+| 8 | Avant la première PR : lire `BRANCH_PROTECTION_REQUIRED.md` (les checks requis au merge) et `CONVENTIONS.md` (conventions de code). Ne merger jamais avec un check requis rouge. | 10 min | Tu listes les 5 checks requis : Backend Coverage >= 65 %, PHPStan Strict (niveau 8), Module Structure Validator, Frontend ESLint + TypeScript, actionlint. |
+| 9 | Déclarer la fin du J1 à ton porteur (fondateur/PM) avec le BC choisi et la première issue ciblée (section 4). | 2 min | Critère de sortie de la section 4 validé ou planifié sur ta première issue. |
+
+Règles de lecture : ne pas ouvrir `docs/archive/`, les dossiers de planification historiques
+(`PLAN_ACTION`, `docs/PLAN_ACTION2/`) ni `PILOTAGE.md` pour chercher du travail (archivés — le backlog vit
+sur GitHub Issues). Si un document listé ci-dessus te renvoie vers un fichier inconnu, signale-le (section 6)
+plutôt que de le chercher longtemps.
+
+## 3. Réflexes anti-pièges
+
+Chaque ligne = une perte de temps déjà vécue, transformée en réflexe d'entrée. À appliquer dès la première
+issue.
+
+| Piège (vécu) | Réflexe d'entrée | Garde existante |
+|---|---|---|
+| Doublons de PRs/branches sur la même issue (#2400 : #2333 x3 PRs, #2329 x2, #2326 x2 branches) | Avant de coder : se self-assigner (`gh issue edit <N> --add-assignee @me`), vérifier TOUTES les branches contenant le numéro d'issue + les PRs ouvertes, puis pousser immédiatement la branche `fix/<issue>-<slug>` avec un commit vide « claim marker #N ». Le nom de branche EST le verrou : une seule branche par issue. | `dev-hub/tools/check-issue-claim-unique.sh` (check « PR Issue Guard » ; signalé cassé au 2026-09-08, non bloquant — cf. section 7) ; `dev-hub/tools/check-crm-branch-protocol.sh` pour le programme CRM |
+| Collision de préfixes de migrations (#1962 : main rouge pour TOUTES les PRs) | Avant tout push d'une PR touchant `api/database/migrations/*` : `bash dev-hub/tools/check-migration-basename-collisions.sh`. Préfixe pris = renuméroter (`000006` -> `000007`) en gardant l'ordre chronologique. | Garde Hygiene Guards (CI) ; `dev-hub/tools/check-migration-prefixes.mjs`, `dev-hub/tools/check-migrations-tenant-schema.sh` |
+| Issue jamais fermée au merge (#2512) | Mettre `Closes #N` (ou `Fixes`/`Resolves`) dans le BODY de la PR, jamais seulement dans le titre ni entre parenthèses. 1 issue = 1 PR. | `dev-hub/tools/check-pr-closes-issue.sh` (bloquant, PA2-OPS-008) ; `dev-hub/tools/check-issues-left-open-by-merged-prs.sh` (rapport non bloquant) |
+| PR « Part of #N » sans issue close | Pour une tranche de campagne : créer une sous-issue de tranche et mettre `Closes #<sous-issue>` dans le body (précédent : sous-issue #7004). | `dev-hub/tools/check-pr-closes-issue.sh` (bloquant) |
+| Issue travaillée hors de son BC, sans label | Ne choisir QUE des issues du BC confié, non assignées, avec critères d'acceptation clairs (labels `Agent-Ready` / `good first issue` idéalement). Une issue sans label BC : ajouter `BC-xx` depuis `dev-hub/governance/bounded-context-registry.json` avant de commencer. Un seul agent par BC à la fois. | Registre machine + `dev-hub/tools/check-bounded-context-registry.sh` (garde CI) ; Module Structure Validator (pas d'import cross-BC) |
+| Feature hors périmètre (freeze scope 60 j, #5147) | Toute feature hors liste de `docs/GOUVERNANCE/FREEZE_SCOPE_60J.md` est refusée en revue. Exception : issue `[FREEZE-EXCEPTION]` décidée par le fondateur, jamais par l'agent. | Revue PR avec renvoi vers `docs/GOUVERNANCE/FREEZE_SCOPE_60J.md` |
+| « Tester en staging » alors qu'il n'existe pas (#1485) | Il n'y a pas de staging réel : le tier dev/continu reçoit chaque push sur `main`, la prod n'est déployée que par GitHub Release publiée. Connaître la topologie : `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md`. Ne pas traiter un rouge externe non requis (Vercel, « Workers Builds ») comme bloquant. | `BRANCH_PROTECTION_REQUIRED.md` (liste des checks requis) ; healthcheck deploy ciblé sur l'instance déployée (#6834/#6973) |
+
+## 4. Critère de sortie d'onboarding & première mission
+
+Un agent est considéré intégré quand il peut, en autonomie et sans assistance :
+
+1. Choisir une issue non assignée de son BC avec critères d'acceptation clairs (`gh issue list --state open`).
+2. Appliquer le cycle complet sans casser une garde : self-assign -> claim marker `fix/<issue>-<slug>` ->
+   implémentation -> PR avec `Closes #N` dans le body et label BC -> 5 checks requis verts (`gh pr checks`) ->
+   merge (`gh pr merge <N> --merge --delete-branch`) ou passage en review.
+3. Expliquer, pour sa PR, pourquoi elle ne déclenche aucun des pièges de la section 3 (migrations, doublons,
+   freeze scope, staging).
+
+Première mission conseillée : une issue `good first issue` (ou à défaut une issue `docs:`/`chore:` simple)
+du BC confié, pour valider le cycle complet sur un petit diff avant de prendre une issue `Agent-Ready`.
+Exercice de validation : réaliser le cycle de bout en bout (étapes 1-9 de la section 2 + une PR mergée) en
+présence du porteur, ou lui remonter la PR en review avec le récap des gardes vérifiées.
+
+## 5. Parcours par rôle
+
+Tous les rôles suivent d'abord la section 2, puis ajoutent leur spécialisation. Le socle de gouvernance
+(section 3) est identique pour tous les rôles techniques.
+
+| Rôle | Complément au parcours J1 | Références |
+|---|---|---|
+| Dev Flutter (front/mobile_apps) | Conventions mobile (interdits : `apiClient.dio.*`, `as List`, `await` avant `runApp()`, `.withOpacity()` ; obligatoires : `requestWithRetry`, `extractDataList`, `StartupGate`, tokens `glass-*`). La liste canonique des 7 apps est `front/mobile_apps/README.md`. | `dev-hub/prompts/00_AGENT_QUICK_CARD.md`, `CONVENTIONS.md` (§ mobile), audit mobile : prompt 08 |
+| Dev backend Laravel (api/) | Conventions PHP (8.4, `strict_types`, modules DDD `App\Modules`, policies explicites, isolation tenant `company_id`). Réflexe migrations #1962 systématique. Tout endpoint nouveau = mise à jour `api/openapi.yaml` (CI OpenAPI sur chaque PR). | `CONVENTIONS.md` (§ PHP/Laravel), `.specify/constitution.md` (§ II-III), `dev-hub/tools/check-migration-basename-collisions.sh` |
+| Agent IA | Mêmes règles qu'un dev + spec kit obligatoire : spec avant code (`.specify/constitution.md` § I), commandes `/speckit-*` (specify, clarify, plan, analyze, tasks, implement), presets actifs par zone (payroll, multitenancy, DZ/CEMAC/CEDEAO). Auto-assignation et claim marker encore plus critiques en parallèle (swarm). | `.specify/constitution.md`, `AGENTS.md` (Spec Kit), `docs/specifications/` (specs validées) |
+| QA | Mêmes règles + savoir distinguer un rouge requis d'un rouge externe non requis (Vercel, Workers Builds) et les gardes signalées cassées (section 7). Savoir rejouer un parcours pilote chronométré. | Prompts 02 (audit gardien), 13 (anti-régression) ; audits 05-09 ; `docs/pilotes/ONBOARDING_PILOTE.md` ; `docs/qa/` |
+| Ops / hotfix | Mêmes règles + topologie de déploiement et SLA bugs pilotes : bloquant = paie/pointage/login impossible, résolution < 24 h, hotfix `hotfix/<issue>-<slug>`, CI minimale, jamais d'auto-merge d'une PR rouge. | `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md`, `docs/ops/SLA_PILOTES.md`, prompt 10 (checklist pré-déploiement), `docs/ops/RUNBOOK_MERGE.md`, template `.github/ISSUE_TEMPLATE/pilot_blocker.yml` |
+| Commercial / marketing | Le parcours technique ne s'applique pas. Contexte produit minimal : `docs/CONTEXT/01_PRODUCT_CONTEXT.md` (promesse, personas, surfaces). Pour tout besoin vitrine/GTM, suivre le protocole dédié. | Renvoi : `docs/PROTOCOLS/03_VITRINE_PRESENTATION.md` |
+
+## 6. Rituel mensuel & boucle d'amélioration
+
+Rituel mensuel (fin de mois, porteur fondateur/PM) : relire la section 7, intégrer les remontées du mois,
+mettre à jour ce protocole (nouveau piège dans la section 3, chemin corrigé dans la section 2) et l'état des
+lieux. L'index des protocoles vit dans `docs/PROTOCOLS/00_INDEX.md`.
+
+Boucle d'amélioration — toute perte de temps rencontrée par un nouvel entrant doit mettre à jour ce
+protocole, via la capitalisation d'expérience :
+
+1. Dès qu'un blocage ou une incohérence documentaire coûte du temps à un nouvel entrant, ouvrir une issue
+   (ou une entrée dans le carnet de capitalisation) avec le format : « j'ai perdu X min à cause de Y ; le
+   doc Z dit A mais la réalité est B ; correctif proposé ».
+2. Les leçons confirmées sont ensuite reportées dans ce protocole (sections 2/3/7) et, si elles touchent
+   les règles de travail, dans `AGENTS.md` + `CHANGELOG.md` (règle existante : toute leçon opérationnelle
+   s'ajoute à `AGENTS.md` à chaque merge).
+3. Un nouvel entrant qui suit ce protocole et tombe sur un document obsolète ne le contourne pas : il le
+   signale avec l'issue de capitalisation, c'est sa contribution à la gouvernance.
+
+Mécanique de capitalisation : voir `docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md`.
+
+## 7. État des lieux au 2026-09-09
+
+Incohérences connues et vérifiées à la date de rédaction — à corriger au fil de l'eau, signalées ici pour
+ne pas piéger un nouvel entrant :
+
+- Parcours d'entrée éclaté : les règles actives sont réparties entre `AGENTS.md`, la quick card, le prompt
+  14, `docs/architecture/AGENT-START-HERE.md`, les quatre fichiers `docs/CONTEXT/01_PRODUCT_CONTEXT.md` à
+  `04_CURRENT_PRIORITIES.md` et `.specify/constitution.md`, sans ordre ni durée. La section 2 de ce protocole
+  est l'ordre unique ; les autres documents restent des références, pas des points d'entrée.
+- `PILOTAGE.md` est ARCHIVÉ (issue #6698, 2026-09-02) : ne plus s'y référer pour une décision. La gestion
+  de projet vit sur GitHub Issues/Projects ; roadmap dans `docs/REFERENTIEL_PRODUIT/ROADMAP.md`.
+- `docs/DEMARRAGE_RAPIDE.md` est obsolète (en-tête : voir `docs/QUICKSTART.md`) mais `docs/README.md` le
+  référence encore dans son tableau « Démarrage rapide ». `docs/README.md` peut donc référencer des
+  documents obsolètes : vérifier un chemin avant de le suivre, et ne lire que la section 2 de ce protocole.
+- `docs/CONTEXT/01_PRODUCT_CONTEXT.md` liste 4 apps mobiles (+ `leopardo_core`) alors qu'`AGENTS.md` en
+  liste 7. La liste canonique : `AGENTS.md` + `front/mobile_apps/README.md` (aligné sur `melos.yaml`).
+- Garde « PR Issue Guard » (`dev-hub/tools/check-issue-claim-unique.sh`) signalée cassée au 2026-09-08
+  (HTTP 403 puis erreur de parsing) : elle rend le check rouge sur toutes les PRs mais n'est PAS bloquante
+  pour le merge (seuls les 5 checks requis de `BRANCH_PROTECTION_REQUIRED.md` bloquent). À corriger dans
+  l'outillage.
+- `docs/pilotes/ONBOARDING_PILOTE.md` pointe vers `docs/pilotes/SLA_PILOTES.md`, qui n'existe pas : le
+  fichier réel est `docs/ops/SLA_PILOTES.md`.

--- a/docs/PROTOCOLS/03_VITRINE_PRESENTATION.md
+++ b/docs/PROTOCOLS/03_VITRINE_PRESENTATION.md
@@ -1,0 +1,135 @@
+# PROTOCOLE 03 — Présentation & vitrine
+
+*Statut : Actif v1.0 — 2026-09-09 | Porteur : fondateur/PM + commercial | Revue : MENSUELLE fin de mois, cf. `docs/PROTOCOLS/00_INDEX.md`*
+
+> Pourquoi : le projet doit pouvoir être présenté à tout moment — site vitrine, README, pitch, démos, dossier commercial — avec les BONS TERMES, sans contredire les autres surfaces ni exposer de chiffres invérifiables. Aujourd'hui trois discours coexistent (README, site statique, dossier go-to-market) et des métriques circulent sans date de mesure. Ce protocole pose une source unique par type d'information, un lexique vitrine, des pitchs par audience, un registre de métriques datées et un rituel de mise à jour mensuelle exécutable.
+
+## 1. Objectif & périmètre
+
+**Objectif.** Garantir qu'en toute situation de présentation (prospect, pilote, investisseur, partenaire, recruteur, communauté open source), le discours tenu est conforme à la source de vérité du moment, dans la langue attendue, avec des chiffres datés et des liens joignables.
+
+**Périmètre couvert.** Surfaces de présentation publiques et commerciales listées au §2 ; discours de référence et procédure de départage (§3) ; lexique vitrine (§4) ; pitchs par audience (§5) ; chiffres datés et registre des métriques (§6) ; rituel mensuel (§7). Ce protocole s'applique aussi aux contenus générés par des agents (issues, PR, réponses commerciales) qui reprennent le discours produit.
+
+**Périmètre exclu.** Les décisions de positionnement et de marque (au fondateur, voir décisions ouvertes §8) ; la rédaction des contenus eux-mêmes ; la réalisation des assets. Ce document ne crée ni ne remplace aucun contenu marketing.
+
+## 2. Surfaces de présentation
+
+| # | Surface | Chemin | Langue | Discours actuel (constat 2026-09-09) | Statut |
+|---|---|---|---|---|---|
+| S1 | Vitrine Next.js (portail Vercel) | `front/web/src/app/(landing)/` (30 pages) + données `front/web/src/modules/vitrine/data/` | FR par défaut (i18n fr/en/ar/tr) | Orientée parcours et conversion ; pricing free/pilot/operations/enterprise aligné sur `PlanSeeder` (ADR-0014) | LIVE `gestionemployer-backend.vercel.app` (`docs/ops/DOMAINS.md`) |
+| S2 | Site statique GitHub Pages | `site/gh-pages/index.html` | EN (bascule FR embarquée) | « Leopardo RH — Open-source HR & Payroll OS » ; stats non datées : 18 modules, 700+ endpoints, 1 900+ tests, 5 apps Flutter, 21 pays | LIVE `kitokoh.github.io/leopardo-hr` ; discours et chiffres divergents |
+| S3 | README racine | `README.md` | EN | « Open-source business operations platform for multi-site and field-based companies » ; section « Project status » | LIVE GitHub ; pose déjà la règle des métriques datées (non appliquée partout) |
+| S4 | Dossier go-to-market | `docs/GOTO_MARKET/README.md` | FR | « Leopardo HR — Mobile-First Company OS » ; se déclare source de vérité business | Sections 02-14 et 99 absentes, cf. `docs/GOTO_MARKET/GOTO_MARKET_AUDIT.md` |
+| S5 | Positionnement & messaging | `docs/GOTO_MARKET/2026_MARKET_LAUNCH_COMPANY_OS/02_POSITIONNEMENT_ET_MESSAGING.md` | FR | Catégorie « Mobile-First Company OS » ; pitchs 15 s / 60 s ; « Leopardo n'est pas… / Leopardo est… » ; objections ; slogans | Référence business actuelle |
+| S6 | Assets marketing | `docs/GOTO_MARKET/ASSETS_PRODUCTION/` (LANDING_PAGE_SPEC, brochure, one-pager, pitch deck, scripts vidéo, prompts) + `assets/{branding,design,screenshots,videos}/` | FR | Specs et supports destinés aux surfaces live | À rattacher explicitement aux surfaces S1-S5 |
+| S7 | Démos & comptes | `docs/DEMO_ACCOUNTS.md`, `docs/DEMO_KIT_DZ.md`, `docs/DEMO_PILOTE_CRM.md`, `dev-hub/demo/README.md`, `docs/GUIDES/GUIDE_TESTEURS_PILOTES.md` | FR/EN | Comptes par persona ; kits DZ et CRM ; seeder `DemoCompanySeeder` | `demo.leopardo-rh.com` en NXDOMAIN (`dev-hub/demo/README.md` vs `docs/ops/DOMAINS.md`, #3452) |
+| S8 | Référentiels produit | `docs/REFERENTIEL_PRODUIT/` (APV.md, ROADMAP.md, COULEURS.md), glossaire `docs/dossierdeConception/14_glossaire/21_GLOSSAIRE_ET_DICTIONNAIRE.md` | FR | Pitch APV (« l'app s'ouvre sur une conversation… ») distinct du pitch GTM ; couleurs et roadmap canoniques | Internes ; sources des termes et du visuel |
+
+Constat : trois discours concurrents (S2, S3, S4), deux vitrines actives (S1, S2), une règle de métriques datées déjà écrite dans S3 mais pas étendue aux autres surfaces, et aucun lexique produit central (le glossaire S8 est technique et daté de mars 2026).
+
+## 3. Règle de la source unique & procédure de départage
+
+### 3.1 Source unique par type d'information
+
+| Type d'information | Source canonique | Conséquence |
+|---|---|---|
+| Positionnement & messaging FR | S5 (`02_POSITIONNEMENT_ET_MESSAGING.md`) | Toute nouvelle formulation s'y rattache ou la modifie d'abord, jamais l'inverse |
+| Positionnement EN | Aucune — décision ouverte DO-1 | Interdiction d'inventer un 4e discours EN en attendant la décision fondateur |
+| URLs, domaines, environnements | `docs/ops/DOMAINS.md` | Registre machine-checkable ; ne pas diffuser d'URL hors registre |
+| Prix, plans, plafonds | `api` (`PlanSeeder.php` / `PlanCode.php`, ADR-0014), miroir UI `front/web/src/modules/vitrine/data/pricing.ts` | Le dossier GTM ne fixe pas les montants |
+| Chiffres & métriques | Registre §6 (mesures datées) | Jamais copiés depuis une surface vers une autre |
+| Marque, couleurs, visuel | `docs/REFERENTIEL_PRODUIT/COULEURS.md` + `assets/branding/` | Lexique §4 à valider (DO-6) |
+| Vocabulaire produit | `docs/REFERENTIEL_PRODUIT/APV.md` + glossaire technique S8 | Termes métier et architecture |
+
+### 3.2 Procédure de départage quand deux surfaces divergent
+
+1. Identifier le type d'information en conflit et remonter à sa source canonique (tableau 3.1).
+2. Si une surface contredit sa source : la surface est en erreur. Ouvrir une issue de correction « vitrine » (§7.3) et corriger la surface — jamais l'inverse — sauf si la source est elle-même dépassée (passer alors à l'étape 3).
+3. Si deux sources de même rang divergent, ou si le conflit porte sur un choix de positionnement : ne pas trancher soi-même. Ouvrir une décision fondateur formulée en une question (options, surfaces impactées, préférence GTM le cas échéant), la tracer en §8, et geler tout nouveau contenu porteur du terme en conflit jusqu'à la décision.
+
+Arbitres par domaine : positionnement, marque, lexique = fondateur ; architecture, métriques techniques = PM / responsable technique ; URLs = registre `docs/ops/DOMAINS.md` (garde existante).
+
+## 4. Lexique vitrine (termes autorisés / interdits / ambigus — à valider)
+
+Tableau de propositions, à valider par le fondateur (DO-6). Tant qu'il n'est pas validé, un terme marqué « ambigu » ne doit pas être utilisé dans un nouveau contenu.
+
+| Terme | Statut proposé | Usage autorisé | À ne pas faire | Justification |
+|---|---|---|---|---|
+| « Company OS » / « Mobile-First Company OS » | Autorisé (FR) | Positionnement et messaging stratégiques (S4, S5) | Le décliner en EN avant DO-1 | Concurrence avec « business operations platform » (S3) et « HR & Payroll OS » (S2) |
+| « Leopardo » / « Leopardo RH » / « Leopardo HR » | Ambigu | Première mention « Leopardo » ; « Leopardo RH » en FR, « Leopardo HR » en EN (traduction) | Mélanger RH et HR dans une même surface ; GTM FR écrit « Leopardo HR » | Variantes non normalisées constatées dans S2, S3, S4 et l'i18n de l'app |
+| « cockpit mobile » | Autorisé (marketing) | Métaphore de positionnement (« le cockpit mobile qui connecte présence, paie… ») | L'employer dans les docs techniques ou le glossaire | Registre commercial, pas produit |
+| « app mobile » | Autorisé | Terme générique désignant les applications Flutter | « application » seul quand on parle du mobile | Précision nécessaire dans les surfaces FR |
+| « pilote » | Autorisé | Client accompagné sur un périmètre réel (dossier `docs/pilotes/`, S7) | « beta tester » | « bêta » suggère un logiciel inachevé ; le pilote est un usage réel suivi |
+| « module » | Autorisé | Capacité métier isolée (bounded context) | « fonctionnalité » pour un module complet | Vocabulaire DDD (S3 product map, APV) |
+| « SIRH » | Interdit | — | « un SIRH », « SIRH mobile » comme catégorie | Positionnement : « pas un SIRH desktop adapté au mobile » (S5) |
+| « PME terrain » | Autorisé | Audience ICP1 : 20-250 salariés, multi-sites (sécurité, BTP, logistique, nettoyage, restauration, retail, maintenance) | « PME » seul dans les pitchs | Cible GTM (S5) |
+| « endpoint » | Nuancé | Surfaces techniques EN uniquement | « endpoint » dans la vitrine FR | Anglicisme technique ; préférer « API », « route » |
+| « paie » / « payroll » | Nuancé | « paie », « bulletins » en FR ; « payroll », « payslips » en EN | Mélanger les langues dans une surface i18n | Règle générale des surfaces multilingues |
+
+## 5. Pitchs par audience
+
+Règle : tout pitch oral s'appuie sur un support écrit existant ; aucun chiffre nouveau en improvisation (cf. §6).
+
+| Audience | Pitch de référence | Supports | Démo / comptes |
+|---|---|---|---|
+| Prospect PME terrain (ICP1) | Pitchs 15 s / 60 s et messages par persona (S5) | S6 : `LEOPARDO_ONE_PAGER.md`, `LEOPARDO_BROCHURE_PLAN.md` ; page vitrine `front/web/src/app/(landing)/` | Parcours vitrine Vercel (S1) ; personas de `docs/DEMO_ACCOUNTS.md` |
+| Cabinet RH / comptable multi-clients (ICP2) | Messages ICP2 de S5 (multi-client, preuves, exports) | One-pager S6 ; `docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md` | Comptes démo par persona RH (S7) |
+| Pilote algérien (DZ) | Kit démo DZ réaliste | `docs/DEMO_KIT_DZ.md` (F-23 #1553) : société fictive, 30 employés, paie DZD clôturée | Comptes `demo-dz` (mot de passe commun indiqué dans le kit) |
+| Investisseur | Pas de dossier GTM dédié (sections 11_INVESTORS / 99_EXECUTIVE absentes, cf. S4) | `docs/GOTO_MARKET/LEOPARDO_STRATEGIC_ANALYSIS.md` ; S6 `LEOPARDO_PITCH_DECK_OUTLINE.md` | Décision ouverte DO-7 |
+| Partenaire intégrateur | Pitch partenaire de S5 + guide intégration | `api/openapi.yaml` ; `docs/GUIDES/GUIDE_INTEGRATION_PARTENAIRES.md` | Environnement local (seeder `DemoCompanySeeder`, `dev-hub/demo/`) |
+| Recruteur | Pages carrières et blog de la vitrine | `front/web/src/app/(landing)/careers`, `(landing)/blog` | Vitrine S1 |
+| Communauté open source | README + CONTRIBUTING + section « Developers » de S2 | `README.md`, `CONTRIBUTING.md`, `site/gh-pages/index.html` | GitHub ; démo locale uniquement (pas `demo.leopardo-rh.com`, NXDOMAIN) |
+
+**Quick-card agent commercial / marketing.** Par où commencer : lire (1) S5 pour les messages, (2) le registre §6 pour les chiffres autorisés, (3) `docs/ops/DOMAINS.md` pour les URLs joignables, (4) `docs/GOTO_MARKET/README.md` pour la carte du dossier. Quel compte pour quelle audience : prospect PME = personas de `docs/DEMO_ACCOUNTS.md` ; pilote DZ = comptes `demo-dz` de `docs/DEMO_KIT_DZ.md` ; pilote CRM = tenants `crm-pilot-alpha`/`crm-pilot-beta` de `docs/DEMO_PILOTE_CRM.md` ; démo technique = seeder `DemoCompanySeeder`. Interdits : `demo.leopardo-rh.com` et les adresses `@leopardo-rh.com` (NXDOMAIN, #3452), tout chiffre non daté, tout terme du §4 marqué interdit ou ambigu.
+
+## 6. Règle des chiffres datés & registre des métriques
+
+**Règle (étendue à toutes les surfaces).** Aucun chiffre de mesure — modules, endpoints, tests, applications, pays, couverture, taux — ne peut figurer sur une surface de présentation (S1-S7, pitchs, dossier commercial, assets) sans (a) une date de mesure et (b) une source de mesure. Format imposé : « 1 900+ tests backend automatisés (mesure du 2026-09-09, suite de tests `api`) ». Cette règle généralise l'avertissement de la section « Project status » de `README.md` (« should not be copied into long-lived marketing claims without updating their measurement date ») que S2 viole aujourd'hui. Les badges dynamiques (CI, couverture) sont tolérés car régénérés par le CI, mais leur valeur affichée doit rester traçable vers une mesure datée.
+
+**Registre des métriques à régénérer** (colonne « constat » vérifié le 2026-09-09) :
+
+| Métrique | Affichage actuel | Où mesurer | Constat au 2026-09-09 |
+|---|---|---|---|
+| Modules métier | « 18 DDD business modules » (S2) | `api/app/Modules` (convention DDD) | 27 dossiers présents — périmètre « module » à définir (DO-4) avant tout chiffre |
+| Endpoints API | « 700+ » (S2, section developers) | `api/openapi.yaml` | ~738 chemins de niveau 1 comptés — script de comptage à fixer |
+| Tests backend | « 1 900+ » (S2) ; badge « coverage 71 % » (S3) | suite de tests `api` (phpunit), gate de couverture | Non re-vérifié — à régénérer à l'étape 1 du rituel |
+| Apps Flutter | « 5 » (S2) | `front/mobile_apps` | 8 dossiers d'apps (dont `leopardo_core`, probablement partagé) — « app publiée » vs « en dev » à définir (DO-4) |
+| Pays | « 21 » au catalogue paie (S2) | catalogue paie `api` ; registre essai `GET /api/v1/supported-countries` (miroir `front/web/src/modules/vitrine/data/supported-countries.ts`, arrêté au 2026-08-16) | Deux périmètres distincts (catalogue paie ≠ pays éligibles à l'essai) à ne pas confondre |
+| Micro-chiffres vitrine | « 99,9 % précision » (données `features.ts`, S1) | équipe produit | À dater ou retirer des surfaces publiques |
+
+Règle de copie : un chiffre ne se copie jamais d'une surface à l'autre ; il se copie depuis sa mesure (colonne « où mesurer »), datée le jour de la copie.
+
+## 7. Rituel de mise à jour mensuelle (checklist exécutable)
+
+Ancré au rituel fin de mois du fondateur (`docs/PROTOCOLS/00_INDEX.md`). Quand : dernier jour ouvré du mois. Qui : PM/fondateur + commercial (1 h) puis validation fondateur (15 min). À la fin du mois de septembre 2026, exécuter ce rituel pour la première fois sur la base du §8.
+
+1. **Régénérer les chiffres.** Mesurer chaque métrique du registre §6 à sa source (« où mesurer »), consigner valeurs et date dans le registre. Livrable : registre §6 à jour.
+2. **Comparer les surfaces.** Parcourir S1-S7 : discours conforme à la source du §3.1 ? chiffres datés et exacts ? URLs joignables (`docs/ops/DOMAINS.md`) ? termes du §4 respectés ? Livrable : liste des écarts.
+3. **Ouvrir une issue de correction « vitrine » par écart.** Modèle : surface concernée, écart constaté, source de vérité, date du constat. Aucun nouveau contenu reprenant l'écart ne doit être publié tant que l'issue n'est pas corrigée.
+4. **Valider les pitchs.** Relire §5 et S5 (positionnement, objections, slogans) : toujours exacts au regard du produit et du marché ? Dater la relecture dans S5. Livrable : pitchs validés du mois.
+5. **Tracer le rapport daté.** Créer `docs/PROTOCOLS/rapports/YYYY-MM_vitrine.md` : résultats des étapes 1-2, issues ouvertes (étape 3), pitchs validés (étape 4), décisions nouvelles à remonter au fondateur. Transmettre le rapport à la revue de fin de mois (`docs/PROTOCOLS/00_INDEX.md`).
+
+## 8. État des lieux au 2026-09-09 & décisions ouvertes
+
+**Constat initial (vérifié par lecture le 2026-09-09).**
+
+- C1. Trois discours concurrents : S3 « Open-source business operations platform » (EN), S2 « Open-source HR & Payroll OS » (EN), S4/S5 « Mobile-First Company OS pour PME terrain » (FR). Aucune version EN validée du positionnement GTM.
+- C2. Nom de marque flottant : « Leopardo » (S3), « Leopardo RH » (S2, i18n FR de l'app), « Leopardo HR » (S4/S5 y compris en français).
+- C3. S2 affiche cinq métriques sans date (18 modules, 700+ endpoints, 1 900+ tests, 5 apps, 21 pays) ; le décompte brut des dossiers (`api/app/Modules` : 27 ; `front/mobile_apps` : 8) suggère des périmètres à clarifier, pas nécessairement des valeurs fausses.
+- C4. `dev-hub/demo/README.md` pointe `demo.leopardo-rh.com` (NXDOMAIN, #3452) et des adresses `@leopardo-rh.com` non joignables ; risque de reprise en démo publique.
+- C5. Deux vitrines actives (S1 Vercel FR, S2 GitHub Pages EN) ; S3 relie « Product site » vers S2. Risque de double discours et de maintenance dédoublée.
+- C6. `docs/GOTO_MARKET/README.md` déclare lui-même les sections 02-14 et 99 absentes : aucun dossier investisseur ni playbook de vente structuré à ce jour (voir `GOTO_MARKET_AUDIT.md`).
+- C7. Surfaces annexes non auditées ce jour : `docs/GOTO_MARKET/SOCIAL_MEDIA_PITCHES.md` et fiches annuaires `docs/GOTO_MARKET/platform-submissions/` — à passer en revue au premier rituel.
+- C8. Le dossier `docs/PROTOCOLS/` est créé avec le présent document (v1.0) ; l'index `00_INDEX.md` et les autres protocoles de la série sont attendus dans la même passe de septembre 2026.
+
+**Décisions ouvertes à trancher par le fondateur (à remonter au PM).**
+
+| # | Décision | Enjeu | Blocage tant que non tranchée |
+|---|---|---|---|
+| DO-1 | Positionnement EN de référence (S3, S2, traduction EN de S5, ou nouveau) | Discours EN des surfaces live | Tout nouveau contenu EN porteur du terme en conflit |
+| DO-2 | Nom de marque et règle RH/HR par langue | C2 | Usage du nom dans les nouveaux contenus |
+| DO-3 | Sort de S2 `site/gh-pages/` (aligner, fusionner dans S1, archiver) | C5 | Mise à jour des stats et du discours EN |
+| DO-4 | Périmètres de mesure des métriques vitrine (module, app publiée, pays) | C3, registre §6 | Publication de tout chiffre sur une surface |
+| DO-5 | Environnement de démo publique à référencer (NXDOMAIN #3452 ; `DEMO_MODE_ENABLED` inactif en prod) | C4, S7 | Tout lien démo publié |
+| DO-6 | Validation du lexique §4 | Cohérence des termes | Emploi des termes ambigus |
+| DO-7 | Création des dossiers GTM investisseur / partenaire (sections 02-14, 99) | C6, pitch investisseur | Pitch investisseur complet |

--- a/docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md
+++ b/docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md
@@ -1,0 +1,178 @@
+# PROTOCOLE 04 — Capitalisation de l'expérience en tâches & issues
+
+> **Statut** : Actif v1.0 — 2026-09-09
+> **Porteur** : chaque agent (constat, issue, implémentation directe) ; agent PM (triage, moisson mensuelle, arbitrage des cas limites)
+> **Revue** : mensuelle, fin de mois — cf. docs/PROTOCOLS/00_INDEX.md
+>
+> **Pourquoi** : les enseignements du travail (succès, échecs, temps perdu, optimisations tentées) sont aujourd'hui bien *documentés* (AGENTS.md, CHANGELOG.md, rétros, rapports datés) mais ne deviennent pas systématiquement *actionnables* : pas de gabarit d'issue de retour d'expérience, pas de label dédié, pas de seuil d'arbitrage « je corrige / je délègue », pas de moisson des rapports figés. Une leçon reste donc là où elle est née — dans la tête ou le rapport de celui qui l'a vécue — et un autre agent la revivra. Ce protocole ferme la boucle.
+
+## 1. Objectif & périmètre
+
+Tout agent doit pouvoir, depuis ce qu'il vient d'apprendre :
+
+1. créer sans friction une issue ou une tâche exploitable ;
+2. l'implémenter lui-même si elle est petite, ou la laisser à un autre agent ;
+3. garantir que l'enseignement servira réellement : l'issue doit être « agent-ready », réalisable par un autre agent sans le contexte de son auteur.
+
+**Périmètre** : toutes les leçons issues du travail sur le dépôt — récidives et bugs évitables, causes de temps perdu, dette découverte, optimisations tentées (validées ou non), succès reproductibles à généraliser.
+
+**Hors périmètre** (flux dédiés existants, non modifiés par ce protocole) :
+
+- bug bloquant pilote → template `pilot_blocker.yml`, SLA < 24 h (docs/ops/SLA_PILOTES.md) ;
+- vulnérabilité de sécurité → template `security_vulnerability.md` ;
+- demande de fonctionnalité → template `feature.yml` (critères d'acceptation obligatoires).
+
+Ce protocole renvoie vers ces flux au lieu de les dupliquer.
+
+## 2. La boucle expérience → issue → leçon
+
+**État actuel (sens unique)** : l'expérience est capitalisée dans des documents — AGENTS.md (règle « mis à jour dès qu'une leçon opérationnelle peut éviter de perdre du temps plus tard », sections de leçons datées), CHANGELOG.md, docs/JOURNAL_RACINE.md, rétros et carnets pilotes (docs/pilotes/), rapports datés figés (docs/validation/). Le sens manquant : documents et notes → issues → correction, puis retour de la correction vers la leçon consolidée.
+
+**Boucle cible en 5 étapes** :
+
+1. **Constat** — au fil de l'eau, un agent identifie une leçon. Il la note immédiatement et brièvement (entrée du jour, docs/JOURNAL_RACINE.md, doc datée existante) pour ne rien perdre.
+2. **Qualification** — arbitrage à seuils (§4) : l'agent décide seul. Zone verte → implémentation directe. Sinon → issue « retour d'expérience » (§3) dans le backlog.
+3. **Exécution** — directe : branche `fix/<issue>-<slug>` (ou `bc/<code>-<slug>` en lot), PR avec `Closes #N` — mêmes règles que toute PR. Déléguée : l'issue étiquetée et priorisée (§6) attend l'affectation par BC ou la moisson.
+4. **Consolidation** — la leçon validée par l'implémentation est consignée : AGENTS.md si leçon opérationnelle (règle existante du fichier), CHANGELOG.md si livraison ; l'issue REX est clôturée en commentaire avec le numéro de PR et ce qui a été confirmé ou infirmé.
+5. **Moisson mensuelle** (§7) — l'agent PM convertit en issues les rapports figés du mois et les notes, trie, déduplique et priorise.
+
+```
+ [1] Constat ──note courte──▶ [2] Qualification (seuils §4)
+                                   │ zone verte          │ sinon
+                                   ▼                     ▼
+                      [3] Implémentation directe   [3'] Issue « REX / dette » (§3)
+                          PR fix/#N (Closes #N)        ▶ backlog, labels, priorité
+                                   │                     │
+                                   ▼                     ▼
+                      [4] Leçon consolidée        [4'] Un AUTRE agent l'implémente
+                          AGENTS.md / CHANGELOG          (issue agent-ready §5)
+                                   │                     │
+                                   └──────────▶ [5] Moisson mensuelle (retour backlog)
+```
+
+Règle de fermeture : une issue REX fermée sans que la leçon ait été consolidée (étape 4) = boucle non fermée.
+
+## 3. Gabarit « retour d'expérience / dette découverte »
+
+**Titre** : `[REX] <BC ou surface> : <verbe à l'infinitif> <objet> — <leçon en 1 ligne>`
+
+Exemples :
+
+- `[REX] BC payroll : verrouiller le nommage des migrations — collisions de préfixes récurrentes`
+- `[REX] .github/workflows : cibler l'instance déployée au healthcheck — gate aveugle sur le tier dev`
+
+**Bloc à copier dans le corps de l'issue** :
+
+```
+## Contexte
+D'où vient la leçon (tâche, incident, rapport daté, rétro) : source + date.
+Pourquoi c'est important pour la suite.
+
+## Symptôme (ou succès reproductible)
+Ce qui a été observé. Pour une leçon positive : ce qui a bien fonctionné
+et à quelles conditions.
+
+## Cause
+Pour un échec : pourquoi c'est arrivé. Pour un succès : ce qui l'a rendu possible.
+
+## Impact
+Coût si on ne fait rien (temps perdu, récidive attendue, risque pilote/produit).
+Justifie la priorité (§6).
+
+## Correction proposée
+Option retenue et pourquoi. Optimisations déjà tentées et leurs résultats
+(évite de re-tester un cul-de-sac).
+
+## Portée
+BC / fichiers / surfaces concernés (chemins réels vérifiés).
+
+## Critères d'acceptation
+- [ ] condition vérifiable 1
+- [ ] condition vérifiable 2
+
+## Définition of Done (issue)
+- [ ] PR mergée avec `Closes #<cette issue>` dans le body (garde #2512)
+- [ ] entrée CHANGELOG.md si livraison
+- [ ] AGENTS.md mis à jour si leçon opérationnelle
+- [ ] tests et lints requis verts (constitution §IV)
+```
+
+Règle de bascule : une leçon décrivant un bug **bloquant** actif en prod passe par `pilot_blocker.yml` (SLA 24 h) ; un besoin de sécurité par `security_vulnerability.md`. Le gabarit ci-dessus couvre la dette et la prévention, pas l'urgence.
+
+## 4. Implémenter directement ou déléguer ?
+
+Principe : l'agent arbitre **seul** grâce aux seuils ci-dessous ; l'agent PM n'arbitre que les cas limites. En cas de doute → issue : une issue coûte cinq minutes, une leçon perdue coûte sa récidive.
+
+| Critère | Implémentation directe | Issue (délégation) |
+|---|---|---|
+| Portée | ≤ 1 fichier (ou ensemble homogène minuscule) | plusieurs fichiers / modules |
+| Effort estimé | ≤ 1 h | > 1 h |
+| BC impacté | confié à l'agent (affectation par BC) | BC d'un autre agent — jamais toucher |
+| Freeze 60 j | hors périmètre gelé | périmètre gelé → issue + `[FREEZE-EXCEPTION]` décidée par le fondateur |
+| Risque | faible (cosmétique, doc, outillage) | donnée, paie, tenant, sécurité, migration → jamais direct |
+| Spec requise | non | oui → spec spec kit d'abord (constitution §I), puis issue |
+| Tests | couverts ou ajout trivial | tests à écrire (logique métier) |
+
+Règles d'exécution :
+
+- Le direct **ne dispense d'aucune règle existante** : branche + claim marker (protocole #2400), `Closes #N` dans le body (#2512), entrée CHANGELOG.md, CI verte (constitution §IV/VII). Le « direct » dispense du ticket, pas des règles.
+- **Auto-limitation** : si l'effort dépasse l'estimation, s'arrêter, ouvrir l'issue REX avec l'analyse déjà produite et laisser la suite au backlog.
+- **Délégation immédiate** : créer l'issue dans la foulée du constat, jamais « plus tard » — une leçon non écrite le jour même est perdue.
+- Le PM ne pilote pas le flux au ticket près : il arbitre (a) les issues au BC/label incertain, (b) les demandes d'exception au freeze (décision du fondateur, jamais de l'agent), (c) la priorité à la moisson. L'agent ops garde son flux dédié (pilot-blocker, hotfix — docs/ops/SLA_PILOTES.md) ; le gardien du merge reste l'agent PM (docs/ops/RUNBOOK_MERGE.md).
+
+## 5. Format « agent-ready »
+
+Toute issue issue d'une leçon doit être réalisable par un **autre** agent sans échange : c'est la condition pour que l'enseignement serve réellement. Exigences minimales, toutes dans le corps de l'issue :
+
+1. **Contexte autonome** — tout ce que l'auteur sait est écrit ; la source de la leçon est citée (fichier + date, ou issue). Jamais de « comme je l'ai dit ».
+2. **Critères d'acceptation vérifiables** — checklist de conditions observables (obligatoire, même exigence que `feature.yml`) : l'agent qui prend l'issue sait quand il a fini.
+3. **DoD explicite** — bloc §3 (PR + `Closes #N` + CHANGELOG + AGENTS.md + tests).
+4. **Portée et fichiers** — chemins réels vérifiés + label BC (registre `dev-hub/governance/bounded-context-registry.json`), pas de « module concerné » vague.
+5. **Pièges connus et tentatives déjà faites** — résultats des optimisations essayées, positifs comme négatifs.
+6. **Découpage** — une issue = un enseignement ; les tickets fourre-tout sont interdits (règle de `dev-hub/prompts/04_CREATE_ISSUES.md`).
+7. **Dédoublonnage préalable** — `gh issue list --search "<mots clés>"` avant création (idem prompt 04).
+
+Auto-test de l'auteur avant de lâcher l'issue : « un agent qui n'a jamais travaillé avec moi peut-il la réaliser sans me poser de question ? » Si non → compléter. Si oui → poser le label `Agent-Ready` : l'issue devient prioritaire pour les agents en recherche de tâche (AGENTS.md, `dev-hub/prompts/01_DRAIN_BACKLOG.md`).
+
+## 6. Labels & triage
+
+**Constat** : aucune catégorie ne distingue aujourd'hui les issues issues d'un retour d'expérience. Les labels existants couvrent le type de travail (bug, enhancement, pilot-blocker, security), le BC (BC-XX du registre), la priorité (`P1` dans `pilot_blocker.yml` ; famille `P0-critical`/`P1-high`/`P2-medium`/`P3-low` préconisée par `dev-hub/prompts/04_CREATE_ISSUES.md`), la préparation (`Agent-Ready`) et le préfixe `[FREEZE-EXCEPTION]` (docs/GOUVERNANCE/FREEZE_SCOPE_60J.md). Quelques tickets historiques portaient la mention `tech-debt` dans leur intitulé (ex. #4508 web/tech-debt — docs/qa/QA_SESSION_2026-08-16-swe-qa-merge-drain.md) sans label ni gabarit canoniques.
+
+**Décisions** :
+
+1. Créer le label **`tech-debt`** (recommandé : catégorie de travail standard pour dette découverte et re-travail évitable) :
+   `gh label create tech-debt --description "Retour d'experience / dette decouverte — protocole 04" --color B60205`
+   Alternative acceptable si l'équipe préfère marquer la source : **`lecon`**. Un seul des deux suffit au tri ; ne pas les empiler.
+2. Labels systématiques d'une issue REX : `BC-XX` (registre), `tech-debt` (ou `lecon`), priorité, et `Agent-Ready` si le format §5 est complet.
+3. Priorité : `P1` seulement pour un re-travail récurrent avéré ou un risque de parcours pilote ; `P2` pour la dette d'hygiène ; les urgences passent par les flux bug/security/pilot-blocker, jamais par `tech-debt`.
+4. Triage : l'auteur pose les labels à la création ; l'agent PM re-trie à la moisson et tranche les BC incertains. Le drain du backlog continue de privilégier `Agent-Ready` et `P1`.
+
+## 7. Moisson mensuelle (checklist)
+
+Rituel de fin de mois — porteur : agent PM, le même jour que la revue des protocoles (cf. docs/PROTOCOLS/00_INDEX.md). Convertir les enseignements figés en issues, trier, prioriser :
+
+1. **Collecter** les sources du mois : rapports datés de `docs/validation/` (fichiers `*_YYYY_MM_DD*` et `*_YYYY-MM-DD*` — figés par nature, cf. docs/validation/README.md : jamais mis à jour rétroactivement, leur contenu doit donc être rejoué en issues) ; rétro pilotes du mois (`docs/pilotes/RETRO_<date>.md`) ; entrées du mois de `docs/JOURNAL_RACINE.md` ; carnets hebdo (`docs/pilotes/CARNET_*.md`) ; notes QA/ops datées.
+2. **Dépouiller** : pour chaque enseignement actionnable, créer UNE issue au gabarit §3 en citant la source datée (fichier + date + n° de rétro/issue si présent).
+3. **Dédupliquer** : recherche préalable `gh issue list --search` ; fusionner avec une issue équivalente ouverte (commentaire de renvoi) plutôt que créer un doublon.
+4. **Étiqueter** : BC, `tech-debt` (ou `lecon`), priorité (§6) ; compléter le format §5 et poser `Agent-Ready` avant de clore la moisson.
+5. **Confronter au freeze** (FREEZE_SCOPE_60J.md) : enseignement hors périmètre autorisé → proposer une issue `[FREEZE-EXCEPTION]` au fondateur (décision humaine), ne pas l'ouvrir en vrac.
+6. **Prioriser** avec le backlog existant (impact x fréquence de récidive) ; les affectations suivent le principe « par BC, un agent par BC » (AGENTS.md).
+7. **Boucler** : chaque leçon majeure du mois a une issue (ouverte, faite ou rejetée motivée) OU une entrée AGENTS.md — aucune leçon ne reste prisonnière d'un rapport figé.
+8. **Tracer** : entrée `docs/JOURNAL_RACINE.md` + entrée CHANGELOG.md (`chore:` moisson) ; lister dans la revue mensuelle les leçons non transformées et pourquoi.
+
+## 8. État des lieux au 2026-09-09
+
+**Capitalisation existante** (sens documents ← expérience ; non modifiée par ce protocole) :
+
+- `AGENTS.md` (racine) : règle de mise à jour continue (« dès qu'une leçon opérationnelle peut éviter de perdre du temps plus tard »), sections de leçons datées (ex. famine du pipeline #3545, gate de deploy #6834/#6973), gardes #2400 (verrou branche + claim marker), #2512 (`Closes #N`), #1962 (collisions de migrations), affectation par BC (registre #5859), freeze #5147.
+- `CHANGELOG.md` (entrée par PR, règle #2417) ; `docs/JOURNAL_RACINE.md` (« qui a fait quoi, quand ») ; `docs/pilotes/RETRO_2026-08-24.md` (rétro baseline #5157) ; `docs/pilotes/CARNET_TEMPLATE.md` (carnets hebdo #5152) ; rapports datés figés `docs/validation/` (cf. README.md).
+- Templates d'issues : `bug.yml`, `feature.yml` (critères d'acceptation obligatoires), `pilot_blocker.yml` (SLA < 24 h), `good_first_issue.md`, `security_vulnerability.md`. Aucun gabarit « retour d'expérience / dette » — trou comblé par §3.
+- Labels existants : BC-XX (registre `dev-hub/governance/bounded-context-registry.json`), `pilot-blocker`, `Agent-Ready`, priorité P0/P1/P2, préfixe `[FREEZE-EXCEPTION]`. Aucun label « lecon » / « tech-debt » — trou comblé par §6.
+- Règles de travail auxquelles ce protocole renvoie sans les réécrire : spec kit (`.specify/constitution.md`) ; 1 issue = 1 PR avec `Closes #N` (#2512) ; branche `fix/<issue>-<slug>` + claim (#2400) ; lots par BC sur `bc/<code>-<slug>` (`docs/GOUVERNANCE/BC_BATCH_BRANCH_PROTOCOL.md`) ; affectation par BC, un agent par BC (AGENTS.md) ; freeze 60 j (`docs/GOUVERNANCE/FREEZE_SCOPE_60J.md`).
+
+**Restes à faire** (hors champ de ce document) :
+
+- créer le label `tech-debt` (ou `lecon`) — commande en §6 ;
+- (fait avec la série) gabarit §3 porté en template `.github/ISSUE_TEMPLATE/retour_experience.yml` — ouvrable via le sélecteur GitHub ;
+- référencer ce protocole dans `docs/PROTOCOLS/00_INDEX.md` (créé avec la série, v1.0 — 2026-09-09) ;
+- première moisson mensuelle : fin septembre 2026 (convertir notamment la rétro pilotes J46 attendue au 2026-10-03 et les rapports datés du mois).

--- a/docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md
+++ b/docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md
@@ -140,8 +140,8 @@ Auto-test de l'auteur avant de lâcher l'issue : « un agent qui n'a jamais trav
 
 **Décisions** :
 
-1. Créer le label **`tech-debt`** (recommandé : catégorie de travail standard pour dette découverte et re-travail évitable) :
-   `gh label create tech-debt --description "Retour d'experience / dette decouverte — protocole 04" --color B60205`
+1. Utiliser le label **`tech-debt`** — il existe déjà sur le dépôt (vérifié 2026-09-09) ; s'il n'a pas de description, l'ajuster :
+   `gh label edit tech-debt --description "Retour d'experience / dette decouverte — protocole 04" --color B60205`
    Alternative acceptable si l'équipe préfère marquer la source : **`lecon`**. Un seul des deux suffit au tri ; ne pas les empiler.
 2. Labels systématiques d'une issue REX : `BC-XX` (registre), `tech-debt` (ou `lecon`), priorité, et `Agent-Ready` si le format §5 est complet.
 3. Priorité : `P1` seulement pour un re-travail récurrent avéré ou un risque de parcours pilote ; `P2` pour la dette d'hygiène ; les urgences passent par les flux bug/security/pilot-blocker, jamais par `tech-debt`.

--- a/docs/PROTOCOLS/05_HARMONISATION_DESIGN.md
+++ b/docs/PROTOCOLS/05_HARMONISATION_DESIGN.md
@@ -1,0 +1,108 @@
+# PROTOCOLE 05 — Harmonisation du design
+
+> **Statut** : Actif v1.0 — 2026-09-09
+> **Porteur** : fondateur/PM (revue design en PR, rituel mensuel) + devs (application des règles au fil de l'eau)
+> **Revue** : mensuelle, fin de mois — cf. docs/PROTOCOLS/00_INDEX.md
+>
+> **Pourquoi** : l'écosystème compte aujourd'hui 7 apps Flutter (employee, manager, hr, platform_admin, marketing, accounting, travel_agent) adossées à un package partagé `leopardo_core`, deux surfaces web (vitrine `front/web`, admin `front/admin-dashboard`) et un futur desktop. Chaque surface a historiquement inventé ses propres valeurs visuelles : hex en dur dans les écrans de pointage, copies locales de fichiers « core » (accounting, travel_agent), tokens tailwind dupliqués entre admin et web. Sans sources canoniques désignées et gardes associées, la moindre nouveauté visuelle diverge et la cohérence perçue du produit se dégrade silencieusement.
+
+## 1. Objectif & périmètre
+
+Garantir qu'aucune surface ne diverge visuellement : une même valeur (couleur, typographie, composant, libellé) doit avoir une source unique, un chemin de modification balisé et une garde qui détecte la dérive.
+
+**Périmètre** : toutes les surfaces de l'écosystème — apps Flutter de `front/mobile_apps/`, vitrine `front/web/`, admin `front/admin-dashboard/`, et, par anticipation, desktop (cf. `docs/PROTOCOLS/06_DISTRIBUTION_DESKTOP.md`).
+
+**Hors périmètre** (flux dédiés existants, non modifiés) : kiosque ZKTeco (`front/zkteco-kiosk`, appareil tiers à thème propriétaire), maquettes et pipeline de refonte visuelle (docs/specifications/REFONTE_VISUELLE_GLOBALE.md). Ce protocole ne recrée ni ne remplace le design system de référence : il désigne les fichiers qui font autorité dans le code et les gardes qui empêchent la divergence.
+
+## 2. Sources canoniques par type
+
+Une source canonique est le SEUL fichier où une valeur se définit. Toute autre occurrence est une consommation, jamais une redéfinition.
+
+| Type | Fichier source (canonique) | Surfaces concernées | Remarques / garde |
+|---|---|---|---|
+| Couleurs mobile | `front/mobile_apps/leopardo_core/lib/core/theme/app_colors.dart` (218 l.) | 7 apps Flutter via core | En-tête APV L.05/L.07 : toute modif → répercuter couche web + `docs/REFERENTIEL_PRODUIT/COULEURS.md`. Garde : `validate-mobile-color-tokens.ps1` (PA2-MOB-011). |
+| Couleurs — pont cross-stack | `docs/REFERENTIEL_PRODUIT/COULEURS.md` | mobile ↔ web ↔ admin | Table Hex ↔ `AppColors.*` ↔ classes Tailwind. Règle L.07 : même commit. |
+| Couleurs / ombres web | `front/admin-dashboard/tailwind.config.js` et `front/web/tailwind.config.ts` | admin-dashboard, vitrine | Échelles déclarées dans les deux configs (emerald, slate, brand, cyan…) et tokens d'ombre `glass-*`/`premium` ; admin : `darkMode: 'class'`. Couleurs de domaine consommées via la palette (ex. `emerald-500`) — cf. `COULEURS.md`. |
+| Typographie | `front/mobile_apps/leopardo_core/lib/core/theme/app_typography.dart` (72 l.) | apps Flutter | Inter, body 16, title 20/24, poids 400/600 ; aligné web via Fonts.bunny/Google Fonts. Référence visuelle : PDF v3 (§2, ligne « Design de référence »). |
+| Thème dark/light | `front/mobile_apps/leopardo_core/lib/core/theme/app_theme.dart` (196 l.) | apps Flutter | Dark = expérience principale des 4 apps historiques (PA2-MOB-012, décision `docs/PLAN_ACTION2/15_DECISION_THEME_MOBILE.md`) ; `lightTheme` maintenu pour previews/tests. |
+| Composants partagés | `front/mobile_apps/leopardo_core/lib/core/widgets/` (14 widgets : glass_card, glass_tile, mobile_surface, pulse_button, leopardo_bottom_nav, empty_state, shimmer_loading, leopardo_badge…) | apps Flutter | Toute brique réutilisable vit ici, jamais dans une app. |
+| Branding tenant | `front/mobile_apps/leopardo_core/lib/core/branding/` (tenant_theme.dart, tenant_branding.dart, tenant_brand_mark.dart, tenant_branding_repository.dart) | apps Flutter multi-tenant | Garde : `validate-mobile-tenant-branding.ps1`. |
+| Textes (i18n) | `shared/i18n/locales/{fr,en,tr,ar}.json` (+ `shared/i18n/README.md`) | toutes surfaces | `fr` = source ; `en/tr/ar` = traductions synchronisées via `shared/i18n/sync/*.js`. Ne jamais éditer de fichiers générés hors locales. |
+| Design de référence (visuel) | `docs/vision/02_design_system/Leopardo_RH_Design_System_v3.pdf` (+ README) ; maquettes `assets/design/mockups/` (REFONTE_VISUELLE_GLOBALE.md) | toutes | README du sous-dossier : pilotage par `docs/REFERENTIEL_PRODUIT/APV.md` + `COULEURS.md`. |
+| Espacements / radius / densité | Aucune source centralisée à ce jour — valeurs dispersées dans `app_theme.dart`, widgets core, configs tailwind | toutes | Chantier ouvert : échelle à créer dans le core avant toute nouvelle surface (R2). Ne pas en inventer dans une app. |
+| Icônes | Pas de catalogue unifié : Material Icons (Flutter, `uses-material-design`), `lucide-react` (`front/web`) | mobile, web | À trancher ; aucune nouvelle bibliothèque d'icônes sans décision. |
+| Desktop (futur) | Aucune — héritera des sources ci-dessus | — | Tokens fenêtre/largeur/densité à définir plus tard (cf. `docs/PROTOCOLS/06_DISTRIBUTION_DESKTOP.md`) ; aucune valeur « desktop » à inventer maintenant. |
+
+## 3. Règles d'or
+
+Chaque règle : condition → action → garde.
+
+**R1 — Aucun hex hardcodé dans les écrans.** *Condition* : un écran ou widget a besoin d'une couleur. *Action* : mobile → `AppColors.*` ; web/admin → classes Tailwind ou tokens des configs ; jamais `Color(0x…)` ni hex inline dans une vue. *Garde* : `dev-hub/tools/validate-mobile-color-tokens.ps1` — échec CI si un littéral `Color(0x…)` apparaît hors `app_colors.dart` (PA2-MOB-011).
+
+**R2 — Toute nouveauté visuelle partagée va dans le core.** *Condition* : une valeur de style, un widget ou un comportement visuel est utile à plus d'un écran, ou à une autre app. *Action* : l'extraire dans `leopardo_core` (`core/theme/` ou `core/widgets/`), jamais dans l'app puis copié. *Garde* : règle « toute modification partagée va dans `leopardo_core` » (`front/mobile_apps/README.md`, `docs/mobile/CONVERGENCE_F27.md`) + revue PR (§4) ; séparation verrouillée par `validate-mobile-apps-split.ps1` (zéro import inter-apps).
+
+**R3 — Nouvelle app → dépend de `leopardo_core`, zéro copie locale.** *Condition* : création ou refonte d'une app mobile. *Action* : dépendance `path: ../leopardo_core` dans le pubspec, réutilisation du theme, des widgets et du branding core ; interdiction de répliquer un fichier core dans l'app (contre-exemples : `app_strings.dart` local d'accounting/travel_agent) ou d'embarquer des assets de marque non alignés. *Garde* : checklist §4 + inventaire de l'audit mensuel §5.
+
+**R4 — Pont web : règle du même commit, étendue (L.07+).** *Condition* : modification d'une couleur ou d'un token visuel partagé. *Action* : `docs/REFERENTIEL_PRODUIT/COULEURS.md` + `app_colors.dart` + `tailwind.config.js` (admin) + `tailwind.config.ts` (web) modifiés dans le MÊME commit — aucune valeur intermédiaire laissée en attente. *Garde* : revue PR §4 (case C7) ; le diff d'une PR UI ne doit contenir aucun hex nouveau hors de ces fichiers.
+
+**R5 — i18n via `shared/i18n`, interdiction des `app_strings` locaux.** *Condition* : un texte visible utilisateur est ajouté ou modifié. *Action* : clé dans `shared/i18n/locales/fr.json`, traductions `en/tr/ar` synchronisées, consommation via le mécanisme i18n de la surface. *Garde* : revue PR (C5) + audit mensuel (I7) ; côté API, gardes existantes `check-*-i18n.py` (ex. `check-accounting-i18n.py`).
+
+**R6 — Dark cohérent partout.** *Condition* : un écran mobile des 4 apps historiques est modifié, ou un composant web sombre est créé. *Action* : mobile → rester sur `ThemeMode.dark` (PA2-MOB-012) et valider le rendu sombre avec les tokens dédiés ; web/admin → variants `dark:` systématiques. *Garde* : capture dark exigée en PR (C2).
+
+**R7 — Branding tenant par le core uniquement.** *Condition* : personnalisation visuelle d'un tenant (couleur, logo, marque). *Action* : passer par `core/branding/` (`TenantTheme.apply`, `TenantBrandMark`) ; jamais de couleur tenant en dur dans un écran. *Garde* : `validate-mobile-tenant-branding.ps1` + revue PR.
+
+**R8 — Desktop : hériter, ne pas inventer.** *Condition* : un futur écran desktop a besoin d'une valeur visuelle. *Action* : consommer les sources canoniques du §2 ; les tokens spécifiques fenêtre/largeur/densité seront définis lors du chantier desktop. *Garde* : renvoi vers `docs/PROTOCOLS/06_DISTRIBUTION_DESKTOP.md` — aucune valeur « desktop » nouvelle dans le code avant cette décision.
+
+## 4. Porte de revue design (checklist PR)
+
+**Déclencheur** : toute PR cochant une surface UI du périmètre dans « Surfaces touchées » du gabarit `.github/PULL_REQUEST_TEMPLATE.md` (Mobile, Admin dashboard, Web ; le Kiosk reste sur son flux dédié, §1). Le template impose déjà des captures avant/après ; la porte ci-dessous l'étend aux critères visuels.
+
+Checklist « revue visuelle » — à cocher par l'auteur, vérifiée par le relecteur :
+
+- **C1 — Cohérence tokens** : aucune couleur, typographie, radius ou ombre nouvelle hors des sources du §2 ; pas de `Color(0x…)` hors `app_colors.dart` (R1).
+- **C2 — Dark** : capture du rendu sombre jointe ; écran cohérent avec les tokens sombres (mobile historique : dark principal, R6).
+- **C3 — États** : les états vide / chargement / erreur / hors-ligne de tout écran modifié sont traités (widgets core : `empty_state`, `shimmer_loading`…).
+- **C4 — Accessibilité** : contraste WCAG AA — ratio ≥ 4.5 texte normal, ≥ 3 texte large (cf. `COULEURS.md`) ; la couleur n'est jamais le seul vecteur d'information ; cibles tactiles correctes.
+- **C5 — i18n** : textes vérifiés en `fr` et `en`, aucune chaîne brute, aucun import de `app_strings` local (R5) ; impact layout RTL (`ar`) examiné si le composant touche la direction.
+- **C6 — Captures avant/après** : jointes pour chaque écran modifié (obligation du template PR).
+- **C7 — Impact cross-stack** : couleur ou token partagé modifié → `COULEURS.md` + `AppColors.dart` + configs Tailwind dans le même commit (R4).
+- **C8 — Pas de copie** : toute brique visuelle réutilisée provient du core (R2, R3).
+
+Règles de blocage : une PR UI sans captures, ou violant C1/C4/C5/C7, est refusée. Toute refonte visuelle d'ampleur exige en plus une maquette de référence (pipeline maquette → code de `docs/specifications/REFONTE_VISUELLE_GLOBALE.md`, mockups sous `assets/design/mockups/`).
+
+## 5. Rituel mensuel d'audit visuel
+
+**Quand** : dernière semaine du mois (aligné sur la revue des protocoles). **Qui** : fondateur/PM + un dev par surface (mobile, web, admin).
+
+1. **Détection automatisée des dérives** — commandes à rejouer :
+   - littéraux hex hors source : logique de `validate-mobile-color-tokens.ps1` sur `front/mobile_apps/` (grep `Color\(0x…` hors `app_colors.dart`) + recherche d'hex inline dans `front/web` et `front/admin-dashboard` hors configs tailwind ;
+   - copies locales de fichiers core : `find front/mobile_apps -path '*/core/*' -name '*.dart' -not -path '*leopardo_core*'` (ex. `app_strings.dart`) ;
+   - duplications de fichiers entre apps (référence : chantier #2661 des 13 repositories byte-identiques) ;
+   - parité des couleurs : diff `COULEURS.md` ↔ `AppColors.dart` ↔ configs Tailwind (aucun hex divergent).
+2. **Captures de référence** — rejouer les parcours clés de chaque surface (connexion, accueil, pointage/facture, navigation), screenshotter, verser dans `docs/design/audits/YYYY-MM/` et comparer aux mois précédents.
+3. **Comparaison surface à surface** — nav, cartes, boutons, états vides : une même action doit avoir le même rendu partout. Objectif : détecter les divergences de type accounting/travel_agent avant qu'elles ne s'installent.
+4. **Rapport** — synthèse courte dans `docs/design/` : conformité par surface, écarts constatés, issues créées. La revue mensuelle des protocoles (00_INDEX.md) arbitre les suites.
+
+**Procédure de remise à niveau d'une app en dérive** : (1) ouvrir des issues « [REX] harmonisation design » listant chaque écart (copies locales, assets, tokens) ; (2) migrer les fichiers répliqués vers `leopardo_core` ou `shared/i18n` et faire consommer la source ; (3) aligner assets et branding sur les références §2 ; (4) re-capturer l'app et clore les issues avec le rapport d'audit suivant.
+
+## 6. Indicateurs de santé
+
+| Indicateur | Seuil sain | Mesure |
+|---|---|---|
+| I1 — Littéraux hex hors `app_colors.dart` / configs tailwind | 0 | garde CI `validate-mobile-color-tokens.ps1` + grep mensuel web/admin |
+| I2 — Copies locales de fichiers core hors `leopardo_core` | 0 | audit §5 (aujourd'hui : 2 — accounting, travel_agent) |
+| I3 — Apps mobiles dépendant de `leopardo_core` | 7/7 | pubspecs de `front/mobile_apps/` |
+| I4 — Parité couleurs COULEURS.md ↔ AppColors ↔ Tailwind | 0 écart | audit §5, étape 1 |
+| I5 — Rapport d'audit visuel du mois présent dans `docs/design/` | 1/mois | revue mensuelle |
+| I6 — PR UI avec captures avant/après | 100 % | porte §4 (C6) |
+| I7 — Fichiers de textes locaux (`app_strings` hors shared/i18n) | 0 | audit §5 (aujourd'hui : 2) |
+
+## 7. État des lieux au 2026-09-09
+
+Dérives constatées, à solder via les règles ci-dessus :
+
+- **accounting & travel_agent** : dépendent bien de `leopardo_core` (pubspec `path: ../leopardo_core`) mais répliquent chacune un `core/i18n/app_strings.dart` LOCAL (296 et 580 lignes, importé par les écrans) au lieu de `shared/i18n` ; ni l'une ni l'autre n'a de dossier `assets/` ni de branding aligné sur les références. Violation R3/R5 — chantier de remise à niveau (§5).
+- **docs/design/ quasi vide** : un seul fichier (`REFONTE_PREMIUM_STATUT.md`) alors que la refonte premium (issues #1625-1628) est en cours ; les comptes-rendus d'audit visuel et statuts de maquettes n'ont pas de domicile stable (§5 étape 4).
+- **Contradiction documentaire** : `docs/REFERENTIEL_PRODUIT/COULEURS.md` indique « le dark mode n'est pas le défaut », contredit par PA2-MOB-012 (`app_theme.dart` : dark = expérience principale des 4 apps historiques) — à corriger dans COULEURS.md.
+- **Duplication de même famille** : 13 fichiers repositories byte-identiques entre employee/manager/hr (chantier QA 2026-08-15, #2661, cf. `front/mobile_apps/README.md`) — copies à migrer vers le core.
+- **Trous de sources** : pas d'échelle centralisée d'espacements/radius, pas de catalogue d'icônes unifié (R2 / §2) ; pas de garde CI dédiée aux `app_strings` locaux (seule la revue PR et l'audit mensuel les détectent aujourd'hui).

--- a/docs/PROTOCOLS/06_DISTRIBUTION_DESKTOP.md
+++ b/docs/PROTOCOLS/06_DISTRIBUTION_DESKTOP.md
@@ -1,0 +1,280 @@
+# PROTOCOLE 06 — Distribution & tests desktop (tranches verticales)
+
+**Statut :** Actif v1.0 — 2026-09-09
+**Porteur :** fondateur/PM + devs mobile
+**Revue :** mensuelle fin de mois, cf. docs/PROTOCOLS/00_INDEX.md
+
+> **Pourquoi.** Leopardo est un produit mobile-first (docs/GOTO_MARKET/01_PRODUCT/POSITIONING.md), mais
+> des besoins terrain émergent hors smartphone (paie sur PC fixe, réseau instable au pointage, saisie
+> de données sensibles). Les 5 apps de lancement ont déjà les scaffolds desktop standards (windows/,
+> macos/, linux/), mais rien ne permet de produire, tester ou distribuer un binaire desktop : aucun
+> script melos, aucun runner CI Windows/macOS, aucun packaging, aucune doc. Ce protocole définit comment
+> extraire, à la demande, des **tranches verticales desktop** et les distribuer proprement — sans faire
+> du desktop un pivot produit.
+
+## 1. Objectif & périmètre
+
+**Objectif.** Produire, à partir des apps Flutter existantes (front/mobile_apps/*),
+des apps desktop (Windows .exe / macOS .app) par « tranches verticales », et les
+tester/distribuer sur 2 canaux (dev/prod) alignés sur la topologie Render
+(docs/ops/RENDER_DEV_PROD_TOPOLOGY.md).
+
+**Périmètre.** Apps éligibles : celles ayant un scaffold desktop
+(leopardo_employee, leopardo_hr, leopardo_manager, leopardo_marketing,
+leopardo_platform_admin) puis, après phase 0, toute app qui en ajoute un.
+Hors périmètre : portage desktop complet des apps, Linux desktop (aucun besoin
+terrain documenté), kiosques ZKTeco (déjà couverts : front/zkteco-kiosk +
+docs/GESTION_PROJET/RUNBOOK_ZKTECO_CLIENT.md). Déclencheurs : une demande de
+module/verticale validée par le fondateur (checklist §2) — jamais une décision
+« on fait du desktop » globale.
+
+## 2. Tranche verticale desktop : définition & critères de déclenchement (checklist)
+
+**Définition.** Déclinaison desktop d'un **périmètre métier borné**, déjà porté
+par une app Flutter et le package partagé leopardo_core, ciblant **une persona**
+et son parcours critique, avec synchro réseau ou hors-ligne explicite et
+consommation de l'API existante.
+
+| Élément | Contenu attendu | Source |
+|---|---|---|
+| Persona | 1 seule (gestionnaire paie, RH, manager d'équipe…) | apps par persona |
+| BC/domaines | 1 à 3 bounded contexts, déjà dans leopardo_core/lib/features (attendance, payrolls, manager, absences, salary_advances…) | leopardo_core |
+| Parcours critiques | ≤ 3 parcours de bout en bout (ex. pointer → consulter → valider) | specs modules |
+| Données & synchro | online via API ; hors-ligne borné (stockage local core + file de synchro) si besoin terrain | leopardo_core (storage/database) |
+| App hôte | l'app persona existante, réutilisée telle quelle (pas de fork) | front/mobile_apps/* |
+
+**Ce qu'une tranche n'est PAS** : un portage écran-à-écran de l'app mobile, une
+nouvelle app par module sans porte produit, un wrapper web, une duplication de
+leopardo_core, ni le début d'un pivot desktop.
+
+**Checklist de déclenchement** (toutes cases vertes requises) :
+- [ ] Un module/verticale exprime un besoin réel daté (pilote client, processus interne).
+- [ ] La persona travaille sur poste fixe (PC de caisse, bureau RH, pointage entrée) ou le mobile est inadapté (saisie longue, écran large, impression).
+- [ ] Besoin hors-ligne ou réseau instable identifié et borné (volume, durée).
+- [ ] Les BC requis existent dans leopardo_core (pas de développement métier neuf pour la tranche).
+- [ ] Les alternatives web (PWA front/web-offline) ou kiosk écartées avec motif.
+- [ ] La tranche ne casse pas le split apps (dev-hub/tools/validate-mobile-apps-split.ps1).
+- [ ] Coût estimé (phases 0→5) < budget pilote ; sortie de pilote définie.
+Décision actée par le fondateur, tracée dans une issue dédiée.
+
+## 3. Cycle de vie en phases (0→5) avec livrables par phase
+
+**Phase 0 — Préparation.** *Livrable : l'app compile en desktop en local.*
+Compléter le scaffold manquant (`flutter create --platforms=windows,macos .` —
+cas de leopardo_accounting et leopardo_travel_agent, android-only) ; corriger
+l'identité produit par app (§4) : titre de fenêtre windows/runner/main.cpp,
+méta-données windows/runner/Runner.rc (FileDescription, OriginalFilename),
+PRODUCT_NAME et PRODUCT_BUNDLE_IDENTIFIER dans
+macos/Runner/Configs/AppInfo.xcconfig, icônes (windows/runner/resources/
+app_icon.ico + AppIcon macOS) ; taille min de fenêtre, single-instance si
+pertinent. La version pubspec reste non touchée (pilotée par le repo, §4).
+
+**Phase 1 — Build CI.** *Livrable : chaque build desktop est produit en CI sur
+un runner dédié.* Besoin à décrire, sans créer les workflows (Annexe A) :
+runners `windows-latest` et `macos-latest` (aujourd'hui : 95 jobs CI, tous
+`ubuntu-latest`, zéro runner windows/macos), matrice apps × OS calquée sur
+mobile-apps-ci.yml, analyze + build --release + upload d'artefacts (l'action
+composite actuelle setup-flutter-android est spécifique Android).
+
+**Phase 2 — Packaging.** *Livrable : artefact installable nommé selon §4.*
+Windows : `.exe` (`flutter build windows --release`), puis `.msix` quand
+l'auto-update sera requis. macOS : `.app` puis `.dmg`. Signature à prévoir
+(code signing Windows ; Developer ID + notarisation macOS) ; **au stade pilote,
+un binaire non signé est acceptable** (limitations SmartScreen / Gatekeeper,
+contournement à documenter aux pilotes).
+
+**Phase 3 — Canal dev vs prod.** *Livrable : les pilotes reçoivent le bon
+binaire.* Rattachement aux 2 volets (§6) : canal dev = builds vers l'API de dev
+continu (Render `render.yaml`), canal prod = builds stables issus d'une GitHub
+Release (tag `vX.Y.Z`, docs/RELEASE_PROCESS.md). Stade pilote : canal dev
+distribué manuellement (lien artefact CI), comme Firebase App Distribution pour
+l'Android staging ; canal prod = assets de la GitHub Release.
+
+**Phase 4 — Tests.** *Livrable : tranche testée avant distribution.* Pyramide
+§5 : unit/widget existants (déjà en CI via mobile-apps-ci.yml), ajout
+d'integration_test desktop, smoke install/upgrade/uninstall côté pilotes.
+
+**Phase 5 — Boucle pilotes.** *Livrable : décision de pérenniser ou arrêter.*
+Retours via issues, correctifs itératifs sur le canal dev, sortie de pilote
+(prod / abandon) actée au rituel mensuel (§7). Pilote sans retour pendant 2
+cycles mensuels → mise en pause de la tranche.
+
+## 4. Cibles & artefacts (tableau Windows/macOS/Linux)
+
+| Cible | Build | Packaging | Signature | Canal | Statut 2026-09-09 |
+|---|---|---|---|---|---|
+| Windows x64 | `flutter build windows --release` | `.exe` ; `.msix` (plus tard) | code signing à prévoir ; pilote = non signé OK | dev puis prod | scaffold seul |
+| macOS (arm64 + x64) | `flutter build macos --release` | `.app` ; `.dmg` | Developer ID + notarisation à prévoir ; pilote = non signé OK | dev puis prod | scaffold seul |
+| Linux | `flutter build linux --release` | — | — | non prioritaire | scaffold seul |
+
+**Convention d'artefacts.** Nom de fichier :
+`<app>-<os>-<arch>-<version>[-dev].<ext>` — ex.
+`leopardo-hr-windows-x64-v4.25.0.exe` (prod, version = tag SemVer du repo) et
+`leopardo-hr-macos-arm64-v4.25.0-rc.1-dev.dmg` (dev, version du commit source).
+- La **version est celle du repo** (tag `vX.Y.Z`, ou SHA pour le dev), jamais la
+  version mobile (`employee-v4.12.0` côté Android, mobile-distribute.yml). Les
+  apps sont toutes à `version: 1.0.0+1` dans leur pubspec (scaffold, non
+  fiable) : la version repo fait foi. `<arch>` : x64/arm64 ; `<app>` = package.
+- Canaux dev/prod dans des emplacements distincts (assets GitHub Release en
+  prod ; artefact CI / partage pilote en dev) ; un build dev n'est jamais
+  présenté comme version stable.
+
+**Identité par app desktop** (héritée des sources design
+docs/PROTOCOLS/05_HARMONISATION_DESIGN.md et du branding existant —
+leopardo_core/lib/core/branding et /theme) :
+
+| App | Nom produit | Bundle id macOS / CompanyName |
+|---|---|---|
+| leopardo_hr | Leopardo RH | com.leopardo.rh |
+| leopardo_employee | Leopardo Employé | com.leopardo.employee |
+| leopardo_manager | Leopardo Manager | com.leopardo.manager |
+| leopardo_platform_admin | Leopardo Admin | com.leopardo.platformadmin |
+| leopardo_marketing | Leopardo Marketing | com.leopardo.marketing |
+
+État réel constaté (copie du scaffold, à corriger en phase 0) : employee, hr,
+manager et platform_admin déclarent tous PRODUCT_NAME `leopardo_rh`, bundle
+`com.leopardo.leopardoRh`, fenêtre et exe `leopardo_rh` ; leopardo_marketing
+déclare PRODUCT_NAME/exe `leopardo_accounting` (bundle
+`com.leopardo.leopardoMarketing` incohérent). Icônes desktop = défaut de
+flutter create (5 windows/runner/resources/app_icon.ico identiques).
+
+## 5. Tests desktop (pyramide)
+
+1. **Unit & widget** (base) : les suites par app tournent déjà en CI
+   (mobile-apps-ci.yml, `flutter test`) ; la tranche ajoute seulement les tests
+   des écrans desktop (layout large, fenêtres) dans test/ de l'app.
+2. **Integration_test** (milieu) : dossier integration_test/ par tranche,
+   exécuté sur device desktop en CI (`flutter test integration_test -d windows`
+   / `-d macos`) : parcours critique de bout en bout contre l'API de dev.
+3. **Smoke install / lancement / mise à jour / désinstallation** (haut) : fiche
+   de recette par pilote à chaque build dev (install propre, 1er lancement,
+   upgrade depuis la version précédente, rollback, désinstallation sans
+   résidu). Pas d'automatisation exigée au stade pilote.
+
+Sortie de phase 4 : analyze vert, integration_test du parcours critique vert sur la cible, smoke signé par un pilote.
+
+## 6. Canaux dev & prod (rattachement aux 2 volets)
+
+Références : docs/ops/RENDER_DEV_PROD_TOPOLOGY.md (2 volets) et
+docs/PROTOCOLS/07_ARCHITECTURE_ENVIRONNEMENTS.md.
+
+| Canal desktop | Déclencheur | Backend cible | Signature | Destinataires |
+|---|---|---|---|---|
+| **dev** | push main (build continu) ou build pilote manuel | dev continu (Render `render.yaml` / deploy-main.yml) | non signé toléré | pilotes de la tranche |
+| **prod** | GitHub Release publiée (tag `vX.Y.Z` → deploy-prod.yml, prod Render `render.prod.yaml`) | prod stable | signé (requis avant distribution large) | clients / déploiement réel |
+
+Alignement mobile : mobile-distribute.yml distribue staging (APK → Firebase App
+Distribution, groupe testeurs-internes) et prod (AAB) selon le tag `v*`
+(correctif #4724 : tags `vX.Y.Z`, `-staging`, `-prod`). Le desktop reprend la
+même logique binaire dev/prod avec ses artefacts ; il n'utilise pas Firebase App
+Distribution et ne crée pas de troisième environnement. Un binaire desktop prod
+ne sort qu'après la porte marché (docs/PROTOCOLS/01_VALIDATION_MARCHE.md) : une
+tranche pérennisée est une version du produit, pas un outil interne.
+
+## 7. Rituel mensuel
+
+Revue du portefeuille desktop en fin de mois, fondateur/PM + devs mobiles.
+Ordre du jour fixe :
+
+1. Portefeuille des tranches (actives / en pause / abandonnées) et leur phase.
+2. Par tranche active : canal courant (dev/prod), builds livrés, retours pilotes
+   (issues ouvertes/closes), coût cumulé.
+3. Décisions : nouvelles tranches (checklist §2), sorties de pilote, identité /
+   version à corriger, échéancier signature/notarisation.
+4. Mise à jour du protocole si une convention dérive ; compte rendu au journal
+   mensuel — les décisions engagent la phase suivante.
+
+## 8. État des lieux au 2026-09-09
+
+**Ce qui existe (vérifié par lecture) :**
+
+- Scaffolds desktop complets (windows/ CMake+runner, macos/ avec
+  Configs/AppInfo.xcconfig, linux/) pour 5 apps : leopardo_employee,
+  leopardo_hr, leopardo_manager, leopardo_marketing, leopardo_platform_admin.
+- Identité desktop par défaut non personnalisée (copie du scaffold, cf. §4).
+- melos.yaml : analyze/format/test/build:android/build:ios uniquement (aucun
+  build:windows/build:macos). Makefile + build.ps1 (employee, hr, manager,
+  platform_admin) : APK staging / AAB prod via dart-define-from-file
+  (.env.staging/.env.production), aucune cible desktop.
+- CI : 56 fichiers de workflows, 95 jobs, tous ubuntu-latest ; aucun runner
+  windows/macos, aucun job desktop. mobile-apps-ci.yml (analyze 8 packages +
+  build APK debug 7 apps) et mobile-distribute.yml (4 apps, tags v*, Firebase
+  App Distribution) ne couvrent que l'Android.
+- Aucune doc desktop dans docs/ (zéro occurrence de `.exe` ni de
+  `flutter build windows|macos`) ; positionnement produit mobile-first
+  (docs/GOTO_MARKET/01_PRODUCT/POSITIONING.md).
+- Précédent de surface standalone distribuée sur PC local hors Flutter : kiosk
+  ZKTeco (front/zkteco-kiosk, bridge Python + SQLite hors-ligne,
+  docs/GESTION_PROJET/RUNBOOK_ZKTECO_CLIENT.md) — valide le besoin poste fixe.
+- Versioning SemVer repo + release par tag `vX.Y.Z` (docs/RELEASE_PROCESS.md) ;
+  2 volets dev/prod (docs/ops/RENDER_DEV_PROD_TOPOLOGY.md).
+
+**Ce qui manque :** builds desktop (aucune cible), CI desktop (runners +
+workflows à valider, Annexe A), packaging (.exe/.msix/.dmg + signature), tests
+desktop (aucun integration_test, pas de smoke), canal de distribution,
+identité desktop par app. leopardo_accounting et leopardo_travel_agent sont
+android-only : une tranche les concernant commence par la phase 0.
+
+## Annexe A. Squelettes à valider
+
+> À VALIDER par le fondateur avant implémentation — n'éditer ni melos.yaml ni
+> .github/workflows sur la seule base de ce protocole.
+
+Extrait melos.yaml (à insérer dans `scripts:`) :
+
+```yaml
+  # ── Desktop builds (protocole 06, tranches verticales) ──────────
+  build:windows:
+    run: flutter build windows --release
+    description: Build Windows desktop (release)
+    exec:
+      concurrency: 1
+    packageFilters:
+      dirExists: windows        # apps ayant un scaffold windows
+      ignore: [leopardo_core]   # bibliothèque partagée, pas une app
+
+  build:macos:
+    run: flutter build macos --release
+    description: Build macOS desktop (release)
+    exec:
+      concurrency: 1
+    packageFilters:
+      dirExists: macos
+      ignore: [leopardo_core]
+```
+
+Workflow GitHub (squelette — runners windows/macos à activer ; tag `v*` pour la
+prod, workflow_dispatch pour le dev) :
+
+```yaml
+name: Desktop - Build Windows/macOS
+on:
+  workflow_dispatch:            # canal dev : build pilote manuel
+  push:
+    tags: ["v*"]                # canal prod : release taguée (cf. §6)
+jobs:
+  build-desktop:
+    name: Desktop ${{ matrix.app }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { app: leopardo_hr,       os: windows-latest, platform: windows }
+          - { app: leopardo_manager,  os: windows-latest, platform: windows }
+          - { app: leopardo_hr,       os: macos-latest,   platform: macos }
+          # étendre la matrice aux seules apps de la tranche active
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2   # variante sans SDK Android
+        with: { channel: stable }
+      - run: flutter pub get
+        working-directory: front/mobile_apps/leopardo_core
+      - run: flutter gen-l10n
+        working-directory: front/mobile_apps/leopardo_core
+      - run: flutter pub get && flutter analyze
+        working-directory: front/mobile_apps/${{ matrix.app }}
+      - run: flutter build ${{ matrix.platform }} --release
+        working-directory: front/mobile_apps/${{ matrix.app }}
+      # renommage §4 + upload-artifact (dev) / assets GitHub Release (prod, signé)
+```

--- a/docs/PROTOCOLS/07_ARCHITECTURE_ENVIRONNEMENTS.md
+++ b/docs/PROTOCOLS/07_ARCHITECTURE_ENVIRONNEMENTS.md
@@ -1,0 +1,129 @@
+# PROTOCOLE 07 — Architecture à deux volets (dev ↔ prod) : gouvernance
+
+> **Statut** : Actif v1.0 — 2026-09-09
+> **Porteur** : fondateur/PM + ops
+> **Revue** : mensuelle, fin de mois — cf. docs/PROTOCOLS/00_INDEX.md
+>
+> **Pourquoi** : le système est piloté par deux volets — développement continu (chaque merge sur `main` atteint les surfaces dev) et production réelle (promue uniquement par tag `vX.Y.Z` validé). Cette séparation est récente et fragile : elle a été construite en requalifiant l'existant (le service `gestionemployerbackend` s'appelait « production » et porte toujours `APP_ENV=production`), et plusieurs documents ont déjà dérivé de la réalité (blueprint non aligné corrigé en PR #6831, seuil de coverage 60 vs 65, inventaire CI obsolète). Sans gouvernance, chaque changement d'infrastructure creuse un écart silencieux entre le déclaratif, la documentation et les services réellement en ligne. Ce protocole rend la dérive visible, tracée en issues et corrigée dans un délai borné.
+
+## 1. Objectif & périmètre
+
+**Objectif** : garantir à tout moment que l'architecture des deux volets reste saine, documentée et sans dérive, c'est-à-dire :
+
+1. Une source de vérité unique de la topologie (§4), actualisée dans la même PR que tout changement d'infrastructure.
+2. Chaque écart doc ↔ réalité détecté (au fil de l'eau ou au rituel mensuel, §5) converti en issue traçable — jamais laissé dans un document figé.
+3. Aucune modification de l'environnement de production hors de la chaîne de promotion par tag (§3).
+4. Aucune décision structurante implémentée sans ADR datée (§6).
+5. Une santé de l'architecture mesurée par des indicateurs à seuils (§7), et un état des lieux de la dette connu à tout instant (§8).
+
+**Périmètre** : les deux volets « dev/continu » et « production (phase 1) » — blueprints et services Render, bases Neon, surfaces Vercel et Cloudflare Pages, workflows de déploiement GitHub Actions, registres d'URLs/domaines, runbooks de déploiement/rollback/incident/observabilité/alerting, ADR d'infrastructure.
+
+**Hors périmètre** (flux dédiés existants, non dupliqués) : la qualité applicative et la CI des PR (protocoles 01 à 04), les incidents pilotes (SLA dédié), la sécurité applicative (SECURITY.md). Ce protocole renvoie vers eux au lieu de les remplacer.
+
+## 2. Topologie de référence (tableau : volet, service, rôle, URL, source de config, état)
+
+Volets vérifiés par lecture du 2026-09-05 (audit HTTP des surfaces) et des fichiers sources cités ; état au 2026-09-09.
+
+| Volet | Service | Rôle | URL | Source de configuration | État |
+|---|---|---|---|---|---|
+| A — dev (continu, push `main`) | API `gestionemployerbackend` (Render web, Starter) | API Laravel dev/test | `https://gestionemployerbackend.onrender.com/api/v1/health` | `render.yaml` (blueprint déclaratif NON auto-sync) + `deploy-main.yml` (hook) | En ligne — HTTP 200, version servie 4.24.0 (retard sur `main`) |
+| A — dev | Queue worker | Drain des files (driver `database`, #5578) | interne | `api/docker-entrypoint.sh` (mono-conteneur web) ; `leopardo-queue-worker` déclaré dans `render.yaml`, non provisionné | Actif via le conteneur web ; pas de service dédié |
+| A — dev | Scheduler | Tâches planifiées (`schedule:run`) | interne | `render.yaml` (`leopardo-scheduler`, non provisionné) | Absent — tâches planifiées non exécutées |
+| A — dev | Données | Base PostgreSQL + cache/session | Neon projet `leopardorh` (`*.eu-west-2.aws.neon.tech`), Redis KV `leopardoai` | `DB_URL`/`REDIS_URL` en `sync: false` (dashboard Render, hors blueprint) | En ligne ; aucun Postgres Render (supprimé, PR #6831) |
+| A — dev | Web Vercel | Portail/vitrine web | `https://gestionemployer-backend.vercel.app` | Intégration Git Vercel | En ligne — doublon `https://leopardo.vercel.app` à clarifier |
+| A — dev | Admin Cloudflare Pages | Back-office super-admin | `https://leo-admin.pages.dev` | `deploy-admin-dashboard.yml` | En ligne |
+| B — prod (phase 1, tag `vX.Y.Z`) | API `leopardo-prod` (Render web, plan free) | API de production | `https://leopardo-prod.onrender.com/api/v1/health` | `render.prod.yaml` + `deploy-prod.yml` (Release publiée) | En ligne — recette 2026-09-04 validée ; chaîne auto Release non testée bout en bout |
+| B — prod | Queue worker | Drain des files | interne | Mono-conteneur web ; `leopardo-queue-worker-prod` commenté (inéligible tier gratuit) | Actif via le conteneur web |
+| B — prod | Scheduler | Tâches planifiées | interne | `leopardo-scheduler-prod` commenté dans `render.prod.yaml` | Absent — bloquant avant trafic client réel |
+| B — prod | Données | Base PostgreSQL + cache/session | Neon projet `LEOPARDO`, branche `production` (`eu-central-1`) ; Redis KV `leopardo-redis-prod` (gratuit, en mémoire) | `render.prod.yaml` (KV) ; `DB_URL` `sync: false` (dashboard + Pulumi ESC `solarnyxss/leopardo-hr/prod`) | En ligne |
+| B — prod | Web Vercel | Portail/web prod | `https://leopardo-prod.vercel.app` | `deploy-prod.yml` (CLI Vercel, pas d'intégration Git) | En ligne |
+| B — prod | Admin Cloudflare Pages | Admin prod | `https://leo-admin-prod.pages.dev` | `deploy-prod.yml` (wrangler) | En ligne |
+| B — prod | Domaine | Nom de marque | `https://leopardo-rh.com` | `docs/ops/DOMAINS.md` (#3452) | Non acheté/pointé (NXDOMAIN, attendu phase 1) |
+| — | Staging | Pré-production | — | `docs/DEPLOYMENT_STAGING.md` = guide cible ; `deploy-staging.yml` rouge volontaire sur `main` | N'existe pas (issue #1485) |
+
+## 3. Principes non négociables (P1…Pn)
+
+- **P1 — Parité de configuration entre volets.** Les deux volets partagent le même schéma de configuration (mêmes clés d'environnement, mêmes drivers de queue/cache, mêmes règles de migration au boot, même `DB_SEARCH_PATH`, même entrypoint). Seules les valeurs (URLs, secrets, budgets, plans) diffèrent. Toute divergence de schéma entre `render.yaml` et `render.prod.yaml` doit être motivée dans une issue ; elle signale une dérive tant qu'elle n'est pas tracée.
+- **P2 — Promotion en production par tag uniquement.** La prod n'évolue que par la chaîne : tag `vX.Y.Z` sur HEAD de `main` (checks requis verts) → `release.yml` crée la Release → `deploy-prod.yml` (`release: published`) déploie les trois surfaces. Règle API Render (limite vérifiée) : le tag doit être HEAD de `main`, sinon l'API recevrait le code de `main` sans garantie ; en `workflow_dispatch` sur un tag plus ancien, avertissement explicite.
+- **P3 — Aucune modification de prod hors `deploy-prod.yml`.** Interdit : sync manuelle du blueprint `render.prod.yaml`, clic « Deploy » dans le dashboard Render sur `leopardo-prod`, intégration Git Vercel/Cloudflare pour la prod, hook de déploiement alternatif ciblant la prod. Toute modification passée hors pipeline est un incident de gouvernance : constat, rollback si besoin, issue.
+- **P4 — Aucune dépendance croisée dev ↔ prod.** Pas de partage de bases, de Redis, de secrets ni d'URLs entre volets. Les secrets/variables de déploiement portent des noms disjoints (`RENDER_PROD_*`, `VERCEL_PROD_*`, `CLOUDFLARE_PROD_*` vs hooks dev) ; le fallback d'un environnement vers l'autre est interdit (#1485 a retiré les fallbacks staging → prod).
+- **P5 — Secrets jamais en clair.** Aucune valeur réelle de secret dans les fichiers versionnés : `sync: false` (saisie dashboard), `generateValue`, ou Pulumi ESC (`solarnyxss/leopardo-hr/prod`) comme référence. Toute clé partagée en clair (chat, ticket) déclenche rotation + issue P0.
+
+## 4. Registre topologie canonique & règle du même commit
+
+- **Source de vérité unique** : `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md` (état vérifié 2026-09-05). Il décrit la réalité des services live, pas le souhaité ; son en-tête porte la date de dernière vérification, mise à jour à chaque audit.
+- **Registres satellites** : `docs/ops/DOMAINS.md` (canonique, machine-checkable) et `docs/ops/DEPLOYMENT_URLS.md` (miroir exécutable des URLs + santé). En cas de doute entre les deux, `DOMAINS.md` fait foi.
+- **Règle du même commit** : toute PR qui modifie l'infrastructure — `render.yaml`, `render.prod.yaml`, les workflows de déploiement (`deploy-main.yml`, `deploy-prod.yml`, `deploy-staging.yml`, `release.yml`, `deploy-admin-dashboard.yml`), les secrets/variables GitHub Actions, le provisionnement Neon/Vercel/Cloudflare — DOIT mettre à jour la topologie (et les registres satellites concernés) dans la même PR. Une PR d'infra sans mise à jour de topologie est refusée en review.
+- **Vérification croisée** : `.github/workflows/README.md` (cartographie des workflows, MAJ 2026-08-29) et `docs/ARCHITECTURE_CICD.md` (MAJ 2026-08-29) doivent rester cohérents entre eux et avec la topologie ; `docs/CI_CD_SECRETS.md` est ré-audité à chaque ajout/suppression/renommage de secret ou variable (règle déjà portée par ce fichier).
+- **Règle de précédence en cas de conflit** : la réalité observable (service live, healthcheck) prime sur la documentation ; parmi les fichiers, le workflow exécutable (`.github/workflows/**`) prime sur sa description (`docs/CI_CD_SECRETS.md` le dit explicitement) ; la description prime sur la topologie si celle-ci n'a pas été vérifiée depuis plus de 45 jours. On corrige toujours le document, jamais l'inverse.
+- **Blueprints non auto-sync** : `render.yaml`/`render.prod.yaml` décrivent ce qui DOIT exister, sans sync automatique. Toute sync manuelle (dashboard → Blueprint) est prudente : Render mappe par `name:` et un renommage recrée un service (doublon/orphelin) — préférer documenter puis agir via le workflow.
+
+## 5. Rituel mensuel de contrôle d'écart (drift) — checklist
+
+Exécuté par ops + fondateur/PM en fin de mois (même fenêtre que la revue des protocoles). Durée cible : 1 h. Résultat : une issue de rituel (checklist cochée + liste des écarts convertis) référencée dans l'en-tête de la topologie.
+
+1. **Surfaces** : `curl -fsS` chaque URL du tableau §2 (`/api/v1/health` pour les API, HTTP 200 pour web/admin). Noter statut HTTP et, pour les API, la version servie par le healthcheck.
+2. **Version servie vs références** : comparer la version servie par l'API dev à `git tag` (dernier tag = code attendu sur `main`). Un retard de l'API dev sur `main` est un écart (rattrapage par `workflow_dispatch` de `deploy-main.yml`).
+3. **Services réels vs déclaratifs** : dans les dashboards Render des deux workspaces, vérifier que les services listés correspondent aux blueprints (noms, plans, `autoDeploy`, base Neon et non Postgres Render, instance KV unique) ; aucun service orphelin/facturé inconnu.
+4. **Workers & files** : contrôler la présence effective des workers/scheduler (dév ou prod), l'état des files (`queue`/`failed_jobs` au healthcheck) et l'absence de jobs bloqués.
+5. **Cartographie workflows** : `ls .github/workflows/*.yml` vs la cartographie de `.github/workflows/README.md` (fichiers ajoutés/supprimés/renommés) ; vérifier que `docs/ARCHITECTURE_CICD.md` et `docs/CI_CD_SECRETS.md` n'annoncent ni workflow disparu, ni seuil faux (ex. coverage 60 vs 65, mobile 21 %), ni secret fantôme.
+6. **Registres & runbooks** : `docs/ops/DOMAINS.md` et `docs/ops/DEPLOYMENT_URLS.md` à jour ; runbooks `RUNBOOK_DEPLOY.md`, `RUNBOOK_ROLLBACK.md`, `RUNBOOK_INCIDENT_P1.md`, `RUNBOOK_OBSERVABILITY.md`, `RUNBOOK_ALERTING.md` cohérents avec la topologie (déclencheurs, URLs, secrets).
+7. **Secrets** : présence effective des secrets attendus (pas de valeur vide → workflow fail-closed) et cohérence avec Pulumi ESC `solarnyxss/leopardo-hr/prod`.
+8. **Conversion en issues** : chaque écart constaté devient une issue selon le protocole 04 (gabarit `[REX]`, labels, priorité) — un écart qui n'a pas d'issue est un écart silencieux (indicateur I1 rouge). La date de vérification est mise à jour en en-tête de `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md` dans la même PR que les correctifs documentaires.
+
+## 6. Décisions d'architecture (ADR) — gabarit
+
+Toute décision structurante touchant l'architecture des deux volets — déclencheur de déploiement, choix de fournisseur ou de base de données, modèle de secrets, création d'un environnement (staging), passage en plan payant, ajout de service — est précédée d'une ADR datée dans `docs/architecture/adr/` (registre existant, numéro séquentiel suivant : 0021), enregistrée dans le tableau du `README.md` du dossier. Une PR qui implémente une décision structurante sans ADR est refusée en review (ADR requise au plus tard dans la même PR).
+
+Gabarit minimal (aligné sur le format des ADR existantes, ex. 0003) :
+
+```markdown
+# ADR 00NN — <titre court à l'impératif>
+
+- Date : AAAA-MM-JJ (date de la décision, pas de la rédaction)
+- Statut : Proposée | Acceptée | Dépréciée (remplacée par ADR 00MM)
+- Issue liée : #<issue de pilotage, si existante>
+
+## Contexte
+Problème traité, contraintes, alternatives écartées et pourquoi.
+
+## Décision
+La position retenue, en une phrase si possible, avec son périmètre exact.
+
+## Conséquences
+Positives et négatives, risques assumés, coûts induits.
+
+## Règles opérationnelles
+Ce que la décision impose concrètement aux PR, workflows et runbooks.
+```
+
+## 7. Indicateurs de santé & seuils
+
+| Indicateur | Définition | Cible | Alerte |
+|---|---|---|---|
+| I1 — Écarts doc ↔ réalité ouverts | Issues étiquetées « dette architecture »/REX non clôturées | 0 écart sans issue associée | Jaune ≥ 5 ouverts ; rouge ≥ 1 écart « bloquant » non traité |
+| I2 — Âge de la dernière vérification de topologie | Date « état vérifié » en en-tête de `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md` | < 45 jours | Rouge au-delà : vérification immédiate requise avant tout déploiement prod |
+| I3 — Délai de correction d'un écart bloquant | Entre la constatation (issue) et la correction ou la décision explicite de report | ≤ 7 jours ouvrés | Rouge au-delà : escalade porteur ; l'écart reste tracé avec responsable |
+| I4 — Dérive de version de l'API dev | Écart entre la version servie et le dernier tag sur `main` | ≤ 1 tag de retard | Jaune ≥ 2 tags : rattrapage `deploy-main.yml` en dispatch |
+| I5 — Couverture des surfaces par la doc | % des services live listés au §2 présents dans `DOMAINS.md` + `DEPLOYMENT_URLS.md` | 100 % | Rouge : tout service live non documenté est un écart immédiat |
+
+Lecture : le porteur consolide I1–I5 à chaque rituel (§5) et les reporte dans l'issue mensuelle ; les valeurs alimentent la revue de fin de mois (00_INDEX).
+
+## 8. État des lieux au 2026-09-09 (dettes connues et issues associées si identifiées)
+
+Règle de précédence : chaque dette ci-dessous DOIT être tracée comme issue (existante ou `[REX]` à créer selon le protocole 04) avant la revue de fin septembre 2026 ; une dette non tracée est un écart silencieux. Rien de ce tableau n'est implémenté par le présent protocole — il fixe la cible et la traçabilité.
+
+| # | Dette constatée (preuve) | État cible | Traçage |
+|---|---|---|---|
+| D1 | `APP_ENV=production` sur le service de dev `gestionemployerbackend` ; variable `vars.PROD_API_BASE_URL` ciblant en réalité le dev ; doublon Vercel `leopardo.vercel.app` (`render.yaml` en tête, `deploy-prod.yml` en tête, topologie §contexte) | Aucun nommage « prod » sur le volet dev : renommage progressif des services et variables une fois la prod validée en continu | Issue à créer (renommage différé volontairement : le mapping Render par `name:` interdit le renommage à chaud) |
+| D2 | API dev en retard sur `main` : sert v4.24.0 alors que des tags récents existent (v4.27.2) ; chaîne auto prod pas encore validée de bout en bout (topologie, §état vérifié 2026-09-05) | API dev ≤ 1 tag de retard (I4) ; chaîne Release → prod validée sur un prochain tag HEAD de `main` | Issue à créer ; rattrapage immédiat par dispatch `deploy-main.yml` |
+| D3 | Staging inexistant (#1485) : `deploy-staging.yml` rouge volontaire sur `main` ; `docs/DEPLOYMENT_STAGING.md` = guide cible uniquement | Décision explicite : provisionner un vrai staging (ADR 0021+) ou acter son absence et neutraliser/documenter le workflow | Issue #1485 (existante) |
+| D4 | Workers/scheduler absents en prod : queue en mono-conteneur web, tâches planifiées NON exécutées ; Neon sur plan gratuit (sans sauvegardes) ; KV Redis en mémoire (`render.prod.yaml` commenté, topologie §écarts) | Plan payant : `leopardo-scheduler-prod` (+ `leopardo-queue-worker-prod` si sortie du mono-conteneur) actifs, Neon payant — avant tout trafic client réel | Issue à créer (P0 conditionnel) |
+| D5 | `docs/CI_CD_SECRETS.md` annonce un seuil de coverage backend à 60 alors que le code exécute 65 (`DEFAULT_BACKEND_COVERAGE_MIN: "65"` dans `tests.yml` et `coverage-gate.yml`) | Document aligné sur le code (65) | Issue de correction documentaire |
+| D6 | `docs/qa/INVENTAIRE_CI_2026-08-19.md` obsolète : 43 workflows inventoriés, certains supprimés depuis (4 `plan-action2-*` nettoyés le 2026-08-29, ajouts postérieurs ; 55 fichiers `.yml` présents) | Inventaire régénéré ou archivé avec renvoi vers `.github/workflows/README.md` | Issue de correction documentaire |
+| D7 | « Coverage mobile minimum 21 % » annoncé dans `docs/ARCHITECTURE_CICD.md` mais introuvable dans `mobile-apps-ci.yml` (aucune gate) | Annonce retirée ou gate réellement câblée (`MOBILE_COVERAGE_MIN`) | Issue à créer (décision à trancher) |
+| D8 | `e2e-staging.yml` nommé « E2E - Playwright Prod Smoke » et visant la PROD (#3906) | Renommage du fichier ou documentation explicite de l'intention « smoke prod » dans la cartographie | Issue #3906 (existante) |
+| D9 | Sauvegardes DB prod désactivées : `database-backup.yml` skippé (secrets `DATABASE_URL`/`BACKUP_S3_BUCKET`/`AWS_*` absents) ; drain GH et supervision queue inertes (topologie §écarts résiduels) | Secrets posés ou Neon payant (backups PITR) ; filets de secours actifs | Issue à créer (P0) |
+| D10 | Rotation des clés Render/Neon/Stripe/Chargily partagées en clair ; vérification `SUPER_ADMIN_PASSWORD` posé sur dev et prod (topologie §écarts résiduels) | Clés régénérées, valeurs réelles dans Pulumi ESC uniquement | Issue à créer (P0 sécurité) |
+
+Fichiers liés (tous vérifiés à la rédaction) : `docs/ops/RENDER_DEV_PROD_TOPOLOGY.md` (état vérifié 2026-09-05), `render.yaml`, `render.prod.yaml`, `.github/workflows/deploy-prod.yml`, `.github/workflows/deploy-main.yml`, `.github/workflows/release.yml`, `.github/workflows/deploy-staging.yml`, `.github/workflows/e2e-staging.yml`, `.github/workflows/mobile-apps-ci.yml`, `.github/workflows/README.md` (MAJ 2026-08-29), `docs/ARCHITECTURE_CICD.md` (MAJ 2026-08-29), `docs/CI_CD_SECRETS.md`, `docs/DEPLOYMENT_STAGING.md`, `docs/qa/INVENTAIRE_CI_2026-08-19.md`, `docs/ops/DOMAINS.md`, `docs/ops/DEPLOYMENT_URLS.md`, `docs/architecture/adr/` (registre + gabarit), `docs/GESTION_PROJET/RUNBOOK_DEPLOY.md` et runbooks associés, `docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,21 @@ Index de la documentation technique et stratégique du projet.
 
 ---
 
+## 📋 Protocoles
+
+| Doc | Contenu |
+|---|---|
+| [`PROTOCOLS/00_INDEX.md`](PROTOCOLS/00_INDEX.md) | **Suite de protocoles** (point d'entrée + rituel mensuel de fin de mois) |
+| [`PROTOCOLS/01_VALIDATION_MARCHE.md`](PROTOCOLS/01_VALIDATION_MARCHE.md) | Porte « OK pour la mise sur le marché » : tests, recette, sign-off |
+| [`PROTOCOLS/02_ONBOARDING_AGENTS.md`](PROTOCOLS/02_ONBOARDING_AGENTS.md) | Intégration d'un nouvel agent / développeur |
+| [`PROTOCOLS/03_VITRINE_PRESENTATION.md`](PROTOCOLS/03_VITRINE_PRESENTATION.md) | Présentation & vitrine : termes, chiffres datés, MàJ mensuelle |
+| [`PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md`](PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md) | Expérience → issues/tâches, implémentation directe ou délégation |
+| [`PROTOCOLS/05_HARMONISATION_DESIGN.md`](PROTOCOLS/05_HARMONISATION_DESIGN.md) | Harmonisation du design (sources canoniques, gardes) |
+| [`PROTOCOLS/06_DISTRIBUTION_DESKTOP.md`](PROTOCOLS/06_DISTRIBUTION_DESKTOP.md) | Apps desktop (.exe/.app) par tranches verticales : build, tests, canaux |
+| [`PROTOCOLS/07_ARCHITECTURE_ENVIRONNEMENTS.md`](PROTOCOLS/07_ARCHITECTURE_ENVIRONNEMENTS.md) | Architecture 2 volets dev/prod : topologie, anti-dérive |
+
+---
+
 ## 🧭 Contexte & conception
 
 | Doc | Contenu |


### PR DESCRIPTION
Suite de protocoles demandée par le fondateur/PM (issue #7048).

**Ajouts**
- `docs/PROTOCOLS/00_INDEX.md` — index + méta-protocole : cycle de vie des protocoles, rituel mensuel de fin de mois, indicateurs, décisions ouvertes.
- `docs/PROTOCOLS/01_VALIDATION_MARCHE.md` — Porte Marché unique et datée (tests, recette générique, re-certification, sign-off fondateur) — consolide RELEASE_READINESS_GATE, REGISTRE_SCENARIOS_TESTS, PLAN_100PCT.
- `docs/PROTOCOLS/02_ONBOARDING_AGENTS.md` — parcours J1 unique + réflexes anti-pièges (#2400, #1962, #2512…), critère de sortie, parcours par rôle.
- `docs/PROTOCOLS/03_VITRINE_PRESENTATION.md` — source unique du discours, lexique vitrine, pitchs par audience, chiffres datés, MàJ mensuelle exécutable.
- `docs/PROTOCOLS/04_CAPITALISATION_EXPERIENCE.md` — boucle expérience → issue → leçon, gabarit REX, arbitrage implémenter/déléguer, moisson mensuelle.
- `docs/PROTOCOLS/05_HARMONISATION_DESIGN.md` — sources canoniques par type, règles d'or, porte de revue design, audit mensuel.
- `docs/PROTOCOLS/06_DISTRIBUTION_DESKTOP.md` — tranches verticales desktop : critères de déclenchement, cycle de vie 0→5, artefacts/canaux dev-prod, pyramide de tests, annexe squelettes à valider.
- `docs/PROTOCOLS/07_ARCHITECTURE_ENVIRONNEMENTS.md` — gouvernance des 2 volets : topologie canonique, règle du même commit, rituel anti-dérive, ADR, dettes D1-D10.
- Gabarits d'issues : `.github/ISSUE_TEMPLATE/retour_experience.yml`, `recette_version.yml`, `revue_mensuelle.md`.
- `docs/README.md` — section « Protocoles ».

**Nature** : documentation + gabarits d'issues uniquement. Aucun workflow, code ou config modifié. Les squelettes CI desktop (annexe du 06) sont proposés à validation, non implémentés.

**Décisions ouvertes** (ne pas merger sans les avoir vues) : positionnement EN et nom de marque (03 §8), activation runners Windows/macOS + 1re tranche desktop pilote (06), arbitrage Render/Neon payants (07), labels tech-debt/lecon (04).

Closes #7048