### PR TITLE
fix(admin): sidebar fixe en desktop — le contenu ne repasse plus sous le menu

### DIFF
--- a/front/admin-dashboard/src/components/layout/Sidebar.vue
+++ b/front/admin-dashboard/src/components/layout/Sidebar.vue
@@ -13,12 +13,12 @@
   <!-- Sidebar -->
   <div
     :class="[
-      'fixed inset-y-0 left-0 z-50 w-64 transform bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl border-r border-slate-200/50 dark:border-slate-800/50 shadow-premium transition-all duration-300 ease-in-out md:static md:translate-x-0',
+      'fixed inset-y-0 left-0 z-50 flex w-64 flex-col overflow-hidden transform bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl border-r border-slate-200/50 dark:border-slate-800/50 shadow-premium transition-all duration-300 ease-in-out md:translate-x-0',
       isOpen ? 'translate-x-0' : '-translate-x-full'
     ]"
   >
     <!-- Logo -->
-    <div class="flex h-20 items-center justify-center border-b border-slate-200/50 dark:border-slate-800/50 px-6">
+    <div class="flex h-20 shrink-0 items-center justify-center border-b border-slate-200/50 dark:border-slate-800/50 px-6">
       <div class="flex items-center">
         <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-brand-500 to-cyan-600 shadow-lg shadow-brand-500/20">
           <span class="text-sm font-bold text-white">LRH</span>
@@ -28,7 +28,7 @@
     </div>
 
     <!-- Navigation -->
-    <nav class="mt-6 px-4" role="navigation" :aria-label="t('navigation.mainMenu', 'Menu principal')">
+    <nav class="mt-6 flex-1 overflow-y-auto px-4 pb-24" role="navigation" :aria-label="t('navigation.mainMenu', 'Menu principal')">
       <div class="space-y-1">
         <router-link
           v-for="item in navigation"

--- a/front/admin-dashboard/src/layouts/DashboardLayout.vue
+++ b/front/admin-dashboard/src/layouts/DashboardLayout.vue
@@ -17,7 +17,7 @@
     <Sidebar
       :is-open="sidebarOpen"
       @close="sidebarOpen = false"
-      class="fixed inset-y-0 left-0 z-50 md:static md:inset-0"
+      class="fixed inset-y-0 left-0 z-50"
     />
 
     <!-- Main content -->
@@ -137,6 +137,16 @@ watch(sidebarOpen, (open) => {
 
 // Close sidebar on route change (navigation on mobile).
 watch(route, () => { sidebarOpen.value = false })
+
+// Échap ferme le tiroir mobile — même comportement que la vitrine et le
+// dashboard web (le tiroir ne se fermait qu'au clic sur l'overlay).
+const handleEscape = (event) => {
+  if (event.key === 'Escape' && sidebarOpen.value) {
+    sidebarOpen.value = false
+  }
+}
+onMounted(() => window.addEventListener('keydown', handleEscape))
+onUnmounted(() => window.removeEventListener('keydown', handleEscape))
 
 // Initialize keyboard shortcuts
 useKeyboardShortcuts()


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference(s):** Closes #7229

**Category:** Bug Fix

---

## 🚀 Changes Description

Corrige la mise en page de l'admin plateforme : le contenu de page était poussé
**sous** la sidebar pour tous les écrans >= 768 px (grande zone blanche au
milieu, défilement obligatoire pour voir la page).

- `Sidebar.vue` : la sidebar reste `fixed` à tous les breakpoints (suppression de
  `md:static`) ; elle devient un conteneur de défilement
  (`flex flex-col overflow-hidden`), logo `shrink-0`, navigation
  `flex-1 overflow-y-auto pb-24` pour dégager le bloc utilisateur en
  `absolute bottom-0`.
- `DashboardLayout.vue` : suppression du `md:static md:inset-0` repassé au
  composant ; ajout de la fermeture du tiroir mobile sur **Échap** (il ne se
  fermait qu'au clic sur l'overlay) — aligné sur la vitrine et le dashboard web.

Cause racine détaillée et mesures dans #7229.

---

## 🗺️ Surfaces touchees

-   [ ] API (`api/app`)
-   [ ] Web (`front/web`)
-   [x] Admin dashboard (`front/admin-dashboard`)
-   [ ] Mobile (`front/mobile_apps/*`)
-   [ ] Kiosk (`front/zkteco-kiosk`)
-   [ ] CI / GitHub Actions (`.github/workflows`)
-   [ ] Docs uniquement (`docs/`, `*.md`)
-   [ ] Infra / config (`render.yaml`, `docker*`, etc.)

---

## 🔌 Contrat API

-   [ ] Cette PR ajoute/modifie une route, un payload de requete, ou une reponse API existante.
-   [x] Aucun changement de contrat API dans cette PR.

---

## ⚠️ Risques residuels

- `GET /api/v1/platform/companies/health` répond en ~19 s : le dashboard reste
  ~20 s sur l'indicateur de chargement avant d'afficher les cartes (perçu comme
  « contenu vide »). **Hors périmètre de cette PR** — vérifié qu'il ne s'agit pas
  d'un bug de rendu (à 35 s le contenu s'affiche entièrement). À traiter
  séparément (`Promise.allSettled` + timeout front, et/ou agrégat API).
- La sidebar devient un conteneur de défilement interne : sur un écran très
  court, la navigation défile désormais à l'intérieur de la sidebar au lieu de
  déborder sur la page (comportement attendu, testé à 800 px de hauteur).

---

## 🎨 Design Review — DSG-6 (PR touchant une UI)

-   [x] Tokens : aucune nouvelle couleur/typo — classes existantes uniquement.
-   [x] États UI couverts (vide, chargement, erreur, succès, disabled).
-   [x] Contraste AA vérifié (texte sur fond).
-   [x] Responsive : rendu contrôlé aux breakpoints principaux — 1440 / 1280 /
    1024 / 900 / 820 / 768 px (sidebar `fixed`, `main` à y=81) et 600 / 390 px
    (sidebar hors écran, contenu pleine largeur).
-   [x] i18n/RTL : aucune chaîne ajoutée ; le libellé Échap réutilise les clés
    existantes ; pas de changement de direction de layout (le rail garde
    `inset-y-0 left-0`, comportement inchangé hors périmètre RTL).

### Preuves

- `eslint src --max-warnings 0` : 0 warning
- `vite build` : OK
- e2e admin `navigation-spa` + `sidebar-unique-entries` + `accessibility-smoke`
  \+ `dashboard-kpi` + `login-smoke` + `login-links` : **19 passed / 1 skipped**
- Mesures avant/après (Vite preview = build de prod, API DEV live) :

| Largeur | Avant | Après |
|---|---|---|
| >= 768 px | `main` à y≈1222, bodyH 1610 | sidebar `fixed` 256x800@(0,0), `main` à **y=81**, bodyH = viewport |
| < 768 px | OK | OK — burger -> x=0, Échap -> x=-256 |
