### PR TITLE
chore(gov): register CatalogInquiryErased/Received in event catalogues — déblocage MSV (#5864/MAT-006)

### DIFF
--- a/dev-hub/governance/event-catalogue.json
+++ b/dev-hub/governance/event-catalogue.json
@@ -107,6 +107,35 @@
       "notes": "Aucun listener enregistré (ni EventServiceProvider, ni Event::listen() dans un ServiceProvider module) — dispatché mais actuellement orphelin. Constat, pas un correctif de cette issue (#5864) : voir CandidateHiringService."
     },
     {
+      "name": "CatalogInquiryErased",
+      "class": "App\\Events\\CatalogInquiryErased",
+      "owner": "BC-28 CATALOG",
+      "version": 1,
+      "status": "active",
+      "payload": {
+        "companyId": "string",
+        "buyerEmail": "string",
+        "inquiryId": "int"
+      },
+      "consumers": [
+        "App\\Listeners\\EraseCrmLeadsOnCatalogInquiryErased"
+      ]
+    },
+    {
+      "name": "CatalogInquiryReceived",
+      "class": "App\\Events\\CatalogInquiryReceived",
+      "owner": "BC-28 CATALOG",
+      "version": 1,
+      "status": "active",
+      "payload": {
+        "companyId": "string",
+        "inquiry": "App\\Modules\\Catalog\\Domain\\Models\\CatalogInquiry"
+      },
+      "consumers": [
+        "App\\Listeners\\CreateCrmLeadFromCatalogInquiry"
+      ]
+    },
+    {
       "name": "CompanyCreated",
       "class": "App\\Events\\CompanyCreated",
       "owner": "BC-02 TENANT",

--- a/docs/architecture/event-catalogue.yaml
+++ b/docs/architecture/event-catalogue.yaml
@@ -17,6 +17,63 @@ conventions:
   consumer_compat: un consumer déclare consumes.from ; CI bloque une version incompatible
 
 events:
+  - name: catalog.inquiry_received
+    version: 1.0.0
+    bc: catalog
+    class: App\Events\CatalogInquiryReceived
+    description: Demande de devis B2B recue via le formulaire public du catalogue d'un tenant (BC-28 C-LEAD #6884). Consommee par CRM (creation d'un lead BC-11) et notifications (BC-13).
+    consumers:
+      - App\Listeners\CreateCrmLeadFromCatalogInquiry
+    schema:
+      type: object
+      required: [event_name, version, occurred_at, company_id, data]
+      properties:
+        event_name: { type: string, enum: [catalog.inquiry_received] }
+        version: { type: string }
+        occurred_at: { type: string, format: date-time }
+        company_id: { type: string, format: uuid }
+        data:
+          type: object
+          required: [inquiry_id]
+          properties:
+            inquiry_id: { type: integer }
+    sample:
+      event_name: catalog.inquiry_received
+      version: "1.0.0"
+      occurred_at: "2026-09-09T12:00:00+00:00"
+      company_id: "11111111-1111-4111-8111-111111111111"
+      data: { inquiry_id: 42 }
+    deprecation: null
+
+  - name: catalog.inquiry_erased
+    version: 1.0.0
+    bc: catalog
+    class: App\Events\CatalogInquiryErased
+    description: Demande de devis B2B EFFACEE (droit d'effacement RGPD, BC-28 C-RGPD #6889). Consommee par CRM (suppression des leads BC-11 lies au meme email acheteur).
+    consumers:
+      - App\Listeners\EraseCrmLeadsOnCatalogInquiryErased
+    schema:
+      type: object
+      required: [event_name, version, occurred_at, company_id, data]
+      properties:
+        event_name: { type: string, enum: [catalog.inquiry_erased] }
+        version: { type: string }
+        occurred_at: { type: string, format: date-time }
+        company_id: { type: string, format: uuid }
+        data:
+          type: object
+          required: [inquiry_id, buyer_email]
+          properties:
+            inquiry_id: { type: integer }
+            buyer_email: { type: string, format: email }
+    sample:
+      event_name: catalog.inquiry_erased
+      version: "1.0.0"
+      occurred_at: "2026-09-09T12:00:00+00:00"
+      company_id: "11111111-1111-4111-8111-111111111111"
+      data: { inquiry_id: 42, buyer_email: "acheteur@example.com" }
+    deprecation: null
+
   - name: company.created
     version: 1.0.0
     bc: platform


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference(s):** n/a — PR typée `chore:` (exempte de l'exigence Closes, garde pr-issue-guard). Concerne la règle #5864 / MAT-006.

**Category:** Chore (gouvernance)

---

## 🚀 Changes Description

**Déblocage du check requis « Module Structure Validator » pour tout le swarm** : deux événements BC-28 CATALOG présents sur `main` (`api/app/Events/CatalogInquiryErased.php`, `CatalogInquiryReceived.php` — C-LEAD #6884 / C-RGPD #6889) n'étaient pas enregistrés dans le catalogue d'événements → `check-event-catalogue.py` (MAT-006, #5864) échouait sur **chaque PR** (dérive de main, vérifiée aussi sur #7115/#7095).

Correction (les deux registres, cohérents avec les phpDocs des événements) :
- `dev-hub/governance/event-catalogue.json` : entrées `CatalogInquiryErased` (payload companyId/buyerEmail/inquiryId, consumer `EraseCrmLeadsOnCatalogInquiryErased`) et `CatalogInquiryReceived` (payload companyId/inquiry, consumer `CreateCrmLeadFromCatalogInquiry`) — owner `BC-28 CATALOG`, v1, active ;
- `docs/architecture/event-catalogue.yaml` : entrées `catalog.inquiry_erased` / `catalog.inquiry_received` v1.0.0 (schéma + sample, consumers) — le référentiel YAML déclaré par les phpDocs n'avait pas non plus les entrées.

**Validé localement** : `python3 dev-hub/tools/check-event-catalogue.py .` → `✅ 23 événements synchronisés` (exit 0).

---

## 🗺️ Surfaces touchees

- [ ] API (`api/app`) — non : lecture des événements existants uniquement
- [ ] Docs / registres : `dev-hub/governance/event-catalogue.json`, `docs/architecture/event-catalogue.yaml`
- [x] Docs uniquement / registres de gouvernance
- [ ] CI / GitHub Actions

---

## 🔌 Contrat API

- [x] Aucun changement de contrat API (aucun code applicatif modifié).

---

## ⚠️ Risques residuels

- Aucun : PR additive sur deux registres ; le guard MAT-006 passe localement et doit passer en CI.
- Note : le registre JSON contenait deux noms dupliqués pré-existants (non touchés par cette PR).

---

## 🛡 Quality Checklist

- [x] **Code Quality:** registres conformes au format existant.
- [x] **Testing:** guard `check-event-catalogue.py` vert en local.
- [x] **Documentation:** registres = documentation versionnée (MAT-006).
- [x] **Security:** aucun secret.
- [x] **Breaking Changes:** aucun.

---

## 📸 Screenshots / Demos

Non applicable.

---

## 🤝 Contributor Agreement

By submitting this PR, I agree that my contributions are licensed under the **MIT License**.
