### PR TITLE
chore: 3 scripts de garde manquants (i18n parity, saturation CI, mojibake)

### DIFF
--- a/dev-hub/tools/check-i18n-locale-parity.py
+++ b/dev-hub/tools/check-i18n-locale-parity.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+check-i18n-locale-parity.py — Parité des clés i18n partagées (fr/en/ar/tr).
+
+Vérifie que les 4 fichiers de `shared/i18n/locales/` (fr, en, ar, tr) exposent le
+même jeu de clés (structure à plat via chemins imbriqués `a.b.c`). `fr` est la
+locale de référence ; toute clé manquante en en/ar/tr est un écart.
+
+Issue #7089 (leçon L-10 : dette i18n récurrente — rapports I18N_DEBT_REPORT_* d'août
+2026). Usage :
+  python3 dev-hub/tools/check-i18n-locale-parity.py [--root DIR] [--warn-only]
+Sortie : 0 = parité OK, 1 = écarts détectés (sauf --warn-only).
+"""
+
+import argparse
+import json
+import os
+import sys
+
+LOCALES = ["fr", "en", "ar", "tr"]
+
+
+def flatten(obj, prefix=""):
+    out = set()
+    for k, v in obj.items():
+        path = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            out |= flatten(v, path)
+        else:
+            out.add(path)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--warn-only", action="store_true")
+    args = ap.parse_args()
+
+    base = os.path.join(args.root, "shared/i18n/locales")
+    keys = {}
+    for loc in LOCALES:
+        path = os.path.join(base, f"{loc}.json")
+        if not os.path.exists(path):
+            print(f"::error::{path} introuvable")
+            return 2
+        with open(path, encoding="utf-8") as fh:
+            keys[loc] = flatten(json.load(fh))
+
+    ref = keys["fr"]
+    problems, infos = [], []
+    infos.append(f"fr : {len(ref)} clés (référence)")
+    for loc in LOCALES[1:]:
+        missing = sorted(ref - keys[loc])
+        extra = sorted(keys[loc] - ref)
+        infos.append(f"{loc} : {len(keys[loc])} clés, {len(missing)} manquantes, {len(extra)} surnuméraires")
+        for k in missing:
+            problems.append(f"{loc} : clé manquante `{k}` (présente en fr)")
+        for k in extra:
+            problems.append(f"{loc} : clé surnuméraire `{k}` (absente en fr) — à supprimer ou ajouter partout")
+
+    for line in infos:
+        print("ℹ", line)
+    if problems:
+        print("\nÉcarts i18n : %d (règle : une clé ajoutée l'est dans les 4 locales — protocole P04/leçon L-10)" % len(problems))
+        for p in problems[:40]:
+            print("❌", p)
+        if len(problems) > 40:
+            print(f"… et {len(problems) - 40} autres")
+        return 0 if args.warn_only else 1
+    print("\n✅ Parité i18n OK (fr/en/ar/tr).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev-hub/tools/check-mojibake-duplicates.py
+++ b/dev-hub/tools/check-mojibake-duplicates.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+check-mojibake-duplicates.py — Garde encodage & doublons (leçons L-09/L-07).
+
+Issue #7091 (triage 2026-09-09) : correctifs d'encodage répétés (mojibake) sur des
+fichiers byte-identiques dupliqués entre apps mobiles (chantier #2661).
+
+Vérifie, sous `front/mobile_apps/` :
+  1. MOJIBAKE : aucun pattern d'encodage cassé dans les .dart (Ã©, â€™, ï¿½, �…).
+  2. DOUBLONS (info) : fichiers byte-identiques présents dans plusieurs apps (hors
+     leopardo_core) → candidats à la migration vers leopardo_core (#2661).
+
+Usage :
+  python3 dev-hub/tools/check-mojibake-duplicates.py [--root DIR] [--warn-only]
+Sortie : 0 = OK (ou --warn-only), 1 = mojibake détecté.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+
+BAD = re.compile(r"Ã©|Ã¨|Ãª|Ã§|Ã¢|Ã´|Ã»|Ã¯|Ã¼|â€™|â€œ|â€|ï¿½|\ufffd")
+
+
+def scan(root):
+    apps_root = os.path.join(root, "front/mobile_apps")
+    mojibake = []
+    by_hash = {}
+    for dirpath, _dirs, files in os.walk(apps_root):
+        for fn in files:
+            if not fn.endswith(".dart"):
+                continue
+            path = os.path.join(dirpath, fn)
+            rel = os.path.relpath(path, apps_root)
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                content = fh.read()
+            for lineno, line in enumerate(content.splitlines(), 1):
+                if BAD.search(line):
+                    mojibake.append(f"{rel}:{lineno}: {line.strip()[:90]}")
+            h = hashlib.sha1(content.encode("utf-8", errors="replace")).hexdigest()
+            by_hash.setdefault(h, []).append(rel)
+    dupes = {h: v for h, v in by_hash.items() if len(v) > 1 and "leopardo_core" not in v[0]}
+    return mojibake, dupes
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--warn-only", action="store_true")
+    args = ap.parse_args()
+    mojibake, dupes = scan(args.root)
+
+    if mojibake:
+        print("❌ Mojibake détecté (%d) :" % len(mojibake))
+        for m in mojibake[:30]:
+            print("   ", m)
+        if len(mojibake) > 30:
+            print(f"    … et {len(mojibake) - 30} autres")
+        return 0 if args.warn_only else 1
+
+    print("✅ Aucun mojibake dans front/mobile_apps.")
+    if dupes:
+        print("\nℹ Doublons byte-identiques entre apps (chantier #2661 — à migrer vers leopardo_core) :")
+        for h, v in list(dupes.items())[:10]:
+            print(f"   - {v[0]}  ≡  {v[1]}")
+        if len(dupes) > 10:
+            print(f"    … et {len(dupes) - 10} autres groupes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev-hub/tools/ci-saturation-report.py
+++ b/dev-hub/tools/ci-saturation-report.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+ci-saturation-report.py — Rapport de saturation CI GitHub Actions.
+
+Issue #7090 (leçon L-12 : saturation CI récurrente, triage 2026-09-09). Mesure
+l'état de la file d'exécution du dépôt : runs `queued` et `in_progress` avec leur
+âge, par workflow et par branche, pour objectiver les goulots (runners, jobs
+coincés, pics d'agents parallèles).
+
+Usage :
+  GITHUB_TOKEN=<token> python3 dev-hub/tools/ci-saturation-report.py [--repo kitokoh/leopardo-hr]
+    [--min-age 10] [--json out.json]
+Sortie : rapport markdown sur stdout. Sortie 0 (outil de mesure, non bloquant).
+"""
+
+import argparse
+import json
+import os
+import time
+import urllib.request
+
+API = "https://api.github.com"
+
+
+def get(url, token):
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", "Bearer " + token)
+    req.add_header("Accept", "application/vnd.github+json")
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read().decode())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default="kitokoh/leopardo-hr")
+    ap.add_argument("--min-age", type=int, default=10, help="âge minimal (min) pour signaler un run en attente")
+    ap.add_argument("--json", default=None, help="écrire le détail brut dans ce fichier")
+    args = ap.parse_args()
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("::error::GITHUB_TOKEN requis")
+        return 2
+
+    now = time.time()
+    runs = []
+    for page in (1, 2):
+        url = f"{API}/repos/{args.repo}/actions/runs?per_page=100&page={page}"
+        batch = get(url, token).get("workflow_runs", [])
+        runs += batch
+        if len(batch) < 100:
+            break
+
+    def age_min(ts):
+        return max(0, (now - time.mktime(time.strptime(ts[:19], "%Y-%m-%dT%H:%M:%S"))) / 60)
+
+    queued = [r for r in runs if r["status"] == "queued"]
+    active = [r for r in runs if r["status"] == "in_progress"]
+    stalled = [r for r in queued if age_min(r["created_at"]) >= args.min_age]
+
+    print(f"# Rapport saturation CI — {args.repo} ({time.strftime('%Y-%m-%d %H:%M UTC', time.gmtime())})\n")
+    print(f"- Runs scrutés : {len(runs)}")
+    print(f"- **Queued : {len(queued)}** | In progress : {len(active)}")
+    print(f"- Queued depuis ≥ {args.min_age} min (signal de saturation) : **{len(stalled)}**\n")
+
+    print("## Top workflows en attente\n")
+    wf = {}
+    for r in stalled:
+        wf[r["name"]] = wf.get(r["name"], 0) + 1
+    for name, n in sorted(wf.items(), key=lambda x: -x[1])[:10]:
+        print(f"- {name} : {n} run(s) en attente")
+
+    print("\n## Runs en attente (âge décroissant)\n")
+    for r in sorted(stalled, key=lambda x: -age_min(x["created_at"]))[:20]:
+        print(f"- [{int(age_min(r['created_at']))} min] {r['name']} — branche `{r['head_branch']}` ({r['id']})")
+
+    print("\n## Pistes (issue #7090 / leçon L-12)")
+    print("1. Job `in_progress` anormalement long → vérifier/annuler (run bloquant la file).")
+    print("2. Vague de branches parallèles → lots BC + quotas de merge.")
+    print("3. Checks requis jamais démarrés → vérifier concurrency/triggers (L-11).")
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"queued": queued, "active": active, "now_epoch": now}, fh, indent=1)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference(s):** PR `chore:` — aucune issue fermée (issues #7089/#7090/#7091/#7119-#7126 déjà traitées par d'autres PR entre-temps ; seuls fichiers encore absents de main livrés ici).
**Category:** Chore / Tooling

## 🚀 Changes Description
3 scripts de garde **absents de main** (vérifié par comparaison d'arbre le 2026-09-09), testés localement :
- `dev-hub/tools/check-i18n-locale-parity.py` — parité des clés i18n fr/en/ar/tr (testé : 4 × 3904 clés, aucune divergence actuelle — garde anti-régression pour la dette i18n).
- `dev-hub/tools/ci-saturation-report.py` — mesure de la file CI (runs queued/in_progress, âge, top workflows) ; exécuté sur le dépôt réel.
- `dev-hub/tools/check-mojibake-duplicates.py` — mojibake + doublons byte-identiques entre apps mobiles (#2661).

## 🗺️ Surfaces
- [ ] API · [ ] Web · [ ] Admin · [ ] Mobile · [ ] Kiosk · [ ] CI/GHA · [x] Outillage (`dev-hub/tools/`) — scripts seuls, aucun câblage CI dans cette PR (décision au tri mensuel, cf. REGISTRE_GARDES.md).

## 🔌 Contrat API
- [x] Aucun changement.

## ⚠️ Risques
- Scripts non câblés en CI (usage local/manuel) — intégration à décider au rituel mensuel (coût vs valeur).

## 🛡 Quality Checklist
- [x] Code Quality (python, docstrings, args) · [x] Verification (tests locaux listés ci-dessus) · [x] Documentation (en-têtes d'usage) · [x] Security (aucun secret) · [x] Breaking Changes: aucun.
