### PR TITLE
fix(web,mobile): réparer l'activation de compte et la checklist d'onboarding

### DIFF
--- a/front/mobile_apps/leopardo_core/lib/core/api/api_payload.dart
+++ b/front/mobile_apps/leopardo_core/lib/core/api/api_payload.dart
@@ -10,6 +10,12 @@ List<dynamic> extractDataList(dynamic payload) {
     if (data is Map && data['items'] is List) {
       return data['items'] as List;
     }
+    // `GET /onboarding-setup/checklist` renvoie {data: {steps: [...]}} et non
+    // une liste nue sous `data` : sans ce cas, l'extraction retombait sur []
+    // et l'ecran d'onboarding mobile affichait a tort « Onboarding termine ! ».
+    if (data is Map && data['steps'] is List) {
+      return data['steps'] as List;
+    }
 
     final items = payload['items'];
     if (items is List) return items;

--- a/front/web/src/app/api/v1/onboarding/invitation/[token]/activate/__tests__/route.test.ts
+++ b/front/web/src/app/api/v1/onboarding/invitation/[token]/activate/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+import { POST } from '../route';
+
+/**
+ * Garde anti-régression — activation de compte (incident 2026-09-10).
+ *
+ * Next.js 15+ passe `params` comme une **Promise** aux Route Handlers. La
+ * version précédente déstructurait `params` sans `await` : `token` valait donc
+ * `undefined`, l'URL amont devenait
+ * `/api/v1/onboarding/invitation/undefined/activate` et le backend répondait
+ * 404 `INVITATION_NOT_FOUND`. Résultat : **toute activation de compte invitée
+ * échouait** via le portail web, en production comme en dev.
+ *
+ * Le test vérifie le contrat d'URL (le token réel est transmis, jamais
+ * « undefined »), la non-exposition du token Sanctum, et la propagation des
+ * codes d'erreur backend.
+ */
+
+jest.mock('@/lib/backend-url', () => ({
+  resolveBackendBaseUrl: jest.fn(() => 'https://backend.example.com'),
+}));
+
+const mockCookieStore = {
+  set: jest.fn(),
+  get: jest.fn(() => undefined),
+};
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(async () => mockCookieStore),
+}));
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+function activateRequest(): NextRequest {
+  return new NextRequest(
+    'https://web.example.com/api/v1/onboarding/invitation/tok-123/activate',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'Abcd1234', password_confirmation: 'Abcd1234' }),
+    },
+  );
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/v1/onboarding/invitation/[token]/activate (proxy)', () => {
+  it('transmet le token de l’URL au backend — jamais "undefined"', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ data: { token: 'sanctum-token', user: { id: 1 } } }, 201),
+    );
+
+    const response = await POST(activateRequest(), {
+      params: Promise.resolve({ token: 'tok-123' }),
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const calledUrl = String(mockFetch.mock.calls[0][0]);
+    expect(calledUrl).toBe(
+      'https://backend.example.com/api/v1/onboarding/invitation/tok-123/activate',
+    );
+    expect(calledUrl).not.toContain('undefined');
+    expect(response.status).toBe(201);
+  });
+
+  it('pose le token Sanctum en cookie httpOnly et ne le renvoie jamais dans le corps', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ data: { token: 'sanctum-secret', user: { id: 1 } } }, 201),
+    );
+
+    const response = await POST(activateRequest(), {
+      params: Promise.resolve({ token: 'tok-123' }),
+    });
+
+    expect(mockCookieStore.set).toHaveBeenCalledWith(
+      'leopardo_token',
+      'sanctum-secret',
+      expect.objectContaining({ httpOnly: true, path: '/' }),
+    );
+
+    const body = (await response.json()) as { data?: Record<string, unknown> };
+    expect(body.data?.token).toBeUndefined();
+    expect(body.data?.user).toEqual({ id: 1 });
+  });
+
+  it('propage le code d’erreur du backend (invitation expirée → 410)', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'INVITATION_EXPIRED' }, 410));
+
+    const response = await POST(activateRequest(), {
+      params: Promise.resolve({ token: 'tok-123' }),
+    });
+
+    expect(response.status).toBe(410);
+    expect(mockCookieStore.set).not.toHaveBeenCalled();
+  });
+});

--- a/front/web/src/app/api/v1/onboarding/invitation/[token]/activate/route.ts
+++ b/front/web/src/app/api/v1/onboarding/invitation/[token]/activate/route.ts
@@ -21,9 +21,14 @@ const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 jours (cohérent avec la route log
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { token: string } },
+  { params }: { params: Promise<{ token: string }> },
 ): Promise<NextResponse> {
-  const { token } = params;
+  // Next.js 15+ : `params` est une Promise dans les Route Handlers. Sans
+  // `await`, la déstructuration renvoie `undefined`, l'URL amont devenait
+  // `/onboarding/invitation/undefined/activate` et le backend répondait 404
+  // INVITATION_NOT_FOUND — l'activation d'un compte invité était donc cassée
+  // en production (le composant de page, lui, attendait bien la Promise).
+  const { token } = await params;
 
   let body: unknown;
   try {


### PR DESCRIPTION
Closes #7189

Deux bugs fonctionnels qui cassaient le parcours d'onboarding, trouvés par audit puis vérifiés.

## 1. Activation de compte — cassée en production (web)

`front/web/src/app/api/v1/onboarding/invitation/[token]/activate/route.ts` déstructurait `params` **sans `await`**. Depuis Next.js 15+, `params` est une **Promise** dans les Route Handlers : `const { token } = params` valait `undefined` → URL amont `/api/v1/onboarding/invitation/undefined/activate` → `404 INVITATION_NOT_FOUND` → **aucune activation de compte invité ne pouvait aboutir**.

Correctif : `params: Promise<{ token: string }>` + `await params`, commentaire explicatif, et **test de route ajouté** (token transmis / token Sanctum non exposé / propagation du code d'erreur backend).

**Vérifié par mutation** : avec le bug réintroduit, le test échoue sur
`Received: ".../invitation/undefined/activate"` — le symptôme prod exact. Avec le correctif : 3/3 verts.

## 2. Checklist d'onboarding mobile — toujours vide

`api_payload.dart::extractDataList()` ignorait la forme `{ data: { steps: [...] } }` renvoyée par `GET /onboarding-setup/checklist` → `[]` → état vide « Onboarding terminé ! » permanent et actions complete/skip inaccessibles.

Correctif additif (n'affecte aucune autre forme déjà gérée).

## Vérifications

| Vérif | Résultat |
|---|---|
| `tsc --noEmit` | 0 erreur |
| `eslint --max-warnings 0` | 0 erreur |
| `next build` | compilé |
| jest | 3 nouveaux tests verts ; 4 suites / 5 tests en échec **pré-existants** (identiques sans ce diff) |
| `dart format --set-exit-if-changed` | OK (formateur utilisé par la CI mobile) |
| `dart analyze` | *No issues found* |

> ℹ️ Le reste des constats d'onboarding (canal d'accès inutilisable faute de mailer configuré, drapeau de complétion du wizard local-only, leads marketing non persistés) est suivi séparément — il ne relève pas de ce correctif.
