### PR TITLE
fix(infra): le probe de disponibilité Redis doit tester une ÉCRITURE (pas un ping)

### DIFF
--- a/api/app/Console/Commands/ProbeAvailabilityCommand.php
+++ b/api/app/Console/Commands/ProbeAvailabilityCommand.php
@@ -86,9 +86,31 @@ class ProbeAvailabilityCommand extends Command
     private function redisIsReachable(): bool
     {
         try {
-            // Quota épuisé (Upstash) = connexion refusée en < 1 s → exception
-            // rapide. Un simple ping avec try/catch suffit pour le failover.
-            return Redis::connection()->ping() !== false;
+            $connection = Redis::connection();
+
+            // ⚠️ Un `ping()` ne suffit PAS (constaté le 2026-09-11).
+            // Un Upstash dont le quota de requêtes est épuisé ACCEPTE la
+            // connexion et répond à PING ; ce sont les commandes suivantes qui
+            // échouent avec « ERR max requests limit exceeded. Limit: 500000 ».
+            // Le probe annonçait donc Redis « up » → CACHE_STORE restait `redis`
+            // → le boot prenait un verrou Redis pour les migrations
+            // (CacheCommandMutex → RedisLock→acquire() → SET) → exception →
+            // « Final migration failure » → conteneur jamais sain → Render
+            // `update_failed` (21 des 30 derniers déploiements dev). Le repli
+            // `file` ne s'engageait jamais.
+            //
+            // On teste donc une ÉCRITURE réelle, exactement ce que feront le
+            // cache et les verrous : si l'écriture échoue, Redis n'est pas
+            // utilisable et l'environnement doit dégrader vers `file`.
+            $probeKey = 'leopardo:availability-probe';
+            // Deux commandes (portable phpredis/Predis, pas d'options variadiques) :
+            // SET puis EXPIRE. La première qui échoue prouve que Redis est inutilisable.
+            $connection->set($probeKey, (string) time());
+            $connection->expire($probeKey, 10);
+
+            // Si l'écriture n'a pas levé, Redis est utilisable (le retour varie
+            // selon le client : « OK » via Predis, objet via phpredis).
+            return true;
         } catch (\Throwable) {
             return false;
         }


### PR DESCRIPTION
Closes #7206

## Pourquoi

Le service **dev est hors service** (21 des 30 derniers déploiements en `update_failed`, dernier `live` le 2026-09-10 18:32). Les logs de boot sont sans ambiguïté :

```
production.ERROR: ERR max requests limit exceeded. Limit: 500000, Usage: 500000 (Upstash)
Final migration failure for database/migrations/public.
```

Quota Upstash épuisé → le verrou Redis des migrations (`RedisLock->acquire()`) échoue → migration en échec → conteneur jamais sain → `update_failed`.

## Le bug de logique

`redisIsReachable()` ne testait qu'un `ping()`, en supposant qu'un quota épuisé « refuse la connexion ». **Faux** : Upstash accepte la connexion et répond à PING ; ce sont les écritures (`SET`) qui échouent. Le probe disait donc « Redis up » → `CACHE_STORE=redis` → verrous Redis → boot fatal, **sans jamais engager le repli `file`**.

## Correctif

Le probe exécute une **écriture réelle** (`SET` + `EXPIRE`, forme portable phpredis/Predis). Toute erreur de commande ⇒ Redis indisponible ⇒ `CACHE_STORE`/`SESSION_DRIVER` → `file` ⇒ le conteneur démarre même avec un Redis inutilisable.

## Conséquence

Débloque le redémarrage du dev **et** la vérification live de l'onboarding (PR #7203) qui était impossible.

⚠️ Côté ops, il reste à **réinitialiser/upgrader l'instance Upstash** : sans cela, le dev tournera en mode dégradé (`file`) en permanence.

## Vérification

| Vérif | Résultat |
|---|---|
| `phpstan -c phpstan-strict.neon` (level 8) | **No errors** |
| `php -l` | OK |