### PR TITLE
fix(desktop): débloque la compilation Windows (STL1011) + canal dev (Closes #7137)

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -83,6 +83,11 @@ jobs:
       - name: Build (verify, non signé)
         working-directory: front/mobile_apps/${{ matrix.app }}
         shell: bash
+        # Fix MSVC 14.51 (runner windows-2025) : <experimental/coroutine> retiré par
+        # la STL récente → local_auth_windows ne compile plus (STL1011). Macro officiel
+        # MSVC ; à retirer quand le plugin sera compatible (suivi #7056).
+        env:
+          CXXFLAGS: "-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
             flutter build windows --debug

--- a/.github/workflows/desktop-distribute.yml
+++ b/.github/workflows/desktop-distribute.yml
@@ -33,7 +33,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write   # publication du canal dev (Release GitHub non signée, P06 §3.4)
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -93,6 +93,12 @@ jobs:
 
       - name: Build ${{ matrix.os.name }} (release)
         shell: bash
+        # Fix MSVC 14.51 (runner windows-2025) : local_auth_windows (dépendance de
+        # leopardo_core) utilise <experimental/coroutine> retiré par la STL récente
+        # (erreur STL1011). Le macro officiel MSVC supprime l'erreur — parade amont
+        # documentée, à retirer quand le plugin sera compatible (suivi #7056).
+        env:
+          CXXFLAGS: "-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
         run: |
           set -euo pipefail
           cd "front/mobile_apps/${{ inputs.app }}"
@@ -113,10 +119,57 @@ jobs:
             du -sh "${ARTIFACT}/${{ inputs.app }}.app"
           fi
 
+      - name: Package + checksums (zip + SHA-256)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF'
+          import hashlib, pathlib, shutil, zipfile
+          app = "${{ inputs.app }}"
+          osname = "${{ matrix.os.name }}"
+          build = "${{ matrix.build }}"
+          base = pathlib.Path(f"front/mobile_apps/{app}/build")
+          if build == "windows":
+              src = base / "windows/x64/runner/Release"
+              target_name = f"{app}.exe"
+          else:
+              src = base / "macos/Build/Products/Release"
+              target_name = f"{app}.app"
+          assert (src / target_name).exists(), f"artefact introuvable: {src / target_name}"
+          out = pathlib.Path("dist"); shutil.rmtree(out, ignore_errors=True); out.mkdir()
+          zip_path = out / f"leopardo-desktop-{app}-{osname}.zip"
+          with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+              z.write(src / target_name, arcname=target_name)
+              if build == "windows":
+                  for child in src.iterdir():
+                      if child.name != target_name and child.is_file():
+                          z.write(child, arcname=child.name)
+          digest = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+          (out / f"leopardo-desktop-{app}-{osname}.sha256").write_text(f"{digest}  {zip_path.name}\n")
+          print(f"{zip_path} sha256={digest}")
+          PYEOF
+
+      - name: Publish dev release (NON SIGNÉ — usage interne, P06 §3.4)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="desktop-${{ inputs.app }}-dev"
+          NOTES="Canal dev desktop — build NON SIGNÉ, usage interne/pilote.
+          App: ${{ inputs.app }} | Plateforme: ${{ matrix.os.name }} | Run: ${{ github.run_id }}
+          Volet API: ${{ inputs.environment }} | Commit: ${{ github.sha }}
+          Aucune distribution publique (protocole P06 / #3257)."
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release upload "${TAG}" dist/* --clobber
+          else
+            gh release create "${TAG}" dist/* --title "Desktop dev — ${{ inputs.app }}" --notes "${NOTES}" --prerelease
+          fi
+
       - name: Upload artifact (canal pilote interne — aucun lien public)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: leopardo-desktop-${{ inputs.app }}-${{ matrix.os.name }}-${{ github.run_id }}
-          path: ${{ matrix.artifact_path }}
+          path: dist/
           if-no-files-found: error
           retention-days: 14

--- a/docs/desktop/README.md
+++ b/docs/desktop/README.md
@@ -46,7 +46,7 @@ chaîne ci-dessous. **Aucune tranche ne s'active sans ligne validée ici.**
 3. **Signature** (obligatoire pour tout canal public) : Windows — certificat code
    signing (+ packaging MSIX si retenu) ; macOS — Developer ID + notarisation +
    stapling. Secrets = GitHub Actions secrets (jamais dans le dépôt).
-4. **Canaux** : dev (GitHub Release `desktop-<app>-dev`, non signé toléré, marqué) →
+4. **Canaux** : dev (GitHub Release `desktop-<app>-dev`, non signé toléré, marqué — ✅ implémenté, lot 3) →
    beta/pilotes (signé, UAT via `docs/ops/RECETTE_UAT_*.md` du BC) → prod
    (GitHub Release semver signée). Auto-update non activé par défaut (décision par
    tranche).


### PR DESCRIPTION
## Contexte
La chaîne desktop (lots 1-2) est en place mais les builds échouaient : les runners `windows-2025`
embarquent MSVC 14.51, qui a retiré `<experimental/coroutine>` → `local_auth_windows` (dépendance
de `leopardo_core`) ne compile plus (**erreur STL1011**), pour `leopardo_accounting` comme pour les
5 apps de `desktop-ci.yml` (10 jobs rouges observés). Ce lot débloque les builds et livre le canal
de distribution `dev` prévu par le registre (`docs/desktop/README.md` §3.4).

## Contenu
- `.github/workflows/desktop-distribute.yml` : `CXXFLAGS=-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` (macro officiel MSVC) ; packaging zip + **SHA-256** ; publication **Release GitHub `desktop-<app>-dev`** (non signée, marquée, pré-release) ; artefact = `dist/` ; `permissions: contents: write`.
- `.github/workflows/desktop-ci.yml` : même fix pour les builds de vérification (5 apps).
- `docs/desktop/README.md` : canal dev marqué implémenté.

## Critères d'acceptation
1. `desktop-dispatch` (workflow_dispatch) : builds Windows **et** macOS verts pour `leopardo_accounting`.
2. Release `desktop-leopardo_accounting-dev` publiée (non signée, marquée) avec zip + `.sha256`.
3. `desktop-ci` vert sur les apps à scaffolding (fin des 10 jobs rouges).
4. Aucune distribution publique (P06 / #3257 respectés).

Closes #7137
Part of #7056 — ne ferme pas le pipeline.