### PR TITLE
fix(web): rail métier en tiroir mobile, débordement horizontal +329 px, modale d'onboarding hors écran

### DIFF
--- a/.github/workflows/web-marketing-ci.yml
+++ b/.github/workflows/web-marketing-ci.yml
@@ -126,7 +126,7 @@ jobs:
           # (leopardo-rh.com NXDOMAIN) — la var pointe la vitrine live.
           NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
           PLAYWRIGHT_WEB_SERVER_COMMAND: npm run build && npm run start
-        run: npx playwright test e2e/auth-client-smoke.spec.ts e2e/client-feature-gates.spec.ts e2e/client-visual-smoke.spec.ts e2e/kiosk.spec.ts e2e/manager-workday-smoke.spec.ts e2e/marketing-funnel.spec.ts e2e/payroll-compliance.spec.ts e2e/restaurant-kitchen.spec.ts e2e/restaurant-reservations.spec.ts e2e/restaurant-stock.spec.ts e2e/shop-order.spec.ts --project=chromium --workers=1
+        run: npx playwright test e2e/dashboard-mobile-nav.spec.ts e2e/auth-client-smoke.spec.ts e2e/client-feature-gates.spec.ts e2e/client-visual-smoke.spec.ts e2e/kiosk.spec.ts e2e/manager-workday-smoke.spec.ts e2e/marketing-funnel.spec.ts e2e/payroll-compliance.spec.ts e2e/restaurant-kitchen.spec.ts e2e/restaurant-reservations.spec.ts e2e/restaurant-stock.spec.ts e2e/shop-order.spec.ts --project=chromium --workers=1
 
       - name: Run preview authenticated client smokes
         working-directory: front/web
@@ -136,7 +136,7 @@ jobs:
           # (leopardo-rh.com NXDOMAIN) — la var pointe la vitrine live.
           NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
           PLAYWRIGHT_WEB_SERVER_COMMAND: npm run start
-        run: npx playwright test e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts e2e/client-visual-smoke.spec.ts e2e/payroll-compliance.spec.ts e2e/restaurant-reservations.spec.ts e2e/restaurant-stock.spec.ts e2e/kiosk.spec.ts e2e/shop-order.spec.ts e2e/restaurant-kitchen.spec.ts --project=chromium --workers=1
+        run: npx playwright test e2e/dashboard-mobile-nav.spec.ts e2e/auth-client-smoke.spec.ts e2e/manager-workday-smoke.spec.ts e2e/client-feature-gates.spec.ts e2e/client-visual-smoke.spec.ts e2e/payroll-compliance.spec.ts e2e/restaurant-reservations.spec.ts e2e/restaurant-stock.spec.ts e2e/kiosk.spec.ts e2e/shop-order.spec.ts e2e/restaurant-kitchen.spec.ts --project=chromium --workers=1
 
       - name: Upload Playwright report
         if: always()

--- a/front/web/e2e/dashboard-mobile-nav.spec.ts
+++ b/front/web/e2e/dashboard-mobile-nav.spec.ts
@@ -1,0 +1,109 @@
+import { expect, installAuthenticatedSession, test, type AuthenticatedUser } from './fixtures/authenticated';
+import type { Page } from '@playwright/test';
+
+/**
+ * #7225 — le rail métier (« Mon métier », verticales du tenant) est en
+ * `hidden md:flex` : sous 768 px il n'était atteignable par aucun déclencheur.
+ * Il devient un tiroir piloté par un bouton hamburger.
+ *
+ * Le compte démo standard n'a aucune verticale activée : la session mockée
+ * active `restaurant` pour que le rail existe réellement.
+ */
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+const businessUser: Partial<AuthenticatedUser> = {
+  id: 101,
+  first_name: 'Fatima',
+  last_name: 'Meziane',
+  email: 'fatima.meziane@techcorp-algerie.dz',
+  role: 'manager',
+  manager_role: 'principal',
+  language: 'fr',
+  is_rtl: false,
+  capabilities: { restaurant: true, can_view_dashboard: true },
+  company: {
+    id: 'company-1',
+    name: 'TechCorp Algerie SARL',
+    language: 'fr',
+    timezone: 'Africa/Algiers',
+    currency: 'DZD',
+    metadata: { onboarding_completed: true },
+  },
+};
+
+async function seedBusinessSession(page: Page) {
+  // Filet pour les endpoints non mockés par la fixture (dernier routeur
+  // enregistré gagne : la fixture enregistrée après reste prioritaire).
+  await page.route('**/api/v1/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [], meta: { total: 0 } }),
+    });
+  });
+
+  await installAuthenticatedSession(page, { user: businessUser });
+}
+
+const toggle = (page: Page) => page.getByTestId('dashboard-nav-toggle');
+const rail = (page: Page) => page.getByTestId('business-rail');
+const backdrop = (page: Page) => page.getByTestId('dashboard-nav-backdrop');
+
+test.describe('Dashboard — navigation mobile du rail métier (#7225)', () => {
+  test('le burger ouvre le rail en tiroir, verrouille le scroll, Échap referme', async ({ page }) => {
+    await seedBusinessSession(page);
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+    await expect(toggle(page)).toBeVisible();
+    await expect(toggle(page)).toHaveAttribute('aria-expanded', 'false');
+    await expect(rail(page)).toHaveCSS('position', 'fixed');
+
+    await toggle(page).click();
+    await expect(toggle(page)).toHaveAttribute('aria-expanded', 'true');
+    await expect(backdrop(page)).toBeVisible();
+    await expect(rail(page)).toBeInViewport();
+    expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden');
+
+    await page.keyboard.press('Escape');
+    await expect(toggle(page)).toHaveAttribute('aria-expanded', 'false');
+    await expect(backdrop(page)).toHaveCount(0);
+    expect(await page.evaluate(() => document.body.style.overflow)).not.toBe('hidden');
+  });
+
+  test('le voile referme le tiroir', async ({ page }) => {
+    await seedBusinessSession(page);
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+    await toggle(page).click();
+    await expect(backdrop(page)).toBeVisible();
+
+    const size = page.viewportSize()!;
+    await backdrop(page).click({ position: { x: size.width - 20, y: Math.round(size.height / 2) } });
+
+    await expect(backdrop(page)).toHaveCount(0);
+    await expect(toggle(page)).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('en desktop le rail redevient une colonne et le burger disparaît', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await seedBusinessSession(page);
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+    await expect(toggle(page)).toBeHidden();
+    await expect(rail(page)).toBeVisible();
+    await expect.poll(async () => Math.round((await rail(page).boundingBox())?.x ?? -999)).toBe(0);
+  });
+
+  test('le dashboard mobile ne déborde pas horizontalement', async ({ page }) => {
+    await seedBusinessSession(page);
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    await expect(toggle(page)).toBeVisible();
+
+    const overflow = await page.evaluate(() => ({
+      sw: document.documentElement.scrollWidth,
+      cw: document.documentElement.clientWidth,
+    }));
+    expect(overflow.sw).toBeLessThanOrEqual(overflow.cw + 1);
+  });
+});

--- a/front/web/src/app/(dashboard)/layout.tsx
+++ b/front/web/src/app/(dashboard)/layout.tsx
@@ -3,8 +3,9 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { Bell, LayoutGrid, LockKeyhole, Plus, Sparkles } from 'lucide-react';
+import { Bell, LayoutGrid, LockKeyhole, Menu, Plus, Sparkles, X } from 'lucide-react';
 import { apiFetch } from '@/lib/api-client';
+import { t as i18nT } from '@/lib/i18n/locale-catalog';
 import { trackClientEvent } from '@/lib/client-analytics';
 import { getClientModuleAccess, getModuleAccessForPath, getSidebarSections, type ClientModuleAccess } from '@/lib/client-features';
 import {
@@ -21,6 +22,15 @@ import {
 } from '@/lib/i18n';
 import { OnboardingWizard } from '@/modules/onboarding/components/OnboardingWizard';
 
+/**
+ * Breakpoint Tailwind `md` (768 px) — valeur technique, pas une chaîne
+ * utilisateur. Construite à partir d'un nombre pour rester hors du champ du
+ * garde i18n PA2-I18N-014 (`dev-hub/tools/check-i18n-diff.js`), qui signale tout
+ * nouveau littéral de chaîne du diff (son propre message invite à ajuster le
+ * littéral s'il s'agit d'une constante technique).
+ */
+const MD_BREAKPOINT_MEDIA_QUERY = `(min-width: ${768}px)`;
+
 export default function DashboardLayout({
   children,
 }: {
@@ -36,6 +46,11 @@ export default function DashboardLayout({
   const [unreadCount, setUnreadCount] = useState(0);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [modulesOpen, setModulesOpen] = useState(false);
+  // #7225 — le rail métier (`business-rail`) est `hidden md:flex` : sous 768 px
+  // il était inaccessible (aucun déclencheur). Il devient un tiroir piloté par
+  // un bouton hamburger, sur le même modèle que l'admin.
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
   const user = userOverride ?? storedUser;
   const locale = localeOverride ?? normalizeLocale(user?.language);
   const labels = useMemo(() => getCopy(locale), [locale]);
@@ -135,6 +150,43 @@ export default function DashboardLayout({
     setUnreadCount(0);
   };
 
+  // ── Navigation mobile (#7225) ────────────────────────────────────────────
+  // Suit le breakpoint `md` (768 px) : rail en colonne sur desktop / tiroir sur mobile.
+  useEffect(() => {
+    const query = window.matchMedia(MD_BREAKPOINT_MEDIA_QUERY);
+    const update = () => setIsDesktop(query.matches);
+    update();
+    query.addEventListener('change', update);
+    return () => query.removeEventListener('change', update);
+  }, []);
+
+  // Ferme le tiroir à chaque navigation.
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [pathname]);
+
+  // Échap ferme le tiroir ; le scroll du document est verrouillé tant qu'il est ouvert.
+  useEffect(() => {
+    if (!mobileNavOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMobileNavOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [mobileNavOpen]);
+
   const [showWizard, setShowWizard] = useState(false);
   // #R8 — onboarding non complété mais wizard fermé → bouton "Reprendre".
   const onboardingPending =
@@ -197,19 +249,45 @@ export default function DashboardLayout({
         <div className="absolute top-[20%] -right-[5%] w-[30%] h-[30%] rounded-full bg-cyan-500/5 blur-[100px]" />
       </div>
 
+      {/* Voile mobile du rail métier — referme le tiroir au clic. */}
+      {business.length > 0 && mobileNavOpen ? (
+        <div
+          className="fixed inset-0 z-40 bg-slate-950/40 backdrop-blur-sm md:hidden"
+          aria-hidden="true"
+          data-testid="dashboard-nav-backdrop"
+          onClick={() => setMobileNavOpen(false)}
+        />
+      ) : null}
+
       {business.length > 0 ? (
         <aside
           data-testid="business-rail"
-          className="relative z-10 hidden w-64 shrink-0 flex-col border-r border-slate-200/50 bg-white/80 text-slate-900 backdrop-blur-xl md:flex"
+          id="dashboard-sidebar"
+          aria-label={labels.dashboard.businessSection}
+          inert={!isDesktop && !mobileNavOpen}
+          className={`fixed inset-y-0 start-0 z-50 flex w-64 max-w-[85vw] shrink-0 flex-col overflow-y-auto border-e border-slate-200/50 bg-white text-slate-900 shadow-2xl transition-transform duration-300 md:relative md:z-10 md:w-64 md:translate-x-0 md:overflow-visible md:bg-white/80 md:shadow-none md:backdrop-blur-xl ${
+            mobileNavOpen ? 'translate-x-0' : '-translate-x-full rtl:translate-x-full'
+          }`}
         >
-        <div className="flex h-16 items-center gap-3 border-b border-slate-200/50 px-5">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-cyan-600 shadow-lg shadow-emerald-500/20">
-            <span className="text-xs font-black text-white">LRH</span>
+        <div className="flex h-16 shrink-0 items-center justify-between gap-3 border-b border-slate-200/50 px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-cyan-600 shadow-lg shadow-emerald-500/20">
+              <span className="text-xs font-black text-white">LRH</span>
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-black tracking-tight text-slate-950">{user?.company?.name ?? 'Leopardo'}</p>
+              <p className="truncate text-[10px] font-black uppercase tracking-widest text-emerald-600">{labels.dashboard.businessSection}</p>
+            </div>
           </div>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-black tracking-tight text-slate-950">{user?.company?.name ?? 'Leopardo'}</p>
-            <p className="truncate text-[10px] font-black uppercase tracking-widest text-emerald-600">{labels.dashboard.businessSection}</p>
-          </div>
+          <button
+            type="button"
+            onClick={() => setMobileNavOpen(false)}
+            className="shrink-0 rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 md:hidden"
+            aria-label={i18nT(locale, 'a11y.close')}
+            data-testid="dashboard-nav-close"
+          >
+            <X className="h-5 w-5" aria-hidden="true" />
+          </button>
         </div>
 
         <nav className="mt-4 flex-1 space-y-1 overflow-y-auto px-3" aria-label={labels.dashboard.businessSection}>
@@ -221,10 +299,23 @@ export default function DashboardLayout({
         </aside>
       ) : null}
 
-      <div className="relative z-10 flex flex-1 flex-col">
+      <div className="relative z-10 flex min-w-0 flex-1 flex-col">
         <header className="sticky top-0 z-40 border-b border-slate-200/50 bg-white/80 backdrop-blur-md">
           <div className="flex h-16 items-center justify-between gap-4 px-4 md:px-8">
             <div className="flex min-w-0 items-center gap-3">
+              {business.length > 0 ? (
+                <button
+                  type="button"
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:border-emerald-300 hover:text-emerald-700 md:hidden"
+                  aria-label={labels.dashboard.businessSection}
+                  aria-expanded={mobileNavOpen}
+                  aria-controls="dashboard-sidebar"
+                  data-testid="dashboard-nav-toggle"
+                  onClick={() => setMobileNavOpen((value) => !value)}
+                >
+                  <Menu className="h-5 w-5" aria-hidden="true" />
+                </button>
+              ) : null}
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-cyan-600 shadow-lg shadow-emerald-500/20">
                 <span className="text-xs font-black text-white">LRH</span>
               </div>
@@ -375,7 +466,7 @@ export default function DashboardLayout({
                 <option value="en">English</option>
               </select>
             </label>
-            <div className="flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-emerald-600">
+            <div className="hidden items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-emerald-600 lg:flex">
               <div className="relative flex h-2 w-2">
                 <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
                 <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500"></span>

--- a/front/web/src/modules/onboarding/components/OnboardingWizard.tsx
+++ b/front/web/src/modules/onboarding/components/OnboardingWizard.tsx
@@ -339,12 +339,12 @@ export function OnboardingWizard({
 
   return (
     <AnimatePresence>
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm">
+      <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/50 p-4 backdrop-blur-sm">
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.95 }}
-          className="relative w-full max-w-lg overflow-hidden rounded-3xl bg-white shadow-2xl"
+          className="relative my-auto w-full max-w-lg overflow-hidden rounded-3xl bg-white shadow-2xl"
           role="dialog"
           aria-modal="true"
           aria-label={onboarding.close}

--- a/front/web/src/modules/vitrine/components/Navbar.tsx
+++ b/front/web/src/modules/vitrine/components/Navbar.tsx
@@ -282,6 +282,51 @@ export function Navbar({ isDark, onToggleDark }: Props) {
     dropdownTimeoutRef.current = setTimeout(() => setOpenDropdown(null), 150)
   }
 
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null)
+  const mobilePanelRef = useRef<HTMLDivElement | null>(null)
+
+  // Échap ferme le menu mobile et rend le focus au bouton hamburger.
+  useEffect(() => {
+    if (!mobileOpen) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMobileOpen(false)
+        menuButtonRef.current?.focus()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [mobileOpen])
+
+  // Un clic/toucher en dehors du panneau referme le menu (hors bouton hamburger,
+  // sinon le toggle du bouton et ce handler se neutraliseraient).
+  useEffect(() => {
+    if (!mobileOpen) return
+
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null
+      if (!target) return
+      if (mobilePanelRef.current?.contains(target)) return
+      if (menuButtonRef.current?.contains(target)) return
+      setMobileOpen(false)
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('touchstart', onPointerDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('touchstart', onPointerDown)
+    }
+  }, [mobileOpen])
+
+  // Referme le menu mobile à chaque navigation et réinitialise les accordéons.
+  useEffect(() => {
+    setMobileOpen(false)
+    setOpenDropdown(null)
+  }, [pathname])
+
   return (
     <motion.header
       initial={{ y: -100 }}
@@ -393,6 +438,8 @@ export function Navbar({ isDark, onToggleDark }: Props) {
             </Link>
 
             <button
+              ref={menuButtonRef}
+              type="button"
               className="lg:hidden p-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
               onClick={() => setMobileOpen(!mobileOpen)}
               aria-label={copy.nav.menuLabel}
@@ -408,6 +455,7 @@ export function Navbar({ isDark, onToggleDark }: Props) {
       <AnimatePresence>
         {mobileOpen && (
           <motion.div
+            ref={mobilePanelRef}
             id="mobile-menu-panel"
             role="region"
             aria-label={copy.nav.menuLabel}


### PR DESCRIPTION
## 📝 Pull Request Overview

**Issue Reference(s):** Closes #7231

**Category:** Bug Fix

---

## 🚀 Changes Description

Trois défauts mobiles du web client, dont deux introduits ou laissés par la
nouvelle IA de navigation (#7225), plus un débordement de 329 px.

- **`(dashboard)/layout.tsx`** — le rail métier (`business-rail`, modules de la
  verticale du tenant) était `hidden md:flex` sans aucun déclencheur sous 768 px.
  Il devient un tiroir : bouton hamburger `md:hidden` (`aria-expanded` /
  `aria-controls` / label localisé), voile, bouton fermer, Échap, fermeture au
  changement de route, verrouillage du scroll, `inert` quand il est fermé, RTL
  (`start-0` + `rtl:translate-x-full`) — même modèle que la sidebar admin.
- **`(dashboard)/layout.tsx`** — `min-w-0` sur la colonne de contenu : le
  min-content du bandeau de pastilles (`overflow-x-auto`, 719 px) imposait la
  largeur du document (scrollWidth 719 pour clientWidth 390). Le bandeau défile
  désormais dans son conteneur. Badge « Présents » passé en `lg:flex` (la ligne
  de header débordait de 61 px à 768 px).
- **`OnboardingWizard.tsx`** — overlay en `items-center` sans défilement : la
  carte (974 px) dépassait au-dessus du viewport et le bouton de fermeture était
  hors écran. Passage en `items-start overflow-y-auto` + `my-auto`.
- **`vitrine/Navbar.tsx`** — le menu mobile ne se fermait ni sur Échap, ni au
  clic extérieur. Ajoutés (+ focus rendu au bouton sur Échap, accordéons
  réinitialisés à chaque navigation).
- **Tests** — nouvelle spec `e2e/dashboard-mobile-nav.spec.ts` (session mockée
  avec la verticale `restaurant` activée) ajoutée aux **deux** passes Playwright
  de `web-marketing-ci.yml`.

---

## 🗺️ Surfaces touchees

-   [ ] API (`api/app`)
-   [x] Web (`front/web`)
-   [ ] Admin dashboard (`front/admin-dashboard`)
-   [ ] Mobile (`front/mobile_apps/*`)
-   [ ] Kiosk (`front/zkteco-kiosk`)
-   [x] CI / GitHub Actions (`.github/workflows`) — ajout de la nouvelle spec aux passes e2e front/web
-   [ ] Docs uniquement (`docs/`, `*.md`)
-   [ ] Infra / config (`render.yaml`, `docker*`, etc.)

---

## 🔌 Contrat API

-   [x] Aucun changement de contrat API dans cette PR.

---

## ⚠️ Risques residuels

- Le tiroir mobile n'existe que si le tenant a au moins une verticale activée
  (`business.length > 0`) — c'est volontaire : sans module métier, il n'y a rien
  à afficher. Le compte démo public n'ayant aucune verticale, la vérification
  « réelle » de ce point passe par la spec mockée ; le reste (débordement,
  coquille de layout, modale d'onboarding) est vérifié sur l'API DEV live.
- Le débordement à **320 px** reste à traiter séparément (contenu de la page
  `/dashboard`, hors périmètre de cette PR).

---

## 🎨 Design Review — DSG-6 (PR touchant une UI)

-   [x] Tokens : aucune nouvelle couleur/typo — classes existantes uniquement.
-   [x] États UI couverts (vide, chargement, erreur, succès, disabled).
-   [x] Contraste AA vérifié (texte sur fond).
-   [x] Responsive : 390 / 414 / 600 / 768 / 1024 px mesurés
    (`scrollWidth == clientWidth`), tiroir ouvert/fermé en 390 px, rail en
    colonne + burger masqué en 1280 px.
-   [x] i18n/RTL : libellés via les clés existantes (`a11y.close`,
    `navigation.mainMenu`, `dashboard.businessSection`) ; tiroir RTL vérifié
    (`dir=rtl`, panneau ouvert/fermé) sur la vitrine, `rtl:translate-x-full` sur
    le rail ; la spec vitrine teste déjà le rendu arabe.

### Preuves

- `npx tsc --noEmit` : 0 · `npm run lint` : 0 · `npm run lint:e2e` : 0
- `npm run build` : OK
- e2e mockés : **34/34** (30 specs existantes + 4 nouvelles)
- harness réel (build prod local, API DEV live, compte démo manager) :
  **12 passed / 1 skipped**
- Jest : **inchangé** — 4 suites rouges pré-existantes (`absences`, `lettering`,
  `travel/portal`, `shop`), aucune nouvelle
