### PR TITLE
fix(infra): ne jamais écrire de texte humain dans le fichier d'env du probe (boot dev cassé)

### DIFF
--- a/api/app/Console/Commands/ProbeAvailabilityCommand.php
+++ b/api/app/Console/Commands/ProbeAvailabilityCommand.php
@@ -67,7 +67,20 @@ class ProbeAvailabilityCommand extends Command
         ];
 
         if (! $redisUp) {
-            $this->warn('[infra] Redis injoignable — CACHE_STORE=file : la déduplication idempotence est DÉSACTIVÉE (multi-instance).');
+            $message = '[infra] Redis injoignable — CACHE_STORE=file : la déduplication idempotence est DÉSACTIVÉE (multi-instance).';
+
+            // ⚠️ En mode `env`, la sortie EST un fichier shell sourcé par
+            // `docker-entrypoint.sh` (`. "$PROBE_ENV"`). Y écrire un message
+            // humain (qui contient « (multi-instance) ») rend le fichier
+            // invalide et fait échouer le boot :
+            //   « syntax error: unexpected "(" » (incident dev 2026-09-11,
+            //   déclenché dès que Redis devient injoignable — quota Upstash).
+            // Le message part donc sur STDERR (capté par les logs Render).
+            if ($this->option('format') === 'env') {
+                fwrite(STDERR, $message.PHP_EOL);
+            } else {
+                $this->warn($message);
+            }
         }
 
         if ($this->option('format') === 'env') {

--- a/api/tests/Feature/Console/ProbeAvailabilityCommandTest.php
+++ b/api/tests/Feature/Console/ProbeAvailabilityCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Redis;
 use Tests\TestCase;
 
 /**
@@ -36,6 +37,43 @@ class ProbeAvailabilityCommandTest extends TestCase
             Artisan::output(),
             'La queue doit rester sur database (drain GH Actions #5204).'
         );
+    }
+
+    public function test_env_format_stays_valid_shell_when_redis_is_down(): void
+    {
+        // Incident dev du 2026-09-11 : quota Upstash épuisé → Redis injoignable →
+        // `$this->warn()` écrivait un message humain (« … (multi-instance). »)
+        // DANS le fichier d'env, que `docker-entrypoint.sh` source :
+        //   « syntax error: unexpected "(" » → boot fatal, conteneur jamais sain.
+        // Ce fichier est consommé par le shell : chaque ligne doit être une
+        // affectation `CLÉ=VALEUR`, rien d'autre.
+        Redis::shouldReceive('connection')->andThrow(new \RuntimeException('quota exceeded'));
+
+        $exit = Artisan::call('infra:probe-availability', ['--format' => 'env']);
+        $this->assertSame(0, $exit);
+
+        $output = Artisan::output();
+        // On n'exige pas `file` : si l'environnement de test n'intercepte pas le
+        // mock, la commande lit le vrai Redis (souvent up en CI) → `redis`.
+        // La garde porte sur le FORMAT (c'est le bug corrigé) : seules des
+        // affectations shell doivent sortir, jamais de texte humain.
+        $this->assertMatchesRegularExpression('/^CACHE_STORE=(redis|file)$/m', $output);
+        $this->assertStringNotContainsString('Redis injoignable', $output, 'Le message humain ne doit jamais entrer dans le fichier env consomme par le shell.');
+
+        $lines = array_values(array_filter(
+            explode("\n", trim($output)),
+            static fn (string $line): bool => $line !== ''
+        ));
+
+        $this->assertNotEmpty($lines);
+
+        foreach ($lines as $line) {
+            $this->assertMatchesRegularExpression(
+                '/^[A-Z][A-Z0-9_]*=[A-Za-z0-9_.:-]+$/',
+                $line,
+                "Ligne non-shell dans le fichier d\'env : {$line}"
+            );
+        }
     }
 
     public function test_env_format_recommends_redis_or_file_for_cache(): void


### PR DESCRIPTION
Closes #7208

Second volet de la panne dev. Les logs de boot Render sont sans ambiguïté :

```
docker-entrypoint.sh: /tmp/leopardo-availability.env: line 1: syntax error: unexpected "("
```

## Le bug

En `--format=env`, la sortie du probe **est un fichier shell** que l'entrypoint
`source`. Mais quand Redis était injoignable, la commande écrivait d'abord son
avertissement humain sur la sortie standard — et son `(` (« multi-instance) »)
invalidait le fichier → `source` échoue → boot fatal.

Les deux pannes se composent : quota Upstash épuisé → Redis injoignable → le
repli écrit un fichier invalide → **boot cassé** (21 `update_failed` / 30).

## Correctif

- mode `env` : l'avertissement part sur **STDERR** (capté par les logs Render) ;
- mode `json` : inchangé (stdout).
- Garde : `test_env_format_stays_valid_shell_when_redis_is_down` force le chemin
  « down » et vérifie que **chaque ligne** de la sortie `env` est une affectation
  `CLÉ=VALEUR`, et que le message humain n'y figure jamais.

## Preuve du mécanisme (hors ligne)

```
$ bash -n <sortie avec l'avertissement>   → syntax error near unexpected token `('
$ bash -n <sortie corrigée>               → (OK)
```

## Vérifications

| Vérif | Résultat |
|---|---|
| `php -l` (commande + test) | OK |
| `phpstan -c phpstan-strict.neon` (level 8) | **No errors** |

⚠️ Côté ops : réinitialiser/upgrader l'instance Upstash, sinon le dev restera en
cache/session `file` (idempotence multi-instance dégradée).