### PR TITLE
refactor(isolation): 5 imports morts supprimés (2 paires, allowlist 54→52) — #6588 lot 2 (Closes #7166)

### DIFF
--- a/api/app/Modules/FuelStation/Infrastructure/Services/FuelImportExportService.php
+++ b/api/app/Modules/FuelStation/Infrastructure/Services/FuelImportExportService.php
@@ -6,7 +6,6 @@ namespace App\Modules\FuelStation\Infrastructure\Services;
 
 use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\FuelStation\Domain\Models\FuelSale;
-use App\Modules\HR\Domain\Models\ExportHistory;
 use App\Support\CsvCellSanitizer;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;

--- a/api/app/Modules/RestaurantManager/Application/Consumers/KitchenOrderNotificationConsumer.php
+++ b/api/app/Modules/RestaurantManager/Application/Consumers/KitchenOrderNotificationConsumer.php
@@ -9,7 +9,6 @@ use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\RestaurantManager\Application\Actions\TransitionOrderAction;
 use App\Modules\RestaurantManager\Domain\Contracts\RestaurantOutboxConsumer;
 use App\Modules\RestaurantManager\Domain\Models\RestaurantOrder;
-use App\Modules\Notification\Infrastructure\Services\CommunicationService;
 
 /**
  * RESTO-808 (#6229) — Consommateur `restaurant.order.created.v1` : notifie

--- a/api/app/Modules/RestaurantManager/Application/Consumers/ServiceOrderNotificationConsumer.php
+++ b/api/app/Modules/RestaurantManager/Application/Consumers/ServiceOrderNotificationConsumer.php
@@ -9,7 +9,6 @@ use App\Core\Auth\Domain\Models\Employee;
 use App\Modules\RestaurantManager\Application\Observers\RestaurantOrderObserver;
 use App\Modules\RestaurantManager\Domain\Contracts\RestaurantOutboxConsumer;
 use App\Modules\RestaurantManager\Domain\Models\RestaurantOrder;
-use App\Modules\Notification\Infrastructure\Services\CommunicationService;
 
 /**
  * RESTO-808 (#6229) — Consommateur `restaurant.order.ready.v1` : notifie

--- a/api/app/Modules/TravelAgency/Application/Actions/TravelManualNotificationAction.php
+++ b/api/app/Modules/TravelAgency/Application/Actions/TravelManualNotificationAction.php
@@ -11,7 +11,6 @@ use App\Shared\Contracts\Notification\EmployeeNotifier;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Throwable;
-use App\Modules\Notification\Infrastructure\Services\CommunicationService;
 
 /**
  * TRAVEL-910 (#6113) — Notifications manuelles legacy gv-back → canaux

--- a/api/app/Modules/TravelAgency/Infrastructure/Services/TravelNotificationConsumer.php
+++ b/api/app/Modules/TravelAgency/Infrastructure/Services/TravelNotificationConsumer.php
@@ -6,7 +6,6 @@ namespace App\Modules\TravelAgency\Infrastructure\Services;
 
 use App\Core\Auth\Domain\Models\Employee;
 use App\Mail\CommunicationMail;
-use App\Modules\Notification\Infrastructure\Services\CommunicationService;
 use App\Modules\TravelAgency\Domain\Contracts\TravelOutboxConsumer;
 use App\Modules\TravelAgency\Domain\Enums\BookingStatus;
 use App\Modules\TravelAgency\Domain\Enums\PaymentStatus;

--- a/dev-hub/tools/module-isolation-allowlist.txt
+++ b/dev-hub/tools/module-isolation-allowlist.txt
@@ -64,5 +64,3 @@ Modules/Recruitment -> Modules/HR
 # App\Contracts\Communication\...Interface.
 Modules/EduManager -> Modules/Notification
 Modules/TravelAgency -> Modules/Notification
-Modules/FuelStation -> Modules/HR
-Modules/RestaurantManager -> Modules/Notification


### PR DESCRIPTION
## Contexte
#6588 lot 2 : suppression d'imports **morts** (analyse du code, commentaires exclus). Allowlist d'isolation **54 → 52**.

## Contenu (5 fichiers, -5 lignes d'import, -2 lignes d'allowlist)
- `TravelAgency` : `CommunicationService` mort dans `TravelManualNotificationAction` + `TravelNotificationConsumer` ;
- `RestaurantManager` : `CommunicationService` mort dans `KitchenOrderNotificationConsumer` + `ServiceOrderNotificationConsumer` ;
- `FuelStation` : `ExportHistory` mort dans `FuelImportExportService` ;
- allowlist : lignes `Modules/RestaurantManager -> Modules/Notification` et `Modules/FuelStation -> Modules/HR` supprimées.

**Correction vs sous-issue** : la paire `Modules/TravelAgency -> Modules/Notification` est **conservée** — il reste un couplage réel (`PushNotificationService` dans `TravelAgentPushConsumer`, à traiter par contrat/événement dans un lot ultérieur). D'où 52 (et non 51) paires restantes.

## Vérifications
- [x] `bash dev-hub/tools/check-module-isolation.sh` → ✅ « Aucun nouvel import croisé (52 violations connues) »
- [x] aucun changement de comportement (les imports supprimés n'étaient jamais référencés)

Closes #7166
Part of #6588 — objectif 0.