### PR TITLE
fix(deploy): ignoreCommand sous la limite de schéma Vercel (256) + garde anti-régression

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -544,3 +544,12 @@ jobs:
         if: needs.detect-changes.outputs.web_changed == 'true'
         working-directory: front/web
         run: npx eslint src --ext .ts,.tsx --max-warnings 0
+
+      # Garde config Vercel (incident 2026-09-10) : un `ignoreCommand` de plus
+      # de 256 caractères fait échouer la validation du schéma et met TOUS les
+      # déploiements en ERROR ; un pathspec relatif au cwd (`front/web` alors que
+      # le cwd vaut déjà `front/web`) saute TOUS les builds. Les deux sont
+      # arrivés — cette étape les attrape avant la production.
+      - name: Vercel config guard (ignoreCommand)
+        if: needs.detect-changes.outputs.web_changed == 'true'
+        run: node dev-hub/tools/check-vercel-config.js

--- a/dev-hub/tools/check-vercel-config.js
+++ b/dev-hub/tools/check-vercel-config.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * check-vercel-config.js — garde sur `front/web/vercel.json` (incident 2026-09-10).
+ *
+ * Deux pièges ont coûté la disponibilité du web public ; cette garde les couvre :
+ *
+ * 1. **Longueur.** Vercel valide `vercel.json` contre un schéma où
+ *    `ignoreCommand` est limité à **256 caractères**. Au-delà, la validation
+ *    échoue et **chaque** déploiement part en `ERROR` — plus rien ne se déploie,
+ *    y compris sur `main` (« vercel.json schema validation failed with the
+ *    following message: `ignoreCommand` should NOT be longer than 256
+ *    characters »).
+ *
+ * 2. **Répertoire d'exécution.** Le projet Vercel a `rootDirectory: front/web`,
+ *    donc `ignoreCommand` s'exécute **depuis `front/web/`**. Un pathspec
+ *    `-- front/web` y devient `front/web/front/web` : il ne matche rien,
+ *    `git diff --quiet` renvoie 0, Vercel interprète `exit 0` comme
+ *    « build ignoré » et **tous** les builds étaient sautés (web public figé
+ *    du 2026-08-19 au 2026-09-10, 100 % des déploiements `CANCELED`, CI verte).
+ *    La commande doit donc résoudre la racine du dépôt (`--show-toplevel` ou
+ *    `git -C`) avant de différencier.
+ *
+ * Usage: node dev-hub/tools/check-vercel-config.js
+ * Exit 0 = config saine ; exit 1 = régression (message ::error::-compatible).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CONFIG_PATH = path.join(ROOT, 'front', 'web', 'vercel.json');
+const MAX_IGNORE_COMMAND = 256; // limite du schéma vercel.json (Vercel)
+
+const errors = [];
+
+let config;
+try {
+  config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+} catch (error) {
+  console.error('❌ VERIF_CONFIG_VERCEL_FAILED');
+  console.error(`- front/web/vercel.json illisible ou JSON invalide : ${error.message}`);
+  process.exit(1);
+}
+
+const command = config.ignoreCommand;
+
+if (typeof command !== 'string' || command.trim() === '') {
+  errors.push('`ignoreCommand` absent ou vide (le garde-fou de quota ne jouerait plus)');
+} else {
+  if (command.length > MAX_IGNORE_COMMAND) {
+    errors.push(
+      `\`ignoreCommand\` fait ${command.length} caractères (limite ${MAX_IGNORE_COMMAND}) — ` +
+        'Vercel rejette le schéma et TOUS les déploiements passent en ERROR',
+    );
+  }
+
+  // Exécuté depuis `front/web` (rootDirectory) : sans résolution de la racine,
+  // un pathspec `front/web` ne matche rien et le build est toujours sauté.
+  if (!/--show-toplevel|-C\s/.test(command)) {
+    errors.push(
+      '`ignoreCommand` ne résout pas la racine du dépôt (`git rev-parse --show-toplevel` ' +
+        'ou `git -C <racine>`) : exécuté depuis front/web, le pathspec `front/web` ne matche rien',
+    );
+  }
+
+  if (!command.includes('front/web')) {
+    errors.push("`ignoreCommand` ne restreint pas le diff à `front/web` (garde de quota absent)");
+  }
+}
+
+if (errors.length > 0) {
+  console.error('❌ VERIF_CONFIG_VERCEL_FAILED');
+  for (const message of errors) {
+    console.error(`- ${message}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `check-vercel-config : OK (ignoreCommand ${command.length}/${MAX_IGNORE_COMMAND} caractères, racine du dépôt résolue)`,
+);

--- a/docs/infra/02_alignement/RUNBOOK_VERCEL_QUOTA_PREVIEWS.md
+++ b/docs/infra/02_alignement/RUNBOOK_VERCEL_QUOTA_PREVIEWS.md
@@ -33,6 +33,13 @@
 > des déploiements `CANCELED`, CI verte). La commande doit donc toujours
 > résoudre la racine du dépôt (`git rev-parse --show-toplevel`) et lancer le
 > diff depuis là. Ne jamais réintroduire un pathspec relatif au cwd.
+>
+> ⚠️ **Limite de schéma** — Vercel **rejette** un `ignoreCommand` de plus de
+> **256 caractères** (`vercel.json schema validation failed`) : le déploiement
+> part alors en `ERROR`, et plus rien ne se déploie. Garder la commande
+> compacte (la version actuelle fait ~220 caractères) et vérifier la longueur
+> après toute modification. Un correctif qui « build correctement » en local
+> peut être refusé par le schéma.
 
 ## Procédure de diagnostic / réparation (dashboard Vercel)
 

--- a/front/web/vercel.json
+++ b/front/web/vercel.json
@@ -70,7 +70,7 @@
   ],
   "cleanUrls": true,
   "trailingSlash": false,
-  "ignoreCommand": "bash -c 'ref=\"${VERCEL_GIT_COMMIT_REF:-}\"; case \"$ref\" in main|staging) ;; *) echo \"ignore: ref=$ref not deployable -> skip\"; exit 0;; esac; root=\"$(git rev-parse --show-toplevel 2>/dev/null)\" || { echo \"ignore: no git toplevel -> build\"; exit 1; }; prev=\"${VERCEL_GIT_PREVIOUS_SHA:-}\"; if [ -n \"$prev\" ] && git -C \"$root\" cat-file -e \"${prev}^{commit}\" 2>/dev/null; then base=\"$prev\"; elif git -C \"$root\" rev-parse --verify --quiet HEAD~1 >/dev/null 2>&1; then base=\"HEAD~1\"; else echo \"ignore: cannot resolve previous SHA -> build\"; exit 1; fi; if git -C \"$root\" diff --quiet \"$base\" HEAD -- front/web; then echo \"ignore: front/web unchanged ($base..HEAD) -> skip\"; exit 0; fi; echo \"ignore: front/web changed ($base..HEAD) -> build\"; exit 1'",
+  "ignoreCommand": "bash -c 'case \"${VERCEL_GIT_COMMIT_REF:-}\" in main|staging);; *) exit 0;; esac;r=$(git rev-parse --show-toplevel)||exit 1;b=${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1};git -C \"$r\" diff --quiet $b HEAD -- front/web||exit 1;exit 0'",
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
Closes #7181

## Contexte

#7179 a corrigé la cause racine du gel du web (pathspec résolu depuis le mauvais cwd) mais a introduit une régression : la commande faisait **400+ caractères**, et Vercel rejette `ignoreCommand` au-delà de **256** (`vercel.json schema validation failed`). Résultat : au lieu de « build ignoré », **chaque** déploiement partait en `ERROR`, **y compris sur `main`** — donc plus aucun déploiement web.

## Correctif

- `ignoreCommand` : **220 caractères**, sémantique inchangée
  (gate `main|staging` ; diff lancé depuis la **racine** du dépôt via
  `git -C "$(git rev-parse --show-toplevel)"` puisque le cwd vaut `front/web` ;
  `VERCEL_GIT_PREVIOUS_SHA` sinon `HEAD~1` ; **fail-safe** → build si le diff
  est indéterminable).
- Garde **anti-régression** `dev-hub/tools/check-vercel-config.js`, branchée sur
  le check **requis** « Frontend — ESLint + TypeScript ».
- Runbook Vercel : limite de schéma documentée.

## Vérifications

| Vérif | Résultat |
|---|---|
| Longueur | 220 ≤ 256 ✅ |
| Rejeu avec les env Vercel, **cwd = `front/web`** | BUILD sur le scénario réel (diff depuis le build gelé du 19/08) ✅ |
| Push sans changement de `front/web` | SKIP (garde de quota conservé) ✅ |
| Branche de preview | SKIP ✅ |
| `VERCEL_GIT_PREVIOUS_SHA` inconnu | BUILD (fail-safe) ✅ |
| Garde testée par mutation | attrape la commande à 400 car. **et** le pathspec relatif au cwd ✅ |
| `actionlint` sur les workflows modifiés | exit 0 ✅ |
